### PR TITLE
Remove hardcoded combat narrative and add creature-aware LLM prompts

### DIFF
--- a/dnd_engine/data/content/dungeons/poisoned_laboratory.json
+++ b/dnd_engine/data/content/dungeons/poisoned_laboratory.json
@@ -57,7 +57,7 @@
     },
     "laboratory": {
       "name": "Main Laboratory",
-      "description": "The heart of the alchemist's workshop. Bubbling cauldrons, distillation equipment, and mysterious glowing liquids cover every surface. A sickly green gas seeps from cracked flasks on the northern workbench. Two animated skeletons guard the northern passage - failed experiments that still move.",
+      "description": "The heart of the alchemist's workshop. Bubbling cauldrons, distillation equipment, and mysterious glowing liquids cover every surface. A sickly green gas seeps from cracked flasks on the northern workbench. Two goblin scavengers lurk among the bubbling equipment, drawn by the smell of alchemical reagents.",
       "exits": {
         "west": "storage",
         "north": "sanctum"
@@ -87,7 +87,7 @@
     },
     "furnace_room": {
       "name": "Furnace Chamber",
-      "description": "A massive furnace roars in the center of this sweltering room, used to heat alchemical reactions. The heat is intense. A large dire wolf, its fur singed and eyes glowing red, guards a pile of treasure near the furnace. Its breath smells of sulfur.",
+      "description": "A massive furnace roars in the center of this sweltering room, used to heat alchemical reactions. The heat is intense. A large wolf, its fur singed and eyes glowing red, lies near the furnace beside a pile of treasure. The beast's breath carries the acrid smell of sulfur.",
       "exits": {
         "east": "storage"
       },
@@ -122,7 +122,7 @@
     },
     "sanctum": {
       "name": "The Mad Alchemist's Sanctum",
-      "description": "The alchemist's private laboratory, filled with his most dangerous experiments. The air crackles with volatile energy. Archibald the Mad, a twisted figure in stained robes, cackles as he throws vials of alchemist's fire in your direction. His workbench is covered in scrolls and potions - the fruits of his insane research.",
+      "description": "The alchemist's private laboratory, filled with his most dangerous experiments. The air crackles with volatile energy. Archibald the Mad, a twisted figure in stained robes, stands at his workbench surrounded by volatile vials and bubbling concoctions. His bloodshot eyes gleam with madness as he mutters incomprehensibly over his work.",
       "exits": {
         "south": "laboratory"
       },

--- a/dnd_engine/data/content/dungeons/the_unquiet_dead_crypt.json
+++ b/dnd_engine/data/content/dungeons/the_unquiet_dead_crypt.json
@@ -9,7 +9,7 @@
   "rooms": {
     "graveyard_entrance": {
       "name": "Overgrown Graveyard",
-      "description": "A rusted iron gate opens into a small graveyard. Ancient headstones lean at odd angles, covered in moss and ivy. At the center stands a stone mausoleum bearing the name 'DAVOS' in weathered letters. The heavy door hangs ajar, revealing darkness within. As you approach, you hear a rattling sound - bones shifting against stone. Two skeletal figures rise from the ground, their empty eye sockets fixing on you as they reach for rusted weapons.",
+      "description": "A rusted iron gate opens into a small graveyard. Ancient headstones lean at odd angles, covered in moss and ivy. At the center stands a stone mausoleum bearing the name 'DAVOS' in weathered letters. The heavy door hangs ajar, revealing darkness within. Two skeletal figures stand among the gravestones, ancient guardians of this cursed place.",
       "exits": {
         "down": "hall_of_the_dead"
       },
@@ -107,7 +107,7 @@
     },
     "eastern_crypt": {
       "name": "Eastern Crypt",
-      "description": "Two large stone coffins are embedded in the northern and southern walls of this burial chamber. Their lids have been pushed aside, revealing empty interiors lined with rotting cloth. Two skeletal guardians stand motionless in the center of the room, their heads turning toward you with an audible creak. Rusted short swords hang from their bony hands as they begin their lurching advance.",
+      "description": "Two large stone coffins are embedded in the northern and southern walls of this burial chamber. Their lids have been pushed aside, revealing empty interiors lined with rotting cloth. Two skeletal guardians stand motionless in the center of the room, rusted short swords hanging from their bony hands.",
       "exits": {
         "west": "antechamber"
       },
@@ -128,7 +128,7 @@
     },
     "northern_crypt": {
       "name": "Northern Crypt",
-      "description": "This burial chamber mirrors its southern counterpart - coffins and memorial plaques line the granite walls, bearing dates that span centuries. Three skeletal warriors guard this section of the crypt, their bones yellowed with age. They drag their short swords along the stone floor, creating an eerie scraping rhythm as they close in.",
+      "description": "This burial chamber mirrors its southern counterpart - coffins and memorial plaques line the granite walls, bearing dates that span centuries. Three skeletal warriors guard this section of the crypt, their bones yellowed with age and draped in tattered remnants of ancient armor.",
       "exits": {
         "south": "antechamber"
       },
@@ -150,7 +150,7 @@
     },
     "southern_crypt": {
       "name": "Southern Crypt",
-      "description": "More ancestral remains rest here, their names carved into brass plaques that have long since tarnished. The air grows colder, and a malevolent presence seems to permeate the chamber. Three skeletons shamble among the coffins, their movements more aggressive than those above. They attack without hesitation.",
+      "description": "More ancestral remains rest here, their names carved into brass plaques that have long since tarnished. The air grows colder, and a malevolent presence seems to permeate the chamber. Three skeletons stand among the coffins, their hollow eyes glowing with an unnatural light.",
       "exits": {
         "up": "antechamber"
       },
@@ -172,7 +172,7 @@
     },
     "family_shrine": {
       "name": "Family Shrine - Chamber of Davos",
-      "description": "A small stone dais rises against the western wall. Upon it rests an ornate coffin, clearly more elaborate than the others you've seen. The lid has been violently smashed inward, splinters of ancient wood scattered across the floor. This was the final resting place of Davos the cleric, whose divine power once sealed away a great evil. In the corner, hunched over a fresh corpse, a pale creature with elongated claws tears at dead flesh. It wears the tattered robes of a cultist. As it becomes aware of your presence, it raises its blood-streaked face and hisses, baring needle-sharp teeth.",
+      "description": "A small stone dais rises against the western wall. Upon it rests an ornate coffin, clearly more elaborate than the others you've seen. The lid has been violently smashed inward, splinters of ancient wood scattered across the floor. This was the final resting place of Davos the cleric, whose divine power once sealed away a great evil. In the corner, hunched over a fresh corpse, a pale creature with elongated claws and needle-sharp teeth feeds on dead flesh. It wears the tattered robes of a cultist, its blood-streaked face twisted in hunger.",
       "examinable_objects": [
         {
           "id": "cultist_corpse",

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -121,12 +121,18 @@ class CLI:
         # Try to get enhanced description from LLM
         enhanced_desc = None
         if self.llm_enhancer:
+            # Load full monster data for creature-aware prompts
+            monsters_data = self.game_state.data_loader.load_monsters()
+            party_size = len(self.game_state.party.characters)
+
             room_data = {
                 "id": room.get("id", room_name.lower().replace(" ", "_")),
                 "name": room_name,
                 "description": basic_desc,
                 "monsters": monster_names,  # Include monster info for LLM
-                "combat_starting": combat_starting  # Flag for combat initiation narrative
+                "combat_starting": combat_starting,  # Flag for combat initiation narrative
+                "monsters_data": monsters_data,  # Full monster definitions for creature-aware prompts
+                "party_size": party_size  # Party size for combat context
             }
             with console.status("", spinner="dots"):
                 enhanced_desc = self.llm_enhancer.get_room_description_sync(room_data, timeout=3.0)


### PR DESCRIPTION
## Summary

Fixes #118

This PR resolves two issues with combat narrative and fixes a critical caching bug:

1. **Removed hardcoded combat narrative** from room descriptions that duplicated LLM-generated combat initiations
2. **Added creature-aware LLM prompts** that tailor combat initiations to creature behavior (undead feel mechanical, beasts feel feral, humanoids feel tactical)
3. **Fixed LLM cache bug** that showed stale combat descriptions after enemies were defeated

## Changes

### Content Updates
- Updated 8 room descriptions across 2 dungeons (`the_unquiet_dead_crypt.json`, `poisoned_laboratory.json`)
- Removed combat initiation phrases like "they charge at you", "raising weapons", "hissing"
- Kept observational enemy presence ("two skeletal guardians stand in the room")

### Code Enhancements
- **`prompts.py`**: Enhanced `build_room_description_prompt()` to accept `monsters_data` and `party_size` parameters
- **`prompts.py`**: Added creature behavior guidance based on monster types:
  - Undead: mechanical precision, relentless advance, emotionless determination
  - Beasts: snarling, prowling, feral aggression, instinctive pack behavior  
  - Humanoids: tactical positioning, drawing weapons, battle cries, coordinated movements
- **`cli.py`**: Updated to pass full monster data and party size to LLM enhancer
- **`enhancer.py`**: Updated both async and sync methods to extract and pass new parameters
- **`enhancer.py`**: **Critical fix**: Changed cache key from `"room_{id}"` to `"room_{id}_combat_{count}_monsters"` to prevent showing combat descriptions after enemies are cleared

### Testing
- Added comprehensive integration test `test_enhancer_creature_aware_prompts()` that verifies:
  - Party size context is included in prompts
  - Creature-specific behavior guidance for undead, humanoids, and beasts
  - Proper prompt construction with monster type, size, and alignment data
- All 40 existing LLM tests pass

## Examples

### Before (Hardcoded in JSON)
```
"As you approach, you hear a rattling sound - bones shifting against stone. 
Two skeletal figures rise from the ground, their empty eye sockets fixing 
on you as they reach for rusted weapons."
```

### After (Observational in JSON, LLM generates combat initiation)
```json
"Two skeletal figures stand among the gravestones, ancient guardians 
of this cursed place."
```

**LLM receives:**
```
Party size: 4 adventurers

Creature behavior guide:
- Undead: mechanical precision, relentless advance, emotionless determination
```

**LLM generates (example):**
```
The skeletal guardians turn toward you with mechanical precision, raising 
their rusted weapons as they begin their relentless advance, bones clattering 
against stone with each step.
```

## Impact

- Eliminates double narrative when entering rooms with enemies
- Combat initiations now vary appropriately by creature type (no more generic "they turn toward you")
- Post-combat "look" commands correctly show cleared rooms instead of stale combat descriptions
- Party size influences narrative context (outnumbered vs surrounding)

## Test Plan

- [x] All unit tests pass (25 prompt tests)
- [x] All integration tests pass (15 enhancer tests including new creature-aware test)
- [x] Manual testing: Enter room with enemies, see creature-appropriate combat initiation
- [x] Manual testing: Defeat enemies, use "look" command, verify no stale combat description

🤖 Generated with [Claude Code](https://claude.com/claude-code)