### PR TITLE
Fix crash when selecting Cancel in spell casting prompt - Fixes #134

### DIFF
--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -3590,7 +3590,8 @@ class CLI:
 
         # 1. Select caster
         caster = self._prompt_party_member_selection("Who will cast a spell?")
-        if not caster:
+        # Handle both None and "Cancel" string (questionary may return either)
+        if not caster or isinstance(caster, str):
             return  # User cancelled
 
         # Check if character can cast spells
@@ -3653,7 +3654,8 @@ class CLI:
             target = self._prompt_party_member_selection(
                 f"Who should {caster.name} heal with {spell_data.get('name')}?"
             )
-            if not target:
+            # Handle both None and "Cancel" string (questionary may return either)
+            if not target or isinstance(target, str):
                 return  # User cancelled
             target_name = target.name
 


### PR DESCRIPTION
## Summary

Fixes crash when user selects "Cancel" during spell casting prompts by adding defensive type checking to handle questionary library returning "Cancel" as a string instead of None.

## Bug Description

When selecting "Cancel" in the spell casting prompt, the application crashed with:
```
AttributeError: 'str' object has no attribute 'get_out_of_combat_spells'
```

## Root Cause

The questionary library was returning the string "Cancel" instead of the expected None value when the Cancel option was selected. The code then attempted to call character methods on this string, causing the crash.

## Changes

### dnd_engine/ui/cli.py

**Caster selection (line 3593-3595):**
- Added `isinstance(caster, str)` check alongside existing `if not caster:` check
- Handles both None and string "Cancel" returns gracefully

**Healing target selection (line 3657-3659):**
- Added same defensive check for healing spell target selection
- Prevents crash if user cancels target selection for healing spells

## Testing

✅ Manually tested reproduction steps from issue #134:
1. Start game with party
2. Type `cast` command
3. Select "Cancel" when prompted "Who will cast a spell?"
4. ✅ Returns gracefully to command prompt (previously crashed)

## Code Review

✅ Reviewed by python-code-reviewer skill:
- No critical issues
- Defensive programming best practice
- Clear comments documenting library quirk
- Minimal, focused change
- No performance or security concerns

## Impact

- **Low risk**: Only adds defensive type checking
- **No behavior change**: Same user experience, just handles edge case properly
- **Fixes critical UX bug**: Users can now cancel spell casting without crashes

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)