### PR TITLE
Fix description box layout and borders

### DIFF
--- a/dnd_engine/ui/rich_ui.py
+++ b/dnd_engine/ui/rich_ui.py
@@ -285,7 +285,8 @@ def print_room_description(title: str, description: str, exits: List[str]) -> No
         content,
         title=f"[bold]{title}[/bold]",
         style="cyan",
-        expand=False
+        expand=False,
+        padding=(1, 2)
     )
     console.print(panel)
 


### PR DESCRIPTION
Add padding=(1, 2) to the room description panel to provide proper spacing between text and borders. This matches the padding used by other narrative panels and fixes the border alignment issue.