### PR TITLE
Implement spell concentration tracking (#122)

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -1210,6 +1210,78 @@ class GameState:
                 "has_duration": effect is not None
             }
 
+    def get_concentration_spell(self, character_name: str) -> Optional[str]:
+        """
+        Get the spell a character is currently concentrating on.
+
+        Args:
+            character_name: Name of the character
+
+        Returns:
+            Spell name if concentrating, None otherwise
+        """
+        for effect in self.time_manager.active_effects:
+            if effect.concentration and effect.caster_name == character_name:
+                return effect.source  # source contains the spell name
+        return None
+
+    def check_concentration_from_damage(self, character_name: str, damage: int) -> dict:
+        """
+        Check if damage breaks a character's concentration on a spell.
+
+        Args:
+            character_name: Name of the character who took damage
+            damage: Amount of damage taken
+
+        Returns:
+            dict with keys:
+                - was_concentrating: bool - whether character was concentrating
+                - concentration_broken: bool - whether concentration was broken
+                - spell_name: str | None - name of spell that was being concentrated on
+                - dc: int | None - DC of the concentration check
+                - save_result: dict | None - result of the saving throw
+        """
+        # Check if character is concentrating
+        spell_name = self.get_concentration_spell(character_name)
+        if not spell_name:
+            return {
+                "was_concentrating": False,
+                "concentration_broken": False,
+                "spell_name": None,
+                "dc": None,
+                "save_result": None
+            }
+
+        # Find the character
+        character = self.party.get_character_by_name(character_name)
+        if not character:
+            # Maybe it's an enemy? For now, only handle party members
+            return {
+                "was_concentrating": True,
+                "concentration_broken": False,
+                "spell_name": spell_name,
+                "dc": None,
+                "save_result": None
+            }
+
+        # Calculate DC: max(10, damage // 2)
+        dc = max(10, damage // 2)
+
+        # Make Constitution saving throw
+        save_result = character.make_saving_throw("constitution", dc)
+
+        # If failed, break concentration
+        if not save_result["success"]:
+            self.time_manager.remove_concentration_effects(character_name)
+
+        return {
+            "was_concentrating": True,
+            "concentration_broken": not save_result["success"],
+            "spell_name": spell_name,
+            "dc": dc,
+            "save_result": save_result
+        }
+
     def _create_spell_effect(
         self,
         spell_data: Dict[str, Any],
@@ -1579,6 +1651,17 @@ class GameState:
                                     "opportunity_attack": True
                                 }
                             ))
+
+                            # Check concentration if target took damage
+                            if result.damage > 0:
+                                concentration_result = self.check_concentration_from_damage(
+                                    target.name,
+                                    result.damage
+                                )
+                                if concentration_result["concentration_broken"]:
+                                    # Store result for later display
+                                    result.concentration_broken = True
+                                    result.broken_spell = concentration_result["spell_name"]
 
                         # Track casualties
                         if not target.is_alive:

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -260,6 +260,12 @@ class CLI:
             if hasattr(entry.creature, 'active_conditions'):
                 combatant_data["conditions"] = list(entry.creature.active_conditions.keys())
 
+            # Add concentration information for players
+            if is_player:
+                concentration_spell = self.game_state.get_concentration_spell(entry.creature.name)
+                if concentration_spell:
+                    combatant_data["concentration"] = concentration_spell
+
             combatants.append(combatant_data)
 
         table = create_combat_table(combatants)
@@ -1587,6 +1593,21 @@ class CLI:
             apply_damage=True
         )
 
+        # Check concentration if target was hit and took damage
+        if result.hit and result.damage > 0 and isinstance(target, Character):
+            concentration_result = self.game_state.check_concentration_from_damage(
+                target.name,
+                result.damage
+            )
+            if concentration_result["concentration_broken"]:
+                spell_name = concentration_result["spell_name"]
+                save_result = concentration_result["save_result"]
+                dc = concentration_result["dc"]
+                console.print(
+                    f"[yellow]💫 {target.name}'s concentration on {spell_name} is broken! "
+                    f"(CON save: {save_result['total']} vs DC {dc})[/yellow]"
+                )
+
         # NEW FLOW: Narrative → Mechanics → Death Narrative → Death Message
 
         # 1. Get and display attack narrative FIRST (if hit)
