### PR TITLE
Fix the issue

### DIFF
--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -1424,7 +1424,7 @@ class CLI:
             return living_members[0]
 
         # Load items data to get item type
-        from dnd_engine.core.data_loader import DataLoader
+        from dnd_engine.rules.loader import DataLoader
         data_loader = DataLoader()
         items_data = data_loader.load_items()
 


### PR DESCRIPTION
Fixed incorrect import path that caused 'take all' command to crash when collecting items. The import was pointing to dnd_engine.core.data_loader but the DataLoader class is actually in dnd_engine.rules.loader.

Fixes #156