### PR TITLE
Add campaign progression system with dungeon unlock tracking

### DIFF
--- a/dnd_engine/core/campaign_progress.py
+++ b/dnd_engine/core/campaign_progress.py
@@ -1,0 +1,392 @@
+# ABOUTME: Campaign progression tracker for multi-dungeon campaigns
+# ABOUTME: Loads campaign definitions, tracks dungeon completion, and handles unlock logic
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DungeonDefinition:
+    """Definition of a dungeon within a campaign."""
+
+    id: str
+    name: str
+    order: int
+    unlocked_by_default: bool
+    boss_defeated_required: bool
+    required_quest_items: list[str]
+    unlocks: list[str]
+    final_dungeon: bool = False
+
+
+@dataclass
+class CampaignDefinition:
+    """
+    Static campaign definition loaded from JSON.
+
+    Defines the structure of a campaign: which dungeons it contains,
+    their order, and unlock requirements.
+    """
+
+    id: str
+    name: str
+    description: str
+    level_range: str
+    estimated_playtime: str
+    starting_room: str
+    dungeons: dict[str, DungeonDefinition]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "CampaignDefinition":
+        """Load campaign definition from dictionary."""
+        dungeons = {}
+        for dungeon_id, dungeon_data in data.get("dungeons", {}).items():
+            completion = dungeon_data.get("completion_criteria", {})
+            dungeons[dungeon_id] = DungeonDefinition(
+                id=dungeon_id,
+                name=dungeon_data.get("name", dungeon_id),
+                order=dungeon_data.get("order", 0),
+                unlocked_by_default=dungeon_data.get("unlocked_by_default", False),
+                boss_defeated_required=completion.get("boss_defeated", False),
+                required_quest_items=completion.get("required_quest_items", []),
+                unlocks=dungeon_data.get("unlocks", []),
+                final_dungeon=dungeon_data.get("final_dungeon", False),
+            )
+
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            description=data.get("description", ""),
+            level_range=data.get("level_range", "1-20"),
+            estimated_playtime=data.get("estimated_playtime", "Unknown"),
+            starting_room=data.get("starting_room", ""),
+            dungeons=dungeons,
+        )
+
+
+@dataclass
+class CampaignProgress:
+    """
+    Player's progress through a campaign.
+
+    Stored in save files, tracks which dungeons have been completed
+    and which are currently unlocked.
+    """
+
+    campaign_id: str
+    completed_dungeons: list[str] = field(default_factory=list)
+    unlocked_dungeons: list[str] = field(default_factory=list)
+    boss_defeats: dict[str, bool] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize progress to dictionary for save files."""
+        return {
+            "campaign_id": self.campaign_id,
+            "completed_dungeons": self.completed_dungeons,
+            "unlocked_dungeons": self.unlocked_dungeons,
+            "boss_defeats": self.boss_defeats,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "CampaignProgress":
+        """Load progress from save file dictionary."""
+        return cls(
+            campaign_id=data.get("campaign_id", ""),
+            completed_dungeons=data.get("completed_dungeons", []),
+            unlocked_dungeons=data.get("unlocked_dungeons", []),
+            boss_defeats=data.get("boss_defeats", {}),
+        )
+
+
+class CampaignProgressTracker:
+    """
+    Manages campaign progression for multi-dungeon campaigns.
+
+    Responsibilities:
+    - Load campaign definitions from JSON files
+    - Track which dungeons are completed/unlocked
+    - Detect dungeon completion (boss defeated + quest items)
+    - Handle unlock logic when dungeons are completed
+    """
+
+    def __init__(self, campaigns_dir: Path | None = None):
+        """
+        Initialize campaign progress tracker.
+
+        Args:
+            campaigns_dir: Directory containing campaign JSON files.
+                          Defaults to dnd_engine/data/content/campaigns/
+        """
+        if campaigns_dir is None:
+            campaigns_dir = (
+                Path(__file__).parent.parent / "data" / "content" / "campaigns"
+            )
+        self.campaigns_dir = Path(campaigns_dir)
+        self._definitions: dict[str, CampaignDefinition] = {}
+
+    def load_campaign_definition(self, campaign_id: str) -> CampaignDefinition | None:
+        """
+        Load a campaign definition by ID.
+
+        Args:
+            campaign_id: Campaign identifier (e.g., "the_unquiet_dead")
+
+        Returns:
+            CampaignDefinition or None if not found
+        """
+        if campaign_id in self._definitions:
+            return self._definitions[campaign_id]
+
+        campaign_file = self.campaigns_dir / f"{campaign_id}.json"
+        if not campaign_file.exists():
+            logger.warning(f"Campaign definition not found: {campaign_file}")
+            return None
+
+        try:
+            with open(campaign_file, encoding="utf-8") as f:
+                data = json.load(f)
+            definition = CampaignDefinition.from_dict(data)
+            self._definitions[campaign_id] = definition
+            return definition
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.error(f"Error loading campaign {campaign_id}: {e}")
+            return None
+
+    def list_available_campaigns(self) -> list[CampaignDefinition]:
+        """
+        List all available campaign definitions.
+
+        Returns:
+            List of CampaignDefinition objects
+        """
+        campaigns = []
+        if not self.campaigns_dir.exists():
+            return campaigns
+
+        for campaign_file in self.campaigns_dir.glob("*.json"):
+            campaign_id = campaign_file.stem
+            definition = self.load_campaign_definition(campaign_id)
+            if definition:
+                campaigns.append(definition)
+
+        return sorted(campaigns, key=lambda c: c.name)
+
+    def create_initial_progress(self, campaign_id: str) -> CampaignProgress | None:
+        """
+        Create initial progress for a new campaign playthrough.
+
+        Args:
+            campaign_id: Campaign to start
+
+        Returns:
+            CampaignProgress with default-unlocked dungeons, or None if invalid
+        """
+        definition = self.load_campaign_definition(campaign_id)
+        if not definition:
+            return None
+
+        unlocked = [
+            dungeon_id
+            for dungeon_id, dungeon in definition.dungeons.items()
+            if dungeon.unlocked_by_default
+        ]
+
+        return CampaignProgress(
+            campaign_id=campaign_id,
+            completed_dungeons=[],
+            unlocked_dungeons=unlocked,
+            boss_defeats={},
+        )
+
+    def is_dungeon_unlocked(
+        self, progress: CampaignProgress, dungeon_id: str
+    ) -> bool:
+        """
+        Check if a dungeon is unlocked for play.
+
+        Args:
+            progress: Current campaign progress
+            dungeon_id: Dungeon to check
+
+        Returns:
+            True if dungeon is unlocked
+        """
+        return dungeon_id in progress.unlocked_dungeons
+
+    def is_dungeon_completed(
+        self, progress: CampaignProgress, dungeon_id: str
+    ) -> bool:
+        """
+        Check if a dungeon has been completed.
+
+        Args:
+            progress: Current campaign progress
+            dungeon_id: Dungeon to check
+
+        Returns:
+            True if dungeon is completed
+        """
+        return dungeon_id in progress.completed_dungeons
+
+    def get_dungeon_state(
+        self, progress: CampaignProgress, dungeon_id: str
+    ) -> str:
+        """
+        Get the state of a dungeon for UI display.
+
+        Args:
+            progress: Current campaign progress
+            dungeon_id: Dungeon to check
+
+        Returns:
+            "completed", "unlocked", or "locked"
+        """
+        if self.is_dungeon_completed(progress, dungeon_id):
+            return "completed"
+        elif self.is_dungeon_unlocked(progress, dungeon_id):
+            return "unlocked"
+        else:
+            return "locked"
+
+    def check_dungeon_completion(
+        self,
+        progress: CampaignProgress,
+        dungeon_id: str,
+        boss_defeated: bool,
+        inventory_item_ids: list[str],
+    ) -> bool:
+        """
+        Check if a dungeon's completion criteria are met.
+
+        Args:
+            progress: Current campaign progress
+            dungeon_id: Dungeon to check
+            boss_defeated: Whether the boss has been defeated
+            inventory_item_ids: List of item IDs in party inventory
+
+        Returns:
+            True if all completion criteria are met
+        """
+        definition = self.load_campaign_definition(progress.campaign_id)
+        if not definition or dungeon_id not in definition.dungeons:
+            return False
+
+        dungeon = definition.dungeons[dungeon_id]
+
+        # Check boss defeat requirement
+        if dungeon.boss_defeated_required and not boss_defeated:
+            return False
+
+        # Check quest item requirements
+        for item_id in dungeon.required_quest_items:
+            if item_id not in inventory_item_ids:
+                return False
+
+        return True
+
+    def record_boss_defeat(
+        self, progress: CampaignProgress, dungeon_id: str
+    ) -> None:
+        """
+        Record that a boss has been defeated in a dungeon.
+
+        Args:
+            progress: Campaign progress to update
+            dungeon_id: Dungeon where boss was defeated
+        """
+        progress.boss_defeats[dungeon_id] = True
+
+    def complete_dungeon(
+        self,
+        progress: CampaignProgress,
+        dungeon_id: str,
+        inventory_item_ids: list[str],
+    ) -> list[str]:
+        """
+        Mark a dungeon as completed and unlock subsequent dungeons.
+
+        Args:
+            progress: Campaign progress to update
+            dungeon_id: Dungeon that was completed
+            inventory_item_ids: Items in party inventory (for criteria check)
+
+        Returns:
+            List of newly unlocked dungeon IDs
+        """
+        definition = self.load_campaign_definition(progress.campaign_id)
+        if not definition or dungeon_id not in definition.dungeons:
+            return []
+
+        # Check if already completed
+        if dungeon_id in progress.completed_dungeons:
+            return []
+
+        # Verify completion criteria
+        boss_defeated = progress.boss_defeats.get(dungeon_id, False)
+        if not self.check_dungeon_completion(
+            progress, dungeon_id, boss_defeated, inventory_item_ids
+        ):
+            return []
+
+        # Mark as completed
+        progress.completed_dungeons.append(dungeon_id)
+
+        # Unlock subsequent dungeons
+        dungeon = definition.dungeons[dungeon_id]
+        newly_unlocked = []
+
+        for unlock_id in dungeon.unlocks:
+            if unlock_id not in progress.unlocked_dungeons:
+                progress.unlocked_dungeons.append(unlock_id)
+                newly_unlocked.append(unlock_id)
+                logger.info(f"Unlocked dungeon: {unlock_id}")
+
+        return newly_unlocked
+
+    def is_campaign_complete(self, progress: CampaignProgress) -> bool:
+        """
+        Check if the entire campaign has been completed.
+
+        Args:
+            progress: Campaign progress to check
+
+        Returns:
+            True if the final dungeon has been completed
+        """
+        definition = self.load_campaign_definition(progress.campaign_id)
+        if not definition:
+            return False
+
+        for dungeon_id, dungeon in definition.dungeons.items():
+            if dungeon.final_dungeon:
+                return dungeon_id in progress.completed_dungeons
+
+        # No final dungeon defined - check if all dungeons completed
+        return all(
+            d_id in progress.completed_dungeons for d_id in definition.dungeons
+        )
+
+    def get_ordered_dungeons(
+        self, campaign_id: str
+    ) -> list[tuple[str, DungeonDefinition]]:
+        """
+        Get dungeons in order for UI display.
+
+        Args:
+            campaign_id: Campaign to get dungeons for
+
+        Returns:
+            List of (dungeon_id, DungeonDefinition) tuples sorted by order
+        """
+        definition = self.load_campaign_definition(campaign_id)
+        if not definition:
+            return []
+
+        return sorted(
+            definition.dungeons.items(), key=lambda x: x[1].order
+        )

--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+from dnd_engine.core.campaign_progress import CampaignProgress
 from dnd_engine.core.character import Character
 from dnd_engine.core.combat import AttackResult, CombatEngine
 from dnd_engine.core.creature import Creature
@@ -168,7 +169,8 @@ class GameState:
         event_bus: EventBus | None = None,
         data_loader: DataLoader | None = None,
         dice_roller: DiceRoller | None = None,
-        campaign_id: str | None = None
+        campaign_id: str | None = None,
+        campaign_progress: CampaignProgress | None = None
     ):
         """
         Initialize the game state.
