### PR TITLE
Fix: Add missing data_loader mock to end turn command tests

### DIFF
--- a/tests/test_end_turn_command.py
+++ b/tests/test_end_turn_command.py
@@ -23,6 +23,7 @@ class TestEndTurnCommand:
         game_state.active_enemies = []
         game_state.event_bus = Mock()
         game_state.dice_roller = Mock()
+        game_state.data_loader = Mock()
         return game_state
 
     @pytest.fixture
@@ -166,6 +167,7 @@ class TestEndTurnIntegration:
         mock_game_state = Mock(spec=GameState)
         mock_game_state.dice_roller = Mock()
         mock_game_state.event_bus = Mock()
+        mock_game_state.data_loader = Mock()
         mock_campaign_manager = Mock()
         cli = CLI(
             game_state=mock_game_state,


### PR DESCRIPTION
## Summary
Fixed `AttributeError` in `test_end_turn_command.py` caused by missing `data_loader` attribute on mock `GameState` objects.

## Problem
The `CLI` class initialization creates a `CombatContextBuilder` which requires `game_state.data_loader`. Mock `GameState` objects in tests didn't include this attribute, causing test failures.

## Solution
Added `game_state.data_loader = Mock()` to:
1. `TestEndTurnCommand.mock_game_state` fixture
2. `TestEndTurnIntegration.test_end_turn_in_help_text` test

## Test Results
- **Before**: 1 failed, 1578 passed, 1 skipped, 8 errors
- **After**: 1587 passed, 1 skipped ✅

All tests now pass successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)