### PR TITLE
Fix: Implement tag-based spell filtering system

### DIFF
--- a/dnd_engine/core/character.py
+++ b/dnd_engine/core/character.py
@@ -1631,19 +1631,12 @@ class Character(Creature):
             if not spell_data:
                 continue
 
-            # Include spell if it has any of these combat-relevant properties:
-            # 1. Has an attack roll (spell attack)
-            # 2. Has a saving throw (AoE, debuff, etc.)
-            # 3. Has damage (even if no attack/save, like Magic Missile)
-            # 4. Is a reaction spell (Shield, Counterspell, etc.)
+            # Use tag-based filtering for combat spells
+            # Tags provide a clean, data-driven way to categorize spells
+            tags = spell_data.get("tags", [])
 
-            has_attack = spell_data.get("attack_type") is not None
-            has_save = spell_data.get("saving_throw_type") is not None
-            has_damage = spell_data.get("damage") is not None
-            is_reaction = spell_data.get("casting_time") == "1 reaction"
-
-            # Include if combat-relevant
-            if has_attack or has_save or has_damage or is_reaction:
+            # Include if spell has "combat" tag
+            if "combat" in tags:
                 castable.append((spell_id, spell_data))
 
         # Sort by spell level (cantrips first, then by level)
@@ -1686,23 +1679,16 @@ class Character(Creature):
             if not spell_data:
                 continue
 
-            # Include spell if it has any of these out-of-combat properties:
-            # 1. Has healing (Cure Wounds, Healing Word, etc.)
-            # 2. Is a ritual spell (Detect Magic, Identify, etc.)
-            # 3. Has utility effects (Light, Mage Armor - any spell without attack/damage)
-            # 4. Has buffs (Bless, Shield of Faith - duration-based beneficial spells)
+            # Use tag-based filtering for out-of-combat spells
+            # Include spells tagged with: utility, healing, ritual
+            # Also include combat spells that are useful outside combat (buff, healing)
+            tags = spell_data.get("tags", [])
 
-            has_healing = spell_data.get("healing") is not None
-            is_ritual = spell_data.get("ritual") is True
-            has_attack = spell_data.get("attack_type") is not None
-            has_damage = spell_data.get("damage") is not None
-
-            # Utility spell: no attack and no damage (includes Light, Detect Magic, Mage Armor, etc.)
-            is_utility = not has_attack and not has_damage
-
-            # Include if it's useful outside combat
-            # (healing, ritual, or utility - basically anything except pure attack/damage spells)
-            if has_healing or is_ritual or is_utility:
+            # Include if spell has utility tags OR is combat spell with utility aspects
+            if "utility" in tags or "healing" in tags or "ritual" in tags:
+                out_of_combat.append((spell_id, spell_data))
+            elif "buff" in tags:
+                # Include combat buffs (like Mage Armor) outside combat
                 out_of_combat.append((spell_id, spell_data))
 
         # Sort by spell level (cantrips first, then by level)

