### PR TITLE
Use web import to read issue 155

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -1563,13 +1563,7 @@ class GameState:
             check_result = character.make_skill_check("stealth", max_enemy_perception, skills_data)
             stealth_results.append(check_result)
 
-            # Display stealth check immediately
-            result_symbol = "✓" if check_result["success"] else "✗"
-            result_text = "SUCCESS" if check_result["success"] else "FAILURE"
-            print(f"🎲 {character.name} Stealth check (vs passive Perception {max_enemy_perception}): "
-                  f"rolled {check_result['roll']} + {check_result['modifier']} = {check_result['total']} - {result_symbol} {result_text}")
-
-            # Emit skill check event
+            # Emit skill check event (UI will handle display)
             self.event_bus.emit(Event(
                 type=EventType.SKILL_CHECK,
                 data={


### PR DESCRIPTION
Remove direct print statement from _check_for_surprise() method that was duplicating the skill check display. The event-driven UI layer (cli.py) already handles displaying stealth checks via the SKILL_CHECK event, so the direct print was redundant.

This fix maintains separation of concerns by keeping all UI display logic in the UI layer and keeping game logic in the game state layer.

Fixes #155