### PR TITLE
Add Cult Hideout dungeon content (#102)

### DIFF
--- a/dnd_engine/data/content/dungeons/cult_hideout.json
+++ b/dnd_engine/data/content/dungeons/cult_hideout.json
@@ -1,0 +1,300 @@
+{
+  "id": "cult_hideout",
+  "name": "The Unquiet Dead: Cult Hideout",
+  "campaign_id": "the_unquiet_dead",
+  "description": "The cult of Durgon has set up their hideout in the basement of an abandoned warehouse in the Warrens. This part of town is known to be a den for thieves and cutthroats, making it the perfect place for dark rituals. The cultists are preparing for something big - their leader has already left for the temple to conduct the final ritual.",
+  "start_room": "cult_hideout.entrance",
+  "level_range": "2-3",
+  "estimated_playtime": "45-60 minutes",
+  "focus": "combat, investigation",
+  "notes": "Second part of a three-part campaign. Features cultist encounters with investigation opportunities. The acolyte boss holds the map to the Temple of Durgon. Some module features simplified: surprise mechanics for first room, alchemy jug as trade goods instead.",
+  "rooms": {
+    "cult_hideout.entrance": {
+      "id": "cult_hideout.entrance",
+      "location_type": "dungeon",
+      "parent": "cult_hideout",
+      "name": "Hideout Entrance",
+      "description": "Stone stairs descend from the hidden cellar door into a dimly lit chamber. Various tables and crates have been repurposed as furniture. Candles line the walls, casting flickering shadows. Two hooded, robed figures sit in the corner, deep in hushed conversation. They wear the symbol of a horned skull wreathed in flames.",
+      "lighting": "dim",
+      "hidden_features": [
+        {
+          "type": "passive_perception",
+          "dc": 14,
+          "on_success": "You overhear the cultists discussing the upcoming ritual to summon Durgon, how the expedition to recover the cleric's skull went smoothly, and their worry that their dark magic has been reanimating the dead. They mention someone named Northam who rose as a ghast and had to be locked away.",
+          "on_failure": null,
+          "trigger": "on_enter",
+          "once_per_room": true
+        }
+      ],
+      "exits": {
+        "up": {
+          "destination": "arden.warrens_alley",
+          "label": "Stairs to the Warrens"
+        },
+        "north": "cult_hideout.robing_room",
+        "east": {
+          "destination": "cult_hideout.smugglers_cache",
+          "hidden": true,
+          "examine_checks": [
+            {
+              "skill": "investigation",
+              "dc": 14,
+              "action": "examine the eastern wall",
+              "on_success": "You find a crack in the wall with a slight draft. Searching carefully, you discover a hidden mechanism that opens a secret door.",
+              "on_failure": "The wall appears solid, though there seems to be a slight draft from somewhere."
+            }
+          ]
+        }
+      },
+      "enemies": [
+        "cultist",
+        "cultist"
+      ],
+      "items": [
+        {
+          "type": "currency",
+          "gold": 0,
+          "silver": 18,
+          "copper": 0
+        }
+      ],
+      "searched": false,
+      "searchable": true
+    },
+    "cult_hideout.smugglers_cache": {
+      "id": "cult_hideout.smugglers_cache",
+      "location_type": "dungeon",
+      "parent": "cult_hideout",
+      "name": "Smuggler's Cache",
+      "description": "This hidden chamber is thick with cobwebs and dust. Assorted crates sit against the walls, and a faded map showing various trade routes hangs on the eastern wall. It appears this room predates the cult's occupation - likely a smuggler's stash from the warehouse's earlier days.",
+      "lighting": "dark",
+      "exits": {
+        "west": {
+          "destination": "cult_hideout.entrance",
+          "hidden": true,
+          "label": "Secret Door"
+        }
+      },
+      "enemies": [],
+      "items": [
+        {
+          "type": "currency",
+          "gold": 100,
+          "silver": 0,
+          "copper": 0
+        }
+      ],
+      "searched": false,
+      "searchable": true
+    },
+    "cult_hideout.robing_room": {
+      "id": "cult_hideout.robing_room",
+      "location_type": "dungeon",
+      "parent": "cult_hideout",
+      "name": "Robing Chamber",
+      "description": "This chamber contains racks hung with dark robes of various sizes, and several empty chests sit against the walls. A snuffed lantern lies in the corner, its oil reservoir dry. The cultists apparently change into their ceremonial garb here before proceeding deeper into the hideout.",
+      "lighting": "dark",
+      "exits": {
+        "south": "cult_hideout.entrance",
+        "east": "cult_hideout.meeting_room"
+      },
+      "enemies": [],
+      "items": [],
+      "searched": false,
+      "searchable": false
+    },
+    "cult_hideout.meeting_room": {
+      "id": "cult_hideout.meeting_room",
+      "location_type": "dungeon",
+      "parent": "cult_hideout",
+      "name": "Meeting Chamber",
+      "description": "A large wooden table dominates the center of this room, its surface covered with melted candle wax and scattered parchments. Four hooded figures sit around it, speaking in urgent tones. Maps and diagrams bearing the horned skull symbol are pinned to the walls.",
+      "lighting": "dim",
+      "hidden_features": [
+        {
+          "type": "passive_perception",
+          "dc": 14,
+          "on_success": "You overhear the cultists discussing how the bones of Durgon are sealed away under an abandoned temple, that they need the skull of the cleric Davos to break the wards, and that their leader has already left for the temple. His second-in-command remains with further orders.",
+          "on_failure": null,
+          "trigger": "on_enter",
+          "once_per_room": true
+        }
+      ],
+      "exits": {
+        "west": "cult_hideout.robing_room",
+        "east": "cult_hideout.passage"
+      },
+      "enemies": [
+        "cultist",
+        "cultist",
+        "cultist",
+        "cultist"
+      ],
+      "items": [
+        {
+          "type": "currency",
+          "gold": 0,
+          "silver": 36,
+          "copper": 0
+        }
+      ],
+      "searched": false,
+      "searchable": true
+    },
+    "cult_hideout.passage": {
+      "id": "cult_hideout.passage",
+      "location_type": "dungeon",
+      "parent": "cult_hideout",
+      "name": "Torchlit Passage",
+      "description": "This corridor shows signs of heavy foot traffic - the stone floor is worn smooth from countless boots. Two standing candelabras flicker at the eastern end, casting dancing shadows. From beyond the eastern door, you can hear rhythmic chanting in an unfamiliar tongue.",
+      "lighting": "dim",
+      "hidden_features": [
+        {
+          "type": "passive_perception",
+          "dc": 14,
+          "on_success": "The chanting from the east is in Infernal - a prayer to Durgon, lord of fire and death, asking for wisdom and strength.",
+          "on_failure": null,
+          "trigger": "on_enter",
+          "once_per_room": true
+        }
+      ],
+      "exits": {
+        "west": "cult_hideout.meeting_room",
+        "east": "cult_hideout.dark_altar",
+        "south": "cult_hideout.iron_cages"
+      },
+      "enemies": [],
+      "items": [],
+      "searched": false,
+      "searchable": false
+    },
+    "cult_hideout.dark_altar": {
+      "id": "cult_hideout.dark_altar",
+      "location_type": "dungeon",
+      "parent": "cult_hideout",
+      "name": "Dark Altar",
+      "description": "The focal point of this chamber is a small obsidian altar against the eastern wall, stained dark with old blood. Three figures stand before it in a semicircle, chanting in Infernal. The center figure wears more ornate robes than his companions - clearly someone of importance within the cult hierarchy. Unholy symbols of Durgon are carved into every surface.",
+      "lighting": "dim",
+      "examinable_objects": [
+        {
+          "id": "dark_altar",
+          "name": "obsidian altar",
+          "description": "A small altar carved from black stone, its surface stained with old blood. Unholy symbols are carved into its sides.",
+          "examine_checks": [
+            {
+              "skill": "religion",
+              "dc": 12,
+              "on_success": "The symbols are dedicated to Durgon, a devil of fire and death who terrorized this region centuries ago before being sealed away by the cleric Davos. The cult seeks to resurrect their master.",
+              "on_failure": "The symbols are clearly evil in nature, but their specific meaning eludes you."
+            }
+          ]
+        }
+      ],
+      "exits": {
+        "west": "cult_hideout.passage"
+      },
+      "enemies": [
+        "acolyte",
+        "cultist",
+        "cultist"
+      ],
+      "items": [
+        {
+          "type": "currency",
+          "gold": 25,
+          "silver": 18,
+          "copper": 0
+        },
+        {
+          "type": "item",
+          "id": "cult_map"
+        }
+      ],
+      "searched": false,
+      "searchable": true,
+      "boss_room": true
+    },
+    "cult_hideout.iron_cages": {
+      "id": "cult_hideout.iron_cages",
+      "location_type": "dungeon",
+      "parent": "cult_hideout",
+      "name": "Chamber of Cages",
+      "description": "Three rusted iron cages stand against the southern wall of this grim chamber. Inside each cage lies the corpse of a humanoid, their bodies bearing signs of torture - burn marks, broken bones, and ritual scarification. The cult has been busy with dark work here.",
+      "lighting": "dark",
+      "examinable_objects": [
+        {
+          "id": "iron_cages",
+          "name": "iron cages",
+          "description": "Three rusted cages containing the tortured remains of the cult's victims.",
+          "examine_checks": [
+            {
+              "skill": "medicine",
+              "dc": 12,
+              "on_success": "The victims died from a combination of torture and blood loss. Based on their wounds, they were likely used in dark rituals - their life force drained to power unholy magic.",
+              "on_failure": "The victims clearly suffered greatly before their deaths."
+            }
+          ]
+        }
+      ],
+      "exits": {
+        "north": "cult_hideout.passage",
+        "south": {
+          "destination": "cult_hideout.dead_chamber",
+          "locked": true,
+          "unlock_methods": [
+            {
+              "skill": "sleight_of_hand",
+              "tool_proficiency": "thieves_tools",
+              "dc": 14,
+              "description": "pick the lock",
+              "silent": true
+            }
+          ]
+        }
+      },
+      "enemies": [],
+      "items": [],
+      "searched": false,
+      "searchable": false
+    },
+    "cult_hideout.dead_chamber": {
+      "id": "cult_hideout.dead_chamber",
+      "location_type": "dungeon",
+      "parent": "cult_hideout",
+      "name": "Dead Chamber",
+      "description": "The stench hits you before you even enter - the overwhelming reek of decay and death. This chamber contains the half-chewed bodies of fallen cultists, their robes torn and bloodied. A weathered statue stands at the northern end, its eyes glinting with red gemstones. In the corner, a hunched creature gnaws at a corpse, too focused on its grisly meal to notice your arrival. This was once Brother Northam, but dark magic has twisted him into something far worse.",
+      "lighting": "dark",
+      "examinable_objects": [
+        {
+          "id": "gemstone_statue",
+          "name": "statue with ruby eyes",
+          "description": "A weathered stone statue of a figure in robes. Its eyes are made of gleaming red rubies.",
+          "examine_checks": [
+            {
+              "skill": "sleight_of_hand",
+              "dc": 12,
+              "on_success": "You carefully pry the ruby eyes from the statue. They're worth about 25 gold pieces each.",
+              "on_failure": "The gems are set firmly in the stone - you'd need more delicate tools or technique to remove them without damage."
+            }
+          ]
+        }
+      ],
+      "exits": {
+        "north": "cult_hideout.iron_cages"
+      },
+      "enemies": [
+        "ghast"
+      ],
+      "items": [
+        {
+          "type": "currency",
+          "gold": 50,
+          "silver": 0,
+          "copper": 0
+        }
+      ],
+      "searched": false,
+      "searchable": true
+    }
+  }
+}

--- a/dnd_engine/data/content/dungeons/town_of_arden.json
+++ b/dnd_engine/data/content/dungeons/town_of_arden.json
@@ -174,11 +174,29 @@
       "name": "The Warrens - Alley Entrance",
       "description": "The cobblestones give way to packed dirt as you enter the oldest part of Arden. Here the buildings lean together like drunken conspirators, their upper stories nearly touching across narrow lanes that twist without logic. This is the Warrens - home to those who cannot afford better and those who prefer not to be found. The town guard rarely patrols these streets after dark, and the locals eye strangers with a mixture of suspicion and calculation. Faded signs mark establishments of dubious reputation: a pawnbroker who asks no questions, a fortune teller whose predictions are said to be unsettlingly accurate, a nameless tavern where the ale is cheap and the clientele cheaper. Somewhere in this maze of alleys and abandoned warehouses, darker things stir - though whether the rumors of hooded figures and strange symbols are truth or tavern tales, none can say for certain.",
       "lighting": "dim",
+      "examinable_objects": [
+        {
+          "id": "basement_door",
+          "name": "weathered basement door",
+          "description": "A heavy wooden door set into the foundation of an abandoned warehouse. A strange symbol is carved deeply into the wood - a horned skull wreathed in flames. The door appears unlocked.",
+          "requires": {
+            "quest_item": "gorgus_journal"
+          },
+          "examine_checks": [
+            {
+              "skill": "religion",
+              "dc": 12,
+              "on_success": "You recognize the symbol as the mark of the Cult of Durgon - an ancient devil-worshipping sect thought to have been destroyed centuries ago. The crude map in the cultist's journal led you right to their door.",
+              "on_failure": "The symbol is unfamiliar to you, though its sinister appearance suggests nothing good lies beyond."
+            }
+          ]
+        }
+      ],
       "exits": {
         "west": "arden.town_road",
         "down": {
           "destination": "cult_hideout.entrance",
-          "label": "Hidden Cellar Door",
+          "label": "Basement Door",
           "requires": {
             "quest_item": "gorgus_journal"
           },

--- a/dnd_engine/data/srd/items.json
+++ b/dnd_engine/data/srd/items.json
@@ -513,7 +513,21 @@
       "quest_item": true,
       "description": "A leather-bound journal recovered from the corpse of a cultist in Davos's tomb. The pages are filled with frantic scrawlings in Common. Reading it reveals: The cultist's name was Gorgus. He was a member of the Cult of Durgon, an ancient devil-worshipping sect. The cult is working to bring their master back from the dead. They needed the skull of the cleric Davos to complete their resurrection ritual. Tucked in the back is a crude map showing a route to the cult's hideout - a basement beneath an abandoned warehouse in the city. The symbol of the Cult of Durgon (a horned skull wreathed in flames) is drawn repeatedly in the margins.",
       "value": 0,
-      "notes": "This is a quest item that should unlock the 'Cult Hideout' dungeon location. Multi-dungeon campaign progression not yet implemented."
+      "notes": "This quest item unlocks the Cult Hideout dungeon location."
+    },
+    "cult_map": {
+      "name": "Cult Leader's Map",
+      "source": "The Unquiet Dead (Adventures Await Studios, OGL)",
+      "type": "consumable",
+      "rarity": "common",
+      "effect_type": "information",
+      "action_required": "free",
+      "target_type": "self",
+      "range": 0,
+      "quest_item": true,
+      "description": "A rough map found among the belongings of the cult's second-in-command. It shows a route to an abandoned temple outside of town, along with notes about 'the final ritual' and 'the bones of Durgon sealed beneath.' A letter accompanying it requests the acolyte join the cult leader at the temple the following night. The symbol of Durgon - a horned skull wreathed in flames - is stamped in red wax at the bottom.",
+      "value": 0,
+      "notes": "This quest item unlocks the Temple of Durgon dungeon location."
     }
   }
 }