--- a/dnd_engine/data/srd/spells.json
+++ b/dnd_engine/data/srd/spells.json
@@ -23,7 +23,8 @@
     "attack_type": "ranged",
     "higher_levels": "This spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "damage"]
   },
   "ray_of_frost": {
     "id": "ray_of_frost",
@@ -49,7 +50,8 @@
     "attack_type": "ranged",
     "higher_levels": "The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "damage", "debuff"]
   },
   "sacred_flame": {
     "id": "sacred_flame",
@@ -78,7 +80,8 @@
     },
     "higher_levels": "The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
     "classes": ["cleric"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "damage"]
   },
   "light": {
     "id": "light",
@@ -99,7 +102,8 @@
     "ritual": false,
     "description": "You touch one object that is no larger than 10 feet in any dimension. Until the spell ends, the object sheds bright light in a 20-foot radius and dim light for an additional 20 feet. The light can be colored as you like. Completely covering the object with something opaque blocks the light. The spell ends if you cast it again or dismiss it as an action.",
     "classes": ["wizard", "cleric", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["utility"]
   },
   "mage_hand": {
     "id": "mage_hand",
@@ -119,7 +123,8 @@
     "ritual": false,
     "description": "A spectral, floating hand appears at a point you choose within range. The hand lasts for the duration or until you dismiss it as an action. The hand vanishes if it is ever more than 30 feet away from you or if you cast this spell again. You can use your action to control the hand. You can use the hand to manipulate an object, open an unlocked door or container, stow or retrieve an item from an open container, or pour the contents out of a vial. You can move the hand up to 30 feet each time you use it. The hand can't attack, activate magic items, or carry more than 10 pounds.",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["utility"]
   },
   "prestidigitation": {
     "id": "prestidigitation",
@@ -139,7 +144,8 @@
     "ritual": false,
     "description": "This spell is a minor magical trick that novice spellcasters use for practice. You create one of the following magical effects within range: You create an instantaneous, harmless sensory effect, such as a shower of sparks, a puff of wind, faint musical notes, or an odd odor. You instantaneously light or snuff out a candle, a torch, or a small campfire. You instantaneously clean or soil an object no larger than 1 cubic foot. You chill, warm, or flavor up to 1 cubic foot of nonliving material for 1 hour. You make a color, a small mark, or a symbol appear on an object or a surface for 1 hour. You create a nonmagical trinket or an illusory image that can fit in your hand and that lasts until the end of your next turn. If you cast this spell multiple times, you can have up to three of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["utility"]
   },
   "magic_missile": {
     "id": "magic_missile",
@@ -164,7 +170,8 @@
     },
     "higher_levels": "When you cast this spell using a spell slot of 2nd level or higher, the spell creates one more dart for each slot level above 1st.",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "damage"]
   },
   "cure_wounds": {
     "id": "cure_wounds",
@@ -188,7 +195,8 @@
     },
     "higher_levels": "When you cast this spell using a spell slot of 2nd level or higher, the healing increases by 1d8 for each slot level above 1st.",
     "classes": ["cleric", "paladin"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "healing"]
   },
   "shield": {
     "id": "shield",
@@ -208,7 +216,8 @@
     "ritual": false,
     "description": "An invisible barrier of magical force appears and protects you. Until the start of your next turn, you have a +5 bonus to AC, including against the triggering attack, and you take no damage from magic missile.",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "defense", "reaction", "buff"]
   },
   "burning_hands": {
     "id": "burning_hands",
@@ -238,7 +247,8 @@
     "area_of_effect": "15-foot cone",
     "higher_levels": "When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "damage", "aoe"]
   },
   "detect_magic": {
     "id": "detect_magic",
@@ -258,7 +268,8 @@
     "ritual": true,
     "description": "For the duration, you sense the presence of magic within 30 feet of you. If you sense magic in this way, you can use your action to see a faint aura around any visible creature or object in the area that bears magic, and you learn its school of magic, if any. The spell can penetrate most barriers, but it is blocked by 1 foot of stone, 1 inch of common metal, a thin sheet of lead, or 3 feet of wood or dirt.",
     "classes": ["wizard", "cleric", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["utility", "ritual"]
   },
   "sleep": {
     "id": "sleep",
@@ -281,7 +292,8 @@
     "area_of_effect": "20-foot radius",
     "higher_levels": "When you cast this spell using a spell slot of 2nd level or higher, roll an additional 2d8 for each slot level above 1st.",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "control", "aoe"]
   },
   "mage_armor": {
     "id": "mage_armor",
@@ -302,7 +314,8 @@
     "ritual": false,
     "description": "You touch a willing creature who isn't wearing armor, and a protective magical force surrounds it until the spell ends. The target's base AC becomes 13 + its Dexterity modifier. The spell ends if the target dons armor or if you dismiss the spell as an action.",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "buff", "defense"]
   },
   "identify": {
     "id": "identify",
@@ -322,7 +335,8 @@
     "ritual": true,
     "description": "You choose one object that you must touch throughout the casting of the spell. If it is a magic item or some other magic-imbued object, you learn its properties and how to use them, whether it requires attunement to use, and how many charges it has, if any. You learn whether any spells are affecting the item and what they are. If the item was created by a spell, you learn which spell created it.",
     "classes": ["wizard"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["utility", "ritual"]
   },
   "scorching_ray": {
     "id": "scorching_ray",
@@ -348,7 +362,8 @@
     "attack_type": "ranged",
     "higher_levels": "When you cast this spell using a spell slot of 3rd level or higher, you create one additional ray for each slot level above 2nd.",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "damage"]
   },
   "hold_person": {
     "id": "hold_person",
@@ -374,7 +389,8 @@
     },
     "higher_levels": "When you cast this spell using a spell slot of 3rd level or higher, you can target one additional humanoid for each slot level above 2nd. The humanoids must be within 30 feet of each other when you target them.",
     "classes": ["wizard", "cleric", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "control", "debuff"]
   },
   "spiritual_weapon": {
     "id": "spiritual_weapon",
@@ -401,7 +417,8 @@
     "attack_type": "melee",
     "higher_levels": "When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for every two slot levels above 2nd.",
     "classes": ["cleric"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "damage"]
   },
   "misty_step": {
     "id": "misty_step",
@@ -420,7 +437,8 @@
     "ritual": false,
     "description": "Briefly surrounded by silvery mist, you teleport up to 30 feet to an unoccupied space that you can see.",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "utility"]
   },
   "fireball": {
     "id": "fireball",
@@ -451,7 +469,8 @@
     "area_of_effect": "20-foot radius sphere",
     "higher_levels": "When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d6 for each slot level above 3rd.",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "damage", "aoe"]
   },
   "counterspell": {
     "id": "counterspell",
@@ -471,7 +490,8 @@
     "description": "You attempt to interrupt a creature in the process of casting a spell. If the creature is casting a spell of 3rd level or lower, its spell fails and has no effect. If it is casting a spell of 4th level or higher, make an ability check using your spellcasting ability. The DC equals 10 + the spell's level. On a success, the creature's spell fails and has no effect.",
     "higher_levels": "When you cast this spell using a spell slot of 4th level or higher, the interrupted spell has no effect if its level is less than or equal to the level of the spell slot you used.",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "reaction", "control"]
   },
   "lightning_bolt": {
     "id": "lightning_bolt",
@@ -502,7 +522,8 @@
     "area_of_effect": "100-foot line (5 feet wide)",
     "higher_levels": "When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d6 for each slot level above 3rd.",
     "classes": ["wizard", "sorcerer"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "damage", "aoe"]
   },
   "revivify": {
     "id": "revivify",
@@ -524,6 +545,7 @@
     "ritual": false,
     "description": "You touch a creature that has died within the last minute. That creature returns to life with 1 hit point. This spell can't return to life a creature that has died of old age, nor can it restore any missing body parts.",
     "classes": ["cleric", "paladin"],
-    "source": "D&D 5E SRD (CC BY 4.0)"
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": ["combat", "utility", "healing"]
   }
 }

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -1684,9 +1684,9 @@ class CLI:
         )
 
         # Check concentration if target was hit and took damage
