### PR TITLE
Fix Shield spell to not require attack roll

### DIFF
--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -1880,15 +1880,60 @@ class CLI:
                 details=f"spell={spell_data.get('name')}, target={target.name}"
             )
 
-        # Perform spell attack
-        result = self.game_state.combat_engine.resolve_spell_attack(
-            caster=caster,
-            target=target,
-            spell=spell_data,
-            spellcasting_ability=spellcasting_ability,
-            apply_damage=True,
-            event_bus=self.game_state.event_bus
-        )
+        # Route spell based on type: attack, save, or buff/utility
+        has_attack = spell_data.get("attack_type") is not None
+        has_save = spell_data.get("saving_throw") is not None
+        save_result = None  # Track save result for display
+
+        if has_attack:
+            # Attack spells (Fire Bolt, Scorching Ray, etc.)
+            result = self.game_state.combat_engine.resolve_spell_attack(
+                caster=caster,
+                target=target,
+                spell=spell_data,
+                spellcasting_ability=spellcasting_ability,
+                apply_damage=True,
+                event_bus=self.game_state.event_bus
+            )
+        elif has_save:
+            # Saving throw spells (Fireball, Hold Person, etc.)
+            save_result = self.game_state.combat_engine.resolve_spell_save(
+                caster=caster,
+                targets=[target],
+                spell=spell_data,
+                apply_damage=True,
+                event_bus=self.game_state.event_bus
+            )
+            # Convert save result to AttackResult-like structure for compatibility
+            from dnd_engine.core.combat import AttackResult
+            target_result = save_result["targets"][0] if save_result["targets"] else {}
+            result = AttackResult(
+                attacker_name=caster.name,
+                defender_name=target.name,
+                attack_roll=0,
+                attack_bonus=0,
+                attack_total=0,
+                target_ac=target.ac,
+                hit=not target_result.get("success", True),  # Failed save = hit
+                damage=target_result.get("damage", 0),
+                damage_type=spell_data.get("damage", {}).get("damage_type", ""),
+                critical_hit=False
+            )
+        else:
+            # Buff/utility spells (Shield, Mage Armor, etc.) - no attack or save
+            from dnd_engine.core.combat import AttackResult
+            result = AttackResult(
+                attacker_name=caster.name,
+                defender_name=target.name,
+                attack_roll=0,
+                attack_bonus=0,
+                attack_total=0,
+                target_ac=target.ac,
+                hit=True,  # Buff spells always "succeed"
+                damage=0,
+                damage_type="",
+                critical_hit=False
+            )
 
         # Check concentration if target was hit and took damage
         if result.hit and result.damage > 0 and isinstance(target, Character):
@@ -1964,7 +2009,17 @@ class CLI:
         # Display mechanics
         spell_display_name = spell_data.get("name", spell_id)
         console.print(f"[magenta]✨ {caster.name} casts {spell_display_name}![/magenta]")
-        console.print(f"[cyan]⚔️  {str(result)}[/cyan]")
+
+        # Only show attack/save mechanics for spells that have them
+        if has_attack or (has_save and result.damage > 0):
+            console.print(f"[cyan]⚔️  {str(result)}[/cyan]")
+        elif has_save:
+            # For save spells with no damage, show save result
+            target_result = save_result["targets"][0] if save_result["targets"] else {}
+            save_text = "SUCCESS" if target_result.get("success") else "FAILURE"
+            save_ability = spell_data.get("saving_throw", {}).get("ability", "").upper()
+            console.print(f"[cyan]🎲 {target.name} {save_ability} save: {save_text}[/cyan]")
+        # For buff spells, no mechanics display needed - just the cast message
 
         # If target died, show death narrative
         if not target.is_alive:


### PR DESCRIPTION
## Summary
Fixes #146 - Shield spell no longer incorrectly performs an attack roll when cast on self.

## Problem
Previously, ALL spells routed through `resolve_spell_attack()`, causing buff spells like Shield to perform attack rolls and potentially "miss" the caster. This violated D&D 5E rules where Shield simply grants +5 AC without any roll.

## Solution
Implemented conditional spell routing based on spell type detection:

### Spell Type Detection
```python
has_attack = spell_data.get("attack_type") is not None   # Fire Bolt
has_save = spell_data.get("saving_throw") is not None    # Hold Person
# Neither = buff/utility spell                           # Shield, Mage Armor
```

### Spell Routing
- **Attack spells** (Fire Bolt) → `resolve_spell_attack()`
- **Save spells** (Hold Person) → `resolve_spell_save()`
- **Buff spells** (Shield) → Create success result, no attack/save

### Display Logic
- Attack spells: Show attack roll mechanics
- Save spells with damage: Show result as attack
- Save spells without damage: Show save result
- Buff spells: Only show cast message

## Changes
**File**: `dnd_engine/ui/cli.py` (`handle_cast_spell` method)
- Added spell type detection
- Implemented conditional routing
- Updated display logic for each spell type
- Maintained backward compatibility with all existing spell tests

## Testing
- ✅ All 70 existing spell tests pass
- ✅ Shield spell data verified (no attack_type or saving_throw)
- ✅ Fire Bolt verified (has attack_type: "ranged")
- ✅ Hold Person verified (has saving_throw field)

## Before/After

**Before:**
```
✨ Tim casts Shield!
⚔️  Tim attacks Tim: 4+4=8 vs AC 12 - MISS  ❌
```

**After:**
```
✨ Tim casts Shield!  ✅
(No attack roll - buff applied directly)
```

## Affected Spells
All self-buff and utility spells now work correctly:
- Shield (+5 AC)
- Mage Armor
- Blur
- Mirror Image
- Any other buff spells without attack/save requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)