### PR TITLE
Fix short rest falsely reporting unconscious characters as 'full health'

### DIFF
--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -4077,6 +4077,9 @@ class CLI:
             hp_recovered = result["hp_recovered"]
             resources = result["resources_recovered"]
 
+            # Get the character to check their current HP status
+            character = self.game_state.party.get_character_by_name(char_name)
+
             print_message(f"{char_name}:")
 
             if hp_recovered > 0:
@@ -4088,7 +4091,11 @@ class CLI:
                 print_message(f"  ⚡ Recovered: {', '.join(formatted_resources)}")
 
             if hp_recovered == 0 and not resources:
-                print_message(f"  Already at full health and resources")
+                # Check if character is at 0 HP (unconscious)
+                if character and character.current_hp == 0:
+                    print_message(f"  ⚠️  Still unconscious (0 HP)")
+                else:
+                    print_message(f"  Already at full health and resources")
 
             print_message("")
 

--- a/tests/test_rest_display_integration.py
+++ b/tests/test_rest_display_integration.py
@@ -1,0 +1,238 @@
+# ABOUTME: Integration tests for rest display UI in CLI
+# ABOUTME: Tests that unconscious characters are correctly reported in rest summaries
+
+import pytest
+from unittest.mock import Mock, patch
+from dnd_engine.ui.cli import CLI
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.party import Party
+from dnd_engine.systems.resources import ResourcePool
+
+
+class TestRestDisplayIntegration:
+    """Integration tests for rest display output"""
+
+    @pytest.fixture
+    def mock_game_state(self):
+        """Create a mock game state with party"""
+        game_state = Mock()
+        game_state.data_loader = Mock()
+        game_state.event_bus = Mock()
+        game_state.time_manager = Mock()
+        return game_state
+
+    @pytest.fixture
+    def healthy_character(self):
+        """Create a healthy character at full HP"""
+        abilities = Abilities(
+            strength=16,
+            dexterity=14,
+            constitution=14,
+            intelligence=10,
+            wisdom=12,
+            charisma=8
+        )
+        character = Character(
+            name="Bob",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=abilities,
+            max_hp=12,
+            ac=16,
+            current_hp=12  # Full HP
+        )
+
+        # Add a short rest resource
+        second_wind = ResourcePool(
+            name="second_wind",
+            current=0,
+            maximum=1,
+            recovery_type="short_rest"
+        )
+        character.add_resource_pool(second_wind)
+
+        return character
+
+    @pytest.fixture
+    def unconscious_character(self):
+        """Create an unconscious character at 0 HP"""
+        abilities = Abilities(
+            strength=10,
+            dexterity=14,
+            constitution=12,
+            intelligence=14,
+            wisdom=10,
+            charisma=10
+        )
+        character = Character(
+            name="Tim",
+            character_class=CharacterClass.WIZARD,
+            level=1,
+            abilities=abilities,
+            max_hp=8,
+            ac=12,
+            current_hp=0  # Unconscious!
+        )
+        return character
+
+    def test_short_rest_displays_unconscious_warning_for_zero_hp_character(
+        self, mock_game_state, healthy_character, unconscious_character
+    ):
+        """Test that short rest correctly displays warning for unconscious character"""
+        # Setup party with both characters
+        party = Party()
+        party.add_character(healthy_character)
+        party.add_character(unconscious_character)
+        mock_game_state.party = party
+
+        cli = CLI(mock_game_state, Mock(), "test_campaign")
+
+        # Capture printed output
+        printed_messages = []
+
+        def capture_print(message):
+            printed_messages.append(str(message))
+
+        # Mock the print functions to capture output and mock user input for short rest choice
+        with patch('dnd_engine.ui.rich_ui.print_message', side_effect=capture_print):
+            with patch('dnd_engine.ui.rich_ui.print_section', side_effect=capture_print):
+                with patch('dnd_engine.ui.rich_ui.print_status_message', side_effect=lambda msg, status: capture_print(msg)):
+                    with patch('builtins.input', return_value='1'):  # Choose short rest
+                        cli.handle_rest()
+
+        # Join all messages for easier assertion
+        full_output = "\n".join(printed_messages)
+
+        # Verify the unconscious character gets the warning
+        assert "Tim" in full_output
+        assert "Still unconscious (0 HP)" in full_output or "⚠️  Still unconscious (0 HP)" in full_output
+
+        # Verify the healthy character gets appropriate message
+        assert "Bob" in full_output
+        assert "Second Wind" in full_output or "Recovered" in full_output
+
+    def test_short_rest_displays_full_health_for_healthy_character_without_resources(
+        self, mock_game_state
+    ):
+        """Test that healthy character with no resources to recover shows 'Already at full health'"""
+        # Create a character at full HP with no resources
+        abilities = Abilities(
+            strength=16,
+            dexterity=14,
+            constitution=14,
+            intelligence=10,
+            wisdom=12,
+            charisma=8
+        )
+        character = Character(
+            name="Alice",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=abilities,
+            max_hp=12,
+            ac=16,
+            current_hp=12  # Full HP
+        )
+        # Don't add any resource pools
+
+        party = Party()
+        party.add_character(character)
+        mock_game_state.party = party
+
+        cli = CLI(mock_game_state, Mock(), "test_campaign")
+
+        # Capture printed output
+        printed_messages = []
+
+        def capture_print(message):
+            printed_messages.append(str(message))
+
+        with patch('dnd_engine.ui.rich_ui.print_message', side_effect=capture_print):
+            with patch('dnd_engine.ui.rich_ui.print_section', side_effect=capture_print):
+                with patch('dnd_engine.ui.rich_ui.print_status_message', side_effect=lambda msg, status: capture_print(msg)):
+                    with patch('builtins.input', return_value='1'):  # Choose short rest
+                        cli.handle_rest()
+
+        full_output = "\n".join(printed_messages)
+
+        # Verify healthy character shows the correct message
+        assert "Alice" in full_output
+        assert "Already at full health and resources" in full_output
+
+    def test_long_rest_heals_unconscious_character_and_displays_hp_recovered(
+        self, mock_game_state, unconscious_character
+    ):
+        """Test that long rest heals unconscious character and shows HP recovery"""
+        party = Party()
+        party.add_character(unconscious_character)
+        mock_game_state.party = party
+
+        cli = CLI(mock_game_state, Mock(), "test_campaign")
+
+        # Capture printed output
+        printed_messages = []
+
+        def capture_print(message):
+            printed_messages.append(str(message))
+
+        with patch('dnd_engine.ui.rich_ui.print_message', side_effect=capture_print):
+            with patch('dnd_engine.ui.rich_ui.print_section', side_effect=capture_print):
+                with patch('dnd_engine.ui.rich_ui.print_status_message', side_effect=lambda msg, status: capture_print(msg)):
+                    with patch('builtins.input', return_value='2'):  # Choose long rest
+                        cli.handle_rest()
+
+        full_output = "\n".join(printed_messages)
+
+        # Verify the character's HP was recovered
+        assert unconscious_character.current_hp == 8
+        assert unconscious_character.current_hp == unconscious_character.max_hp
+
+        # Verify the output shows HP recovery
+        assert "Tim" in full_output
+        assert "HP recovered: 8" in full_output or "❤️  HP recovered: 8" in full_output
+
+        # Should NOT show the unconscious warning after long rest
+        assert "Still unconscious" not in full_output
+
+    def test_mixed_party_displays_all_statuses_correctly(
+        self, mock_game_state, healthy_character, unconscious_character
+    ):
+        """Test that a party with mixed health statuses displays correctly"""
+        # Damage the healthy character a bit so they recover HP on long rest
+        healthy_character.current_hp = 6
+
+        party = Party()
+        party.add_character(healthy_character)
+        party.add_character(unconscious_character)
+        mock_game_state.party = party
+
+        cli = CLI(mock_game_state, Mock(), "test_campaign")
+
+        # Capture printed output
+        printed_messages = []
+
+        def capture_print(message):
+            printed_messages.append(str(message))
+
+        with patch('dnd_engine.ui.rich_ui.print_message', side_effect=capture_print):
+            with patch('dnd_engine.ui.rich_ui.print_section', side_effect=capture_print):
+                with patch('dnd_engine.ui.rich_ui.print_status_message', side_effect=lambda msg, status: capture_print(msg)):
+                    with patch('builtins.input', return_value='2'):  # Choose long rest
+                        cli.handle_rest()
+
+        full_output = "\n".join(printed_messages)
+
+        # Verify Bob shows HP recovery
+        assert "Bob" in full_output
+        # Bob should recover 6 HP (from 6 to 12)
+        assert "6" in full_output
+
+        # Verify Tim shows HP recovery
+        assert "Tim" in full_output
+        # Tim should recover 8 HP (from 0 to 8)
+        assert "8" in full_output
+
+        # Both should be healed now
+        assert healthy_character.current_hp == 12
+        assert unconscious_character.current_hp == 8