-        if result.hit and result.damage > 0 and isinstance(targets[0], Character):
+        if result.hit and result.damage > 0 and isinstance(target, Character):
             concentration_result = self.game_state.check_concentration_from_damage(
-                targets[0].name,
+                target.name,
                 result.damage
             )
             if concentration_result["concentration_broken"]:
@@ -1694,7 +1694,7 @@ class CLI:
                 save_result = concentration_result["save_result"]
                 dc = concentration_result["dc"]
                 console.print(
-                    f"[yellow]💫 {targets[0].name}'s concentration on {spell_name} is broken! "
+                    f"[yellow]💫 {target.name}'s concentration on {spell_name} is broken! "
                     f"(CON save: {save_result['total']} vs DC {dc})[/yellow]"
                 )
 
@@ -1736,7 +1736,7 @@ class CLI:
                     self.display_narrative_panel(death_narrative)
 
             # 4. Display defeated message after death narrative
-            print_status_message(f"{targets[0].name} is defeated!", "success")
+            print_status_message(f"{target.name} is defeated!", "success")
 
         return True
 
@@ -1801,7 +1801,22 @@ class CLI:
                     else:
                         slot_info = f"({ordinal}, no slots)"
 
-                spell_choices.append(f"{spell_display_name} - {damage_dice} {damage_type} {slot_info}")
+                # Build spell description based on available information
+                if damage_dice and damage_type:
+                    # Damage spell: show damage
+                    description = f"{damage_dice} {damage_type}"
+                else:
+                    # Non-damage spell: show tags or school
+                    tags = sdata.get("tags", [])
+                    if tags:
+                        # Show primary tag (skip "combat" as it's implied)
+                        non_combat_tags = [t for t in tags if t != "combat"]
+                        description = non_combat_tags[0] if non_combat_tags else "combat"
+                    else:
+                        # Fallback to school
+                        description = sdata.get("school", "spell")
+
+                spell_choices.append(f"{spell_display_name} - {description} {slot_info}")
 
             # Use questionary for selection
             from questionary import select

