### PR TITLE
Implementation task

### DIFF
--- a/dnd_engine/llm/enhancer.py
+++ b/dnd_engine/llm/enhancer.py
@@ -159,13 +159,14 @@ class LLMEnhancer:
 
         room_data = event.data
         cache_key = f"room_{room_data.get('id', 'unknown')}"
+        combat_starting = room_data.get('combat_starting', False)
 
         # Check cache
         if self.cache is not None and cache_key in self.cache:
             enhanced = self.cache[cache_key]
         else:
             # Generate enhancement with timing
-            prompt = build_room_description_prompt(room_data)
+            prompt = build_room_description_prompt(room_data, combat_starting=combat_starting)
             start_time = time.time()
             enhanced = await self.provider.generate(prompt)
             latency_ms = (time.time() - start_time) * 1000
@@ -419,7 +420,8 @@ class LLMEnhancer:
         if self.cache and cache_key in self.cache:
             return self.cache[cache_key]
 
-        prompt = build_room_description_prompt(room_data)
+        combat_starting = room_data.get('combat_starting', False)
+        prompt = build_room_description_prompt(room_data, combat_starting=combat_starting)
 
         async def generate():
             start_time = time.time()

--- a/dnd_engine/llm/prompts.py
+++ b/dnd_engine/llm/prompts.py
@@ -4,12 +4,13 @@
 from typing import Any
 
 
-def build_room_description_prompt(room_data: dict[str, Any]) -> str:
+def build_room_description_prompt(room_data: dict[str, Any], combat_starting: bool = False) -> str:
     """
     Build prompt for room description enhancement.
 
     Args:
         room_data: Room info (name, description, exits, contents, monsters)
+        combat_starting: If True, include combat initiation narrative in description
 
     Returns:
         Formatted prompt for LLM
@@ -43,12 +44,22 @@ def build_room_description_prompt(room_data: dict[str, Any]) -> str:
                 monster_list = ", ".join(monster_parts[:-1]) + f", and {monster_parts[-1]}"
                 monster_context = f"\nPresent in the room: {monster_list} (hostile)"
 
+    # Build instruction based on whether combat is starting
+    if combat_starting and monster_context:
+        instruction = """Add vivid sensory details (sights, sounds, smells) in 2-3 sentences. Make it immersive but concise.
+
+IMPORTANT: This is the moment combat begins. Naturally transition from describing the room into the combat initiation - describe how the enemies react to the party's presence, their threatening stance or aggressive movement toward the party, and the immediate tension as battle is about to erupt. Make it feel like a seamless escalation from scene-setting to action. Do NOT use phrases like "combat begins" - show it through the enemies' actions and the rising tension."""
+    elif monster_context:
+        instruction = " Acknowledge the presence of hostile creatures naturally in your description - describe their stance, readiness, or threatening demeanor."
+    else:
+        instruction = ""
+
     prompt = f"""Enhance this D&D dungeon room description with atmospheric details:
 
 Room: {room_type}
 Basic description: {base_desc}{monster_context}
 
-Add vivid sensory details (sights, sounds, smells) in 2-3 sentences. Make it immersive but concise.{" Acknowledge the presence of hostile creatures naturally in your description - describe their stance, readiness, or threatening demeanor." if monster_context else ""}"""
+Add vivid sensory details (sights, sounds, smells) in 2-3 sentences. Make it immersive but concise.{instruction}"""
 
     return prompt
 


### PR DESCRIPTION
Resolves the redundant combat initiation messaging by integrating combat-start narrative directly into room descriptions when entering a room with enemies.

## Changes

### Core Implementation
- **prompts.py**: Added `combat_starting` flag to `build_room_description_prompt()`
  - When True with monsters present, LLM generates combat initiation narrative
  - Instructions emphasize seamless transition from scene to action
  - When False, uses standard monster acknowledgment

- **enhancer.py**: Updated room description methods to pass through flag
  - `_enhance_room_description()` extracts combat_starting from room_data
  - `get_room_description_sync()` passes flag to prompt builder

- **cli.py**: Modified `display_room()` to detect combat start
  - Detects when entering room with enemies while not in combat
  - Sets `combat_starting=True` flag in room_data for LLM
  - Removed separate yellow narrative box from `_on_combat_start()`
  - Preserved combat warning message and functional UI elements

### Testing
- **test_prompts.py**: Added 5 new unit tests for combat_starting flag
  - Tests for True/False behavior with/without monsters
  - Verifies default behavior (False) maintained

- **test_llm_enhancer_integration.py**: Added 3 integration tests
  - Validates prompt construction with combat_starting context
  - Tests LLM enhancer passes flag correctly through chain

## Result
- Players now see single, cohesive narrative when entering combat
- No more redundant yellow box on combat initiation
- Mid-combat and post-combat yellow boxes preserved
- Combat warning and initiative table maintained
- All 39 tests passing