### PR TITLE
Chore: Random fixes and torch implementation

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -253,13 +253,16 @@ class GameState:
         room = self.get_current_room()
         base_lighting = room.get("lighting", "bright")
 
-        # Check for temporary lighting effects (Light spell, etc.)
+        # Check for temporary lighting effects (Light spell, torches, etc.)
         # Look for active lighting effects in the time manager
         from dnd_engine.systems.time_manager import EffectType
         for effect in self.time_manager.active_effects:
+            # Check for Light spell
             if effect.effect_type == EffectType.SPELL and effect.source.lower() == "light":
-                # Light spell provides bright light
                 return "bright"
+            # Check for light-providing items (torches, lanterns, etc.)
+            if effect.effect_data.get("light_level"):
+                return effect.effect_data["light_level"]
 
         # If room is dark and character has darkvision, treat as dim
         if base_lighting == "dark" and character.darkvision_range > 0:

--- a/dnd_engine/data/content/dungeons/poisoned_laboratory.json
+++ b/dnd_engine/data/content/dungeons/poisoned_laboratory.json
@@ -20,6 +20,12 @@
           "type": "item",
           "id": "acid_vial",
           "visible": true
+        },
+        {
+          "type": "item",
+          "id": "torch",
+          "quantity": 3,
+          "visible": true
         }
       ],
       "searched": false,

--- a/dnd_engine/data/srd/items.json
+++ b/dnd_engine/data/srd/items.json
@@ -473,6 +473,20 @@
       "description": "A spell scroll bears the words of a single spell, written in a mystical cipher. If the spell is on your class's spell list, you can use an action to read the scroll and cast its spell. This scroll contains cure wounds.",
       "value": 50
     },