--- a/tests/test_spell_tags.py
+++ b/tests/test_spell_tags.py
@@ -1,0 +1,238 @@
+# ABOUTME: Unit tests for spell tag-based filtering system
+# ABOUTME: Tests get_castable_spells and get_out_of_combat_spells tag logic
+
+import pytest
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+
+
+@pytest.fixture
+def wizard():
+    """Create a level 1 wizard for testing"""
+    return Character(
+        name="Test Wizard",
+        character_class=CharacterClass.WIZARD,
+        level=1,
+        abilities=Abilities(
+            strength=8,
+            dexterity=14,
+            constitution=12,
+            intelligence=16,
+            wisdom=10,
+            charisma=10
+        ),
+        max_hp=8,
+        ac=12,
+        spellcasting_ability="int",
+        known_spells=[
+            "fire_bolt",  # combat
+            "light",  # utility
+            "mage_hand",  # utility
+            "magic_missile",  # combat
+            "mage_armor",  # combat + buff
+            "detect_magic",  # utility + ritual
+            "sleep"  # combat + control
+        ],
+        prepared_spells=[
+            "fire_bolt",
+            "light",
+            "mage_hand",
+            "magic_missile",
+            "mage_armor",
+            "detect_magic",
+            "sleep"
+        ]
+    )
+
+
+@pytest.fixture
+def spells_data():
+    """Spell data with tags for testing"""
+    return {
+        "fire_bolt": {
+            "id": "fire_bolt",
+            "name": "Fire Bolt",
+            "level": 0,
+            "tags": ["combat", "damage"]
+        },
+        "light": {
+            "id": "light",
+            "name": "Light",
+            "level": 0,
+            "tags": ["utility"]
+        },
+        "mage_hand": {
+            "id": "mage_hand",
+            "name": "Mage Hand",
+            "level": 0,
+            "tags": ["utility"]
+        },
+        "magic_missile": {
+            "id": "magic_missile",
+            "name": "Magic Missile",
+            "level": 1,
+            "tags": ["combat", "damage"]
+        },
+        "mage_armor": {
+            "id": "mage_armor",
+            "name": "Mage Armor",
+            "level": 1,
+            "tags": ["combat", "buff", "defense"]
+        },
+        "detect_magic": {
+            "id": "detect_magic",
+            "name": "Detect Magic",
+            "level": 1,
+            "tags": ["utility", "ritual"]
+        },
+        "sleep": {
+            "id": "sleep",
+            "name": "Sleep",
+            "level": 1,
+            "tags": ["combat", "control", "aoe"]
+        }
+    }
+
+
+class TestSpellTagFiltering:
+    """Tests for tag-based spell filtering"""
+
+    def test_get_castable_spells_returns_only_combat_spells(self, wizard, spells_data):
+        """Combat spells should include all spells with 'combat' tag"""
+        castable = wizard.get_castable_spells(spells_data)
+        spell_names = [s[1]["name"] for s in castable]
+
+        # Should include all combat-tagged spells
+        assert "Fire Bolt" in spell_names
+        assert "Magic Missile" in spell_names
+        assert "Mage Armor" in spell_names
+        assert "Sleep" in spell_names
+
+        # Should NOT include utility-only spells
+        assert "Light" not in spell_names
+        assert "Mage Hand" not in spell_names
+        assert "Detect Magic" not in spell_names
+
+    def test_get_castable_spells_count(self, wizard, spells_data):
+        """Should return exactly 4 combat spells"""
+        castable = wizard.get_castable_spells(spells_data)
+        assert len(castable) == 4
+
+    def test_get_castable_spells_sorted_by_level(self, wizard, spells_data):
+        """Combat spells should be sorted by level (cantrips first)"""
+        castable = wizard.get_castable_spells(spells_data)
+        levels = [s[1]["level"] for s in castable]
+
+        # Cantrips (level 0) should come before level 1 spells
+        assert levels == sorted(levels)
+        assert levels[0] == 0  # First spell is cantrip
+
+    def test_get_out_of_combat_spells_includes_utility(self, wizard, spells_data):
+        """Out-of-combat should include utility, healing, ritual, and buff spells"""
+        out_of_combat = wizard.get_out_of_combat_spells(spells_data)
+        spell_names = [s[1]["name"] for s in out_of_combat]
+
+        # Should include utility spells
+        assert "Light" in spell_names
+        assert "Mage Hand" in spell_names
+        assert "Detect Magic" in spell_names
+
+        # Should include buffs (useful before combat)
+        assert "Mage Armor" in spell_names
+
+        # Should NOT include pure combat spells
+        assert "Fire Bolt" not in spell_names
+        assert "Magic Missile" not in spell_names
+        assert "Sleep" not in spell_names
+
+    def test_spell_without_tags_not_included(self, wizard):
+        """Spells without tags should not be included in any list"""
+        spells_without_tags = {
+            "test_spell": {
+                "id": "test_spell",
+                "name": "Test Spell",
+                "level": 1
+                # No tags field
+            }
+        }
+
+        wizard.prepared_spells = ["test_spell"]
+
+        castable = wizard.get_castable_spells(spells_without_tags)
+        out_of_combat = wizard.get_out_of_combat_spells(spells_without_tags)
+
+        assert len(castable) == 0
+        assert len(out_of_combat) == 0
+
+    def test_spell_with_empty_tags_not_included(self, wizard):
+        """Spells with empty tags list should not be included"""
+        spells_empty_tags = {
+            "test_spell": {
+                "id": "test_spell",
+                "name": "Test Spell",
+                "level": 1,
+                "tags": []
+            }
+        }
+
+        wizard.prepared_spells = ["test_spell"]
+
+        castable = wizard.get_castable_spells(spells_empty_tags)
+        out_of_combat = wizard.get_out_of_combat_spells(spells_empty_tags)
+
+        assert len(castable) == 0
+        assert len(out_of_combat) == 0
+
+    def test_multiple_tags_work_correctly(self, wizard, spells_data):
+        """Spells with multiple tags should appear in appropriate lists"""
+        # Mage Armor has tags: ["combat", "buff", "defense"]
+        # Should appear in combat list (has "combat" tag)
+        castable = wizard.get_castable_spells(spells_data)
+        castable_names = [s[1]["name"] for s in castable]
+        assert "Mage Armor" in castable_names
+
+        # Should also appear in out-of-combat list (has "buff" tag)
+        out_of_combat = wizard.get_out_of_combat_spells(spells_data)
+        out_of_combat_names = [s[1]["name"] for s in out_of_combat]
+        assert "Mage Armor" in out_of_combat_names
+
+    def test_ritual_tag_includes_in_out_of_combat(self, wizard, spells_data):
+        """Spells with 'ritual' tag should appear in out-of-combat list"""
+        out_of_combat = wizard.get_out_of_combat_spells(spells_data)
+        spell_names = [s[1]["name"] for s in out_of_combat]
+
+        assert "Detect Magic" in spell_names
+
+    def test_control_spell_only_in_combat(self, wizard, spells_data):
+        """Control spells with 'combat' tag should only appear in combat list"""
+        # Sleep has tags: ["combat", "control", "aoe"]
+        castable = wizard.get_castable_spells(spells_data)
+        castable_names = [s[1]["name"] for s in castable]
+        assert "Sleep" in castable_names
+
+        # Should NOT appear in out-of-combat (no utility/healing/ritual/buff tags)
+        out_of_combat = wizard.get_out_of_combat_spells(spells_data)
+        out_of_combat_names = [s[1]["name"] for s in out_of_combat]
+        assert "Sleep" not in out_of_combat_names
+
+    def test_empty_prepared_spells_returns_empty_lists(self, wizard, spells_data):
+        """With no prepared spells, both methods should return empty lists"""
+        wizard.prepared_spells = []
+
+        castable = wizard.get_castable_spells(spells_data)
+        out_of_combat = wizard.get_out_of_combat_spells(spells_data)
+
+        assert len(castable) == 0
+        assert len(out_of_combat) == 0
+
+    def test_spell_not_in_data_ignored(self, wizard, spells_data):
+        """Spells in prepared_spells but not in spells_data should be ignored"""
+        wizard.prepared_spells = ["fire_bolt", "nonexistent_spell", "magic_missile"]
+
+        castable = wizard.get_castable_spells(spells_data)
+        spell_names = [s[1]["name"] for s in castable]
+
+        # Should only include the 2 valid spells
+        assert len(castable) == 2
+        assert "Fire Bolt" in spell_names
+        assert "Magic Missile" in spell_names