--- a/tests/test_rest_system.py
+++ b/tests/test_rest_system.py
@@ -438,3 +438,110 @@ class TestLongRest:
         assert character_for_long_rest.current_hp == 20
         assert character_for_long_rest.resource_pools["spell_slots"].current == 3
         assert result["hp_recovered"] == 10
+
+
+class TestUnconsciousCharacterRest:
+    """Test rest behavior for unconscious (0 HP) characters"""
+
+    @pytest.fixture
+    def unconscious_character(self):
+        """Create an unconscious character at 0 HP"""
+        abilities = Abilities(
+            strength=10,
+            dexterity=14,
+            constitution=12,
+            intelligence=14,
+            wisdom=10,
+            charisma=10
+        )
+        character = Character(
+            name="Unconscious Wizard",
+            character_class=CharacterClass.WIZARD,
+            level=1,
+            abilities=abilities,
+            max_hp=8,
+            ac=12,
+            current_hp=0  # Unconscious
+        )
+
+        # Add a short rest resource
+        arcane_recovery = ResourcePool(
+            name="arcane_recovery",
+            current=0,
+            maximum=1,
+            recovery_type="short_rest"
+        )
+        character.add_resource_pool(arcane_recovery)
+
+        return character
+
+    def test_short_rest_with_unconscious_character_reports_zero_hp(self, unconscious_character):
+        """Test that short rest correctly reports unconscious character at 0 HP"""
+        result = unconscious_character.take_short_rest()
+
+        # Character should still be at 0 HP (short rest doesn't heal HP in MVP)
+        assert unconscious_character.current_hp == 0
+        assert result["hp_recovered"] == 0
+        assert result["character"] == "Unconscious Wizard"
+        assert result["rest_type"] == "short"
+
+    def test_short_rest_unconscious_character_recovers_resources(self, unconscious_character):
+        """Test that unconscious character still recovers resources on short rest"""
+        result = unconscious_character.take_short_rest()
+
+        # Resources should still be recovered even at 0 HP
+        assert "arcane_recovery" in result["resources_recovered"]
+        assert unconscious_character.resource_pools["arcane_recovery"].current == 1
+
+    def test_long_rest_heals_unconscious_character(self, unconscious_character):
+        """Test that long rest heals unconscious character to full HP"""
+        result = unconscious_character.take_long_rest()
+
+        # Long rest should restore all HP
+        assert unconscious_character.current_hp == 8
+        assert unconscious_character.current_hp == unconscious_character.max_hp
+        assert result["hp_recovered"] == 8
+        assert result["character"] == "Unconscious Wizard"
+
+    def test_character_at_zero_hp_is_distinguishable_from_full_hp(self):
+        """Test that we can distinguish between 0 HP and full HP characters"""
+        abilities = Abilities(
+            strength=10,
+            dexterity=14,
+            constitution=12,
+            intelligence=14,
+            wisdom=10,
+            charisma=10
+        )
+
+        # Character at 0 HP
+        unconscious = Character(
+            name="Unconscious",
+            character_class=CharacterClass.WIZARD,
+            level=1,
+            abilities=abilities,
+            max_hp=8,
+            ac=12,
+            current_hp=0
+        )
+
+        # Character at full HP
+        healthy = Character(
+            name="Healthy",
+            character_class=CharacterClass.WIZARD,
+            level=1,
+            abilities=abilities,
+            max_hp=8,
+            ac=12,
+            current_hp=8
+        )
+
+        # Test short rest results
+        unconscious_result = unconscious.take_short_rest()
+        healthy_result = healthy.take_short_rest()
+
+        # Both should report 0 hp_recovered, but we should be able to check current_hp
+        assert unconscious_result["hp_recovered"] == 0
+        assert healthy_result["hp_recovered"] == 0
+        assert unconscious.current_hp == 0  # Still unconscious
+        assert healthy.current_hp == 8  # Still healthy


