### PR TITLE
Implement Sleep spell HP pool mechanics

### DIFF
--- a/dnd_engine/core/combat.py
+++ b/dnd_engine/core/combat.py
@@ -765,3 +765,165 @@ class CombatEngine:
                     total_damage += extra_roll.total
 
         return total_damage
+
+    def resolve_spell_hp_pool(
+        self,
+        caster,
+        targets: list,
+        spell,
+        upcast_level: Optional[int] = None,
+        event_bus=None
+    ) -> Dict[str, Any]:
+        """
+        Resolve a spell that affects creatures based on an HP pool.
+
+        Used for spells like Sleep and Color Spray that roll dice to determine
+        how many HP worth of creatures are affected, then apply effects starting
+        with the lowest HP creature.
+
+        Args:
+            caster: The creature casting the spell
+            targets: List of creatures that could be affected
+            spell: Spell object or dict containing:
+                - "name": spell name
+                - "hp_pool": dict with "dice" and optionally "higher_levels"
+                - "effect": dict with condition to apply
+                - "level": spell level
+            upcast_level: Spell slot level used (for upcasting)
+            event_bus: Optional EventBus instance for event emission
+
+        Returns:
+            Dictionary with spell cast results:
+            {
+                "spell_name": str,
+                "caster": str,
+                "hp_pool_rolled": int,
+                "hp_pool_remaining": int,
+                "affected_targets": [
+                    {"name": str, "hp": int, "condition": str},
+                    ...
+                ],
+                "unaffected_targets": [
+                    {"name": str, "hp": int, "reason": str},
+                    ...
+                ]
+            }
+        """
+        from dnd_engine.utils.events import Event, EventType
+
+        # Get spell info
+        if hasattr(spell, 'name'):
+            spell_name = spell.name
+            spell_level = spell.level
+            hp_pool_info = spell.hp_pool
+            effect_info = spell.effect
+        else:
+            spell_name = spell.get("name", "Unknown Spell")
+            spell_level = spell.get("level", 1)
+            hp_pool_info = spell.get("hp_pool", {})
+            effect_info = spell.get("effect", {})
+
+        # Determine cast level for upcasting
+        actual_level = upcast_level if upcast_level else spell_level
+
+        # Roll HP pool
+        base_dice = hp_pool_info.get("dice", "5d8")
+        hp_pool_roll = self.dice_roller.roll(base_dice)
+        hp_pool = hp_pool_roll.total
+
+        # Handle upcasting (Sleep adds 2d8 per level above 1st)
+        if actual_level > spell_level:
+            extra_levels = actual_level - spell_level
+            higher_levels_dice = hp_pool_info.get("higher_levels_dice", "2d8")
+            for _ in range(extra_levels):
+                extra_roll = self.dice_roller.roll(higher_levels_dice)
+                hp_pool += extra_roll.total
+
+        hp_pool_rolled = hp_pool
+
+        # Get condition to apply
+        condition = effect_info.get("condition", "unconscious")
+        duration = effect_info.get("duration_rounds", 10)  # 1 minute = 10 rounds
+
+        # Get immunity types (undead and constructs are immune to Sleep)
+        immune_types = hp_pool_info.get("immune_types", ["undead", "construct"])
+
+        # Filter and sort targets by current HP (ascending)
+        valid_targets = []
+        immune_targets = []
+
+        for target in targets:
+            if not target.is_alive:
+                continue
+
+            # Check creature type immunity
+            creature_type = getattr(target, 'creature_type', None) or getattr(target, 'type', '')
+            if isinstance(creature_type, str) and creature_type.lower() in immune_types:
+                immune_targets.append({
+                    "name": target.name,
+                    "hp": target.current_hp,
+                    "reason": f"immune ({creature_type})"
+                })
+                continue
+
+            valid_targets.append(target)
+
+        # Sort by current HP ascending
+        valid_targets.sort(key=lambda t: t.current_hp)
+
+        affected_targets = []
+        unaffected_targets = list(immune_targets)  # Start with immune creatures
+
+        # Apply effect to creatures until HP pool is exhausted
+        for target in valid_targets:
+            if hp_pool >= target.current_hp:
+                # Affect this creature
+                hp_pool -= target.current_hp
+
+                # Apply the condition with duration
+                if hasattr(target, 'apply_condition_with_metadata'):
+                    target.apply_condition_with_metadata(
+                        condition=condition,
+                        duration_type="rounds",
+                        duration=duration
+                    )
+                elif hasattr(target, 'add_condition'):
+                    target.add_condition(condition)
+
+                affected_targets.append({
+                    "name": target.name,
+                    "hp": target.current_hp,
+                    "condition": condition
+                })
+            else:
+                # Not enough HP pool remaining
+                unaffected_targets.append({
+                    "name": target.name,
+                    "hp": target.current_hp,
+                    "reason": "not enough HP pool remaining"
+                })
+
+        # Emit event
+        if event_bus:
+            event = Event(
+                type=EventType.SPELL_CAST,
+                data={
+                    "spell_name": spell_name,
+                    "caster": caster.name,
+                    "spell_level": spell_level,
+                    "slot_level": actual_level,
+                    "hp_pool_rolled": hp_pool_rolled,
+                    "affected_count": len(affected_targets),
+                    "condition": condition
+                }
+            )
+            event_bus.emit(event)
+
+        return {
+            "spell_name": spell_name,
+            "caster": caster.name,
+            "hp_pool_rolled": hp_pool_rolled,
+            "hp_pool_remaining": hp_pool,
+            "affected_targets": affected_targets,
+            "unaffected_targets": unaffected_targets
+        }

