### PR TITLE
Enhance UX for ending combat turns by adding helpful hint

### DIFF
--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -3547,6 +3547,10 @@ class CLI:
         remaining_actions = str(turn_state)
         print_status_message(f"Remaining this turn: {remaining_actions}", "info")
 
+        # Suggest ending turn if player wants to skip remaining actions
+        if turn_state.has_any_action():
+            print_status_message("Type 'done' or 'pass' to end your turn", "info")
+
         # Emit item used event
         self.game_state.event_bus.emit(Event(
             type=EventType.ITEM_USED,
@@ -3645,6 +3649,10 @@ class CLI:
         # Show remaining actions
         remaining_actions = str(turn_state)
         print_status_message(f"Remaining this turn: {remaining_actions}", "info")
+
+        # Suggest ending turn if player wants to skip remaining actions
+        if turn_state.has_any_action():
+            print_status_message("Type 'done' or 'pass' to end your turn", "info")
 
         # Emit item used event
         self.game_state.event_bus.emit(Event(
@@ -3830,6 +3838,10 @@ class CLI:
         # Show remaining actions
         remaining_actions = str(turn_state)
         print_status_message(f"Remaining this turn: {remaining_actions}", "info")
+
+        # Suggest ending turn if player wants to skip remaining actions
+        if turn_state.has_any_action():
+            print_status_message("Type 'done' or 'pass' to end your turn", "info")
 
         # Emit item used event
         self.game_state.event_bus.emit(Event(

--- a/tests/test_end_turn_command.py
+++ b/tests/test_end_turn_command.py
@@ -176,3 +176,68 @@ class TestEndTurnIntegration:
                 # Verify end turn command is in the list
                 command_texts = [cmd[0] for cmd in commands]
                 assert any("end turn" in cmd or "done" in cmd or "pass" in cmd for cmd in command_texts)
+
+    def test_hint_shown_after_item_use(self):
+        """Test that a helpful hint is shown after using an item with actions remaining"""
+        from unittest.mock import Mock, patch, MagicMock
+        from dnd_engine.systems.action_economy import TurnState
+
+        # Create mocks
+        with patch('dnd_engine.ui.cli.GameState'):
+            cli = CLI()
+            cli.game_state = Mock()
+            cli.game_state.in_combat = True
+            cli.game_state.initiative_tracker = Mock()
+            cli.game_state.data_loader = Mock()
+            cli.game_state.dice_roller = Mock()
+            cli.game_state.event_bus = Mock()
+            cli.game_state.party = Mock()
+
+            # Create character with inventory
+            character = Mock()
+            character.name = "TestCharacter"
+            character.inventory = Mock()
+
+            # Create turn state with actions remaining
+            turn_state = TurnState()
+            turn_state.action_available = False  # Action used
+            turn_state.bonus_action_available = True  # Bonus action still available
+
+            # Setup initiative tracker
+            combatant = Mock()
+            combatant.creature = character
+            cli.game_state.initiative_tracker.get_current_combatant.return_value = combatant
+            cli.game_state.initiative_tracker.get_current_turn_state.return_value = turn_state
+            cli.game_state.party.characters = [character]
+
+            # Mock inventory and item data
+            item_data = {
+                "name": "Potion of Healing",
+                "action_required": "action",
+                "effect": {"type": "healing", "dice": "2d4+2"}
+            }
+            cli.game_state.data_loader.load_items.return_value = {
+                "consumables": {"potion_of_healing": item_data}
+            }
+            character.inventory.use_item.return_value = (True, item_data)
+            character.inventory.get_items_by_category.return_value = [
+                Mock(item_id="potion_of_healing")
+            ]
+
+            # Mock apply_item_effect
+            with patch('dnd_engine.ui.cli.apply_item_effect') as mock_apply:
+                mock_result = Mock()
+                mock_result.message = "You heal 6 HP"
+                mock_result.effect_type = "healing"
+                mock_result.success = True
+                mock_apply.return_value = mock_result
+
+                # Track status messages
+                with patch('dnd_engine.ui.cli.print_status_message') as mock_status:
+                    cli.handle_use_item_combat("potion_of_healing")
+
+                    # Verify the hint was shown
+                    calls = [str(call) for call in mock_status.call_args_list]
+                    hint_shown = any("done" in str(call).lower() or "pass" in str(call).lower()
+                                     for call in calls)
+                    assert hint_shown, "Hint about ending turn should be shown after item use with actions remaining"


### PR DESCRIPTION
## Summary

Enhances the user experience by adding a helpful hint after actions that shows users how to end their turn when actions remain.

## Changes

- Added hint "Type 'done' or 'pass' to end your turn" after item usage
- Hint only displays when actions remain (not when turn is fully used)
- Applied consistently across all item usage methods
- Added test coverage for the new UX enhancement

Fixes #160

—

Generated with [Claude Code](https://claude.ai/code)