### PR DESCRIPTION
## Summary
Fixes #168 - Short rest now correctly reports unconscious characters instead of falsely claiming they are at "full health and resources".

## Problem
When an unconscious character (0 HP) took a short rest, the rest summary incorrectly displayed:
```
Tim:
  Already at full health and resources
```
Even though `status` showed the character was still at 0/8 HP (unconscious).

## Solution
Modified `_display_rest_results()` in CLI to check the character's actual HP:
- When no HP/resources are recovered, we now look up the character object
- If `current_hp == 0`, display: `"⚠️  Still unconscious (0 HP)"`
- Otherwise, display: `"Already at full health and resources"` (existing behavior)

## Changes
- **dnd_engine/ui/cli.py**: Added HP check before displaying rest status message
- **tests/test_rest_system.py**: Added 4 unit tests for unconscious character rest behavior
- **tests/test_rest_display_integration.py**: New file with 4 integration tests verifying UI output

## Test Results
✅ All 25 rest-related tests pass (21 unit + 4 integration)

### Unit Tests
- Verify unconscious characters stay at 0 HP after short rest
- Verify resources still recover even at 0 HP
- Verify long rest heals unconscious characters
- Verify we can distinguish 0 HP from full HP states

### Integration Tests
- Verify short rest displays unconscious warning for 0 HP characters
- Verify healthy characters show "full health" message
- Verify long rest heals and displays HP recovery
- Verify mixed party with different health states displays correctly

## Impact
- **Bug severity**: Medium - Misleading UI, but doesn't affect game mechanics
- **Risk level**: Low - Minimal change, only affects display logic
- **Test coverage**: Comprehensive - Both unit and integration tests added

🤖 Generated with [Claude Code](https://claude.com/claude-code)