### PR TITLE
Fix issues from PR #139 code review

### DIFF
--- a/dnd_engine/core/creature.py
+++ b/dnd_engine/core/creature.py
@@ -228,7 +228,9 @@ class Creature:
                             "condition": condition_name,
                             "save_result": save_result
                         })
-                        continue
+                    # Skip duration processing for conditions with repeat saves
+                    # The repeat save is the primary mechanism for ending the condition
+                    continue
 
             # Decrement duration for round-based conditions
             if metadata.get("duration_type") == "rounds":

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -3824,8 +3824,6 @@ class CLI:
         # Parse command for options
         parts = command.split()
         dungeon_name = None
-        reset_hp = True
-        reset_conditions = True
 
         # Check for --dungeon option
         if len(parts) > 1 and parts[1] == "--dungeon" and len(parts) > 2:

--- a/tests/test_creature.py
+++ b/tests/test_creature.py
@@ -371,8 +371,9 @@ class TestCreature:
 
             # Either still paralyzed (failed save) or removed (passed save - rare)
             if creature.has_condition("paralyzed"):
-                # Failed save - duration should decrement
-                assert creature.active_conditions["paralyzed"]["duration_remaining"] == initial_duration - 1
+                # Failed save - with repeat saves enabled, duration does NOT decrement
+                # The repeat save is the primary mechanism for ending the condition
+                assert creature.active_conditions["paralyzed"]["duration_remaining"] == initial_duration
 
     def test_conditions_backward_compatibility(self):
         """Test that conditions property returns set of condition names"""


### PR DESCRIPTION
## Summary
Addresses two critical issues identified in the code review of PR #139.

## Issues Fixed

### 1. **Condition Duration Bug** (Medium Severity)
**Problem**: Conditions with both repeat saves AND duration were being double-penalized. When a repeat save failed, the duration still decremented, meaning the condition was trying to end via two mechanisms simultaneously.

**Fix**: Modified `process_end_of_turn_conditions()` in `creature.py` to skip duration processing when repeat saves are enabled. When `allow_repeat_save=True`, the repeat save is now the primary (and only) mechanism for ending the condition.

**Impact**: Ghoul paralysis and other conditions with repeat saves now work as intended - they last indefinitely until the save succeeds, rather than counting down while also requiring saves.

### 2. **Unused Variables** (Low Severity)
**Problem**: `reset_hp` and `reset_conditions` variables were defined but never used in the `handle_reset_dungeon` function in `cli.py`.

**Fix**: Removed the unused variables (lines 3827-3828).

**Impact**: Cleaner code, removes ruff linter warnings.

## Changes
- `dnd_engine/core/creature.py`: Added `continue` after repeat save processing to skip duration decrement
- `dnd_engine/ui/cli.py`: Removed 2 unused variable declarations
- `tests/test_creature.py`: Updated test assertion to match new behavior (duration no longer decrements with repeat saves)

## Testing
✅ All condition-related tests passing (8/8)
- test_creature_conditions
- test_apply_condition_with_metadata
- test_can_take_actions_with_various_conditions
- test_process_end_of_turn_conditions_duration_countdown
- test_process_end_of_turn_conditions_repeat_save_success
- test_process_end_of_turn_conditions_repeat_save_failure (updated)
- test_conditions_backward_compatibility
- test_creature_multiple_conditions

## Related
- Fixes code review issues from PR #139
- Closes items from the code review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)