@@ -1868,6 +1889,39 @@ class CLI:
             apply_damage=True,
             event_bus=self.game_state.event_bus
         )
+
+        # Check concentration if target was hit and took damage
+        if result.hit and result.damage > 0 and isinstance(target, Character):
+            concentration_result = self.game_state.check_concentration_from_damage(
+                target.name,
+                result.damage
+            )
+            if concentration_result["concentration_broken"]:
+                spell_name = concentration_result["spell_name"]
+                save_result = concentration_result["save_result"]
+                dc = concentration_result["dc"]
+                console.print(
+                    f"[yellow]💫 {target.name}'s concentration on {spell_name} is broken! "
+                    f"(CON save: {save_result['total']} vs DC {dc})[/yellow]"
+                )
+
+        # Handle concentration for caster's new spell
+        if spell_data.get("concentration", False):
+            # Check if caster is already concentrating
+            previous_spell = self.game_state.get_concentration_spell(caster.name)
+            if previous_spell:
+                console.print(
+                    f"[yellow]💫 {caster.name} stops concentrating on {previous_spell}[/yellow]"
+                )
+                self.game_state.time_manager.remove_concentration_effects(caster.name)
+
+            # Add new concentration effect
+            effect = self.game_state._create_spell_effect(spell_data, caster.name, target.name)
+            if effect:
+                self.game_state.time_manager.add_effect(effect)
+                console.print(
+                    f"[cyan]🎯 {caster.name} begins concentrating on {spell_display_name}[/cyan]"
+                )
 
         # Display narrative if available
         if self.llm_enhancer and result.hit:
@@ -2292,6 +2346,21 @@ class CLI:
                     event_bus=self.game_state.event_bus,
                     action=action  # Pass action data for saving throw processing
                 )
+
+                # Check concentration if target was hit and took damage
+                if result.hit and result.damage > 0:
+                    concentration_result = self.game_state.check_concentration_from_damage(
+                        target.name,
+                        result.damage
+                    )
+                    if concentration_result["concentration_broken"]:
+                        spell_name = concentration_result["spell_name"]
+                        save_result = concentration_result["save_result"]
+                        dc = concentration_result["dc"]
+                        console.print(
+                            f"[yellow]💫 {target.name}'s concentration on {spell_name} is broken! "
+                            f"(CON save: {save_result['total']} vs DC {dc})[/yellow]"
+                        )
 
                 # Display saving throw results if triggered
                 if result.hit and "saving_throw" in action:
@@ -3993,7 +4062,7 @@ class CLI:
                 use_arrow_keys=True
             ).ask()
 
-            if not selected:
+            if not selected or selected == "Cancel":
                 return  # User cancelled
 
             spell_id, spell_data = selected
@@ -4169,16 +4238,12 @@ class CLI:
 
     def handle_time(self) -> None:
         """Display the current game time."""
-        from dnd_engine.ui.printing import print_section, print_message
-
         elapsed_time = self.game_state.time_manager.get_elapsed_time_display()
         print_section("Game Time")
         print_message(f"Time elapsed: {elapsed_time}")
 
     def handle_effects(self) -> None:
         """Display all active effects on party members."""
-        from dnd_engine.ui.printing import print_section, print_message
-
         effects = self.game_state.time_manager.get_all_effects()
 
         if not effects:

--- a/dnd_engine/ui/rich_ui.py
+++ b/dnd_engine/ui/rich_ui.py
@@ -220,6 +220,11 @@ def create_combat_table(combatants: List[Dict[str, Any]]) -> Table:
                 status = "[green]ACTIVE[/green]"
                 color = "white"
 
