### PR TITLE
Fix KeyError in skill check event handler during surprise mechanics

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -1573,6 +1573,7 @@ class GameState:
             self.event_bus.emit(Event(
                 type=EventType.SKILL_CHECK,
                 data={
+                    "character": character.name,
                     **check_result,
                     "action": f"stealth check (vs passive Perception {max_enemy_perception})"
                 }


### PR DESCRIPTION
## Summary
- Fix KeyError: 'character' in skill check event handler during surprise mechanics
- Add missing 'character' field to event data for consistency with other skill check emissions

## Problem
During surprise round stealth checks, the skill check event handler in the UI crashed with:
```
KeyError: 'character'
File "dnd_engine/ui/cli.py", line 4661
```

## Solution
Added `"character": character.name` to the skill check event data in `game_state.py:1576`, making it consistent with other skill check event emissions in the codebase (e.g., line 474).

## Changes
- `dnd_engine/core/game_state.py:1576` - Added character name to event data

## Testing
- [x] Manual gameplay test confirmed fix works
- [x] No more KeyError during surprise mechanics
- [x] Character names display correctly in skill check output
- [x] Code review completed - no security, performance, or quality concerns

## Code Review
✅ Approved - Minimal, focused change that maintains consistency with existing patterns

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)