### PR TITLE
Fix dea

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -1647,51 +1647,65 @@ class GameState:
             if not enemy.is_alive and self.initiative_tracker:
                 self.initiative_tracker.remove_combatant(enemy)
 
-        # Check if combat is over (all enemies dead OR party wiped)
+        # Check if combat is over
         if self.initiative_tracker:
             all_enemies_dead = all(not enemy.is_alive for enemy in self.active_enemies)
             party_wiped = self.party.is_wiped()
 
-            if all_enemies_dead or party_wiped:
+            # Check if all party members are unconscious (unable to act)
+            all_party_unconscious = all(
+                char.is_unconscious or char.is_dead
+                for char in self.party.characters
+            )
+
+            if all_enemies_dead or party_wiped or all_party_unconscious:
                 self._end_combat()
 
     def _end_combat(self) -> None:
         """End combat and perform cleanup."""
-        # Calculate XP from defeated enemies
+        # Determine if party won or lost
+        all_enemies_dead = all(not enemy.is_alive for enemy in self.active_enemies)
+        victory = all_enemies_dead
+
         total_xp = 0
-        monsters = self.data_loader.load_monsters()
 
-        for enemy in self.active_enemies:
-            if not enemy.is_alive:
-                # Find enemy XP value
-                for monster_id, monster_data in monsters.items():
-                    if monster_data["name"] == enemy.name:
-                        total_xp += monster_data.get("xp", 0)
-                        break
+        # Only award XP on victory
+        if victory:
+            # Calculate XP from defeated enemies
+            monsters = self.data_loader.load_monsters()
 
-        # Award XP to all party members (split evenly)
-        if total_xp > 0 and len(self.party.characters) > 0:
-            xp_per_character = total_xp // len(self.party.characters)
-            for character in self.party.characters:
-                character.gain_xp(xp_per_character)
+            for enemy in self.active_enemies:
+                if not enemy.is_alive:
+                    # Find enemy XP value
+                    for monster_id, monster_data in monsters.items():
+                        if monster_data["name"] == enemy.name:
+                            total_xp += monster_data.get("xp", 0)
+                            break
 
-                # Check for level-up (can level up multiple times if enough XP)
-                while character.check_for_level_up(self.data_loader, self.event_bus):
-                    pass  # Level-up event already emitted by check_for_level_up
+            # Award XP to all party members (split evenly)
+            if total_xp > 0 and len(self.party.characters) > 0:
+                xp_per_character = total_xp // len(self.party.characters)
+                for character in self.party.characters:
+                    character.gain_xp(xp_per_character)
+
+                    # Check for level-up (can level up multiple times if enough XP)
+                    while character.check_for_level_up(self.data_loader, self.event_bus):
+                        pass  # Level-up event already emitted by check_for_level_up
 
         # Clear combat state
         self.in_combat = False
         self.initiative_tracker = None
 
-        # Remove defeated enemies from room
+        # Remove defeated enemies from room only on victory
         room = self.get_current_room()
-        room["enemies"] = []
+        if victory:
+            room["enemies"] = []
 
         # Emit combat end event
         self.event_bus.emit(Event(
             type=EventType.COMBAT_END,
             data={
-                "victory": True,
+                "victory": victory,
                 "xp_gained": total_xp,
                 "xp_per_character": total_xp // len(self.party.characters) if len(self.party.characters) > 0 else 0
             }

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -4505,8 +4505,16 @@ class CLI:
                 if is_party_turn:
                     # Check if character is unconscious and needs death save
                     if party_character.is_unconscious:
-                        self.process_death_save_turn(party_character)
-                        # Advance turn after death save
+                        # Stabilized characters skip their turn (no death saves needed)
+                        if party_character.stabilized:
+                            print_status_message(
+                                f"{party_character.name} is unconscious but stabilized (no action needed).",
+                                "info"
+                            )
+                        else:
+                            # Unstabilized unconscious character makes death save
+                            self.process_death_save_turn(party_character)
+                        # Advance turn after death save or stabilized skip
                         self.game_state.initiative_tracker.next_turn()
                         # Check if combat is over
                         self.game_state._check_combat_end()
@@ -4625,19 +4633,29 @@ class CLI:
         # Clear enemy numbers when combat ends
         self.enemy_numbers.clear()
 
+        victory = event.data.get("victory", True)
         total_xp = event.data.get("xp_gained", 0)
         xp_per_char = event.data.get("xp_per_character", 0)
-        print_status_message(
-            f"Victory! Party gained {total_xp} XP ({xp_per_char} XP per character)",
-            "success"
-        )
+
+        if victory:
+            print_status_message(
+                f"Victory! Party gained {total_xp} XP ({xp_per_char} XP per character)",
+                "success"
+            )
+        else:
+            print_error("Defeat! All party members have fallen unconscious.")
+            print_status_message(
+                "The enemies remain in the room. Consider healing and regrouping before attempting combat again.",
+                "warning"
+            )
 
         # Log combat end
         from dnd_engine.utils.logging_config import get_logging_config
         logging_config = get_logging_config()
         if logging_config:
+            result = "Victory" if victory else "Defeat"
             logging_config.log_combat_event(
-                f"Combat ended - Total XP: {total_xp}, XP per character: {xp_per_char}"
+                f"Combat ended - {result} - Total XP: {total_xp}, XP per character: {xp_per_char}"
             )
 
         # Reset combat status flag


### PR DESCRIPTION
Fixes three critical bugs that caused an infinite loop in combat:

1. Stabilized characters no longer make death saves or take turns
   - Added check to skip stabilized characters' turns with info message
   - Previously stabilized characters would repeatedly roll (returning 0)

2. Combat now ends when all party members are unconscious
   - Added detection for party defeat scenario
   - Combat terminates if all party members are unconscious/dead
   - Previously only checked for all enemies dead or party fully wiped

3. Defeat handling now works properly
   - Victory/defeat is properly detected and displayed
   - XP only awarded on victory, not defeat
   - Enemies remain in room on defeat for retry opportunity
   - UI shows appropriate defeat message with guidance

Changes:
- dnd_engine/ui/cli.py: Skip stabilized characters' turns in combat loop
- dnd_engine/core/game_state.py: Add all-unconscious check to combat end
- dnd_engine/core/game_state.py: Only award XP and remove enemies on victory
- dnd_engine/ui/cli.py: Display defeat message when party loses

Fixes #171