### PR DESCRIPTION
## Problem
After resting and preparing spells (Burning Hands, Mage Armor, Sleep), only 2 appeared in combat spell selection:
- ✅ Fire Bolt (cantrip)
- ✅ Burning Hands
- ❌ Mage Armor (missing!)
- ❌ Sleep (missing!)

The property-based filtering logic excluded spells like Sleep (area effect with no saving throw) and Mage Armor (defensive buff with no attack/damage).

## Solution
Implement tag-based architecture for spell categorization:

### Changes
1. **Add tags to all 22 spells** in `spells.json` with semantic categories:
   - `combat`, `utility`, `damage`, `healing`, `buff`, `debuff`, `control`, `defense`, `reaction`, `ritual`, `aoe`

2. **Refactor `get_castable_spells()`** to use simple tag check:
   ```python
   if "combat" in tags:
       castable.append((spell_id, spell_data))
   ```

3. **Refactor `get_out_of_combat_spells()`** to check utility tags:
   ```python
   if "utility" in tags or "healing" in tags or "ritual" in tags or "buff" in tags:
       out_of_combat.append((spell_id, spell_data))
   ```

4. **Improve spell UI** to show tag descriptions for non-damage spells:
   - Fire Bolt - 1d10 fire (cantrip)
   - Burning Hands - 3d6 fire (1st, 2 slots)
   - **Mage Armor - buff (1st, 2 slots)** ← Better!
   - **Sleep - control (1st, 2 slots)** ← Better!

### Benefits
- ✅ **Data-driven** - No string parsing or heuristics
- ✅ **Easily extensible** - New spells just need appropriate tags
- ✅ **Multi-purpose** - Tags can be leveraged by LLM narrator for richer descriptions
- ✅ **Clear separation** - Maintains distinction between combat and utility spells
- ✅ **Flexible categorization** - Spells can have multiple tags (e.g., Mage Armor has `combat`, `buff`, `defense`)

## Test Plan
- ✅ Added 11 comprehensive unit tests covering tag-based filtering logic
- ✅ All tests passing
- ✅ Manually tested in-game: all 4 prepared spells now appear in combat

## Architecture Alignment
This change follows the project's **data-driven design** principle (see `.claude/CLAUDE.md`):
> "All content (monsters, items, spells, dungeons) stored in JSON, not hardcoded"

Tags provide a clean, maintainable way to categorize spells without hardcoding filtering logic.

Fixes the spell filtering bug reported by @JoeCotellese

🤖 Generated with [Claude Code](https://claude.com/claude-code)