+            # Add concentration info if present
+            concentration = combatant.get("concentration")
+            if concentration:
+                status += f"\n[magenta]🎯 {concentration}[/magenta]"
+
         name_style = "bold yellow" if combatant.get("is_player") else "white"
 
         table.add_row(

--- a/tests/test_concentration.py
+++ b/tests/test_concentration.py
@@ -1,0 +1,314 @@
+# ABOUTME: Unit tests for spell concentration mechanics
+# ABOUTME: Tests concentration tracking, damage-triggered checks, and concentration breaking
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.utils.events import EventBus
+from dnd_engine.systems.time_manager import ActiveEffect, EffectType
+
+
+@pytest.fixture
+def sample_character():
+    """Create a sample character for testing"""
+    return Character(
+        name="Test Wizard",
+        character_class=CharacterClass.WIZARD,
+        level=5,
+        abilities=Abilities(
+            strength=8,
+            dexterity=14,
+            constitution=14,  # +2 modifier
+            intelligence=16,
+            wisdom=12,
+            charisma=10
+        ),
+        max_hp=30,
+        ac=12
+    )
+
+
+@pytest.fixture
+def game_state_with_character(sample_character):
+    """Create game state with a character"""
+    party = Party([sample_character])
+    event_bus = EventBus()
+
+    with patch('dnd_engine.core.game_state.DataLoader') as mock_loader_class:
+        mock_loader = Mock()
+        mock_loader.load_dungeon.return_value = {
+            "name": "Test Dungeon",
+            "start_room": "test_room",
+            "rooms": {
+                "test_room": {
+                    "name": "Test Room",
+                    "description": "A test room",
+                    "exits": {},
+                    "items": []
+                }
+            }
+        }
+        mock_loader.load_skills.return_value = {}
+        mock_loader.load_items.return_value = {
+            "weapons": {},
+            "consumables": {},
+            "armor": {}
+        }
+        mock_loader.load_spells.return_value = {
+            "bless": {
+                "name": "Bless",
+                "level": 1,
+                "concentration": True,
+                "duration": 60
+            },
+            "mage_hand": {
+                "name": "Mage Hand",
+                "level": 0,
+                "concentration": True,
+                "duration": 60
+            },
+            "magic_missile": {
+                "name": "Magic Missile",
+                "level": 1,
+                "concentration": False
+            }
+        }
+        mock_loader_class.return_value = mock_loader
+
+        game_state = GameState(
+            party=party,
+            dungeon_name="test_dungeon",
+            event_bus=event_bus
+        )
+
+    game_state.current_room_id = "test_room"
+    return game_state
+
+
+class TestGetConcentrationSpell:
+    """Test getting active concentration spell"""
+
+    def test_no_concentration_returns_none(self, game_state_with_character, sample_character):
+        """Test that None is returned when not concentrating"""
+        result = game_state_with_character.get_concentration_spell(sample_character.name)
+        assert result is None
+
+    def test_returns_concentration_spell_name(self, game_state_with_character, sample_character):
+        """Test that spell name is returned when concentrating"""
+        # Add a concentration effect
+        effect = ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="bless",
+            duration_minutes=60,
+            remaining_minutes=60,
+            target_name=sample_character.name,
+            caster_name=sample_character.name,
+            concentration=True
+        )
+        game_state_with_character.time_manager.add_effect(effect)
+
+        result = game_state_with_character.get_concentration_spell(sample_character.name)
+        assert result == "bless"
+
+    def test_different_character_concentration(self, game_state_with_character):
+        """Test that concentration is character-specific"""
+        # Add concentration for a different character
+        effect = ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="bless",
+            duration_minutes=60,
+            remaining_minutes=60,
+            target_name="Other Character",
+            caster_name="Other Character",
+            concentration=True
+        )
+        game_state_with_character.time_manager.add_effect(effect)
+
+        # Should not return concentration for our test character
+        result = game_state_with_character.get_concentration_spell("Test Wizard")
+        assert result is None
+
+
+class TestConcentrationFromDamage:
+    """Test damage-triggered concentration checks"""
+
+    def test_no_concentration_no_check(self, game_state_with_character, sample_character):
+        """Test that no check occurs when not concentrating"""
+        result = game_state_with_character.check_concentration_from_damage(
+            sample_character.name,
+            10
+        )
+
+        assert result["was_concentrating"] is False
+        assert result["concentration_broken"] is False
+        assert result["spell_name"] is None
+
+    def test_low_damage_dc_10(self, game_state_with_character, sample_character):
+        """Test that low damage (< 20) uses DC 10"""
+        # Add concentration
+        effect = ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="bless",
+            duration_minutes=60,
+            remaining_minutes=60,
+            target_name=sample_character.name,
+            caster_name=sample_character.name,
+            concentration=True
+        )
+        game_state_with_character.time_manager.add_effect(effect)
+
+        # Mock saving throw to succeed
+        with patch.object(sample_character, 'make_saving_throw') as mock_save:
+            mock_save.return_value = {
+                "success": True,
+                "roll": 12,
+                "modifier": 2,
+                "total": 14
+            }
+
+            result = game_state_with_character.check_concentration_from_damage(
+                sample_character.name,
+                5  # Low damage
+            )
+
+            # DC should be max(10, 5//2) = max(10, 2) = 10
+            assert result["dc"] == 10
+            assert result["was_concentrating"] is True
+            assert result["concentration_broken"] is False
+            mock_save.assert_called_once_with("constitution", 10)
+
+    def test_high_damage_dc_half_damage(self, game_state_with_character, sample_character):
+        """Test that high damage uses DC = damage // 2"""
+        # Add concentration
+        effect = ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="bless",
+            duration_minutes=60,
+            remaining_minutes=60,
+            target_name=sample_character.name,
+            caster_name=sample_character.name,
+            concentration=True
+        )
+        game_state_with_character.time_manager.add_effect(effect)
+
+        # Mock saving throw
+        with patch.object(sample_character, 'make_saving_throw') as mock_save:
+            mock_save.return_value = {
+                "success": True,
+                "roll": 18,
+                "modifier": 2,
+                "total": 20
+            }
+
+            result = game_state_with_character.check_concentration_from_damage(
+                sample_character.name,
+                30  # High damage
+            )
+
+            # DC should be max(10, 30//2) = max(10, 15) = 15
+            assert result["dc"] == 15
+            mock_save.assert_called_once_with("constitution", 15)
+
+    def test_failed_save_breaks_concentration(self, game_state_with_character, sample_character):
+        """Test that failed save breaks concentration"""
+        # Add concentration
+        effect = ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="bless",
+            duration_minutes=60,
+            remaining_minutes=60,
+            target_name=sample_character.name,
+            caster_name=sample_character.name,
+            concentration=True
+        )
+        game_state_with_character.time_manager.add_effect(effect)
+
+        # Mock saving throw to fail
+        with patch.object(sample_character, 'make_saving_throw') as mock_save:
+            mock_save.return_value = {
+                "success": False,
+                "roll": 5,
+                "modifier": 2,
+                "total": 7
+            }
+
+            result = game_state_with_character.check_concentration_from_damage(
+                sample_character.name,
+                10
+            )
+
+            assert result["was_concentrating"] is True
+            assert result["concentration_broken"] is True
+            assert result["spell_name"] == "bless"
+
+            # Verify concentration was actually removed
+            remaining_spell = game_state_with_character.get_concentration_spell(sample_character.name)
+            assert remaining_spell is None
+
+    def test_successful_save_maintains_concentration(self, game_state_with_character, sample_character):
+        """Test that successful save maintains concentration"""
+        # Add concentration
+        effect = ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="bless",
+            duration_minutes=60,
+            remaining_minutes=60,
+            target_name=sample_character.name,
+            caster_name=sample_character.name,
+            concentration=True
+        )
+        game_state_with_character.time_manager.add_effect(effect)
+
+        # Mock saving throw to succeed
+        with patch.object(sample_character, 'make_saving_throw') as mock_save:
+            mock_save.return_value = {
+                "success": True,
+                "roll": 15,
+                "modifier": 2,
+                "total": 17
+            }
+
+            result = game_state_with_character.check_concentration_from_damage(
+                sample_character.name,
+                10
+            )
+
+            assert result["was_concentrating"] is True
+            assert result["concentration_broken"] is False
+
+            # Verify concentration is still active
+            remaining_spell = game_state_with_character.get_concentration_spell(sample_character.name)
+            assert remaining_spell == "bless"
+
+    def test_multiple_damage_instances(self, game_state_with_character, sample_character):
+        """Test multiple damage checks in sequence"""
+        # Add concentration
+        effect = ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="bless",
+            duration_minutes=60,
+            remaining_minutes=60,
+            target_name=sample_character.name,
+            caster_name=sample_character.name,
+            concentration=True
+        )
+        game_state_with_character.time_manager.add_effect(effect)
+
+        # First hit - succeed
+        with patch.object(sample_character, 'make_saving_throw') as mock_save:
+            mock_save.return_value = {"success": True, "roll": 15, "modifier": 2, "total": 17}
+            result1 = game_state_with_character.check_concentration_from_damage(sample_character.name, 10)
+            assert result1["concentration_broken"] is False
+
+        # Second hit - fail
+        with patch.object(sample_character, 'make_saving_throw') as mock_save:
+            mock_save.return_value = {"success": False, "roll": 3, "modifier": 2, "total": 5}
+            result2 = game_state_with_character.check_concentration_from_damage(sample_character.name, 10)
+            assert result2["concentration_broken"] is True
+
+        # Verify concentration is gone
+        assert game_state_with_character.get_concentration_spell(sample_character.name) is None


