### PR TITLE
Add dungeon completion detection for campaign progression (#102)

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
-from dnd_engine.core.campaign_progress import CampaignProgress
+from dnd_engine.core.campaign_progress import CampaignProgress, CampaignProgressTracker
 from dnd_engine.core.character import Character
 from dnd_engine.core.combat import AttackResult, CombatEngine
 from dnd_engine.core.creature import Creature
@@ -202,6 +202,16 @@ class GameState:
 
         # Campaign progress for multi-dungeon campaigns
         self.campaign_progress = campaign_progress
+
+        # Campaign tracker for checking completion criteria
+        self.campaign_tracker: CampaignProgressTracker | None = None
+        if campaign_progress:
+            try:
+                campaigns_dir = self.data_loader.data_path / "content" / "campaigns"
+                if campaigns_dir.exists():
+                    self.campaign_tracker = CampaignProgressTracker(campaigns_dir)
+            except (AttributeError, TypeError):
+                pass
 
         # Room registry for cross-dungeon navigation
         # May be None if data_path is unavailable (e.g., in tests with mocked loaders)
@@ -2407,6 +2417,76 @@ class GameState:
                 "xp_per_character": total_xp // len(self.party.characters) if len(self.party.characters) > 0 else 0
             }
         ))
+
+        # Check for boss defeat and dungeon completion (campaign progression)
+        if victory and room.get("boss_room"):
+            self._handle_boss_defeat()
+
+    def _handle_boss_defeat(self) -> None:
+        """Handle boss defeat for campaign progression."""
+        if not self.campaign_progress or not self.campaign_tracker:
+            return
+
+        # Record boss defeat for current dungeon
+        self.campaign_tracker.record_boss_defeat(
+            self.campaign_progress, self.dungeon_name
+        )
+
+        # Emit boss defeated event
+        self.event_bus.emit(Event(
+            type=EventType.BOSS_DEFEATED,
+            data={
+                "dungeon_id": self.dungeon_name,
+                "dungeon_name": self.dungeon.get("name", self.dungeon_name)
+            }
+        ))
+
+        # Check if dungeon completion criteria are now met
+        self._check_dungeon_completion()
+
+    def _check_dungeon_completion(self) -> None:
+        """Check if current dungeon is complete and unlock next dungeons."""
+        if not self.campaign_progress or not self.campaign_tracker:
+            return
+
+        # Get quest items in party inventory
+        inventory_item_ids = []
+        for character in self.party.characters:
+            for item in character.inventory.items.values():
+                inventory_item_ids.append(item.item_id)
+
+        # Try to complete the dungeon
+        newly_unlocked = self.campaign_tracker.complete_dungeon(
+            self.campaign_progress,
+            self.dungeon_name,
+            inventory_item_ids
+        )
+
+        if newly_unlocked:
+            # Get dungeon names for display
+            unlocked_names = []
+            for dungeon_id in newly_unlocked:
+                definition = self.campaign_tracker.load_campaign_definition(
+                    self.campaign_progress.campaign_id
+                )
+                if definition and dungeon_id in definition.dungeons:
+                    unlocked_names.append(definition.dungeons[dungeon_id].name)
+                else:
+                    unlocked_names.append(dungeon_id)
+
+            # Emit dungeon completed event
+            self.event_bus.emit(Event(
+                type=EventType.DUNGEON_COMPLETED,
+                data={
+                    "dungeon_id": self.dungeon_name,
+                    "dungeon_name": self.dungeon.get("name", self.dungeon_name),
+                    "newly_unlocked": newly_unlocked,
+                    "unlocked_names": unlocked_names,
+                    "campaign_complete": self.campaign_tracker.is_campaign_complete(
+                        self.campaign_progress
+                    )
+                }
+            ))
 
     def record_combat_event(self, event: CombatEvent) -> None:
         """

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -3,6 +3,8 @@
 
 from typing import Any, Optional
 
+from rich.panel import Panel
+
 from dnd_engine.core.character import Character, CharacterClass
 from dnd_engine.llm.npc_chat import NPCChatManager
 from dnd_engine.core.dice import format_dice_with_modifier
@@ -93,6 +95,8 @@ class CLI:
         self.game_state.event_bus.subscribe(EventType.COMBAT_START, self._on_combat_start)
         self.game_state.event_bus.subscribe(EventType.COMBAT_END, self._on_combat_end)
         self.game_state.event_bus.subscribe(EventType.COMBAT_FLED, self._on_combat_fled)
+        self.game_state.event_bus.subscribe(EventType.BOSS_DEFEATED, self._on_boss_defeated)
+        self.game_state.event_bus.subscribe(EventType.DUNGEON_COMPLETED, self._on_dungeon_completed)
         self.game_state.event_bus.subscribe(EventType.ITEM_ACQUIRED, self._on_item_acquired)
         self.game_state.event_bus.subscribe(EventType.GOLD_ACQUIRED, self._on_gold_acquired)
         self.game_state.event_bus.subscribe(EventType.ROOM_ENTER, self._on_room_enter)
@@ -5152,6 +5156,46 @@ class CLI:
 
         # Auto-save after combat
         self._auto_save("after_combat")
+
+    def _on_boss_defeated(self, event: Event) -> None:
+        """Handle boss defeated event."""
+        dungeon_name = event.data.get("dungeon_name", "Unknown")
+        console.print()
+        console.print(
+            Panel(
+                f"[bold yellow]⚔️ BOSS DEFEATED![/bold yellow]\n\n"
+                f"You have defeated the boss of {dungeon_name}!",
+                border_style="yellow"
+            )
+        )
+
+    def _on_dungeon_completed(self, event: Event) -> None:
+        """Handle dungeon completed event."""
+        dungeon_name = event.data.get("dungeon_name", "Unknown")
+        unlocked_names = event.data.get("unlocked_names", [])
+        campaign_complete = event.data.get("campaign_complete", False)
+
+        console.print()
+
+        if campaign_complete:
+            console.print(
+                Panel(
+                    "[bold green]🎉 CAMPAIGN COMPLETE! 🎉[/bold green]\n\n"
+                    f"You have completed {dungeon_name} and finished the entire campaign!\n\n"
+                    "[dim]Congratulations, brave adventurers![/dim]",
+                    border_style="green"
+                )
+            )
+        else:
+            unlocked_text = "\n".join(f"  🔓 {name}" for name in unlocked_names)
+            console.print(
+                Panel(
+                    f"[bold cyan]✨ DUNGEON COMPLETE![/bold cyan]\n\n"
+                    f"You have completed {dungeon_name}!\n\n"
+                    f"[bold]New areas unlocked:[/bold]\n{unlocked_text}",
+                    border_style="cyan"
+                )
+            )
 
     def _on_combat_fled(self, event: Event) -> None:
         """Handle combat fled event."""

--- a/dnd_engine/utils/events.py
+++ b/dnd_engine/utils/events.py
@@ -79,6 +79,10 @@ class EventType(Enum):
     HOUR_PASSED = "hour_passed"
     EFFECT_EXPIRED = "effect_expired"
 
+    # Campaign progression events
+    BOSS_DEFEATED = "boss_defeated"
+    DUNGEON_COMPLETED = "dungeon_completed"
+
 
 @dataclass
 class Event:

--- a/tests/test_campaign_progress.py
+++ b/tests/test_campaign_progress.py
@@ -353,3 +353,121 @@ class TestAllCampaignFilesValid:
             assert (
                 starting_dungeon is not None
             ), f"Campaign {campaign.id} has no unlocked starting dungeon"
+
+
+class TestDungeonCompletionDetection:
+    """Tests for dungeon completion detection in GameState."""
+
+    def test_boss_defeat_recorded_in_boss_room(self, campaigns_dir, sample_campaign_data):
+        """Test that boss defeat is recorded when combat ends in boss_room."""
+        from unittest.mock import MagicMock, patch
+
+        from dnd_engine.core.character import Character, CharacterClass
+        from dnd_engine.core.creature import Abilities
+        from dnd_engine.core.party import Party
+        from dnd_engine.utils.events import EventType
+
+        # Create a character
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        char = Character(
+            name="Test Hero",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=abilities,
+            max_hp=10,
+            ac=10,
+            current_hp=10,
+        )
+        party = Party([char])
+
+        # Create campaign progress
+        tracker = CampaignProgressTracker(campaigns_dir)
+        progress = tracker.create_initial_progress("test_campaign")
+
+        # Mock data loader and dungeon
+        mock_loader = MagicMock()
+        mock_loader.load_dungeon.return_value = {
+            "id": "dungeon1",
+            "name": "First Dungeon",
+            "start_room": "dungeon1.entrance",
+            "rooms": {
+                "dungeon1.boss_room": {
+                    "id": "dungeon1.boss_room",
+                    "name": "Boss Chamber",
+                    "boss_room": True,
+                    "enemies": [],
+                    "exits": {},
+                }
+            },
+        }
+        mock_loader.load_monsters.return_value = {}
+        mock_loader.data_path = campaigns_dir.parent
+
+        # Patch GameState to use our mocks
+        with patch.object(
+            CampaignProgressTracker, "__init__", lambda self, path=None: None
+        ):
+            from dnd_engine.core.game_state import GameState
+
+            # Create game state with campaign progress
+            game_state = GameState(
+                party=party,
+                dungeon_name="dungeon1",
+                data_loader=mock_loader,
+                campaign_id="test_campaign",
+                campaign_progress=progress,
+            )
+
+            # Manually set up campaign tracker
+            game_state.campaign_tracker = tracker
+            game_state.current_room_id = "dungeon1.boss_room"
+
+            # Track events
+            events_emitted = []
+
+            def capture_event(event):
+                events_emitted.append(event.type)
+
+            game_state.event_bus.subscribe(EventType.BOSS_DEFEATED, capture_event)
+
+            # Call boss defeat handler
+            game_state._handle_boss_defeat()
+
+            # Verify boss defeat was recorded
+            assert progress.boss_defeats.get("dungeon1") is True
+            assert EventType.BOSS_DEFEATED in events_emitted
+
+    def test_dungeon_completion_unlocks_next(self, campaigns_dir, sample_campaign_data):
+        """Test that completing a dungeon unlocks the next one."""
+        tracker = CampaignProgressTracker(campaigns_dir)
+        progress = tracker.create_initial_progress("test_campaign")
+
+        # Record boss defeat
+        tracker.record_boss_defeat(progress, "dungeon1")
+
+        # Complete with required quest item
+        newly_unlocked = tracker.complete_dungeon(
+            progress, "dungeon1", inventory_item_ids=["quest_key"]
+        )
+
+        assert "dungeon1" in progress.completed_dungeons
+        assert "dungeon2" in newly_unlocked
+        assert "dungeon2" in progress.unlocked_dungeons
+
+    def test_dungeon_not_completed_without_quest_item(
+        self, campaigns_dir, sample_campaign_data
+    ):
+        """Test that dungeon isn't completed without required quest item."""
+        tracker = CampaignProgressTracker(campaigns_dir)
+        progress = tracker.create_initial_progress("test_campaign")
+
+        # Record boss defeat but no quest item
+        tracker.record_boss_defeat(progress, "dungeon1")
+
+        # Try to complete without quest item
+        newly_unlocked = tracker.complete_dungeon(
+            progress, "dungeon1", inventory_item_ids=[]
+        )
+
+        assert "dungeon1" not in progress.completed_dungeons
+        assert newly_unlocked == []


### PR DESCRIPTION
## Summary
- Integrates CampaignProgressTracker with GameState to detect boss defeats in boss_room locations
- Automatically checks dungeon completion when boss is defeated (examining inventory for required quest items)
- Unlocks next dungeons when all completion criteria are met
- Adds UI notifications showing boss defeat and newly unlocked dungeons

## Changes
- Added `BOSS_DEFEATED` and `DUNGEON_COMPLETED` event types to events.py
- Added `_handle_boss_defeat()` and `_check_dungeon_completion()` methods to GameState
- Added event handlers in CLI for displaying boss defeat and dungeon completion panels
- Added tests for boss defeat recording, dungeon completion unlocking, and quest item requirements

## Test plan
- [x] All 22 campaign progress tests pass
- [x] Ruff checks pass
- [ ] Manual test: Defeat boss in crypt → see boss defeated notification
- [ ] Manual test: With quest item → see dungeon completed and next dungeon unlocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)