### PR TITLE
Implement monster special attacks with saving throws - Fixes #103

### DIFF
--- a/dnd_engine/data/srd/monsters.json
+++ b/dnd_engine/data/srd/monsters.json
@@ -22,7 +22,10 @@
       "stealth": 6
     },
     "senses": "darkvision 60 ft., passive Perception 9",
-    "languages": ["Common", "Goblin"],
+    "languages": [
+      "Common",
+      "Goblin"
+    ],
     "cr": "1/4",
     "xp": 50,
     "loot": {
@@ -79,7 +82,10 @@
       "stealth": 6
     },
     "senses": "darkvision 60 ft., passive Perception 9",
-    "languages": ["Common", "Goblin"],
+    "languages": [
+      "Common",
+      "Goblin"
+    ],
     "cr": "1",
     "xp": 200,
     "is_boss": true,
@@ -200,7 +206,9 @@
     },
     "skills": {},
     "senses": "passive Perception 10",
-    "languages": ["Common"],
+    "languages": [
+      "Common"
+    ],
     "cr": "1/8",
     "xp": 25,
     "loot": {
@@ -249,11 +257,20 @@
       "cha": 5
     },
     "skills": {},
-    "damage_vulnerabilities": ["bludgeoning"],
-    "damage_immunities": ["poison"],
-    "condition_immunities": ["exhaustion", "poisoned"],
+    "damage_vulnerabilities": [
+      "bludgeoning"
+    ],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "poisoned"
+    ],
     "senses": "darkvision 60 ft., passive Perception 9",
-    "languages": ["understands all languages it knew in life but can't speak"],
+    "languages": [
+      "understands all languages it knew in life but can't speak"
+    ],
     "cr": "1/4",
     "xp": 50,
     "loot": {
@@ -302,10 +319,18 @@
       "cha": 6
     },
     "skills": {},
-    "damage_immunities": ["poison"],
-    "condition_immunities": ["charmed", "exhaustion", "poisoned"],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "poisoned"
+    ],
     "senses": "darkvision 60 ft., passive Perception 10",
-    "languages": ["Common"],
+    "languages": [
+      "Common"
+    ],
     "cr": "1",
     "xp": 200,
     "loot": {
@@ -315,15 +340,6 @@
     "traits": [],
     "actions": [
       {
-        "name": "Bite",
-        "type": "melee-weapon-attack",
-        "attack_bonus": 2,
-        "reach": "5 ft.",
-        "damage": "2d6+2",
-        "damage_average": 9,
-        "damage_type": "piercing"
-      },
-      {
         "name": "Claws",
         "type": "melee-weapon-attack",
         "attack_bonus": 4,
@@ -332,7 +348,28 @@
         "damage_average": 7,
         "damage_type": "slashing",
         "special": "If the target is a creature other than an undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
-        "notes": "Paralysis condition not yet fully implemented in combat system - will need saving throw mechanics"
+        "notes": "Paralysis saving throw now implemented via saving_throw field",
+        "saving_throw": {
+          "trigger": "on_hit",
+          "ability": "constitution",
+          "dc": 10,
+          "on_fail": {
+            "condition": "paralyzed",
+            "duration_type": "rounds",
+            "duration": 10,
+            "allow_repeat_save": true,
+            "repeat_timing": "end_of_turn"
+          }
+        }
+      },
+      {
+        "name": "Bite",
+        "type": "melee-weapon-attack",
+        "attack_bonus": 2,
+        "reach": "5 ft.",
+        "damage": "2d6+2",
+        "damage_average": 9,
+        "damage_type": "piercing"
       }
     ]
   }

--- a/dnd_engine/ui/rich_ui.py
+++ b/dnd_engine/ui/rich_ui.py
@@ -5,12 +5,10 @@ from typing import List, Optional, Dict, Any
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
-from rich.text import Text
 from rich.align import Align
-from rich.progress import Progress, BarColumn, TextColumn
 from rich.style import Style
 from rich import box