### PR DESCRIPTION
## Summary
Implements complete D&D 5E spell concentration mechanics with damage-triggered Constitution saving throws, automatic concentration breaking, and UI display.

## Changes

### Core Mechanics
- **get_concentration_spell()** - Query what spell a character is concentrating on
- **check_concentration_from_damage()** - Handle damage-triggered CON saves with DC = max(10, damage ÷ 2)
- Automatic concentration breaking on failed saves

### Combat Integration
Concentration checks trigger after damage from:
- ✅ Player attacks
- ✅ Enemy attacks  
- ✅ Spell attacks
- ✅ Opportunity attacks

### Combat Spell Casting
- Casting new concentration spell breaks previous concentration
- Creates and tracks effects via time_manager
- Clear UI feedback for concentration start/stop

### UI Display
- Combat status table shows active concentration with 🎯 icon
- Concentration check messages include DC and save total
- Status updates in real-time as concentration changes

### Bug Fixes
- Fixed import errors in `handle_time()` and `handle_effects()`
- Fixed exploration spell cancel handling

## Testing
- ✅ 9 comprehensive unit tests covering all mechanics
- ✅ Manual testing confirms:
  - Concentration displays in combat status
  - Damage triggers appropriate DC checks
  - Failed saves break concentration with clear messaging
  - UI updates correctly

## Test Plan
1. Cast concentration spell (Detect Magic, Mage Hand, Hold Person)
2. Verify concentration shows in combat status table
3. Take damage from enemy
4. Verify concentration check appears with DC and save result
5. Cast second concentration spell - verify first breaks

## Screenshots
```
                  COMBAT INITIATIVE
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━┳━━━━━━━━━━━━━━━━━┓
┃ Combatant    ┃ Initiative ┃ HP  ┃     Status      ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━╇━━━━━━━━━━━━━━━━━┩
│   Skeleton 1 │     19     │ 9/9 │     ACTIVE      │
│   Tim        │     16     │ 8/8 │     ACTIVE      │
│              │            │     │ 🎯 Detect Magic │
└──────────────┴────────────┴─────┴─────────────────┘

💫 Tim's concentration on Detect Magic is broken! (CON save: 3 vs DC 10)
```

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)