@@ -180,6 +182,7 @@ class GameState:
             data_loader: Data loader for loading content (creates new if not provided)
             dice_roller: Dice roller (creates new if not provided)
             campaign_id: Optional campaign ID for quest tracking (e.g., "the_unquiet_dead")
+            campaign_progress: Optional campaign progress for multi-dungeon campaigns
         """
         self.party = party
         self.event_bus = event_bus or EventBus()
@@ -196,6 +199,9 @@ class GameState:
         if campaign_id is None:
             campaign_id = self.dungeon.get("campaign_id")
         self.campaign_id = campaign_id
+
+        # Campaign progress for multi-dungeon campaigns
+        self.campaign_progress = campaign_progress
 
         # Room registry for cross-dungeon navigation
         # May be None if data_path is unavailable (e.g., in tests with mocked loaders)

--- a/dnd_engine/core/save_slot_manager.py
+++ b/dnd_engine/core/save_slot_manager.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from dnd_engine.core.campaign_progress import CampaignProgress
 from dnd_engine.core.character import Character, CharacterClass
 from dnd_engine.core.creature import Abilities
 from dnd_engine.core.dice import DiceRoller
@@ -147,7 +148,8 @@ class SaveSlotManager:
         self,
         slot_number: int,
         game_state: GameState,
-        playtime_delta: int = 0
+        playtime_delta: int = 0,
+        campaign_progress: CampaignProgress | None = None
     ) -> Path:
         """
         Save game state to a specific slot.