--- a/dnd_engine/data/srd/monsters.json
+++ b/dnd_engine/data/srd/monsters.json
@@ -304,6 +304,210 @@
       }
     ]
   },
+  "cultist": {
+    "name": "Cultist",
+    "source": "D&D 5E SRD (CC BY 4.0) / The Unquiet Dead (Adventures Await Studios, OGL)",
+    "size": "medium",
+    "type": "humanoid (any race)",
+    "alignment": "any non-good",
+    "ac": 12,
+    "ac_source": "leather armor",
+    "hp": "2d8",
+    "hp_average": 9,
+    "speed": 30,
+    "abilities": {
+      "str": 11,
+      "dex": 12,
+      "con": 10,
+      "int": 10,
+      "wis": 11,
+      "cha": 10
+    },
+    "skills": {
+      "deception": 2,
+      "religion": 2
+    },
+    "senses": "passive Perception 10",
+    "passive_perception": 10,
+    "languages": [
+      "Common"
+    ],
+    "cr": "1/8",
+    "xp": 25,
+    "loot": {
+      "silver": 10
+    },
+    "traits": [
+      {
+        "name": "Dark Devotion",
+        "description": "The cultist has advantage on saving throws against being charmed or frightened."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Scimitar",
+        "type": "melee-weapon-attack",
+        "attack_bonus": 3,
+        "reach": "5 ft.",
+        "damage": "1d6+1",
+        "damage_average": 4,
+        "damage_type": "slashing"
+      }
+    ]
+  },
+  "acolyte": {
+    "name": "Acolyte",
+    "source": "D&D 5E SRD (CC BY 4.0) / The Unquiet Dead (Adventures Await Studios, OGL)",
+    "size": "medium",
+    "type": "humanoid (any race)",
+    "alignment": "any alignment",
+    "ac": 10,
+    "ac_source": "unarmored",
+    "hp": "2d8",
+    "hp_average": 9,
+    "speed": 30,
+    "abilities": {
+      "str": 10,
+      "dex": 10,
+      "con": 10,
+      "int": 10,
+      "wis": 14,
+      "cha": 11
+    },
+    "skills": {
+      "medicine": 4,
+      "religion": 2
+    },
+    "senses": "passive Perception 12",
+    "passive_perception": 12,
+    "languages": [
+      "Common"
+    ],
+    "cr": "1/4",
+    "xp": 50,
+    "is_boss": true,
+    "loot": {
+      "gold": 15
+    },
+    "traits": [],
+    "spellcasting": {
+      "ability": "wisdom",
+      "spell_dc": 12,
+      "spell_attack": 4,
+      "slots": {
+        "1": 3
+      },
+      "cantrips": ["sacred_flame"],
+      "spells_known": ["bless", "cure_wounds", "sanctuary"]
+    },
+    "actions": [
+      {
+        "name": "Club",
+        "type": "melee-weapon-attack",
+        "attack_bonus": 2,
+        "reach": "5 ft.",
+        "damage": "1d4",
+        "damage_average": 2,
+        "damage_type": "bludgeoning"
+      },
+      {
+        "name": "Sacred Flame",
+        "type": "spell-attack",
+        "range": "60 ft.",
+        "damage": "1d8",
+        "damage_average": 4,
+        "damage_type": "radiant",
+        "special": "Target must succeed on a DC 12 Dexterity saving throw or take the damage. The target gains no benefit from cover for this saving throw."
+      }
+    ]
+  },
+  "ghast": {
+    "name": "Ghast",
+    "source": "D&D 5E SRD (CC BY 4.0) / The Unquiet Dead (Adventures Await Studios, OGL)",
+    "size": "medium",
+    "type": "undead",
+    "alignment": "chaotic evil",
+    "ac": 13,
+    "ac_source": "natural armor",
+    "hp": "8d8",
+    "hp_average": 36,
+    "speed": 30,
+    "abilities": {
+      "str": 16,
+      "dex": 17,
+      "con": 10,
+      "int": 11,
+      "wis": 10,
+      "cha": 8
+    },
+    "skills": {},
+    "damage_resistances": [
+      "necrotic"
+    ],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": "darkvision 60 ft., passive Perception 10",
+    "passive_perception": 10,
+    "languages": [
+      "Common"
+    ],
+    "cr": "2",
+    "xp": 450,
+    "is_boss": true,
+    "loot": {
+      "gold": 5,
+      "silver": 20
+    },
+    "traits": [
+      {
+        "name": "Stench",
+        "description": "Any creature that starts its turn within 5 feet of the ghast must succeed on a DC 10 Constitution saving throw or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the ghast's Stench for 24 hours."
+      },
+      {
+        "name": "Turn Defiance",
+        "description": "The ghast and any ghouls within 30 feet of it have advantage on saving throws against effects that turn undead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "type": "melee-weapon-attack",
+        "attack_bonus": 5,
+        "reach": "5 ft.",
+        "damage": "2d8+3",
+        "damage_average": 12,
+        "damage_type": "piercing"
+      },
+      {
+        "name": "Claws",
+        "type": "melee-weapon-attack",
+        "attack_bonus": 5,
+        "reach": "5 ft.",
+        "damage": "2d6+3",
+        "damage_average": 10,
+        "damage_type": "slashing",
+        "special": "If the target is a creature other than an undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "saving_throw": {
+          "trigger": "on_hit",
+          "ability": "constitution",
+          "dc": 10,
+          "on_fail": {
+            "condition": "paralyzed",
+            "duration_type": "rounds",
+            "duration": 10,
+            "allow_repeat_save": true,
+            "repeat_timing": "end_of_turn"
+          }
+        }
+      }
+    ]
+  },
   "ghoul": {
     "name": "Ghoul",
     "source": "D&D 5E SRD (CC BY 4.0) / The Unquiet Dead (Adventures Await Studios, OGL)",


### PR DESCRIPTION
## Summary
- Adds **Cult Hideout** dungeon (dungeon 2 of 3 in "The Unquiet Dead" campaign)
- Adds 3 new monsters: Cultist (CR 1/8), Acolyte (CR 1/4, boss), Ghast (CR 2, boss)
- Adds `cult_map` quest item (required to unlock Temple of Durgon)
- Updates Town of Arden with examinable basement door in the Warrens (requires `gorgus_journal` to see)

### Dungeon Layout (8 rooms)
| Room | Enemies | Notable Features |
|------|---------|------------------|
| Hideout Entrance | 2 cultists | Hidden perception check, secret door east |
| Smuggler's Cache | — | Secret room, 100gp treasure |
| Robing Chamber | — | Empty, cultist robes |
| Meeting Chamber | 4 cultists | Hidden perception check |
| Torchlit Passage | — | Corridor with chanting sounds |
| **Dark Altar** (boss) | Acolyte + 2 cultists | `cult_map` quest item |
| Chamber of Cages | — | Locked door south, torture victims |
| Dead Chamber | Ghast | Locked room, statue with ruby eyes |

### Playtested Features
- ✓ Conditional exit from Warrens (requires `gorgus_journal`)
- ✓ Examinable basement door with Religion DC 12 check
- ✓ Stealth/surprise round mechanics
- ✓ All combat encounters
- ✓ Boss fight (Acolyte defeated, cult_map collected)
- ✓ Quest item collection working

Part of #102 (Campaign Progression). Temple of Durgon content tracked in #207.

## Test plan
- [x] Playtest dungeon navigation through all 8 rooms
- [x] Verify conditional basement door appears only with journal
- [x] Test combat encounters (entrance, meeting room, boss room)
- [x] Verify boss defeat awards XP and drops cult_map
- [x] Confirm quest item adds to inventory

🤖 Generated with [Claude Code](https://claude.com/claude-code)