+    "torch": {
+      "name": "Torch",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "consumable",
+      "rarity": "common",
+      "effect_type": "light",
+      "light_level": "bright",
+      "duration_minutes": 60,
+      "action_required": "action",
+      "target_type": "self",
+      "range": 0,
+      "description": "A torch burns for 1 hour, providing bright light in a 20-foot radius and dim light for an additional 20 feet.",
+      "value": 0.01
+    },
     "gorgus_journal": {
       "name": "Cultist's Journal",
       "source": "The Unquiet Dead (Adventures Await Studios, OGL)",

--- a/dnd_engine/llm/prompts.py
+++ b/dnd_engine/llm/prompts.py
@@ -179,7 +179,7 @@ IMPORTANT: This is the moment combat begins. Naturally transition from describin
     # Build transition narrative instruction
     transition_instruction = ""
     if is_entering:
-        transition_instruction = "\n\nNarrative Context: The party is ENTERING this room. Include a brief transition that describes their entrance (e.g., 'As you step through the doorway...' or 'Leaving the previous chamber behind...'). Make it feel like they're arriving for the first time."
+        transition_instruction = "\n\nNarrative Context: The party is ENTERING this room. We don't know where they came from last nor do we know how they get into this room (i.e., door, opening, etc). Make it feel like they're arriving for the first time without describing the entrance way."
     else:
         transition_instruction = "\n\nNarrative Context: The party is already IN this room, examining it more closely. Do NOT describe them entering or transitioning - they're already here. Focus on what they observe in the moment."
 

--- a/dnd_engine/systems/item_effects.py
+++ b/dnd_engine/systems/item_effects.py
@@ -1,10 +1,13 @@
 # ABOUTME: Item effect system for applying consumable effects to creatures
-# ABOUTME: Handles healing potions, damage items, buffs, condition removal, and spell scrolls
+# ABOUTME: Handles healing potions, damage items, buffs, condition removal, light sources, and spell scrolls
 
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, TYPE_CHECKING
 from dnd_engine.core.dice import DiceRoller
 from dnd_engine.core.creature import Creature
 from dnd_engine.utils.events import Event, EventType, EventBus
+
+if TYPE_CHECKING:
+    from dnd_engine.systems.time_manager import TimeManager
 
 
 class ItemEffectResult:
@@ -28,7 +31,8 @@ def apply_item_effect(
     item_info: Dict[str, Any],
     target: Creature,
     dice_roller: Optional[DiceRoller] = None,
-    event_bus: Optional[EventBus] = None
+    event_bus: Optional[EventBus] = None,
+    time_manager: Optional["TimeManager"] = None
 ) -> ItemEffectResult:
     """
     Apply an item's effect to a target creature.
@@ -38,6 +42,7 @@ def apply_item_effect(
     - damage: Deals damage (e.g., alchemist's fire, acid vial)
     - condition_removal: Removes status conditions (e.g., elixir of health)
     - buff: Adds temporary conditions/effects (e.g., antitoxin, potion of heroism)
+    - light: Provides light for a duration (e.g., torch)
     - spell: Placeholder for spell scrolls (not yet implemented)
 
     Args:
@@ -45,6 +50,7 @@ def apply_item_effect(
         target: Creature to apply the effect to
         dice_roller: DiceRoller instance (creates new one if not provided)
         event_bus: Optional event bus for emitting events
+        time_manager: Optional time manager for creating timed effects (required for light effects)
 
     Returns:
         ItemEffectResult describing what happened
@@ -68,6 +74,8 @@ def apply_item_effect(
         return _apply_condition_removal_effect(item_info, target, event_bus)
     elif effect_type == "buff":
         return _apply_buff_effect(item_info, target, event_bus)
+    elif effect_type == "light":
+        return _apply_light_effect(item_info, target, time_manager, event_bus)
     elif effect_type == "spell":
         return _apply_spell_effect(item_info, target, dice_roller, event_bus)
     else:
@@ -428,4 +436,79 @@ def _apply_spell_effect(
         success=False,
         effect_type="spell",
         message=f"{item_name} cannot be used - spell system not yet implemented (spell: {spell_id})"
+    )
+
+
+def _apply_light_effect(
+    item_info: Dict[str, Any],
+    target: Creature,
+    time_manager: Optional["TimeManager"],
+    event_bus: Optional[EventBus]
+) -> ItemEffectResult:
+    """
+    Apply a light effect that illuminates the area for a duration.
+
+    Creates an ActiveEffect in the time manager that provides light.
+    The get_effective_lighting() method in GameState checks for these effects.
+
+    Args:
+        item_info: Item data containing light configuration
+        target: Creature using the light source (for tracking purposes)
+        time_manager: TimeManager to register the timed effect
+        event_bus: Optional event bus for emitting events
+
+    Returns:
+        ItemEffectResult with light effect details
+    """
+    from dnd_engine.systems.time_manager import ActiveEffect, EffectType
+
+    item_name = item_info.get("name", "Unknown Light Source")
+    duration_minutes = item_info.get("duration_minutes", 60)
+    light_level = item_info.get("light_level", "bright")
+
+    if time_manager is None:
+        return ItemEffectResult(
+            success=False,
+            effect_type="light",
+            message=f"{item_name} cannot be used - time manager not available"
+        )
+
+    # Create an ActiveEffect for the light source
+    light_effect = ActiveEffect(
+        effect_type=EffectType.BUFF,
+        source=item_name,
+        duration_type="minutes",
+        duration_value=duration_minutes,
+        remaining_value=duration_minutes,
+        target_name="party",
+        description=f"{item_name} providing {light_level} light",
+        concentration=False,
+        effect_data={"light_level": light_level}
+    )
+
+    time_manager.add_effect(light_effect)
+
+    # Emit event
+    if event_bus is not None:
+        event = Event(
+            type=EventType.BUFF_APPLIED,
+            data={
+                "target": "party",
+                "item": item_name,
+                "effect": "light",
+                "light_level": light_level,
+                "duration_minutes": duration_minutes
+            }
+        )
+        event_bus.emit(event)
+
+    # Build result message
+    duration_text = f"{duration_minutes} minutes" if duration_minutes < 60 else f"{duration_minutes // 60} hour"
+    message = f"{item_name} lit! Provides {light_level} light for {duration_text}."
+
+    return ItemEffectResult(
+        success=True,
+        effect_type="light",
+        amount=duration_minutes,
+        message=message
     )

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -3452,7 +3452,8 @@ class CLI:
             item_info=item_info,
             target=target,
             dice_roller=self.game_state.dice_roller,
-            event_bus=self.game_state.event_bus
+            event_bus=self.game_state.event_bus,
+            time_manager=self.game_state.time_manager
         )
 
         # Display the result
@@ -3578,7 +3579,8 @@ class CLI:
             item_info=used_item_data,
             target=character,
             dice_roller=self.game_state.dice_roller,
-            event_bus=self.game_state.event_bus
+            event_bus=self.game_state.event_bus,
+            time_manager=self.game_state.time_manager
         )
 
         # Display the result
@@ -3672,7 +3674,8 @@ class CLI:
             item_info=used_item_data,
             target=target,
             dice_roller=self.game_state.dice_roller,
-            event_bus=self.game_state.event_bus
+            event_bus=self.game_state.event_bus,
+            time_manager=self.game_state.time_manager
         )
 
         # Display the result with target information
@@ -3869,7 +3872,8 @@ class CLI:
             item_info=item_data,
             target=character,
             dice_roller=self.game_state.dice_roller,
-            event_bus=self.game_state.event_bus
+            event_bus=self.game_state.event_bus,
+            time_manager=self.game_state.time_manager
         )
 
         # Display the result


### PR DESCRIPTION
## Summary
- Fix questionary Cancel selection returning string instead of None (was causing errors when cancelling unlock method selection)
- Add dark lighting to specimen chamber in poisoned laboratory for light spell testing
- Add torch item with light effect system for illuminating dark rooms
- Update room entrance narrative prompt to avoid describing entrance ways

## Changes
- **Bug fix**: Handle questionary returning "Cancel" string in addition to None
- **Content**: Specimen chamber now has `lighting: "dark"`, changed exits to north/south
- **Feature**: Torch consumable that provides 1 hour of bright light
- **Prompt**: Room entrance narrative no longer assumes door/entrance type

## Test plan
- [x] Existing tests pass
- [ ] Manual test: Cancel unlock method selection (no error)
- [ ] Manual test: Use torch in dark room (provides light)

🤖 Generated with [Claude Code](https://claude.com/claude-code)