@@ -156,6 +158,7 @@ class SaveSlotManager:
             slot_number: Slot number (1-10)
             game_state: Current game state to save
             playtime_delta: Seconds to add to playtime (for this session)
+            campaign_progress: Optional campaign progress for multi-dungeon campaigns
 
         Returns:
             Path to the saved file
@@ -188,7 +191,7 @@ class SaveSlotManager:
         slot.party_levels = [char.level for char in game_state.party.characters]
 
         # Save to file
-        return self._save_slot_file(slot_number, slot, game_state)
+        return self._save_slot_file(slot_number, slot, game_state, campaign_progress)
 
     def load_game(
         self,
@@ -196,7 +199,7 @@ class SaveSlotManager:
         event_bus: EventBus | None = None,
         data_loader: DataLoader | None = None,
         dice_roller: DiceRoller | None = None
-    ) -> GameState:
+    ) -> tuple[GameState, CampaignProgress | None]:
         """
         Load game state from a specific slot.
 
@@ -207,7 +210,7 @@ class SaveSlotManager:
             dice_roller: Dice roller (creates new if not provided)
 
         Returns:
-            Loaded GameState
+            Tuple of (GameState, CampaignProgress or None)
 
         Raises:
             ValueError: If slot number is out of range or slot is empty
@@ -249,12 +252,17 @@ class SaveSlotManager:
             dice_roller
         )
 
+        # Deserialize campaign progress if present
+        campaign_progress = None
+        if "campaign_progress" in slot_data:
+            campaign_progress = CampaignProgress.from_dict(slot_data["campaign_progress"])
+
         # Update last_played timestamp
         slot_data["metadata"]["last_played"] = datetime.now().isoformat()
         with open(slot_path, 'w', encoding='utf-8') as f:
             json.dump(slot_data, f, indent=2, ensure_ascii=False)
 
-        return game_state
+        return game_state, campaign_progress
 
     def clear_slot(self, slot_number: int) -> None:
         """
@@ -298,7 +306,8 @@ class SaveSlotManager:
         self,
         slot_number: int,
         slot: SaveSlot,