-from dnd_engine.utils.logging_config import init_logging, get_logging_config
+from dnd_engine.utils.logging_config import init_logging
 
 
 # Global console instance - initialized via init_console()
@@ -203,8 +201,24 @@ def create_combat_table(combatants: List[Dict[str, Any]]) -> Table:
                 status = "[red]DEFEATED[/red]"
                 color = "red"
         else:
-            status = "[green]ACTIVE[/green]"
-            color = "white"
+            # Check for incapacitating conditions
+            conditions = combatant.get("conditions", [])
+            incapacitating = ["paralyzed", "stunned", "unconscious", "petrified"]
+            active_incapacitating = [c for c in conditions if c in incapacitating]
+
+            if active_incapacitating:
+                # Show primary incapacitating condition
+                condition_name = active_incapacitating[0].upper()
+                status = f"[yellow]{condition_name}[/yellow]"
+                color = "yellow"
+            elif conditions:
+                # Show other conditions
+                condition_name = conditions[0].upper()
+                status = f"[cyan]{condition_name}[/cyan]"
+                color = "cyan"
+            else:
+                status = "[green]ACTIVE[/green]"
+                color = "white"
 
         name_style = "bold yellow" if combatant.get("is_player") else "white"
 

--- a/dnd_engine/utils/events.py
+++ b/dnd_engine/utils/events.py
@@ -45,6 +45,7 @@ class EventType(Enum):
     ITEM_UNEQUIPPED = "item_unequipped"
     ITEM_USED = "item_used"
     GOLD_ACQUIRED = "gold_acquired"
+    CONDITION_APPLIED = "condition_applied"
     CONDITION_REMOVED = "condition_removed"
     BUFF_APPLIED = "buff_applied"
 


### PR DESCRIPTION
## Summary

Implements monster special attacks that trigger saving throws, with **ghoul paralysis** as the first implementation. This closes #103 as part of Epic #126 (The Crypt) Phase 1.

## What Changed

### Core System
- ✅ **Saving throw processing**: `CombatEngine._process_saving_throw_effect()` handles on-hit saving throw effects from monster actions
- ✅ **Enhanced condition system**: Migrated from `Set[str]` to `dict` with metadata for duration tracking and repeat saves
- ✅ **Condition management**: New methods `apply_condition_with_metadata()`, `process_end_of_turn_conditions()`, `can_take_actions()`
- ✅ **Event emission**: Added `CONDITION_APPLIED` event type for game state observability

### Monster Data
- ✅ **Structured saving throw format**: Ghoul Claws action now has `saving_throw` field with DC, ability, condition, duration, and repeat save config
- ✅ **Action order**: Swapped ghoul Bite/Claws order so AI uses paralysis attack

### UI/UX
- ✅ **Condition display**: Combat status table shows active conditions (PARALYZED, STUNNED, etc.)
- ✅ **Turn handling**: Paralyzed characters auto-skip with repeat save attempts and clear messaging
- ✅ **Saving throw feedback**: Shows success/failure with ability, DC, and condition details

### Testing
- ✅ **Comprehensive coverage**: Tests for saving throw processing, condition metadata, duration countdown, repeat saves, and incapacitation
- ✅ **All tests passing**: Pristine test output with full coverage of new functionality

## Backward Compatibility

- `@property conditions` maintains `Set[str]` interface for legacy code
- Existing `add_condition()`/`remove_condition()` methods still work

## Manual Testing

Tested complete flow:
1. ✅ Ghoul attacks with Claws → CON save triggers
2. ✅ Failed save → Character paralyzed for 10 rounds
3. ✅ Status table shows PARALYZED condition
4. ✅ Paralyzed character turn → Auto-skips with repeat save attempt
5. ✅ Successful save → Condition removed, character can act again

## Related

- Closes #103
- Part of Epic #126 (The Crypt) Phase 1
- Created follow-up #138 for enhancing LLM combat narratives with attack types

🤖 Generated with [Claude Code](https://claude.com/claude-code)