### PR TITLE
Implement GraphQL API

### DIFF
--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -2386,6 +2386,16 @@ class CLI:
             }
         ))
 
+        # End player turn
+        self.game_state.initiative_tracker.next_turn()
+
+        # Check if combat is over
+        self.game_state._check_combat_end()
+
+        if self.game_state.in_combat:
+            # Process enemy turns
+            self.process_enemy_turns()
+
     def handle_use_item_combat_attack(self, item_id: str, item_data: Dict[str, Any], user: Character, target) -> None:
         """
         Handle using an attack-type consumable item during combat on an enemy target.


### PR DESCRIPTION
Using a healing item (like Potion of Healing) during combat now properly ends the player's turn, preventing multiple actions in the same turn.

Previously, handle_use_item_combat_with_target() consumed the action but did not call next_turn(), allowing players to continue taking actions.

This fix adds turn advancement logic consistent with other combat action handlers (handle_attack, handle_use_item_combat_attack, handle_stabilize).

Fixes #71