-        game_state: GameState | None
+        game_state: GameState | None,
+        campaign_progress: CampaignProgress | None = None
     ) -> Path:
         """
         Save slot data and game state to disk.
@@ -307,6 +316,7 @@ class SaveSlotManager:
             slot_number: Slot number (1-10)
             slot: SaveSlot metadata
             game_state: Optional game state (None for empty slots)
+            campaign_progress: Optional campaign progress for multi-dungeon campaigns
 
         Returns:
             Path to the saved file
@@ -334,6 +344,9 @@ class SaveSlotManager:
                 "action_history": game_state.action_history,
                 "last_entry_direction": game_state.last_entry_direction
             }
+            # Include campaign progress if present
+            if campaign_progress:
+                slot_data["campaign_progress"] = campaign_progress.to_dict()
         else:
             # Empty slot
             slot_data["party"] = []

--- a/dnd_engine/data/content/campaigns/poisoned_laboratory.json
+++ b/dnd_engine/data/content/campaigns/poisoned_laboratory.json
@@ -3,8 +3,18 @@
   "name": "The Poisoned Laboratory",
   "description": "A standalone adventure in an abandoned alchemist's workshop filled with dangerous fumes, volatile chemicals, and failed experiments.",
   "level_range": "1",
-  "starting_dungeon": "poisoned_laboratory",
-  "dungeons": [
-    "poisoned_laboratory"
-  ]
+  "estimated_playtime": "1 hour",
+  "starting_room": "poisoned_laboratory.entrance",
+  "dungeons": {
+    "poisoned_laboratory": {
+      "name": "The Poisoned Laboratory",
+      "order": 1,
+      "unlocked_by_default": true,
+      "completion_criteria": {
+        "boss_defeated": true
+      },
+      "unlocks": [],
+      "final_dungeon": true
+    }
+  }
 }

--- a/dnd_engine/data/content/campaigns/the_unquiet_dead.json
+++ b/dnd_engine/data/content/campaigns/the_unquiet_dead.json
@@ -1,11 +1,40 @@
 {
   "id": "the_unquiet_dead",
   "name": "The Unquiet Dead",
-  "description": "A three-part campaign investigating a cult's plot to summon a devil. Begin in the Town of Arden, explore the Davos Family Crypt, and uncover the dark conspiracy that threatens the realm.",
+  "description": "A three-part campaign investigating a cult's plot to summon the devil Durgon. The skeletons of the Davos family have begun to rise from their ancient crypt, and strange figures have been seen skulking in the dark.",
   "level_range": "1-3",
-  "starting_dungeon": "town_of_arden",
-  "dungeons": [
-    "town_of_arden",
-    "the_unquiet_dead_crypt"
-  ]
+  "estimated_playtime": "2-3 hours",
+  "starting_room": "arden.town_square",
+  "dungeons": {
+    "the_unquiet_dead_crypt": {
+      "name": "Davos Family Crypt",
+      "order": 1,
+      "unlocked_by_default": true,
+      "completion_criteria": {
+        "boss_defeated": true,
+        "required_quest_items": ["gorgus_journal"]
+      },
+      "unlocks": ["cult_hideout"]
+    },
+    "cult_hideout": {
+      "name": "Cult Hideout",
+      "order": 2,
+      "unlocked_by_default": false,
+      "completion_criteria": {
+        "boss_defeated": true,
+        "required_quest_items": ["cult_map"]
+      },
+      "unlocks": ["temple_of_durgon"]
+    },
+    "temple_of_durgon": {
+      "name": "Temple of Durgon",
+      "order": 3,
+      "unlocked_by_default": false,
+      "completion_criteria": {
+        "boss_defeated": true
+      },
+      "unlocks": [],
+      "final_dungeon": true
+    }
+  }
 }

--- a/dnd_engine/ui/main_menu_v2.py
+++ b/dnd_engine/ui/main_menu_v2.py
@@ -1,17 +1,17 @@
 # ABOUTME: Main menu system with new save slot system and migration support
 # ABOUTME: Handles menu display, save slot selection, character vault integration, and migration
 
-from pathlib import Path
-
 import questionary
 from rich.panel import Panel
 
+from dnd_engine.core.campaign_progress import CampaignProgressTracker
 from dnd_engine.core.character import Character
 from dnd_engine.core.character_factory import CharacterFactory
 from dnd_engine.core.character_vault_v2 import CharacterVaultV2
 from dnd_engine.core.game_state import GameState
 from dnd_engine.core.migration import MigrationManager
 from dnd_engine.core.party import Party
+from dnd_engine.core.room_registry import RoomRegistry
 from dnd_engine.core.save_slot_manager import SaveSlotManager
 from dnd_engine.rules.loader import DataLoader
 from dnd_engine.ui.rich_ui import (
@@ -45,6 +45,7 @@ class MainMenuV2:
         self.slot_manager = SaveSlotManager()
         self.vault = CharacterVaultV2()
         self.data_loader = DataLoader()
+        self.campaign_tracker = CampaignProgressTracker()
 
         # Track current slot for save operations
         self.current_slot_number: int | None = None
@@ -224,8 +225,12 @@ class MainMenuV2:
                 print_error(f"Slot {slot_num} is empty.")
                 return None
 
-            # Load game state
-            game_state = self.slot_manager.load_game(slot_num)
+            # Load game state - returns tuple of (game_state, campaign_progress)
+            game_state, campaign_progress = self.slot_manager.load_game(slot_num)
+
+            # Store campaign progress on game_state if available
+            if campaign_progress:
+                game_state.campaign_progress = campaign_progress
 
             print_status_message(f"Loaded: {slot.get_display_name()}", "success")
 
@@ -297,20 +302,37 @@ class MainMenuV2:
                     console.print("\n[yellow]Cancelled.[/yellow]")
                     return None
 
-            # Step 4: Create game state
+            # Step 4: Create game state with campaign progress
             party = Party(party_characters)
+            campaign_progress = campaign_info.get("campaign_progress")
+
+            # Use room registry to find the dungeon containing the starting room
+            starting_room = campaign_info["starting_room"]
+            dungeons_path = self.data_loader.data_path / "content" / "dungeons"
+            room_registry = RoomRegistry(dungeons_path)
+            starting_dungeon = room_registry.get_dungeon_for_room(starting_room)
+
+            if not starting_dungeon:
+                print_error(f"Could not find dungeon for room: {starting_room}")
+                return None
+
             game_state = GameState(
                 party=party,
-                dungeon_name=campaign_info["starting_dungeon"],
+                dungeon_name=starting_dungeon,
                 campaign_id=campaign_info["campaign_id"],
-                data_loader=self.data_loader
+                data_loader=self.data_loader,
+                campaign_progress=campaign_progress
             )
 
-            # Step 5: Save to slot
+            # Override to start at the campaign's specific starting room
+            game_state.current_room_id = starting_room
+
+            # Step 5: Save to slot with campaign progress
             self.slot_manager.save_game(
                 slot_number=slot_num,
                 game_state=game_state,
-                playtime_delta=0
+                playtime_delta=0,
+                campaign_progress=campaign_progress
             )
 
             # Step 6: Record character usage in vault
@@ -439,42 +461,29 @@ class MainMenuV2:
         """
         Select a campaign to play.
 
