### PR TITLE
Refactor: Extract combat context assembly to service layer (#175)

### DIFF
--- a/dnd_engine/systems/combat_context/__init__.py
+++ b/dnd_engine/systems/combat_context/__init__.py
@@ -1,0 +1,6 @@
+# ABOUTME: Public API for combat context assembly service
+# ABOUTME: Exports CombatContextBuilder for use by UI layers
+
+from dnd_engine.systems.combat_context.builder import CombatContextBuilder
+
+__all__ = ["CombatContextBuilder"]

--- a/dnd_engine/systems/combat_context/assemblers.py
+++ b/dnd_engine/systems/combat_context/assemblers.py
@@ -1,0 +1,149 @@
+# ABOUTME: Helper functions for gathering combat context data from various sources
+# ABOUTME: Used by CombatContextBuilder to assemble complete context dictionaries
+
+import logging
+from typing import Dict, Any, Optional
+from dnd_engine.core.character import Character
+from dnd_engine.core.creature import Creature
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.systems.inventory import EquipmentSlot
+
+logger = logging.getLogger(__name__)
+
+
+def get_weapon_context(
+    attacker: Character | Creature,
+    data_loader: DataLoader,
+    action_data: Optional[Dict[str, Any]] = None,
+) -> tuple[str, str]:
+    """
+    Get weapon name and damage type for an attacker.
+
+    Args:
+        attacker: The attacking Character or Creature
+        data_loader: DataLoader for accessing item data
+        action_data: For spells or Creature actions, the action/spell dict
+
+    Returns:
+        Tuple of (weapon_name, damage_type)
+            - weapon_name: Display name of weapon/spell/attack
+            - damage_type: Type of damage or empty string
+    """
+    # If action_data is provided (spell or enemy action), use it directly
+    if action_data:
+        weapon_name = action_data.get("name", "attack")
+        damage_type = action_data.get("damage_type", "")
+        return weapon_name, damage_type
+
+    # Check if attacker is a Character (player)
+    if isinstance(attacker, Character):
+        # Player character - get equipped weapon
+        equipped_weapon = attacker.inventory.get_equipped_item(EquipmentSlot.WEAPON)
+        if equipped_weapon:
+            items_data = data_loader.load_items()
+            weapon_data = items_data.get("weapons", {}).get(equipped_weapon, {})
+            weapon_name = weapon_data.get("name", equipped_weapon)
+            damage_type = weapon_data.get("damage_type", "bludgeoning")
+            if not weapon_data:
+                logger.warning(f"Weapon '{equipped_weapon}' not found in items data")
+            return weapon_name, damage_type
+        else:
+            # Unarmed attack
+            return "unarmed strike", "bludgeoning"
+    else:
+        # Enemy creature without action data
+        return "attack", ""
+
+
+def get_attacker_race(
+    attacker: Character | Creature,
+    data_loader: DataLoader,
+    monster_cache: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> str:
+    """
+    Get race or type for an attacker.
+
+    For Characters: looks up race name in races data
+    For Creatures: uses "type" field from monster data
+
+    Args:
+        attacker: The attacking Character or Creature
+        data_loader: DataLoader for accessing race/monster data
+        monster_cache: Optional pre-built cache of monster name -> monster data
+
+    Returns:
+        Race/type string (empty string if not found)
+    """
+    # Check if attacker is a Character (player)
+    if isinstance(attacker, Character):
+        races_data = data_loader.load_races()
+        race_data = races_data.get(attacker.race, {})
+        race_name = race_data.get("name", "")
+        if not race_name:
+            logger.warning(f"Race '{attacker.race}' not found in race data")
+        return race_name
+    else:
+        # For enemies, use cache if available, otherwise search
+        if monster_cache:
+            monster_data = monster_cache.get(attacker.name, {})
+        else:
+            monsters = data_loader.load_monsters()
+            monster_data = next(
+                (mdata for mdata in monsters.values() if mdata["name"] == attacker.name),
+                {},
+            )
+
+        if not monster_data:
+            logger.warning(f"Monster '{attacker.name}' not found in monster data")
+            return ""
+        return monster_data.get("type", "")
+
+
+def get_defender_armor(
+    defender: Character | Creature,
+    data_loader: DataLoader,
+    monster_cache: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> str:
+    """
+    Get armor description for a defender.
+
+    For Characters: looks up equipped armor type
+    For Creatures: uses ac_source from monster data
+
+    Args:
+        defender: The defending Character or Creature
+        data_loader: DataLoader for accessing item/monster data
+        monster_cache: Optional pre-built cache of monster name -> monster data
+
+    Returns:
+        Armor description string (empty string if none)
+    """
+    # Check if defender is a Character (player)
+    if isinstance(defender, Character):
+        equipped_armor = defender.inventory.get_equipped_item(EquipmentSlot.ARMOR)
+        if equipped_armor:
+            items_data = data_loader.load_items()
+            armor_data = items_data.get("armor", {}).get(equipped_armor, {})
+            armor_type = armor_data.get("armor_type", "")
+            if not armor_data:
+                logger.warning(f"Armor '{equipped_armor}' not found in items data")
+            if armor_type:
+                return f"{armor_type} armor"
+        return ""
+    else:
+        # For enemies, use cache if available, otherwise search
+        if monster_cache:
+            monster_data = monster_cache.get(defender.name, {})
+        else:
+            monsters = data_loader.load_monsters()
+            monster_data = next(
+                (mdata for mdata in monsters.values() if mdata["name"] == defender.name),
+                {},
+            )
+
+        if not monster_data:
+            logger.warning(f"Monster '{defender.name}' not found in monster data")
+            return ""
+
+        ac_source = monster_data.get("ac_source", "")
+        return ac_source if ac_source else ""

--- a/dnd_engine/systems/combat_context/builder.py
+++ b/dnd_engine/systems/combat_context/builder.py
@@ -1,0 +1,143 @@
+# ABOUTME: Main CombatContextBuilder class for assembling combat action context
+# ABOUTME: Coordinates data gathering and builds complete LLM context dictionaries
+
+from typing import Dict, Any, Optional
+from dnd_engine.core.character import Character
+from dnd_engine.core.creature import Creature
+from dnd_engine.core.combat import AttackResult
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.systems.combat_context.assemblers import (
+    get_weapon_context,
+    get_attacker_race,
+    get_defender_armor,
+)
+
+# Number of recent combat actions to include for LLM context
+COMBAT_HISTORY_CONTEXT_SIZE = 12
+
+
+class CombatContextBuilder:
+    """
+    Service for assembling combat action context for narrative generation.
+
+    This class encapsulates all the logic for gathering data from various sources
+    (items, monsters, races, game state) and building complete context dictionaries
+    for LLM narrative generation.
+    """
+
+    def __init__(self, data_loader: DataLoader, game_state):
+        """
+        Initialize the context builder.
+
+        Args:
+            data_loader: DataLoader for accessing game content data
+            game_state: GameState for accessing current game state
+        """
+        self.data_loader = data_loader
+        self.game_state = game_state
+        # Cache for monster name -> monster data lookups (performance optimization)
+        self._monster_cache: Optional[Dict[str, Dict[str, Any]]] = None
+
+    def get_monster_by_name(self, name: str) -> Dict[str, Any]:
+        """
+        Get monster data by name with caching for performance.
+
+        Args:
+            name: Monster name to look up
+
+        Returns:
+            Monster data dictionary, or empty dict if not found
+        """
+        if self._monster_cache is None:
+            # Build cache on first access
+            monsters = self.data_loader.load_monsters()
+            self._monster_cache = {
+                monster_data["name"]: monster_data
+                for monster_data in monsters.values()
+            }
+        return self._monster_cache.get(name, {})
+
+    def build_attack_context(
+        self,
+        attacker: Character | Creature,
+        defender: Character | Creature,
+        result: AttackResult,
+        action_data: Optional[Dict[str, Any]] = None,
+        is_spell: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Build complete context dictionary for an attack action.
+
+        This method gathers all necessary context from various sources:
+        - Weapon/spell information
+        - Attacker race/type
+        - Defender armor
+        - Location and combat history
+        - Battlefield state
+
+        Args:
+            attacker: The attacking Character or Creature
+            defender: The defending Character or Creature
+            result: AttackResult from combat engine
+            action_data: Optional action/spell data dict (for enemies/spells)
+            is_spell: Whether this is a spell attack
+
+        Returns:
+            Complete context dictionary for LLM narrative generation
+        """
+        # Ensure monster cache is initialized (lazy loading)
+        if self._monster_cache is None:
+            monsters = self.data_loader.load_monsters()
+            self._monster_cache = {
+                monster_data["name"]: monster_data
+                for monster_data in monsters.values()
+            }
+
+        # Get weapon/spell context
+        weapon_name, damage_type = get_weapon_context(
+            attacker, self.data_loader, action_data
+        )
+
+        # Get attacker race/type (with monster cache for performance)
+        attacker_race = get_attacker_race(
+            attacker, self.data_loader, self._monster_cache
+        )
+
+        # Get defender armor (with monster cache for performance)
+        defender_armor = get_defender_armor(
+            defender, self.data_loader, self._monster_cache
+        )
+
+        # Get location
+        current_room = self.game_state.get_current_room()
+        location = current_room.get("name", "")
+
+        # Get combat history
+        combat_history = self.game_state.get_recent_combat_history(
+            count=COMBAT_HISTORY_CONTEXT_SIZE
+        )
+
+        # Get battlefield state
+        battlefield_state = self.game_state.get_battlefield_state()
+
+        # Build complete context dictionary
+        context = {
+            "attacker": result.attacker_name,
+            "defender": result.defender_name,
+            "damage": result.damage,
+            "critical": result.critical_hit,
+            "hit": result.hit,
+            "location": location,
+            "weapon": weapon_name,
+            "damage_type": damage_type,
+            "attacker_race": attacker_race,
+            "defender_armor": defender_armor,
+            "combat_history": combat_history,
+            "battlefield_state": battlefield_state,
+        }
+
+        # Add spell flag if applicable
+        if is_spell:
+            context["is_spell"] = True
+
+        return context

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -9,6 +9,7 @@ from dnd_engine.utils.events import Event, EventType
 from dnd_engine.systems.inventory import EquipmentSlot
 from dnd_engine.systems.condition_manager import ConditionManager
 from dnd_engine.systems.ai import EnemyAI
+from dnd_engine.systems.combat_context import CombatContextBuilder
 from dnd_engine.ui.debug_console import DebugConsole
 from dnd_engine.ui.rich_ui import (
     console,
@@ -63,6 +64,9 @@ class CLI:
 
         # Enemy AI for combat decisions
         self.enemy_ai = EnemyAI()
+
+        # Combat context builder for assembling narrative context
+        self.context_builder = CombatContextBuilder(game_state.data_loader, game_state)
 
         # Combat display management
         self.combat_status_shown = False
@@ -1694,57 +1698,14 @@ class CLI:
 
         # 1. Get and display attack narrative FIRST (if hit)
         if self.llm_enhancer and result.hit:
-            room = self.game_state.get_current_room()
-            location = room.get("name", "")
-
-            # Get weapon name and damage type
-            weapon_name = "weapon"
-            damage_type = ""
-            if equipped_weapon and weapon_data:
-                weapon_name = weapon_data.get("name", equipped_weapon)
-                damage_type = weapon_data.get("damage_type", "")
-
-            # Get attacker race
-            races_data = self.game_state.data_loader.load_races()
-            attacker_race_data = races_data.get(attacker.race, {})
-            attacker_race = attacker_race_data.get("name", "")
-
-            # Get defender armor type (for enemies, check monster data)
-            defender_armor = ""
-            if isinstance(target, Character):
-                # Target is player - get equipped armor
-                equipped_armor_id = target.inventory.get_equipped_item(EquipmentSlot.ARMOR)
-                if equipped_armor_id:
-                    armor_data = items_data.get("armor", {}).get(equipped_armor_id, {})
-                    armor_type = armor_data.get("armor_type", "")
-                    if armor_type:
-                        defender_armor = f"{armor_type} armor"
-            else:
-                # Target is enemy - try to get from monster data or AC source
-                monsters = self.game_state.data_loader.load_monsters()
-                for mid, mdata in monsters.items():
-                    if mdata["name"] == target.name:
-                        ac_source = mdata.get("ac_source", "")
-                        if ac_source:
-                            defender_armor = ac_source
-                        break
+            # Build complete attack context using service
+            attack_context = self.context_builder.build_attack_context(
+                attacker, target, result
+            )
 
             with console.status("", spinner="dots"):
                 narrative = self.llm_enhancer.get_combat_narrative_sync(
-                    action_data={
-                        "attacker": result.attacker_name,
-                        "defender": result.defender_name,
-                        "damage": result.damage,
-                        "critical": result.critical_hit,
-                        "hit": result.hit,
-                        "location": location,
-                        "weapon": weapon_name,
-                        "damage_type": damage_type,
-                        "attacker_race": attacker_race,
-                        "defender_armor": defender_armor,
-                        "combat_history": self._get_combat_history_for_llm(),
-                        "battlefield_state": self._build_battlefield_state()
-                    },
+                    action_data=attack_context,
                     timeout=20.0
                 )
             if narrative:
@@ -2070,34 +2031,18 @@ class CLI:
 
         # Display narrative if available
         if self.llm_enhancer and result.hit:
-            room = self.game_state.get_current_room()
-            location = room.get("name", "")
-
-            damage_info = spell_data.get("damage", {})
-            damage_type = damage_info.get("damage_type", "magical")
-
-            # Get caster race
-            races_data = self.game_state.data_loader.load_races()
-            caster_race_data = races_data.get(caster.race, {})
-            caster_race = caster_race_data.get("name", "")
+            # Build complete attack context using service with spell data
+            spell_action_data = {
+                "name": spell_data.get("name", "spell"),
+                "damage_type": spell_data.get("damage", {}).get("damage_type", "magical")
+            }
+            attack_context = self.context_builder.build_attack_context(
+                caster, target, result, action_data=spell_action_data, is_spell=True
+            )
 
             with console.status("", spinner="dots"):
                 narrative = self.llm_enhancer.get_combat_narrative_sync(
-                    action_data={
-                        "attacker": result.attacker_name,
-                        "defender": result.defender_name,
-                        "damage": result.damage,
-                        "critical": result.critical_hit,
-                        "hit": result.hit,
-                        "location": location,
-                        "weapon": spell_data.get("name", "spell"),
-                        "damage_type": damage_type,
-                        "attacker_race": caster_race,
-                        "defender_armor": "",
-                        "combat_history": self._get_combat_history_for_llm(),
-                        "battlefield_state": self._build_battlefield_state(),
-                        "is_spell": True
-                    },
+                    action_data=attack_context,
                     timeout=20.0
                 )
             if narrative:
@@ -2582,42 +2527,14 @@ class CLI:
 
                 # Get and display attack narrative FIRST (if hit)
                 if self.llm_enhancer and result.hit:
-                    room = self.game_state.get_current_room()
-                    location = room.get("name", "")
-
-                    # Get weapon name and damage type from action
-                    weapon_name = action.get("name", "weapon")
-                    damage_type = action.get("damage_type", "")
-
-                    # Get attacker type/race from monster data
-                    attacker_race = monster_data.get("type", "")
-
-                    # Get defender armor (target is always a player character here)
-                    defender_armor = ""
-                    items_data = self.game_state.data_loader.load_items()
-                    equipped_armor_id = target.inventory.get_equipped_item(EquipmentSlot.ARMOR)
-                    if equipped_armor_id:
-                        armor_data = items_data.get("armor", {}).get(equipped_armor_id, {})
-                        armor_type = armor_data.get("armor_type", "")
-                        if armor_type:
-                            defender_armor = f"{armor_type} armor"
+                    # Build complete attack context using service
+                    attack_context = self.context_builder.build_attack_context(
+                        enemy, target, result, action_data=action
+                    )
 
                     with console.status("", spinner="dots"):
                         narrative = self.llm_enhancer.get_combat_narrative_sync(
-                            action_data={
-                                "attacker": result.attacker_name,
-                                "defender": result.defender_name,
-                                "damage": result.damage,
-                                "critical": result.critical_hit,
-                                "hit": result.hit,
-                                "location": location,
-                                "weapon": weapon_name,
-                                "damage_type": damage_type,
-                                "attacker_race": attacker_race,
-                                "defender_armor": defender_armor,
-                                "combat_history": self._get_combat_history_for_llm(),
-                                "battlefield_state": self._build_battlefield_state()
-                            },
+                            action_data=attack_context,
                             timeout=20.0
                         )
                     if narrative:

--- a/tests/test_combat_context_builder.py
+++ b/tests/test_combat_context_builder.py
@@ -1,0 +1,377 @@
+# ABOUTME: Unit tests for CombatContextBuilder class
+# ABOUTME: Tests context assembly with mocked dependencies
+
+import pytest
+from unittest.mock import Mock, MagicMock
+from dnd_engine.systems.combat_context.builder import CombatContextBuilder
+from dnd_engine.core.combat import AttackResult
+from dnd_engine.core.character import Character
+from dnd_engine.core.creature import Creature
+from dnd_engine.systems.inventory import EquipmentSlot
+
+
+class TestCombatContextBuilder:
+    """Test the CombatContextBuilder class."""
+
+    def setup_method(self):
+        """Create test fixtures."""
+        self.data_loader = Mock()
+        self.game_state = Mock()
+
+        # Setup default mock returns
+        self.data_loader.load_items.return_value = {
+            "weapons": {
+                "longsword": {
+                    "name": "Longsword",
+                    "damage": "1d8",
+                    "damage_type": "slashing",
+                },
+                "shortbow": {
+                    "name": "Shortbow",
+                    "damage": "1d6",
+                    "damage_type": "piercing",
+                },
+            },
+            "armor": {
+                "chainmail": {"name": "Chainmail", "armor_type": "heavy"},
+                "leather_armor": {"name": "Leather Armor", "armor_type": "light"},
+            },
+        }
+
+        self.data_loader.load_races.return_value = {
+            "human": {"name": "Human"},
+            "elf": {"name": "Elf"},
+        }
+
+        self.data_loader.load_monsters.return_value = {
+            "skeleton": {
+                "name": "Skeleton",
+                "type": "undead",
+                "ac_source": "armor scraps",
+                "actions": [
+                    {"name": "Shortsword", "damage_type": "piercing"},
+                    {"name": "Shortbow", "damage_type": "piercing"},
+                ],
+            },
+            "zombie": {
+                "name": "Zombie",
+                "type": "undead",
+                "ac_source": "",
+                "actions": [{"name": "Slam", "damage_type": "bludgeoning"}],
+            },
+        }
+
+        self.game_state.get_current_room.return_value = {"name": "Dark Crypt"}
+        self.game_state.get_recent_combat_history.return_value = [
+            "Fighter attacked Skeleton for 8 damage",
+            "Skeleton attacked Fighter for 5 damage",
+        ]
+        self.game_state.get_battlefield_state.return_value = {
+            "party_hp": [("Fighter", 25, 30)],
+            "enemy_hp": [("Skeleton", 8, 13)],
+        }
+
+        self.builder = CombatContextBuilder(self.data_loader, self.game_state)
+
+    def test_build_player_attack_context_with_weapon(self):
+        """Test building context for player attack with equipped weapon."""
+        # Create player character
+        player = Mock(spec=Character)
+        player.name = "Fighter"
+        player.race = "human"
+        player.inventory = Mock()
+        player.inventory.get_equipped_item.side_effect = (
+            lambda slot: "longsword" if slot == EquipmentSlot.WEAPON else None
+        )
+
+        # Create enemy
+        enemy = Mock(spec=Creature)
+        enemy.name = "Skeleton"
+
+        # Create attack result
+        result = AttackResult(
+            attacker_name="Fighter",
+            defender_name="Skeleton",
+            attack_roll=18,
+            attack_bonus=5,
+            target_ac=13,
+            hit=True,
+            critical_hit=False,
+            damage=10,
+            advantage=False,
+            disadvantage=False,
+        )
+
+        # Build context
+        context = self.builder.build_attack_context(player, enemy, result)
+
+        # Verify structure
+        assert context["attacker"] == "Fighter"
+        assert context["defender"] == "Skeleton"
+        assert context["damage"] == 10
+        assert context["critical"] is False
+        assert context["hit"] is True
+        assert context["location"] == "Dark Crypt"
+        assert context["weapon"] == "Longsword"
+        assert context["damage_type"] == "slashing"
+        assert context["attacker_race"] == "Human"
+        assert context["defender_armor"] == "armor scraps"
+        assert len(context["combat_history"]) == 2
+        assert context["battlefield_state"] == {
+            "party_hp": [("Fighter", 25, 30)],
+            "enemy_hp": [("Skeleton", 8, 13)],
+        }
+
+    def test_build_player_attack_context_unarmed(self):
+        """Test building context for player unarmed attack."""
+        player = Mock(spec=Character)
+        player.name = "Monk"
+        player.race = "elf"
+        player.inventory = Mock()
+        player.inventory.get_equipped_item.return_value = None
+
+        enemy = Mock(spec=Creature)
+        enemy.name = "Zombie"
+
+        result = AttackResult(
+            attacker_name="Monk",
+            defender_name="Zombie",
+            attack_roll=15,
+            attack_bonus=3,
+            target_ac=8,
+            hit=True,
+            critical_hit=False,
+            damage=6,
+            advantage=False,
+            disadvantage=False,
+        )
+
+        context = self.builder.build_attack_context(player, enemy, result)
+
+        assert context["weapon"] == "unarmed strike"
+        assert context["damage_type"] == "bludgeoning"
+        assert context["attacker_race"] == "Elf"
+        assert context["defender_armor"] == ""  # Zombie has no ac_source
+
+    def test_build_enemy_attack_context(self):
+        """Test building context for enemy attack against player."""
+        enemy = Mock(spec=Creature)
+        enemy.name = "Skeleton"
+
+        player = Mock(spec=Character)
+        player.name = "Fighter"
+        player.race = "human"
+        player.inventory = Mock()
+        player.inventory.get_equipped_item.side_effect = (
+            lambda slot: "chainmail" if slot == EquipmentSlot.ARMOR else None
+        )
+
+        result = AttackResult(
+            attacker_name="Skeleton",
+            defender_name="Fighter",
+            attack_roll=12,
+            attack_bonus=4,
+            target_ac=16,
+            hit=False,
+            critical_hit=False,
+            damage=0,
+            advantage=False,
+            disadvantage=False,
+        )
+
+        action_data = {"name": "Shortsword", "damage_type": "piercing"}
+
+        context = self.builder.build_attack_context(
+            enemy, player, result, action_data=action_data
+        )
+
+        assert context["attacker"] == "Skeleton"
+        assert context["defender"] == "Fighter"
+        assert context["weapon"] == "Shortsword"
+        assert context["damage_type"] == "piercing"
+        assert context["attacker_race"] == "undead"
+        assert context["defender_armor"] == "heavy armor"
+        assert context["hit"] is False
+
+    def test_build_spell_attack_context(self):
+        """Test building context for spell attack."""
+        player = Mock(spec=Character)
+        player.name = "Wizard"
+        player.race = "elf"
+        player.inventory = Mock()
+        player.inventory.get_equipped_item.return_value = None
+
+        enemy = Mock(spec=Creature)
+        enemy.name = "Skeleton"
+
+        result = AttackResult(
+            attacker_name="Wizard",
+            defender_name="Skeleton",
+            attack_roll=20,
+            attack_bonus=7,
+            target_ac=13,
+            hit=True,
+            critical_hit=True,
+            damage=16,
+            advantage=False,
+            disadvantage=False,
+        )
+
+        spell_data = {"name": "Fire Bolt", "damage_type": "fire"}
+
+        context = self.builder.build_attack_context(
+            player, enemy, result, action_data=spell_data, is_spell=True
+        )
+
+        assert context["weapon"] == "Fire Bolt"
+        assert context["damage_type"] == "fire"
+        assert context["is_spell"] is True
+        assert context["critical"] is True
+
+    def test_build_context_with_unknown_race(self):
+        """Test building context when race is not in data."""
+        player = Mock(spec=Character)
+        player.name = "Dragonborn"
+        player.race = "dragonborn"  # Not in mock data
+        player.inventory = Mock()
+        player.inventory.get_equipped_item.return_value = None
+
+        enemy = Mock(spec=Creature)
+        enemy.name = "Skeleton"
+
+        result = AttackResult(
+            attacker_name="Dragonborn",
+            defender_name="Skeleton",
+            attack_roll=15,
+            attack_bonus=4,
+            target_ac=13,
+            hit=True,
+            critical_hit=False,
+            damage=8,
+            advantage=False,
+            disadvantage=False,
+        )
+
+        context = self.builder.build_attack_context(player, enemy, result)
+
+        assert context["attacker_race"] == ""  # Fallback to empty string
+
+    def test_build_context_with_unknown_monster(self):
+        """Test building context when monster is not in data."""
+        player = Mock(spec=Character)
+        player.name = "Fighter"
+        player.race = "human"
+        player.inventory = Mock()
+        player.inventory.get_equipped_item.return_value = None
+
+        enemy = Mock(spec=Creature)
+        enemy.name = "Beholder"  # Not in mock data
+
+        result = AttackResult(
+            attacker_name="Fighter",
+            defender_name="Beholder",
+            attack_roll=15,
+            attack_bonus=5,
+            target_ac=18,
+            hit=False,
+            critical_hit=False,
+            damage=0,
+            advantage=False,
+            disadvantage=False,
+        )
+
+        context = self.builder.build_attack_context(player, enemy, result)
+
+        assert context["defender_armor"] == ""  # Fallback to empty string
+
+    def test_build_context_with_no_armor(self):
+        """Test building context when defender has no equipped armor."""
+        enemy = Mock(spec=Creature)
+        enemy.name = "Skeleton"
+
+        player = Mock(spec=Character)
+        player.name = "Rogue"
+        player.race = "elf"
+        player.inventory = Mock()
+        player.inventory.get_equipped_item.return_value = None  # No armor
+
+        result = AttackResult(
+            attacker_name="Skeleton",
+            defender_name="Rogue",
+            attack_roll=15,
+            attack_bonus=4,
+            target_ac=14,
+            hit=True,
+            critical_hit=False,
+            damage=5,
+            advantage=False,
+            disadvantage=False,
+        )
+
+        action_data = {"name": "Shortsword", "damage_type": "piercing"}
+
+        context = self.builder.build_attack_context(
+            enemy, player, result, action_data=action_data
+        )
+
+        assert context["defender_armor"] == ""  # No armor equipped
+
+    def test_build_context_with_empty_combat_history(self):
+        """Test building context when combat has just started."""
+        self.game_state.get_recent_combat_history.return_value = []
+
+        player = Mock(spec=Character)
+        player.name = "Fighter"
+        player.race = "human"
+        player.inventory = Mock()
+        player.inventory.get_equipped_item.return_value = None
+
+        enemy = Mock(spec=Creature)
+        enemy.name = "Skeleton"
+
+        result = AttackResult(
+            attacker_name="Fighter",
+            defender_name="Skeleton",
+            attack_roll=15,
+            attack_bonus=5,
+            target_ac=13,
+            hit=True,
+            critical_hit=False,
+            damage=8,
+            advantage=False,
+            disadvantage=False,
+        )
+
+        context = self.builder.build_attack_context(player, enemy, result)
+
+        assert context["combat_history"] == []
+
+    def test_build_context_without_action_data(self):
+        """Test building context for enemy attack without action data."""
+        enemy = Mock(spec=Creature)
+        enemy.name = "Skeleton"
+
+        player = Mock(spec=Character)
+        player.name = "Fighter"
+        player.race = "human"
+        player.inventory = Mock()
+        player.inventory.get_equipped_item.return_value = None
+
+        result = AttackResult(
+            attacker_name="Skeleton",
+            defender_name="Fighter",
+            attack_roll=10,
+            attack_bonus=4,
+            target_ac=14,
+            hit=False,
+            critical_hit=False,
+            damage=0,
+            advantage=False,
+            disadvantage=False,
+        )
+
+        # No action_data provided
+        context = self.builder.build_attack_context(enemy, player, result)
+
+        assert context["weapon"] == "attack"  # Default fallback
+        assert context["damage_type"] == ""


### PR DESCRIPTION
## Summary
Extract ~150 lines of duplicated combat context assembly code from CLI into a dedicated `CombatContextBuilder` service, following the Enemy AI refactor pattern established in #173.

Closes #175

## Changes

### New Service Layer (`dnd_engine/systems/combat_context/`)
- **CombatContextBuilder**: Main service class for assembling LLM context dictionaries
- **assemblers.py**: Helper functions for data gathering (weapons, races, armor)
- **Monster name lookup caching** for O(1) performance (vs O(n) linear search)
- **Type-safe `isinstance()` checks** instead of duck typing
- **Debug logging** for missing data (weapons, races, monsters, armor)

### CLI Integration
The CLI now delegates all context assembly to the service:
- `handle_attack()`: Reduced from ~54 lines to 8 lines
- `process_enemy_turns()`: Reduced from ~42 lines to 8 lines  
- `handle_cast_spell()`: Reduced from ~32 lines to 11 lines
- **Total reduction**: ~128 lines of duplicated code eliminated

### Testing
- ✅ 9 comprehensive unit tests (100% pass rate)
- ✅ Edge cases covered: unknown data, no equipment, empty history, spells
- ✅ Mock objects use proper `spec=Character/Creature` for type safety
- ✅ No regressions: 1558 existing tests still pass

## Benefits

### DRY Principle
Context assembly logic now lives in one place, used by 3 different command handlers.

### Testability
Service can be unit tested independently with mocked dependencies.

### Reusability
Future UIs (web interface, API) can use the same service.

### Maintainability
Adding new context fields (terrain, weather, morale) requires changes in only one place.

### Performance
Monster lookups are now O(1) via caching instead of O(n) linear search on every attack.

### Developer Experience
Logging helps identify data issues during development and playtesting.

## Architecture

Follows the pattern established in #173 (Enemy AI refactor):
- Location: `dnd_engine/systems/` (not a new `services/` dir)
- Structure: subdirectory with `__init__.py` exporting public API
- Clean separation: assemblers in separate module
- Builder pattern: single entry point with coordinated helper calls

## Code Quality

### Performance Optimization
- Monster cache built lazily on first use
- O(1) lookups for all subsequent combat actions
- Cache persists for the lifetime of the CLI session

### Type Safety
- Uses `isinstance()` for explicit type checking
- Handles `Character` and `Creature` types correctly
- Test mocks use proper `spec=` for compile-time checking

### Error Handling
- Graceful fallbacks for missing data (empty strings)
- Warning logs help identify data file issues
- No exceptions thrown for bad data

## Test Plan

### Unit Tests
- ✅ Player attacks with weapon
- ✅ Player unarmed attacks
- ✅ Enemy attacks against players
- ✅ Spell attacks (with `is_spell` flag)
- ✅ Unknown race handling
- ✅ Unknown monster handling  
- ✅ No armor equipped
- ✅ Empty combat history
- ✅ Enemy attacks without action data

### Integration
Verified no regressions in 1558 existing tests including:
- Character creation
- Combat mechanics
- Spell casting
- Campaign management
- Auto-save functionality

### Manual Testing
Ready for manual combat scenario testing per `CLAUDE.md`:
```bash
uv run dnd-game
# Create new game
# Select players from existing list
# Begin adventure in the crypt
# Test combat with various scenarios
```

## Files Changed
```
dnd_engine/systems/combat_context/__init__.py   |   6 +
dnd_engine/systems/combat_context/assemblers.py | 149 ++++++++++
dnd_engine/systems/combat_context/builder.py    | 143 +++++++++
dnd_engine/ui/cli.py                            | 129 ++------
tests/test_combat_context_builder.py            | 377 ++++++++++++++++++++++++
5 files changed, 698 insertions(+), 106 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)