### PR TITLE
Fix: Handle BattlefieldState dataclass in combat prompt generation

### DIFF
--- a/dnd_engine/llm/prompts.py
+++ b/dnd_engine/llm/prompts.py
@@ -245,12 +245,19 @@ def build_combat_action_prompt(action_data: dict[str, Any]) -> str:
     # Build battlefield state context
     battlefield_context = ""
     if battlefield_state:
-        party_hp = battlefield_state.get("party_hp", [])
-        enemy_hp = battlefield_state.get("enemy_hp", [])
+        # BattlefieldState is a dataclass, not a dict - access attributes directly
+        party_combatants = getattr(battlefield_state, "party_combatants", [])
+        enemy_combatants = getattr(battlefield_state, "enemy_combatants", [])
 
-        if party_hp or enemy_hp:
-            party_status = ", ".join([f"{name} {hp}/{max_hp}" for name, hp, max_hp in party_hp])
-            enemy_status = ", ".join([f"{name} {hp}/{max_hp}" for name, hp, max_hp in enemy_hp])
+        if party_combatants or enemy_combatants:
+            party_status = ", ".join([
+                f"{c.display_name} {c.current_hp}/{c.max_hp}"
+                for c in party_combatants if c.is_alive
+            ])
+            enemy_status = ", ".join([
+                f"{c.display_name} {c.current_hp}/{c.max_hp}"
+                for c in enemy_combatants if c.is_alive
+            ])
             battlefield_context = (
                 f"Battlefield: Party [{party_status}] | Enemies [{enemy_status}]\n\n"
             )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -6,6 +6,7 @@ from dnd_engine.llm.prompts import (
     build_room_description_prompt,
     build_victory_prompt,
 )
+from dnd_engine.core.game_state import BattlefieldState, CombatantStatus
 
 
 class TestRoomDescriptionPrompt:
@@ -329,6 +330,84 @@ class TestCombatActionPrompt:
         assert "round 3" in prompt.lower()
         assert "ongoing battle" in prompt.lower()
         assert "Gimli" in prompt
+
+    def test_build_combat_action_with_battlefield_state(self) -> None:
+        """Test combat action prompt with BattlefieldState dataclass."""
+        # Create a BattlefieldState with party and enemy combatants
+        party_combatants = [
+            CombatantStatus(
+                name="Thorin",
+                display_name="Thorin",
+                current_hp=25,
+                max_hp=30,
+                is_alive=True,
+                conditions=[],
+                is_player=True,
+                ac=16
+            ),
+            CombatantStatus(
+                name="Bjorn",
+                display_name="Bjorn",
+                current_hp=15,
+                max_hp=28,
+                is_alive=True,
+                conditions=[],
+                is_player=True,
+                ac=14
+            )
+        ]
+
+        enemy_combatants = [
+            CombatantStatus(
+                name="Skeleton",
+                display_name="Skeleton 1",
+                current_hp=10,
+                max_hp=13,
+                is_alive=True,
+                conditions=[],
+                is_player=False,
+                ac=13
+            ),
+            CombatantStatus(
+                name="Skeleton",
+                display_name="Skeleton 2",
+                current_hp=8,
+                max_hp=13,
+                is_alive=True,
+                conditions=[],
+                is_player=False,
+                ac=13
+            )
+        ]
+
+        battlefield_state = BattlefieldState(
+            party_combatants=party_combatants,
+            enemy_combatants=enemy_combatants,
+            round_number=2,
+            current_turn="Thorin",
+            in_combat=True
+        )
+
+        action_data = {
+            "attacker": "Thorin",
+            "defender": "Skeleton 1",
+            "weapon": "battleaxe",
+            "damage": 7,
+            "hit": True,
+            "battlefield_state": battlefield_state
+        }
+
+        # This should not raise an AttributeError
+        prompt = build_combat_action_prompt(action_data)
+
+        # Verify the prompt was built successfully
+        assert "Thorin" in prompt
+        assert "Skeleton 1" in prompt or "Skeleton" in prompt
+        assert prompt is not None
+        assert len(prompt) > 0
+
+        # Verify battlefield context is included
+        assert "Battlefield:" in prompt or "25/30" in prompt or "10/13" in prompt
 
 
 class TestDeathPrompt:


### PR DESCRIPTION
## Summary
- Fixed AttributeError when enemy AI executes turn during combat
- Updated prompt generation to correctly handle BattlefieldState dataclass

## Problem
The `build_combat_action_prompt` function was calling `.get()` on `BattlefieldState`, treating it like a dictionary. However, `BattlefieldState` is a dataclass with attributes, not dict keys.

This caused the error:
```
✗ ERROR: 'BattlefieldState' object has no attribute 'get'
```

## Solution
- Changed from using `.get("party_hp")` to `getattr(battlefield_state, "party_combatants", [])`
- Updated to access the correct attributes: `party_combatants` and `enemy_combatants`
- Each combatant is a `CombatantStatus` dataclass with proper fields

## Test Coverage
Added unit test `test_build_combat_action_with_battlefield_state` that:
- Creates realistic BattlefieldState with party and enemy combatants
- Verifies prompt generation doesn't raise AttributeError
- Confirms battlefield context is included in the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)