-        Returns:
-            Dict with campaign_id and starting_dungeon, or None if cancelled
-        """
-        import json
+        Shows campaigns with dungeon progression info:
+        - ✓ = completed, 🔓 = unlocked/available, 🔒 = locked
 
+        Returns:
+            Dict with campaign_id, starting_dungeon, and campaign_progress, or None if cancelled
+        """
         console.print()
         print_section("SELECT CAMPAIGN")
 
         # List available campaigns
-        campaigns_dir = Path(__file__).parent.parent / "data" / "content" / "campaigns"
-        campaign_files = list(campaigns_dir.glob("*.json"))
+        campaigns = self.campaign_tracker.list_available_campaigns()
 
-        if not campaign_files:
+        if not campaigns:
             print_error("No campaigns found!")
             return None
 
-        # Load campaign metadata
-        campaigns = []
-        for campaign_file in campaign_files:
-            try:
-                with open(campaign_file) as f:
-                    campaign_data = json.load(f)
-                    campaigns.append(campaign_data)
-            except Exception:
-                continue
-
-        if not campaigns:
-            print_error("No valid campaigns found!")
-            return None
-
-        # Build choices for questionary
+        # Build choices for questionary with rich display
         choices = []
         for campaign in campaigns:
-            level_range = campaign.get("level_range", "Any")
-            display = f"{campaign['name']} (Level {level_range})"
-            choices.append(questionary.Choice(title=display, value=campaign["id"]))
+            level_range = campaign.level_range
+            playtime = campaign.estimated_playtime
+            display = f"{campaign.name} (Level {level_range}, ~{playtime})"
+            choices.append(questionary.Choice(title=display, value=campaign.id))
 
         choices.append(questionary.Choice(title="← Back", value=None))
 
@@ -490,16 +499,56 @@ class MainMenuV2:
         if not selected_id:
             return None
 
-        # Find the selected campaign
-        selected = next((c for c in campaigns if c["id"] == selected_id), None)
-        if not selected:
+        # Find the selected campaign definition
+        definition = self.campaign_tracker.load_campaign_definition(selected_id)
+        if not definition:
+            return None
+
+        # Create initial progress for new game
+        progress = self.campaign_tracker.create_initial_progress(selected_id)
+        if not progress:
+            return None
+
+        # Display dungeon progression info
+        console.print()
+        print_section(f"{definition.name} - Dungeon Progression")
+        console.print()
+        console.print(f"[dim]{definition.description}[/dim]")
+        console.print()
+
+        # Show dungeons with lock states
+        ordered_dungeons = self.campaign_tracker.get_ordered_dungeons(selected_id)
+        for dungeon_id, dungeon_def in ordered_dungeons:
+            state = self.campaign_tracker.get_dungeon_state(progress, dungeon_id)
+
+            # State icons
+            if state == "completed":
+                icon = "[green]✓[/green]"
+            elif state == "unlocked":
+                icon = "[cyan]🔓[/cyan]"
+            else:
+                icon = "[dim]🔒[/dim]"
+
+            # Dungeon display
+            if state == "locked":
+                console.print(f"  {icon} [dim]{dungeon_def.name}[/dim]")
+            else:
+                console.print(f"  {icon} {dungeon_def.name}")
+
+        console.print()
+
+        # Use campaign's starting_room to determine where to begin
+        starting_room = definition.starting_room
+        if not starting_room:
+            print_error("Campaign has no starting room defined!")
             return None
 
         return {
-            "campaign_id": selected["id"],
-            "name": selected["name"],
-            "level_range": selected.get("level_range", "Any"),
-            "starting_dungeon": selected["starting_dungeon"]
+            "campaign_id": definition.id,
+            "name": definition.name,
+            "level_range": definition.level_range,
+            "starting_room": starting_room,
+            "campaign_progress": progress
         }
 
     def handle_character_vault(self) -> None:

