### PR TITLE
Add quest items and conditional exits for Phase 1 world system

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -389,6 +389,11 @@ class GameState:
         if self.is_exit_locked(direction):
             return False  # Door is locked
 
+        # Check if exit requirements are met (quest items, etc.)
+        req_check = self.check_exit_requirements(direction)
+        if not req_check["met"]:
+            return False  # Requirements not met
+
         # Track direction for flee mechanic (before moving)
         self.last_entry_direction = direction
 
@@ -495,6 +500,100 @@ class GameState:
             return False
 
         return exit_info.get("locked", False)
+
+    def party_has_quest_item(self, item_id: str) -> bool:
+        """
+        Check if any party member has a specific quest item.
+
+        Args:
+            item_id: The item ID to check for
+
+        Returns:
+            True if any party member has the item
+        """
+        for character in self.party.characters:
+            if character.inventory.has_item(item_id):
+                return True
+        return False
+
+    def check_exit_requirements(self, direction: str) -> dict[str, Any]:
+        """
+        Check if exit requirements are met for a direction.
+
+        Args:
+            direction: Direction to check
+
+        Returns:
+            Dict with:
+            - met: bool - Whether all requirements are met
+            - missing: list - List of unmet requirement descriptions
+        """
+        exit_info = self.get_exit_info(direction)
+        if not exit_info:
+            return {"met": True, "missing": []}
+
+        requires = exit_info.get("requires")
+        if not requires:
+            return {"met": True, "missing": []}
+
+        missing = []
+
+        # Check quest_item requirement
+        if "quest_item" in requires:
+            item_id = requires["quest_item"]
+            if not self.party_has_quest_item(item_id):
+                # Get item name from data loader if available
+                item_name = item_id
+                if self.data_loader:
+                    items_data = self.data_loader.load_items()
+                    for category in items_data.values():
+                        if item_id in category:
+                            item_name = category[item_id].get("name", item_id)
+                            break
+                missing.append(f"Requires: {item_name}")
+
+        return {"met": len(missing) == 0, "missing": missing}
+
+    def is_exit_hidden(self, direction: str) -> bool:
+        """
+        Check if an exit should be hidden (requirements not met + hidden_until_unlocked).
+
+        Args:
+            direction: Direction to check
+
+        Returns:
+            True if exit should be hidden from player
+        """
+        exit_info = self.get_exit_info(direction)
+        if not exit_info:
+            return False
+
+        # If not marked as hidden_until_unlocked, always show
+        if not exit_info.get("hidden_until_unlocked", False):
+            return False
+
+        # Check if requirements are met
+        req_check = self.check_exit_requirements(direction)
+        return not req_check["met"]
+
+    def get_available_exits(self) -> dict[str, Any]:
+        """
+        Get exits that should be shown to the player.
+
+        Filters out exits that are hidden due to unmet requirements.
+
+        Returns:
+            Dict of direction -> exit info for visible exits
+        """
+        current_room = self.get_current_room()
+        all_exits = current_room.get("exits", {})
+
+        visible_exits = {}
+        for direction, exit_info in all_exits.items():
+            if not self.is_exit_hidden(direction):
+                visible_exits[direction] = exit_info
+
+        return visible_exits
 
     def get_unlock_methods(self, direction: str) -> list[dict[str, Any]]:
         """

--- a/dnd_engine/data/content/dungeons/town_of_arden.json
+++ b/dnd_engine/data/content/dungeons/town_of_arden.json
@@ -174,7 +174,15 @@
       "description": "The cobblestones give way to packed dirt as you enter the oldest part of Arden. Here the buildings lean together like drunken conspirators, their upper stories nearly touching across narrow lanes that twist without logic. This is the Warrens - home to those who cannot afford better and those who prefer not to be found. The town guard rarely patrols these streets after dark, and the locals eye strangers with a mixture of suspicion and calculation. Faded signs mark establishments of dubious reputation: a pawnbroker who asks no questions, a fortune teller whose predictions are said to be unsettlingly accurate, a nameless tavern where the ale is cheap and the clientele cheaper. Somewhere in this maze of alleys and abandoned warehouses, darker things stir - though whether the rumors of hooded figures and strange symbols are truth or tavern tales, none can say for certain.",
       "lighting": "dim",
       "exits": {
-        "west": "arden.town_road"
+        "west": "arden.town_road",
+        "down": {
+          "destination": "cult_hideout.entrance",
+          "label": "Hidden Cellar Door",
+          "requires": {
+            "quest_item": "gorgus_journal"
+          },
+          "hidden_until_unlocked": true
+        }
       },
       "enemies": [],
       "items": [],

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -103,7 +103,7 @@ class CLI:
         # Extract room name and basic description
         room_name = room.get("name", "Unknown Room")
         basic_desc = room.get("description", self.game_state.get_room_description())
-        exits = room.get("exits", [])
+        exits = self.game_state.get_available_exits()
 
         # Check for monsters in the room
         enemy_ids = room.get("enemies", [])
@@ -890,11 +890,13 @@ class CLI:
     def handle_move(self, direction: str) -> None:
         """Handle movement command."""
         if not direction:
-            # Show available exits
-            room = self.game_state.get_current_room()
-            exits = room.get("exits", [])
+            # Show available exits (filtered by requirements)
+            exits = self.game_state.get_available_exits()
             if exits:
-                print_status_message(f"Specify a direction. Available exits: {', '.join(exits)}", "warning")
+                print_status_message(
+                    f"Specify a direction. Available exits: {', '.join(exits)}",
+                    "warning"
+                )
             else:
                 print_status_message("No exits available from this room.", "warning")
             return
@@ -902,6 +904,13 @@ class CLI:
         # Check if exit is locked before attempting move
         if self.game_state.is_exit_locked(direction):
             self.handle_unlock(direction)
+            return
+
+        # Check if exit requirements are met (quest items, etc.)
+        req_check = self.game_state.check_exit_requirements(direction)
+        if not req_check["met"]:
+            for reason in req_check["missing"]:
+                print_error(reason)
             return
 
         # Move without checking for enemies yet
@@ -917,10 +926,12 @@ class CLI:
                 print_error("You cannot move during combat!")
             else:
                 # Show available exits when movement fails
-                room = self.game_state.get_current_room()
-                exits = room.get("exits", [])
+                exits = self.game_state.get_available_exits()
                 if exits:
-                    print_error(f"You cannot go {direction} from here. Available exits: {', '.join(exits)}")
+                    print_error(
+                        f"You cannot go {direction} from here. "
+                        f"Available exits: {', '.join(exits)}"
+                    )
                 else:
                     print_error("No exits available from this room.")
 
@@ -3317,11 +3328,13 @@ class CLI:
                         item_data = items_data[category].get(inv_item.item_id, {})
                         item_name = item_data.get("name", inv_item.item_id)
                         is_equipped = (inv_item.item_id == weapon_id or inv_item.item_id == armor_id)
+                        is_quest_item = item_data.get("quest_item", False)
 
                         inventory_items[category].append({
                             "name": item_name,
                             "quantity": inv_item.quantity,
-                            "equipped": is_equipped
+                            "equipped": is_equipped,
+                            "quest_item": is_quest_item
                         })
 
             # Display character title with player number

--- a/dnd_engine/ui/rich_ui.py
+++ b/dnd_engine/ui/rich_ui.py
@@ -163,7 +163,7 @@ def create_inventory_table(items: dict[str, list[dict[str, Any]]]) -> Table:
 
     Args:
         items: Dict with categories (weapons, armor, consumables)
-               Each category has list of {name, quantity, equipped}
+               Each category has list of {name, quantity, equipped, quest_item}
 
     Returns:
         Formatted Rich Table
@@ -177,8 +177,11 @@ def create_inventory_table(items: dict[str, list[dict[str, Any]]]) -> Table:
     for category, item_list in items.items():
         for item in item_list:
             status = "[bold yellow]⚔ EQUIPPED[/bold yellow]" if item.get("equipped") else "—"
+            item_name = item.get("name", "Unknown")
+            if item.get("quest_item"):
+                item_name = f"[bold cyan]★[/bold cyan] {item_name}"
             table.add_row(
-                item.get("name", "Unknown"),
+                item_name,
                 category.capitalize(),
                 str(item.get("quantity", 1)),
                 status

--- a/tests/test_quest_items.py
+++ b/tests/test_quest_items.py
@@ -1,0 +1,315 @@
+# ABOUTME: Tests for quest item functionality including display markers and behavior.
+# ABOUTME: Verifies quest items show star marker in inventory and conditional exits work.
+
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.ui.rich_ui import create_inventory_table
+from dnd_engine.utils.events import EventBus
+
+
+class TestQuestItemDisplay:
+    """Test that quest items display with the star marker."""
+
+    def test_quest_item_shows_star_marker(self):
+        """Quest items should display with a cyan star prefix."""
+        items = {
+            "consumables": [
+                {
+                    "name": "Cultist's Journal",
+                    "quantity": 1,
+                    "equipped": False,
+                    "quest_item": True
+                }
+            ]
+        }
+        table = create_inventory_table(items)
+        # Render the table to string to check contents
+        console = Console(file=StringIO(), force_terminal=True)
+        console.print(table)
+        output = console.file.getvalue()
+
+        # Should contain the star marker
+        assert "★" in output
+        assert "Cultist's Journal" in output
+
+    def test_regular_item_no_star_marker(self):
+        """Regular items should not have the star marker."""
+        items = {
+            "consumables": [
+                {
+                    "name": "Potion of Healing",
+                    "quantity": 1,
+                    "equipped": False,
+                    "quest_item": False
+                }
+            ]
+        }
+        table = create_inventory_table(items)
+        console = Console(file=StringIO(), force_terminal=True)
+        console.print(table)
+        output = console.file.getvalue()
+
+        # Should NOT contain the star marker
+        assert "★" not in output
+        assert "Potion of Healing" in output
+
+    def test_mixed_items_only_quest_has_star(self):
+        """Only quest items should have the star marker in mixed inventory."""
+        items = {
+            "consumables": [
+                {
+                    "name": "Potion of Healing",
+                    "quantity": 2,
+                    "equipped": False,
+                    "quest_item": False
+                },
+                {
+                    "name": "Cultist's Journal",
+                    "quantity": 1,
+                    "equipped": False,
+                    "quest_item": True
+                }
+            ],
+            "weapons": [
+                {
+                    "name": "Longsword",
+                    "quantity": 1,
+                    "equipped": True,
+                    "quest_item": False
+                }
+            ]
+        }
+        table = create_inventory_table(items)
+        console = Console(file=StringIO(), force_terminal=True)
+        console.print(table)
+        output = console.file.getvalue()
+
+        # Star should appear only once (for the journal)
+        assert output.count("★") == 1
+        assert "Cultist's Journal" in output
+        assert "Potion of Healing" in output
+        assert "Longsword" in output
+
+    def test_quest_item_without_flag_defaults_to_no_star(self):
+        """Items without quest_item field should default to no star."""
+        items = {
+            "consumables": [
+                {
+                    "name": "Mystery Item",
+                    "quantity": 1,
+                    "equipped": False
+                    # No quest_item field
+                }
+            ]
+        }
+        table = create_inventory_table(items)
+        console = Console(file=StringIO(), force_terminal=True)
+        console.print(table)
+        output = console.file.getvalue()
+
+        assert "★" not in output
+        assert "Mystery Item" in output
+
+
+@pytest.fixture
+def test_party():
+    """Create a simple test party."""
+    abilities = Abilities(
+        strength=10,
+        dexterity=14,
+        constitution=14,
+        intelligence=10,
+        wisdom=12,
+        charisma=10
+    )
+    character = Character(
+        name="Test Hero",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=abilities,
+        max_hp=12,
+        ac=16
+    )
+    return Party([character])
+
+
+class TestConditionalExits:
+    """Test conditional exit requirements based on quest items."""
+
+    def test_party_has_quest_item_when_present(self, test_party):
+        """Party should report having an item when a character has it."""
+        event_bus = EventBus()
+        data_loader = DataLoader()
+
+        game_state = GameState(
+            party=test_party,
+            dungeon_name="town_of_arden",
+            event_bus=event_bus,
+            data_loader=data_loader
+        )
+
+        # Add quest item to character's inventory
+        test_party.characters[0].inventory.add_item("gorgus_journal", "consumables")
+
+        assert game_state.party_has_quest_item("gorgus_journal") is True
+
+    def test_party_has_quest_item_when_absent(self, test_party):
+        """Party should report not having an item when no one has it."""
+        event_bus = EventBus()
+        data_loader = DataLoader()
+
+        game_state = GameState(
+            party=test_party,
+            dungeon_name="town_of_arden",
+            event_bus=event_bus,
+            data_loader=data_loader
+        )
+
+        assert game_state.party_has_quest_item("gorgus_journal") is False
+
+    def test_exit_requirements_met_with_quest_item(self, test_party):
+        """Exit requirements should be met when party has required item."""
+        event_bus = EventBus()
+        data_loader = DataLoader()
+
+        game_state = GameState(
+            party=test_party,
+            dungeon_name="town_of_arden",
+            event_bus=event_bus,
+            data_loader=data_loader
+        )
+
+        # Manually set up a room with conditional exit for testing
+        game_state.dungeon["rooms"]["test_room"] = {
+            "id": "test_room",
+            "name": "Test Room",
+            "description": "A test room",
+            "exits": {
+                "north": {
+                    "destination": "other_room",
+                    "requires": {"quest_item": "gorgus_journal"}
+                }
+            }
+        }
+        game_state.current_room_id = "test_room"
+
+        # Without the item, requirements not met
+        req_check = game_state.check_exit_requirements("north")
+        assert req_check["met"] is False
+        assert len(req_check["missing"]) > 0
+
+        # Add the item
+        test_party.characters[0].inventory.add_item("gorgus_journal", "consumables")
+
+        # With the item, requirements met
+        req_check = game_state.check_exit_requirements("north")
+        assert req_check["met"] is True
+        assert len(req_check["missing"]) == 0
+
+    def test_exit_hidden_until_unlocked(self, test_party):
+        """Exits marked hidden_until_unlocked should not appear without item."""
+        event_bus = EventBus()
+        data_loader = DataLoader()
+
+        game_state = GameState(
+            party=test_party,
+            dungeon_name="town_of_arden",
+            event_bus=event_bus,
+            data_loader=data_loader
+        )
+
+        # Set up room with hidden conditional exit
+        game_state.dungeon["rooms"]["test_room"] = {
+            "id": "test_room",
+            "name": "Test Room",
+            "description": "A test room",
+            "exits": {
+                "west": "normal_room",
+                "down": {
+                    "destination": "secret_room",
+                    "requires": {"quest_item": "gorgus_journal"},
+                    "hidden_until_unlocked": True
+                }
+            }
+        }
+        game_state.current_room_id = "test_room"
+
+        # Without item, hidden exit should not be in available exits
+        available = game_state.get_available_exits()
+        assert "west" in available
+        assert "down" not in available
+
+        # Add the item
+        test_party.characters[0].inventory.add_item("gorgus_journal", "consumables")
+
+        # With item, hidden exit should now be visible
+        available = game_state.get_available_exits()
+        assert "west" in available
+        assert "down" in available
+
+    def test_exit_without_requirements_always_available(self, test_party):
+        """Exits without requires field should always be available."""
+        event_bus = EventBus()
+        data_loader = DataLoader()
+
+        game_state = GameState(
+            party=test_party,
+            dungeon_name="town_of_arden",
+            event_bus=event_bus,
+            data_loader=data_loader
+        )
+
+        # Check a normal exit (town square has multiple exits without requirements)
+        game_state.current_room_id = "arden.town_square"
+        req_check = game_state.check_exit_requirements("north")
+        assert req_check["met"] is True
+
+    def test_move_blocked_without_required_item(self, test_party):
+        """Movement should fail when exit requirements not met."""
+        event_bus = EventBus()
+        data_loader = DataLoader()
+
+        game_state = GameState(
+            party=test_party,
+            dungeon_name="town_of_arden",
+            event_bus=event_bus,
+            data_loader=data_loader
+        )
+
+        # Set up room with conditional exit
+        game_state.dungeon["rooms"]["test_room"] = {
+            "id": "test_room",
+            "name": "Test Room",
+            "description": "A test room",
+            "exits": {
+                "north": {
+                    "destination": "arden.town_square",
+                    "requires": {"quest_item": "gorgus_journal"}
+                }
+            }
+        }
+        game_state.dungeon["rooms"]["arden.town_square"] = game_state.dungeon["rooms"].get(
+            "arden.town_square", {"id": "arden.town_square", "name": "Town Square"}
+        )
+        game_state.current_room_id = "test_room"
+
+        # Without item, move should fail
+        success = game_state.move("north", check_for_enemies=False)
+        assert success is False
+        assert game_state.current_room_id == "test_room"
+
+        # Add the item
+        test_party.characters[0].inventory.add_item("gorgus_journal", "consumables")
+
+        # With item, move should succeed
+        success = game_state.move("north", check_for_enemies=False)
+        assert success is True
+        assert game_state.current_room_id == "arden.town_square"


### PR DESCRIPTION
## Summary
- Add quest item marker (★) in inventory display for items with `quest_item: true`
- Implement conditional exits with `requires` field for quest item checks
- Add `hidden_until_unlocked` support to hide exits until requirements are met
- Add Warrens → Cult Hideout conditional exit (requires gorgus_journal)

## Changes
- **game_state.py**: Add `party_has_quest_item`, `check_exit_requirements`, `is_exit_hidden`, `get_available_exits` methods
- **cli.py**: Use `get_available_exits()` for exit display, show requirement errors on blocked movement
- **rich_ui.py**: Add ★ marker prefix for quest items in inventory table
- **town_of_arden.json**: Add hidden conditional exit from Warrens to Cult Hideout

## Test plan
- [x] Quest item marker displays correctly (★ Cultist's Journal)
- [x] Regular items don't show marker
- [x] Hidden exit not visible without required item (Warrens only shows "west")
- [x] Hidden exit becomes visible with item (Warrens shows "west, down")
- [x] Movement blocked without required quest item
- [x] Movement allowed with required quest item
- [x] 10 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)