### PR TITLE
Add party management debug commands (/addcharacter, /removecharacter)

### DIFF
--- a/tests/test_debug_console.py
+++ b/tests/test_debug_console.py
@@ -659,8 +659,8 @@ class TestPartyManagementCommands:
 
         initial_count = len(party.characters)
 
-        # Try level > 20
-        console.cmd_add_character(["wizard", "elf", "25"])
+        # Try level > 20 (use valid race so it tests level validation)
+        console.cmd_add_character(["wizard", "high_elf", "25"])
 
         # Should not add character
         assert len(party.characters) == initial_count


### PR DESCRIPTION
## Summary
Implements party management commands for the debug console to enable rapid party composition testing and QA workflows.

## Changes

### New Commands
- **`/addcharacter <class> [race] [level]`** - Add new party member with flexible optional arguments
  - `/addcharacter wizard` - random race, level 1
  - `/addcharacter wizard high_elf` - specified race, level 1  
  - `/addcharacter wizard high_elf 5` - fully specified
  - `/addcharacter fighter 3` - random race, specified level
  
- **`/removecharacter <name>`** - Remove party member with confirmation prompt

### Improvements
- Dynamically displays actual available classes and races in help text
- Characters created with proper spellcasting initialization for casters
- Characters receive starting equipment appropriate to their class
- HP calculated correctly for multi-level characters (uses average rolls)
- Auto-assigns skill proficiencies based on class

### Code Quality
- Added 15 comprehensive unit tests (all passing)
- Updated `/help` to include Party Management section
- Removed redundant `/create` command (functionality covered by flexible `/addcharacter`)

## Testing
```bash
# Run party management tests
uv run pytest tests/test_debug_console.py::TestPartyManagementCommands -v

# All 15 tests passing ✓
```

## Use Cases
- **Quick party composition testing**: `/addcharacter wizard`, `/addcharacter fighter`
- **Level testing**: `/addcharacter rogue 10` to test high-level mechanics
- **Class variety testing**: Rapidly create diverse parties for combat balance
- **Bug reproduction**: Quickly recreate specific party compositions from bug reports

## Related Issues
Related to #110 (implements MEDIUM priority party management commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)