--- a/tests/test_campaign_progress.py
+++ b/tests/test_campaign_progress.py
@@ -1,0 +1,355 @@
+# ABOUTME: Tests for campaign progression system
+# ABOUTME: Verifies campaign definition loading, progress tracking, and unlock logic
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.core.campaign_progress import (
+    CampaignDefinition,
+    CampaignProgress,
+    CampaignProgressTracker,
+)
+
+
+@pytest.fixture
+def sample_campaign_data() -> dict:
+    """Sample campaign definition for testing."""
+    return {
+        "id": "test_campaign",
+        "name": "Test Campaign",
+        "description": "A test campaign",
+        "level_range": "1-3",
+        "estimated_playtime": "1-2 hours",
+        "starting_room": "dungeon1.entrance",
+        "dungeons": {
+            "dungeon1": {
+                "name": "First Dungeon",
+                "order": 1,
+                "unlocked_by_default": True,
+                "completion_criteria": {
+                    "boss_defeated": True,
+                    "required_quest_items": ["quest_key"],
+                },
+                "unlocks": ["dungeon2"],
+            },
+            "dungeon2": {
+                "name": "Second Dungeon",
+                "order": 2,
+                "unlocked_by_default": False,
+                "completion_criteria": {
+                    "boss_defeated": True,
+                },
+                "unlocks": ["dungeon3"],
+            },
+            "dungeon3": {
+                "name": "Final Dungeon",
+                "order": 3,
+                "unlocked_by_default": False,
+                "completion_criteria": {
+                    "boss_defeated": True,
+                },
+                "unlocks": [],
+                "final_dungeon": True,
+            },
+        },
+    }
+
+
+@pytest.fixture
+def campaigns_dir(sample_campaign_data) -> Path:
+    """Create temporary campaigns directory with test data."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        campaigns_path = Path(tmpdir)
+        campaign_file = campaigns_path / "test_campaign.json"
+        with open(campaign_file, "w") as f:
+            json.dump(sample_campaign_data, f)
+        yield campaigns_path
+
+
+class TestCampaignDefinition:
+    """Tests for CampaignDefinition dataclass."""
+
+    def test_from_dict(self, sample_campaign_data):
+        """Test loading campaign definition from dictionary."""
+        definition = CampaignDefinition.from_dict(sample_campaign_data)
+
+        assert definition.id == "test_campaign"
+        assert definition.name == "Test Campaign"
+        assert len(definition.dungeons) == 3
+        assert "dungeon1" in definition.dungeons
+        assert definition.dungeons["dungeon1"].unlocked_by_default is True
+        assert definition.dungeons["dungeon2"].unlocked_by_default is False
+
+    def test_dungeon_completion_criteria(self, sample_campaign_data):
+        """Test that completion criteria are parsed correctly."""
+        definition = CampaignDefinition.from_dict(sample_campaign_data)
+
+        dungeon1 = definition.dungeons["dungeon1"]
+        assert dungeon1.boss_defeated_required is True
+        assert dungeon1.required_quest_items == ["quest_key"]
+
+        dungeon2 = definition.dungeons["dungeon2"]
+        assert dungeon2.boss_defeated_required is True
+        assert dungeon2.required_quest_items == []
+
+    def test_final_dungeon_flag(self, sample_campaign_data):
+        """Test that final_dungeon flag is parsed."""
+        definition = CampaignDefinition.from_dict(sample_campaign_data)
+
+        assert definition.dungeons["dungeon1"].final_dungeon is False
+        assert definition.dungeons["dungeon3"].final_dungeon is True
+
+
+class TestCampaignProgress:
+    """Tests for CampaignProgress dataclass."""
+
+    def test_to_dict_and_from_dict(self):
+        """Test serialization round-trip."""
+        progress = CampaignProgress(
+            campaign_id="test_campaign",
+            completed_dungeons=["dungeon1"],
+            unlocked_dungeons=["dungeon1", "dungeon2"],
+            boss_defeats={"dungeon1": True},
+        )
+
+        data = progress.to_dict()
+        restored = CampaignProgress.from_dict(data)
+
+        assert restored.campaign_id == progress.campaign_id
+        assert restored.completed_dungeons == progress.completed_dungeons
+        assert restored.unlocked_dungeons == progress.unlocked_dungeons
+        assert restored.boss_defeats == progress.boss_defeats
+
+
+class TestCampaignProgressTracker:
+    """Tests for CampaignProgressTracker class."""
+
+    def test_load_campaign_definition(self, campaigns_dir):
+        """Test loading campaign definition from file."""
+        tracker = CampaignProgressTracker(campaigns_dir)
+        definition = tracker.load_campaign_definition("test_campaign")
+
+        assert definition is not None
+        assert definition.id == "test_campaign"
+        assert len(definition.dungeons) == 3
+
+    def test_load_nonexistent_campaign(self, campaigns_dir):
+        """Test loading non-existent campaign returns None."""
+        tracker = CampaignProgressTracker(campaigns_dir)
+        definition = tracker.load_campaign_definition("nonexistent")
+
+        assert definition is None
+
+    def test_list_available_campaigns(self, campaigns_dir):
+        """Test listing available campaigns."""
+        tracker = CampaignProgressTracker(campaigns_dir)
+        campaigns = tracker.list_available_campaigns()
+
+        assert len(campaigns) == 1
+        assert campaigns[0].id == "test_campaign"
+
+    def test_create_initial_progress(self, campaigns_dir):
+        """Test creating initial progress for a campaign."""
+        tracker = CampaignProgressTracker(campaigns_dir)
+        progress = tracker.create_initial_progress("test_campaign")
+
+        assert progress is not None
+        assert progress.campaign_id == "test_campaign"
+        assert progress.completed_dungeons == []
+        assert "dungeon1" in progress.unlocked_dungeons
+        assert "dungeon2" not in progress.unlocked_dungeons
+
+    def test_dungeon_state_tracking(self, campaigns_dir):
+        """Test dungeon state (locked/unlocked/completed)."""
+        tracker = CampaignProgressTracker(campaigns_dir)
+        progress = tracker.create_initial_progress("test_campaign")
+
+        assert tracker.get_dungeon_state(progress, "dungeon1") == "unlocked"
+        assert tracker.get_dungeon_state(progress, "dungeon2") == "locked"
+        assert tracker.get_dungeon_state(progress, "dungeon3") == "locked"
+
+    def test_check_dungeon_completion_all_criteria(self, campaigns_dir):
+        """Test completion check with all criteria met."""
+        tracker = CampaignProgressTracker(campaigns_dir)
+        progress = tracker.create_initial_progress("test_campaign")
+
+        # Missing boss defeat and quest item
+        assert not tracker.check_dungeon_completion(
+            progress, "dungeon1", boss_defeated=False, inventory_item_ids=[]
+        )
+
+        # Has quest item but no boss defeat
+        assert not tracker.check_dungeon_completion(
+            progress, "dungeon1", boss_defeated=False, inventory_item_ids=["quest_key"]
+        )
+
+        # Boss defeated but no quest item
+        assert not tracker.check_dungeon_completion(
+            progress, "dungeon1", boss_defeated=True, inventory_item_ids=[]
+        )
+
+        # All criteria met
+        assert tracker.check_dungeon_completion(
+            progress, "dungeon1", boss_defeated=True, inventory_item_ids=["quest_key"]
+        )
+
+    def test_complete_dungeon_unlocks_next(self, campaigns_dir):
+        """Test that completing a dungeon unlocks the next one."""
+        tracker = CampaignProgressTracker(campaigns_dir)
+        progress = tracker.create_initial_progress("test_campaign")
+
+        # Record boss defeat
+        tracker.record_boss_defeat(progress, "dungeon1")
+
+        # Complete dungeon1 with quest item
+        newly_unlocked = tracker.complete_dungeon(
+            progress, "dungeon1", inventory_item_ids=["quest_key"]
+        )
+
+        assert "dungeon1" in progress.completed_dungeons
+        assert "dungeon2" in newly_unlocked
+        assert "dungeon2" in progress.unlocked_dungeons
+        assert tracker.get_dungeon_state(progress, "dungeon1") == "completed"
+        assert tracker.get_dungeon_state(progress, "dungeon2") == "unlocked"
+
+    def test_complete_dungeon_without_criteria_fails(self, campaigns_dir):
+        """Test that completing dungeon without criteria doesn't unlock next."""
+        tracker = CampaignProgressTracker(campaigns_dir)
+        progress = tracker.create_initial_progress("test_campaign")
+
+        # Try to complete without boss defeat
+        newly_unlocked = tracker.complete_dungeon(
+            progress, "dungeon1", inventory_item_ids=["quest_key"]
+        )
+
+        assert newly_unlocked == []
+        assert "dungeon1" not in progress.completed_dungeons
+
+    def test_campaign_complete_check(self, campaigns_dir):
+        """Test checking if campaign is complete."""
+        tracker = CampaignProgressTracker(campaigns_dir)
+        progress = tracker.create_initial_progress("test_campaign")
+
+        assert not tracker.is_campaign_complete(progress)
+
+        # Complete all dungeons
+        progress.completed_dungeons = ["dungeon1", "dungeon2", "dungeon3"]
+
+        assert tracker.is_campaign_complete(progress)
+
+    def test_get_ordered_dungeons(self, campaigns_dir):
+        """Test getting dungeons in order."""
+        tracker = CampaignProgressTracker(campaigns_dir)
+        ordered = tracker.get_ordered_dungeons("test_campaign")
+
+        assert len(ordered) == 3
+        assert ordered[0][0] == "dungeon1"
+        assert ordered[1][0] == "dungeon2"
+        assert ordered[2][0] == "dungeon3"
+
+
+class TestRealCampaign:
+    """Test with the actual 'the_unquiet_dead' campaign."""
+
+    def test_load_unquiet_dead_campaign(self):
+        """Test loading the real campaign file."""
+        tracker = CampaignProgressTracker()
+        definition = tracker.load_campaign_definition("the_unquiet_dead")
+
+        assert definition is not None
+        assert definition.id == "the_unquiet_dead"
+        assert definition.name == "The Unquiet Dead"
+        assert "the_unquiet_dead_crypt" in definition.dungeons
+        assert "cult_hideout" in definition.dungeons
+        assert "temple_of_durgon" in definition.dungeons
+
+    def test_unquiet_dead_unlock_chain(self):
+        """Test the unlock chain for The Unquiet Dead."""
+        tracker = CampaignProgressTracker()
+        progress = tracker.create_initial_progress("the_unquiet_dead")
+
+        # Only crypt should be unlocked initially
+        assert tracker.is_dungeon_unlocked(progress, "the_unquiet_dead_crypt")
+        assert not tracker.is_dungeon_unlocked(progress, "cult_hideout")
+        assert not tracker.is_dungeon_unlocked(progress, "temple_of_durgon")
+
+        # Simulate completing crypt with journal
+        tracker.record_boss_defeat(progress, "the_unquiet_dead_crypt")
+        newly_unlocked = tracker.complete_dungeon(
+            progress, "the_unquiet_dead_crypt", inventory_item_ids=["gorgus_journal"]
+        )
+
+        assert "cult_hideout" in newly_unlocked
+        assert tracker.is_dungeon_unlocked(progress, "cult_hideout")
+
+
+class TestAllCampaignFilesValid:
+    """Test that all campaign JSON files in the campaigns directory are valid."""
+
+    def test_all_campaign_files_load_successfully(self):
+        """Test that every campaign JSON file can be loaded without errors."""
+        tracker = CampaignProgressTracker()
+        campaigns = tracker.list_available_campaigns()
+
+        # Should have at least one campaign
+        assert len(campaigns) > 0, "No campaigns found!"
+
+        for campaign in campaigns:
+            # Each campaign should have required fields
+            assert campaign.id, "Campaign missing id"
+            assert campaign.name, f"Campaign {campaign.id} missing name"
+            assert campaign.starting_room, f"Campaign {campaign.id} missing starting_room"
+
+            # Dungeons should be a dict, not a list
+            assert isinstance(
+                campaign.dungeons, dict
+            ), f"Campaign {campaign.id}: dungeons should be dict, got {type(campaign.dungeons)}"
+            assert len(campaign.dungeons) > 0, f"Campaign {campaign.id} has no dungeons"
+
+            # Each dungeon should have required fields
+            for dungeon_id, dungeon in campaign.dungeons.items():
+                assert dungeon.name, f"Dungeon {dungeon_id} missing name"
+                assert isinstance(
+                    dungeon.order, int
+                ), f"Dungeon {dungeon_id} order should be int"
+                assert isinstance(
+                    dungeon.unlocks, list
+                ), f"Dungeon {dungeon_id} unlocks should be list"
+
+    def test_all_campaigns_create_valid_progress(self):
+        """Test that initial progress can be created for all campaigns."""
+        tracker = CampaignProgressTracker()
+        campaigns = tracker.list_available_campaigns()
+
+        for campaign in campaigns:
+            progress = tracker.create_initial_progress(campaign.id)
+            assert progress is not None, f"Failed to create progress for {campaign.id}"
+            assert progress.campaign_id == campaign.id
+
+            # Should have at least one unlocked dungeon
+            assert (
+                len(progress.unlocked_dungeons) > 0
+            ), f"Campaign {campaign.id} has no initially unlocked dungeons"
+
+    def test_all_campaigns_have_starting_dungeon(self):
+        """Test that all campaigns have a valid starting dungeon."""
+        tracker = CampaignProgressTracker()
+        campaigns = tracker.list_available_campaigns()
+
+        for campaign in campaigns:
+            progress = tracker.create_initial_progress(campaign.id)
+            ordered = tracker.get_ordered_dungeons(campaign.id)
+
+            # Find first unlocked dungeon
+            starting_dungeon = None
+            for dungeon_id, _ in ordered:
+                if tracker.is_dungeon_unlocked(progress, dungeon_id):
+                    starting_dungeon = dungeon_id
+                    break
+
+            assert (
+                starting_dungeon is not None
+            ), f"Campaign {campaign.id} has no unlocked starting dungeon"