--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -134,6 +134,12 @@ class CombatSpellResult:
     # Deaths
     killed_targets: List[str] = field(default_factory=list)
 
+    # HP Pool results (spell_type == "hp_pool", e.g., Sleep)
+    hp_pool_rolled: Optional[int] = None
+    hp_pool_remaining: Optional[int] = None
+    affected_targets: Optional[List[Dict[str, Any]]] = None
+    unaffected_targets: Optional[List[Dict[str, Any]]] = None
+
     # Error handling
     error: Optional[str] = None
 
@@ -1344,6 +1350,7 @@ class GameState:
         spell_name = spell_data.get("name", "Unknown Spell")
         has_attack = spell_data.get("attack_type") is not None
         has_save = spell_data.get("saving_throw") is not None
+        has_hp_pool = spell_data.get("hp_pool") is not None
         target_type = spell_data.get("target_type")
 
         # Resolve targets based on target_type
@@ -1377,6 +1384,11 @@ class GameState:
             return self._resolve_combat_attack_spell(
                 caster, targets[0], spell_data, spellcasting_ability,
                 spell_name, broke_concentration
+            )
+        elif has_hp_pool:
+            return self._resolve_combat_hp_pool_spell(
+                caster, targets, spell_data, spell_name,
+                is_area, broke_concentration
             )
         elif has_save:
             return self._resolve_combat_save_spell(
@@ -1515,6 +1527,48 @@ class GameState:
             now_concentrating=now_concentrating,
             target_concentration_breaks=target_conc_breaks,
             killed_targets=killed
+        )
+
+    def _resolve_combat_hp_pool_spell(
+        self,
+        caster: Character,
+        targets: List[Creature],
+        spell_data: Dict[str, Any],
+        spell_name: str,
+        is_area: bool,
+        broke_concentration: Optional[str]
+    ) -> "CombatSpellResult":
+        """Resolve HP pool spells like Sleep that affect creatures based on HP total."""
+        # Delegate to combat engine
+        result = self.combat_engine.resolve_spell_hp_pool(
+            caster=caster,
+            targets=targets,
+            spell=spell_data,
+            event_bus=self.event_bus
+        )
+
+        # Handle concentration for caster (Sleep is not concentration, but others might be)
+        now_concentrating = False
+        if spell_data.get("concentration", False):
+            effect_target = targets[0].name if targets else ""
+            effect = self._create_spell_effect(spell_data, caster.name, effect_target)
+            if effect:
+                self.time_manager.add_effect(effect)
+                now_concentrating = True
+
+        return CombatSpellResult(
+            success=True,
+            spell_name=spell_name,
+            caster_name=caster.name,
+            targets=[t["name"] for t in result["affected_targets"]],
+            is_area_effect=is_area,
+            spell_type="hp_pool",
+            hp_pool_rolled=result["hp_pool_rolled"],
+            hp_pool_remaining=result["hp_pool_remaining"],
+            affected_targets=result["affected_targets"],
+            unaffected_targets=result["unaffected_targets"],
+            broke_concentration=broke_concentration,
+            now_concentrating=now_concentrating
         )
 
     def _resolve_combat_auto_hit_spell(

--- a/dnd_engine/data/srd/spells.json
+++ b/dnd_engine/data/srd/spells.json
@@ -374,6 +374,16 @@
     "ritual": false,
     "description": "This spell sends creatures into a magical slumber. Roll 5d8; the total is how many hit points of creatures this spell can affect. Creatures within 20 feet of a point you choose within range are affected in ascending order of their current hit points (ignoring unconscious creatures). Starting with the creature that has the lowest current hit points, each creature affected by this spell falls unconscious until the spell ends, the sleeper takes damage, or someone uses an action to shake or slap the sleeper awake. Subtract each creature's hit points from the total before moving on to the creature with the next lowest hit points. A creature's hit points must be equal to or less than the remaining total for that creature to be affected.",
     "area_of_effect": "20-foot radius",
+    "hp_pool": {
+      "dice": "5d8",
+      "higher_levels_dice": "2d8",
+      "immune_types": ["undead", "construct"]
+    },
+    "effect": {
+      "condition": "unconscious",
+      "duration_rounds": 10,
+      "ends_on_damage": true
+    },
     "higher_levels": "When you cast this spell using a spell slot of 2nd level or higher, roll an additional 2d8 for each slot level above 1st.",
     "classes": [
       "wizard",

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -2025,6 +2025,40 @@ class CLI:
                 )
             return  # Early return for area effects
 
+        # Handle HP pool spells (Sleep, Color Spray)
+        if result.spell_type == "hp_pool":
+            console.print(f"[bold cyan]✨ {result.caster_name} casts {result.spell_name}![/bold cyan]")
+            console.print(f"[cyan]🎲 HP Pool: {result.hp_pool_rolled}[/cyan]")
+
+            # Show affected targets
+            if result.affected_targets:
+                for target_info in result.affected_targets:
+                    condition = target_info.get("condition", "affected")
+                    console.print(
+                        f"  [green]💤 {target_info['name']} ({target_info['hp']} HP) "
+                        f"falls {condition}![/green]"
+                    )
+
+            # Show unaffected targets
+            if result.unaffected_targets:
+                for target_info in result.unaffected_targets:
+                    reason = target_info.get("reason", "unaffected")
+                    console.print(
+                        f"  [yellow]{target_info['name']} ({target_info['hp']} HP) - {reason}[/yellow]"
+                    )
+
+            # Display remaining HP pool
+            if result.hp_pool_remaining and result.hp_pool_remaining > 0:
+                console.print(f"[dim]HP Pool remaining: {result.hp_pool_remaining}[/dim]")
+
+            # Display new concentration
+            if result.now_concentrating:
+                console.print(
+                    f"[cyan]🎯 {result.caster_name} begins concentrating on "
+                    f"{result.spell_name}[/cyan]"
+                )
+            return  # Early return for HP pool spells
+
         # Display target concentration breaks for single-target spells
         for conc_break in result.target_concentration_breaks:
             save_result = conc_break.get("save_result", {})

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -251,6 +251,19 @@ The deterministic heart of the game. No randomness except dice rolls.
   - `calculate_damage()`: Weapon dice + modifiers
   - `apply_damage()`: Reduce HP, handle temp HP
   - `check_critical()`: Natural 20 = crit (double damage dice)
+  - `resolve_spell_hp_pool()`: HP pool spells (Sleep, Color Spray)
+- **HP Pool Spell Flow** (Sleep, Color Spray):
+  ```
+  1. Roll HP pool dice (e.g., 5d8 for Sleep)
+  2. Sort targets by current HP (ascending)
+  3. For each target (lowest HP first):
+     - Skip if immune (undead/construct for Sleep)
+     - If current HP <= remaining pool:
+       - Apply condition (unconscious)
+       - Subtract HP from pool
+     - Else: not enough pool remaining
+  4. Return affected/unaffected targets
+  ```
 - **Attack Flow**:
   ```
   1. Roll 1d20 + attack bonus

--- a/tests/test_sleep_spell.py
+++ b/tests/test_sleep_spell.py
@@ -1,0 +1,373 @@
+# ABOUTME: Unit tests for Sleep spell HP pool mechanics
+# ABOUTME: Tests resolve_spell_hp_pool in combat engine and routing in game_state
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from dnd_engine.core.combat import CombatEngine
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.creature import Creature
+
+
+class TestResolveSpellHpPool:
+    """Tests for CombatEngine.resolve_spell_hp_pool() method."""
+
+    @pytest.fixture
+    def combat_engine(self):
+        """Create a combat engine with seeded dice roller."""
+        roller = DiceRoller(seed=42)
+        return CombatEngine(dice_roller=roller)
+
+    @pytest.fixture
+    def sleep_spell(self):
+        """Sleep spell data."""
+        return {
+            "id": "sleep",
+            "name": "Sleep",
+            "level": 1,
+            "hp_pool": {
+                "dice": "5d8",
+                "higher_levels_dice": "2d8",
+                "immune_types": ["undead", "construct"]
+            },
+            "effect": {
+                "condition": "unconscious",
+                "duration_rounds": 10
+            }
+        }
+
+    @pytest.fixture
+    def caster(self):
+        """Create a caster creature."""
+        caster = MagicMock()
+        caster.name = "Wizard"
+        return caster
+
+    @pytest.fixture
+    def low_hp_target(self):
+        """Create a low HP target."""
+        target = MagicMock(spec=Creature)
+        target.name = "Goblin"
+        target.current_hp = 5
+        target.is_alive = True
+        target.creature_type = "humanoid"
+        target.apply_condition_with_metadata = MagicMock()
+        target.add_condition = MagicMock()
+        return target
+
+    @pytest.fixture
+    def high_hp_target(self):
+        """Create a high HP target."""
+        target = MagicMock(spec=Creature)
+        target.name = "Ogre"
+        target.current_hp = 50
+        target.is_alive = True
+        target.creature_type = "giant"
+        target.apply_condition_with_metadata = MagicMock()
+        target.add_condition = MagicMock()
+        return target
+
+    @pytest.fixture
+    def undead_target(self):
+        """Create an undead target (immune to Sleep)."""
+        target = MagicMock(spec=Creature)
+        target.name = "Skeleton"
+        target.current_hp = 8
+        target.is_alive = True
+        target.creature_type = "undead"
+        target.apply_condition_with_metadata = MagicMock()
+        target.add_condition = MagicMock()
+        return target
+
+    def test_sleep_affects_low_hp_creature(
+        self, combat_engine, sleep_spell, caster, low_hp_target
+    ):
+        """Sleep should affect creatures with HP <= pool."""
+        # Seed dice to get predictable HP pool (5d8 with seed 42)
+        result = combat_engine.resolve_spell_hp_pool(
+            caster=caster,
+            targets=[low_hp_target],
+            spell=sleep_spell
+        )
+
+        assert result["spell_name"] == "Sleep"
+        assert result["caster"] == "Wizard"
+        assert result["hp_pool_rolled"] > 0
+        assert len(result["affected_targets"]) == 1
+        assert result["affected_targets"][0]["name"] == "Goblin"
+        assert result["affected_targets"][0]["condition"] == "unconscious"
+        low_hp_target.apply_condition_with_metadata.assert_called_once_with(
+            condition="unconscious",
+            duration_type="rounds",
+            duration=10
+        )
+
+    def test_sleep_does_not_affect_high_hp_creature(
+        self, combat_engine, sleep_spell, caster, high_hp_target
+    ):
+        """Sleep should not affect creatures with HP > pool."""
+        result = combat_engine.resolve_spell_hp_pool(
+            caster=caster,
+            targets=[high_hp_target],
+            spell=sleep_spell
+        )
+
+        # With 5d8 (max 40), a 50 HP creature should not be affected
+        assert len(result["affected_targets"]) == 0
+        assert len(result["unaffected_targets"]) == 1
+        assert result["unaffected_targets"][0]["name"] == "Ogre"
+        assert "not enough HP pool" in result["unaffected_targets"][0]["reason"]
+        high_hp_target.apply_condition_with_metadata.assert_not_called()
+
+    def test_sleep_targets_in_ascending_hp_order(self, combat_engine, sleep_spell, caster):
+        """Sleep should affect creatures starting with lowest HP."""
+        # Create targets with different HP
+        target_5hp = MagicMock(spec=Creature)
+        target_5hp.name = "Goblin1"
+        target_5hp.current_hp = 5
+        target_5hp.is_alive = True
+        target_5hp.creature_type = "humanoid"
+        target_5hp.apply_condition_with_metadata = MagicMock()
+        target_5hp.add_condition = MagicMock()
+
+        target_10hp = MagicMock(spec=Creature)
+        target_10hp.name = "Goblin2"
+        target_10hp.current_hp = 10
+        target_10hp.is_alive = True
+        target_10hp.creature_type = "humanoid"
+        target_10hp.apply_condition_with_metadata = MagicMock()
+        target_10hp.add_condition = MagicMock()
+
+        target_15hp = MagicMock(spec=Creature)
+        target_15hp.name = "Hobgoblin"
+        target_15hp.current_hp = 15
+        target_15hp.is_alive = True
+        target_15hp.creature_type = "humanoid"
+        target_15hp.apply_condition_with_metadata = MagicMock()
+        target_15hp.add_condition = MagicMock()
+
+        # Pass targets in non-sorted order
+        targets = [target_15hp, target_5hp, target_10hp]
+
+        result = combat_engine.resolve_spell_hp_pool(
+            caster=caster,
+            targets=targets,
+            spell=sleep_spell
+        )
+
+        # Should affect lowest HP first
+        affected_names = [t["name"] for t in result["affected_targets"]]
+        # 5hp goblin should always be first if affected
+        if affected_names:
+            assert affected_names[0] == "Goblin1"
+
+    def test_sleep_ignores_undead(
+        self, combat_engine, sleep_spell, caster, undead_target
+    ):
+        """Sleep should not affect undead creatures."""
+        result = combat_engine.resolve_spell_hp_pool(
+            caster=caster,
+            targets=[undead_target],
+            spell=sleep_spell
+        )
+
+        assert len(result["affected_targets"]) == 0
+        assert len(result["unaffected_targets"]) == 1
+        assert "immune" in result["unaffected_targets"][0]["reason"]
+        undead_target.apply_condition_with_metadata.assert_not_called()
+
+    def test_sleep_ignores_dead_creatures(self, combat_engine, sleep_spell, caster):
+        """Sleep should skip dead creatures."""
+        dead_target = MagicMock(spec=Creature)
+        dead_target.name = "DeadGoblin"
+        dead_target.current_hp = 0
+        dead_target.is_alive = False
+        dead_target.creature_type = "humanoid"
+        dead_target.apply_condition_with_metadata = MagicMock()
+        dead_target.add_condition = MagicMock()
+
+        result = combat_engine.resolve_spell_hp_pool(
+            caster=caster,
+            targets=[dead_target],
+            spell=sleep_spell
+        )
+
+        assert len(result["affected_targets"]) == 0
+        # Dead creatures are filtered out, not added to unaffected
+        dead_target.apply_condition_with_metadata.assert_not_called()
+
+    def test_sleep_hp_pool_exhaustion(self, combat_engine, sleep_spell, caster):
+        """Sleep should stop affecting creatures when HP pool is exhausted."""
+        # Create multiple low HP targets
+        targets = []
+        for i in range(10):
+            target = MagicMock(spec=Creature)
+            target.name = f"Goblin{i}"
+            target.current_hp = 7
+            target.is_alive = True
+            target.creature_type = "humanoid"
+            target.apply_condition_with_metadata = MagicMock()
+            target.add_condition = MagicMock()
+            targets.append(target)
+
+        result = combat_engine.resolve_spell_hp_pool(
+            caster=caster,
+            targets=targets,
+            spell=sleep_spell
+        )
+
+        # With 5d8 (avg 22.5), should affect ~3 goblins at 7 HP each
+        # Total affected HP should not exceed hp_pool_rolled
+        total_affected_hp = sum(t["hp"] for t in result["affected_targets"])
+        assert total_affected_hp <= result["hp_pool_rolled"]
+
+        # Some should be unaffected due to exhausted pool
+        assert len(result["unaffected_targets"]) > 0
+
+    def test_sleep_returns_remaining_hp_pool(
+        self, combat_engine, sleep_spell, caster, low_hp_target
+    ):
+        """Sleep should return the remaining HP pool after affecting targets."""
+        result = combat_engine.resolve_spell_hp_pool(
+            caster=caster,
+            targets=[low_hp_target],
+            spell=sleep_spell
+        )
+
+        # Remaining should be: rolled - affected HP
+        expected_remaining = result["hp_pool_rolled"] - low_hp_target.current_hp
+        assert result["hp_pool_remaining"] == expected_remaining
+
+    def test_sleep_emits_event(self, combat_engine, sleep_spell, caster, low_hp_target):
+        """Sleep should emit a SPELL_CAST event."""
+        event_bus = MagicMock()
+
+        result = combat_engine.resolve_spell_hp_pool(
+            caster=caster,
+            targets=[low_hp_target],
+            spell=sleep_spell,
+            event_bus=event_bus
+        )
+
+        event_bus.emit.assert_called_once()
+        event = event_bus.emit.call_args[0][0]
+        assert event.data["spell_name"] == "Sleep"
+        assert event.data["caster"] == "Wizard"
+
+
+class TestGameStateCastSpellCombatHpPool:
+    """Tests for game_state.cast_spell_combat() routing to HP pool spells."""
+
+    @pytest.fixture
+    def mock_game_state(self):
+        """Create a mock game state with necessary components."""
+        from dnd_engine.core.game_state import GameState
+
+        with patch.object(GameState, '__init__', lambda self: None):
+            gs = GameState()
+            gs.combat_engine = MagicMock()
+            gs.event_bus = MagicMock()
+            gs.time_manager = MagicMock()
+            gs.active_enemies = []
+            gs.dice_roller = DiceRoller(seed=42)
+
+            # Mock get_concentration_spell
+            gs.get_concentration_spell = MagicMock(return_value=None)
+            gs._create_spell_effect = MagicMock(return_value=None)
+
+            return gs
+
+    @pytest.fixture
+    def sleep_spell_data(self):
+        """Sleep spell data dictionary."""
+        return {
+            "id": "sleep",
+            "name": "Sleep",
+            "level": 1,
+            "target_type": "area",
+            "concentration": False,
+            "hp_pool": {
+                "dice": "5d8",
+                "higher_levels_dice": "2d8",
+                "immune_types": ["undead", "construct"]
+            },
+            "effect": {
+                "condition": "unconscious",
+                "duration_rounds": 10
+            }
+        }
+
+    @pytest.fixture
+    def caster(self):
+        """Create a caster character."""
+        from dnd_engine.core.character import Character
+        caster = MagicMock(spec=Character)
+        caster.name = "TestWizard"
+        return caster
+
+    def test_cast_spell_combat_routes_to_hp_pool(
+        self, mock_game_state, sleep_spell_data, caster
+    ):
+        """cast_spell_combat should route hp_pool spells correctly."""
+        # Setup mock enemy
+        enemy = MagicMock()
+        enemy.name = "Goblin"
+        enemy.current_hp = 7
+        enemy.is_alive = True
+        mock_game_state.active_enemies = [enemy]
+
+        # Setup combat engine response
+        mock_game_state.combat_engine.resolve_spell_hp_pool.return_value = {
+            "spell_name": "Sleep",
+            "caster": "TestWizard",
+            "hp_pool_rolled": 25,
+            "hp_pool_remaining": 18,
+            "affected_targets": [{"name": "Goblin", "hp": 7, "condition": "unconscious"}],
+            "unaffected_targets": []
+        }
+
+        result = mock_game_state.cast_spell_combat(
+            caster=caster,
+            spell_data=sleep_spell_data,
+            target=None,  # Area spell
+            spellcasting_ability="int"
+        )
+
+        # Verify routing
+        mock_game_state.combat_engine.resolve_spell_hp_pool.assert_called_once()
+        assert result.spell_type == "hp_pool"
+        assert result.hp_pool_rolled == 25
+        assert len(result.affected_targets) == 1
+
+    def test_hp_pool_spell_result_fields(
+        self, mock_game_state, sleep_spell_data, caster
+    ):
+        """CombatSpellResult should have correct hp_pool fields."""
+        enemy = MagicMock()
+        enemy.name = "Goblin"
+        enemy.is_alive = True
+        mock_game_state.active_enemies = [enemy]
+
+        mock_game_state.combat_engine.resolve_spell_hp_pool.return_value = {
+            "spell_name": "Sleep",
+            "caster": "TestWizard",
+            "hp_pool_rolled": 30,
+            "hp_pool_remaining": 5,
+            "affected_targets": [{"name": "Goblin", "hp": 7, "condition": "unconscious"}],
+            "unaffected_targets": [{"name": "Ogre", "hp": 50, "reason": "not enough HP pool remaining"}]
+        }
+
+        result = mock_game_state.cast_spell_combat(
+            caster=caster,
+            spell_data=sleep_spell_data,
+            target=None,
+            spellcasting_ability="int"
+        )
+
+        assert result.success is True
+        assert result.spell_name == "Sleep"
+        assert result.spell_type == "hp_pool"
+        assert result.hp_pool_rolled == 30
+        assert result.hp_pool_remaining == 5
+        assert result.affected_targets is not None
+        assert result.unaffected_targets is not None


### PR DESCRIPTION
## Summary
- Add `resolve_spell_hp_pool()` to CombatEngine for HP pool spell resolution
- Add routing in game_state.py to detect and handle hp_pool spells
- Add display logic in cli.py for HP pool spell results
- Add hp_pool data to Sleep spell in spells.json
- Add 10 unit tests covering the mechanics
- Update ARCHITECTURE.md with HP pool spell flow

## Details

The Sleep spell now correctly:
- Rolls 5d8 for the HP pool
- Affects creatures in ascending HP order (lowest HP first)
- Respects creature type immunities (undead/construct)
- Applies unconscious condition with proper duration
- Displays affected/unaffected targets with reasons

This architecture also supports Color Spray (same hp_pool mechanic) when added later.

## Test plan
- [x] Unit tests pass (10 new tests in test_sleep_spell.py)
- [x] Manual testing via terminal - Sleep affects Goblin, skips Ghoul (undead)
- [x] Unconscious creatures skip their turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)