--- a/tests/test_save_slot_manager.py
+++ b/tests/test_save_slot_manager.py
@@ -165,8 +165,8 @@ class TestSaveSlotManager:
             playtime_delta=60
         )
 
-        # Load
-        loaded_state = save_manager.load_game(slot_number=4)
+        # Load - now returns tuple of (game_state, campaign_progress)
+        loaded_state, campaign_progress = save_manager.load_game(slot_number=4)
 
         assert loaded_state is not None
         assert len(loaded_state.party.characters) == 1
@@ -174,6 +174,8 @@ class TestSaveSlotManager:
         assert loaded_state.party.characters[0].level == 3
         assert loaded_state.party.characters[0].current_hp == 25
         assert loaded_state.dungeon_name == "test_dungeon"
+        # No campaign progress saved, so should be None
+        assert campaign_progress is None
 
     def test_load_game_from_empty_slot_raises_error(self, save_manager):
         """Test that loading from empty slot raises ValueError."""
@@ -302,8 +304,8 @@ class TestSaveSlotManager:
         assert slot.party_composition == ["Test Hero", "Wizard Friend"]
         assert slot.party_levels == [3, 3]
 
-        # Load
-        loaded_state = save_manager.load_game(slot_number=10)
+        # Load - returns tuple of (game_state, campaign_progress)
+        loaded_state, _ = save_manager.load_game(slot_number=10)
         assert len(loaded_state.party.characters) == 2
         assert loaded_state.party.characters[0].name == "Test Hero"
         assert loaded_state.party.characters[1].name == "Wizard Friend"


### PR DESCRIPTION
## Summary
- Add `CampaignProgressTracker` class to manage multi-dungeon campaign progression
- Track dungeon states: locked 🔒, unlocked 🔓, completed ✓
- Support unlock chains based on boss defeats and quest items
- Integrate campaign progress into save/load system
- Start new games in town (Arden) instead of directly in dungeon
- Fix `poisoned_laboratory.json` schema to match campaign format

## Test plan
- [x] All 34 tests pass (19 campaign progress + 15 save slot manager)
- [x] Manual testing: New Game starts in Town Square
- [x] Manual testing: Dungeon progression UI shows lock states
- [x] Code review passed (ruff clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)