### PR TITLE
Refactor: Move target_type logic from CLI to game engine (#210)

### DIFF
--- a/dnd_engine/systems/targeting.py
+++ b/dnd_engine/systems/targeting.py
@@ -1,0 +1,200 @@
+# ABOUTME: Targeting requirements service for spells and items
+# ABOUTME: Provides API for CLI to query targeting requirements without interpreting game data
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class ValidTargets(Enum):
+    """
+    Types of valid targets for spells and items.
+
+    Used by CLI to determine what target selection prompt to show,
+    without CLI needing to interpret game data directly.
+    """
+
+    SELF = "self"  # Caster only
+    ALLY = "ally"  # Allies (including self)
+    ENEMY = "enemy"  # Enemies only
+    AREA = "area"  # Area effect (all enemies)
+    ANY = "any"  # Any creature
+
+
+@dataclass
+class TargetingRequirements:
+    """
+    Targeting requirements for a spell or item.
+
+    Provides all information CLI needs to handle target selection
+    without interpreting game data directly. The game engine translates
+    spell/item data into these requirements.
+
+    Attributes:
+        valid_targets: What type of targets are allowed
+        needs_target_selection: Whether CLI should prompt for target
+        can_target_self: Whether caster can be a valid target
+        is_area_effect: Whether this affects all valid targets
+        missing_target_type: Warning flag if data was missing target_type
+    """
+
+    valid_targets: ValidTargets
+    needs_target_selection: bool
+    can_target_self: bool
+    is_area_effect: bool
+    missing_target_type: bool = field(default=False)
+
+    def is_valid_target_type(self, target_type: str) -> bool:
+        """
+        Check if a given target type is valid for this spell/item.
+
+        Args:
+            target_type: "self", "ally", or "enemy"
+
+        Returns:
+            True if the target type is valid
+        """
+        if self.valid_targets == ValidTargets.SELF:
+            return target_type == "self"
+        elif self.valid_targets == ValidTargets.ALLY:
+            # Ally spells can target self or allies
+            return target_type in ("self", "ally")
+        elif self.valid_targets == ValidTargets.ENEMY:
+            return target_type == "enemy"
+        elif self.valid_targets == ValidTargets.AREA:
+            # Area effects target all enemies, no individual selection
+            return target_type == "enemy"
+        elif self.valid_targets == ValidTargets.ANY:
+            # Any can target anyone
+            return target_type in ("self", "ally", "enemy")
+        return False
+
+    def get_prompt_type(self) -> str | None:
+        """
+        Get the type of prompt CLI should show.
+
+        Returns:
+            "enemy" for enemy selection, "ally" for ally selection,
+            "any" for any creature selection, or None if no prompt needed.
+        """
+        if not self.needs_target_selection:
+            return None
+
+        if self.valid_targets == ValidTargets.ENEMY:
+            return "enemy"
+        elif self.valid_targets == ValidTargets.ALLY:
+            return "ally"
+        elif self.valid_targets == ValidTargets.ANY:
+            return "any"
+        return None
+
+
+def get_spell_targeting_requirements(spell_data: dict[str, Any]) -> TargetingRequirements:
+    """
+    Get targeting requirements for a spell.
+
+    Translates spell data into targeting requirements that CLI can use
+    without needing to interpret game data directly.
+
+    Args:
+        spell_data: Spell data dictionary (from spells.json or similar)
+
+    Returns:
+        TargetingRequirements for the spell
+    """
+    target_type = spell_data.get("target_type")
+    missing_target_type = target_type is None
+
+    # Default to enemy if missing (matches current CLI behavior)
+    if target_type is None:
+        target_type = "enemy"
+
+    return _create_targeting_requirements(target_type, missing_target_type)
+
+
+def get_item_targeting_requirements(item_data: dict[str, Any]) -> TargetingRequirements:
+    """
+    Get targeting requirements for an item.
+
+    Translates item data into targeting requirements that CLI can use
+    without needing to interpret game data directly.
+
+    Args:
+        item_data: Item data dictionary (from items.json or similar)
+
+    Returns:
+        TargetingRequirements for the item
+    """
+    target_type = item_data.get("target_type")
+
+    # Items default to self if missing (matches current CLI behavior)
+    if target_type is None:
+        target_type = "self"
+
+    return _create_targeting_requirements(target_type, missing_target_type=False)
+
+
+def _create_targeting_requirements(
+    target_type: str, missing_target_type: bool = False
+) -> TargetingRequirements:
+    """
+    Create targeting requirements from a target_type string.
+
+    Internal helper that maps target_type values to TargetingRequirements.
+
+    Args:
+        target_type: "self", "ally", "enemy", "area", or "any"
+        missing_target_type: Whether the original data was missing target_type
+
+    Returns:
+        TargetingRequirements for the target type
+    """
+    if target_type == "self":
+        return TargetingRequirements(
+            valid_targets=ValidTargets.SELF,
+            needs_target_selection=False,
+            can_target_self=True,
+            is_area_effect=False,
+            missing_target_type=missing_target_type,
+        )
+    elif target_type == "ally":
+        return TargetingRequirements(
+            valid_targets=ValidTargets.ALLY,
+            needs_target_selection=True,
+            can_target_self=True,  # Can heal/buff yourself
+            is_area_effect=False,
+            missing_target_type=missing_target_type,
+        )
+    elif target_type == "enemy":
+        return TargetingRequirements(
+            valid_targets=ValidTargets.ENEMY,
+            needs_target_selection=True,
+            can_target_self=False,
+            is_area_effect=False,
+            missing_target_type=missing_target_type,
+        )
+    elif target_type == "area":
+        return TargetingRequirements(
+            valid_targets=ValidTargets.AREA,
+            needs_target_selection=False,
+            can_target_self=False,
+            is_area_effect=True,
+            missing_target_type=missing_target_type,
+        )
+    elif target_type == "any":
+        return TargetingRequirements(
+            valid_targets=ValidTargets.ANY,
+            needs_target_selection=True,
+            can_target_self=True,
+            is_area_effect=False,
+            missing_target_type=missing_target_type,
+        )
+    else:
+        # Unknown target_type - default to enemy
+        return TargetingRequirements(
+            valid_targets=ValidTargets.ENEMY,
+            needs_target_selection=True,
+            can_target_self=False,
+            is_area_effect=False,
+            missing_target_type=True,  # Mark as problematic
+        )

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -15,6 +15,11 @@ from dnd_engine.systems.combat_context import CombatContextBuilder
 from dnd_engine.systems.combat_middleware import ActionResult, CombatActionExecutor
 from dnd_engine.systems.condition_manager import ConditionManager
 from dnd_engine.systems.inventory import EquipmentSlot
+from dnd_engine.systems.targeting import (
+    get_item_targeting_requirements,
+    get_spell_targeting_requirements,
+    ValidTargets,
+)
 from dnd_engine.ui.debug_console import DebugConsole
 from dnd_engine.ui.rich_ui import (
     console,
@@ -812,26 +817,24 @@ class CLI:
                 item_id, item_data = item_selection
                 item_name = item_data.get("name", item_id)
 
-                # Check if item can target others
-                target_type = item_data.get("target_type", "self")
-                if target_type == "any":
+                # Get targeting requirements from game engine (not interpreting data directly)
+                targeting = get_item_targeting_requirements(item_data)
+
+                if targeting.valid_targets == ValidTargets.ANY:
                     # Prompt for target selection (allies within range)
                     target = self._prompt_combat_ally_selection(item_name, item_data, character)
                     if not isinstance(target, Character):
                         return  # User cancelled or invalid selection
-                    # Execute the use with selected target
                     self.handle_use_item_combat_with_target(item_id, item_data, character, target)
-                elif target_type == "enemy":
+                elif targeting.valid_targets == ValidTargets.ENEMY:
                     # Prompt for enemy target selection
                     target = self._prompt_enemy_selection()
                     if target is None or target == "Cancel":
                         return  # User cancelled
-                    # Execute attack with item on enemy
                     self.handle_use_item_combat_attack(item_id, item_data, character, target)
                 else:
-                    # Self-target only
+                    # Self-target only (SELF or default)
                     target = character
-                    # Execute the use with selected target
                     self.handle_use_item_combat_with_target(item_id, item_data, character, target)
                 return
 
@@ -877,12 +880,12 @@ class CLI:
                 print_error(f"{character.name} doesn't have a consumable '{item_id}' in inventory.")
                 return
 
-            # Determine target based on item type and player specification
-            target_type = found_item_data.get("target_type", "self")
+            # Get targeting requirements from game engine (not interpreting data directly)
+            targeting = get_item_targeting_requirements(found_item_data)
 
             if player_id:
                 # Player specified a target - validate it
-                if target_type == "enemy":
+                if targeting.valid_targets == ValidTargets.ENEMY:
                     print_error(f"{found_item_data.get('name', found_item)} must target an enemy. Use the enemy name or number.")
                     return
 
@@ -893,11 +896,11 @@ class CLI:
 
                 # Use item on specified target
                 self.handle_use_item_combat_with_target(found_item, found_item_data, character, target)
-            elif target_type == "enemy":
+            elif targeting.valid_targets == ValidTargets.ENEMY:
                 # Item requires enemy target but none specified
                 print_error(f"{found_item_data.get('name', found_item)} requires an enemy target. Specify the target (e.g., 'use {item_id} skeleton 1')")
                 return
-            elif target_type == "any":
+            elif targeting.valid_targets == ValidTargets.ANY:
                 # Item can target anyone but no target specified - default to self
                 self.handle_use_item_combat_with_target(found_item, found_item_data, character, character)
             else:
@@ -2138,37 +2141,40 @@ class CLI:
                 print_error(f"No {ordinal}-level spell slots available!")
                 return
 
-        # Determine and select target based on spell target_type
-        target_type = spell_data.get("target_type")
+        # Get targeting requirements from game engine (not interpreting data directly)
+        targeting = get_spell_targeting_requirements(spell_data)
         spell_display_name = spell_data.get("name", spell_id)
 
-        # Route targeting based on data-driven target_type field
-        if target_type == "area":
+        # Warn if spell data is missing target_type
+        if targeting.missing_target_type:
+            print_error(f"Warning: Spell '{spell_display_name}' missing target_type, defaulting to enemy targeting")
+
+        # Route targeting based on requirements from game engine
+        if targeting.is_area_effect:
             # Area effect spells - target all living enemies
             target = None  # Special marker for area effects
             print_status_message(f"{caster.name} casts {spell_display_name}!", "info")
-        elif target_type == "self":
+        elif targeting.valid_targets == ValidTargets.SELF:
             # Self-only spells
             target = caster
             print_status_message(f"{caster.name} targets themselves with {spell_display_name}", "info")
-        elif target_type == "ally":
+        elif targeting.valid_targets == ValidTargets.ALLY:
             # Allied target (including self)
             target = self._prompt_combat_ally_selection(spell_display_name, spell_data, caster)
-        elif target_type == "enemy":
+        elif targeting.valid_targets == ValidTargets.ENEMY:
             # Single enemy target
             target = self._prompt_enemy_selection()
-        elif target_type == "any":
+        elif targeting.valid_targets == ValidTargets.ANY:
             # Any creature (rare - Light, Identify, etc.)
             # For now, prompt ally selection (can be expanded later)
             target = self._prompt_combat_ally_selection(spell_display_name, spell_data, caster)
         else:
-            # Fallback: missing target_type, default to enemy
-            print_error(f"Warning: Spell '{spell_display_name}' missing target_type, defaulting to enemy targeting")
+            # Fallback should not happen, but handle gracefully
             target = self._prompt_enemy_selection()
 
         # Handle target cancellation - nothing consumed yet so just return
         # Note: target=None is valid for area effects, so check for explicit "Cancel"
-        if target == "Cancel" or (target is None and target_type != "area"):
+        if target == "Cancel" or (target is None and not targeting.is_area_effect):
             return
 
         # NOW consume spell slot (will be auto-refunded by middleware if action fails)
@@ -4697,11 +4703,11 @@ class CLI:
         except (EOFError, KeyboardInterrupt):
             return
 
-        # 3. Select target if needed (based on target_type)
+        # 3. Select target if needed (using targeting requirements from game engine)
         target_name = None
-        target_type = spell_data.get("target_type")
+        targeting = get_spell_targeting_requirements(spell_data)
 
-        if target_type == "ally":
+        if targeting.valid_targets == ValidTargets.ALLY:
             # Ally-targeting spells need a target selection
             target = self._prompt_party_member_selection(
                 f"Who should {caster.name} target with {spell_data.get('name')}?"
@@ -4710,7 +4716,7 @@ class CLI:
             if not target or isinstance(target, str):
                 return  # User cancelled
             target_name = target.name
-        elif target_type == "any":
+        elif targeting.valid_targets == ValidTargets.ANY:
             # "Any" target type - for now, treat like ally (can expand later for objects/items)
             target = self._prompt_party_member_selection(
                 f"Who should {caster.name} target with {spell_data.get('name')}?"

--- a/tests/systems/test_targeting.py
+++ b/tests/systems/test_targeting.py
@@ -1,0 +1,283 @@
+# ABOUTME: Unit tests for the targeting requirements service
+# ABOUTME: Tests that CLI can query targeting requirements without interpreting game data directly
+
+from dnd_engine.systems.targeting import (
+    TargetingRequirements,
+    ValidTargets,
+    get_item_targeting_requirements,
+    get_spell_targeting_requirements,
+)
+
+
+class TestValidTargetsEnum:
+    """Tests for the ValidTargets enum."""
+
+    def test_valid_targets_has_expected_values(self):
+        """ValidTargets enum should have all expected target types."""
+        assert ValidTargets.SELF.value == "self"
+        assert ValidTargets.ALLY.value == "ally"
+        assert ValidTargets.ENEMY.value == "enemy"
+        assert ValidTargets.AREA.value == "area"
+        assert ValidTargets.ANY.value == "any"
+
+
+class TestTargetingRequirements:
+    """Tests for the TargetingRequirements dataclass."""
+
+    def test_self_target_does_not_need_selection(self):
+        """Self-targeting spells/items should not need target selection."""
+        req = TargetingRequirements(
+            valid_targets=ValidTargets.SELF,
+            needs_target_selection=False,
+            can_target_self=True,
+            is_area_effect=False,
+        )
+        assert not req.needs_target_selection
+        assert req.can_target_self
+
+    def test_enemy_target_needs_selection(self):
+        """Enemy-targeting spells/items should need target selection."""
+        req = TargetingRequirements(
+            valid_targets=ValidTargets.ENEMY,
+            needs_target_selection=True,
+            can_target_self=False,
+            is_area_effect=False,
+        )
+        assert req.needs_target_selection
+        assert not req.can_target_self
+
+    def test_area_effect_does_not_need_selection(self):
+        """Area effect spells should not need target selection."""
+        req = TargetingRequirements(
+            valid_targets=ValidTargets.AREA,
+            needs_target_selection=False,
+            can_target_self=False,
+            is_area_effect=True,
+        )
+        assert not req.needs_target_selection
+        assert req.is_area_effect
+
+
+class TestGetSpellTargetingRequirements:
+    """Tests for get_spell_targeting_requirements function."""
+
+    def test_enemy_spell_returns_enemy_requirements(self):
+        """Spell with target_type='enemy' should return enemy targeting requirements."""
+        spell_data = {
+            "name": "Fire Bolt",
+            "target_type": "enemy",
+            "level": 0,
+        }
+        req = get_spell_targeting_requirements(spell_data)
+
+        assert req.valid_targets == ValidTargets.ENEMY
+        assert req.needs_target_selection is True
+        assert req.can_target_self is False
+        assert req.is_area_effect is False
+
+    def test_self_spell_returns_self_requirements(self):
+        """Spell with target_type='self' should return self targeting requirements."""
+        spell_data = {
+            "name": "Shield",
+            "target_type": "self",
+            "level": 1,
+        }
+        req = get_spell_targeting_requirements(spell_data)
+
+        assert req.valid_targets == ValidTargets.SELF
+        assert req.needs_target_selection is False
+        assert req.can_target_self is True
+        assert req.is_area_effect is False
+
+    def test_ally_spell_returns_ally_requirements(self):
+        """Spell with target_type='ally' should return ally targeting requirements."""
+        spell_data = {
+            "name": "Cure Wounds",
+            "target_type": "ally",
+            "level": 1,
+        }
+        req = get_spell_targeting_requirements(spell_data)
+
+        assert req.valid_targets == ValidTargets.ALLY
+        assert req.needs_target_selection is True
+        assert req.can_target_self is True  # Can heal yourself
+        assert req.is_area_effect is False
+
+    def test_area_spell_returns_area_requirements(self):
+        """Spell with target_type='area' should return area targeting requirements."""
+        spell_data = {
+            "name": "Burning Hands",
+            "target_type": "area",
+            "level": 1,
+        }
+        req = get_spell_targeting_requirements(spell_data)
+
+        assert req.valid_targets == ValidTargets.AREA
+        assert req.needs_target_selection is False
+        assert req.can_target_self is False
+        assert req.is_area_effect is True
+
+    def test_any_spell_returns_any_requirements(self):
+        """Spell with target_type='any' should return any targeting requirements."""
+        spell_data = {
+            "name": "Light",
+            "target_type": "any",
+            "level": 0,
+        }
+        req = get_spell_targeting_requirements(spell_data)
+
+        assert req.valid_targets == ValidTargets.ANY
+        assert req.needs_target_selection is True
+        assert req.can_target_self is True  # Can target yourself
+        assert req.is_area_effect is False
+
+    def test_missing_target_type_defaults_to_enemy(self):
+        """Spell without target_type should default to enemy targeting."""
+        spell_data = {
+            "name": "Unknown Spell",
+            "level": 1,
+            # No target_type field
+        }
+        req = get_spell_targeting_requirements(spell_data)
+
+        assert req.valid_targets == ValidTargets.ENEMY
+        assert req.needs_target_selection is True
+        # Should include warning flag for missing target_type
+        assert req.missing_target_type is True
+
+
+class TestGetItemTargetingRequirements:
+    """Tests for get_item_targeting_requirements function."""
+
+    def test_healing_potion_returns_any_requirements(self):
+        """Healing potion with target_type='any' should return any targeting."""
+        item_data = {
+            "name": "Potion of Healing",
+            "effect_type": "healing",
+            "target_type": "any",
+        }
+        req = get_item_targeting_requirements(item_data)
+
+        assert req.valid_targets == ValidTargets.ANY
+        assert req.needs_target_selection is True
+        assert req.can_target_self is True
+
+    def test_self_buff_item_returns_self_requirements(self):
+        """Self-targeting buff item should return self requirements."""
+        item_data = {
+            "name": "Antitoxin",
+            "effect_type": "buff",
+            "target_type": "self",
+        }
+        req = get_item_targeting_requirements(item_data)
+
+        assert req.valid_targets == ValidTargets.SELF
+        assert req.needs_target_selection is False
+        assert req.can_target_self is True
+
+    def test_attack_item_returns_enemy_requirements(self):
+        """Attack item with target_type='enemy' should return enemy requirements."""
+        item_data = {
+            "name": "Alchemist's Fire",
+            "effect_type": "damage",
+            "target_type": "enemy",
+        }
+        req = get_item_targeting_requirements(item_data)
+
+        assert req.valid_targets == ValidTargets.ENEMY
+        assert req.needs_target_selection is True
+        assert req.can_target_self is False
+
+    def test_missing_target_type_defaults_to_self(self):
+        """Item without target_type should default to self targeting."""
+        item_data = {
+            "name": "Unknown Potion",
+            "effect_type": "buff",
+            # No target_type field
+        }
+        req = get_item_targeting_requirements(item_data)
+
+        # Items default to self (unlike spells which default to enemy)
+        assert req.valid_targets == ValidTargets.SELF
+        assert req.needs_target_selection is False
+        assert req.can_target_self is True
+
+
+class TestTargetingRequirementsHelperMethods:
+    """Tests for helper methods on TargetingRequirements."""
+
+    def test_is_valid_target_for_self_spell(self):
+        """Self spells should only allow self as valid target."""
+        req = TargetingRequirements(
+            valid_targets=ValidTargets.SELF,
+            needs_target_selection=False,
+            can_target_self=True,
+            is_area_effect=False,
+        )
+        assert req.is_valid_target_type("self")
+        assert not req.is_valid_target_type("ally")
+        assert not req.is_valid_target_type("enemy")
+
+    def test_is_valid_target_for_ally_spell(self):
+        """Ally spells should allow self and ally targets."""
+        req = TargetingRequirements(
+            valid_targets=ValidTargets.ALLY,
+            needs_target_selection=True,
+            can_target_self=True,
+            is_area_effect=False,
+        )
+        assert req.is_valid_target_type("self")
+        assert req.is_valid_target_type("ally")
+        assert not req.is_valid_target_type("enemy")
+
+    def test_is_valid_target_for_any_spell(self):
+        """Any spells should allow all target types."""
+        req = TargetingRequirements(
+            valid_targets=ValidTargets.ANY,
+            needs_target_selection=True,
+            can_target_self=True,
+            is_area_effect=False,
+        )
+        assert req.is_valid_target_type("self")
+        assert req.is_valid_target_type("ally")
+        assert req.is_valid_target_type("enemy")
+
+    def test_prompt_type_for_enemy_targeting(self):
+        """Enemy targeting should return 'enemy' prompt type."""
+        req = TargetingRequirements(
+            valid_targets=ValidTargets.ENEMY,
+            needs_target_selection=True,
+            can_target_self=False,
+            is_area_effect=False,
+        )
+        assert req.get_prompt_type() == "enemy"
+
+    def test_prompt_type_for_ally_targeting(self):
+        """Ally targeting should return 'ally' prompt type."""
+        req = TargetingRequirements(
+            valid_targets=ValidTargets.ALLY,
+            needs_target_selection=True,
+            can_target_self=True,
+            is_area_effect=False,
+        )
+        assert req.get_prompt_type() == "ally"
+
+    def test_prompt_type_for_self_targeting(self):
+        """Self targeting should return None (no prompt needed)."""
+        req = TargetingRequirements(
+            valid_targets=ValidTargets.SELF,
+            needs_target_selection=False,
+            can_target_self=True,
+            is_area_effect=False,
+        )
+        assert req.get_prompt_type() is None
+
+    def test_prompt_type_for_area_targeting(self):
+        """Area targeting should return None (no prompt needed)."""
+        req = TargetingRequirements(
+            valid_targets=ValidTargets.AREA,
+            needs_target_selection=False,
+            can_target_self=False,
+            is_area_effect=True,
+        )
+        assert req.get_prompt_type() is None


### PR DESCRIPTION
## Summary
- Add targeting requirements service that translates spell/item `target_type` into structured requirements
- CLI now queries this service instead of interpreting game data directly
- Resolves separation of concerns issue where CLI was making game logic decisions

## Changes
- Add `dnd_engine/systems/targeting.py` with:
  - `ValidTargets` enum (SELF, ALLY, ENEMY, AREA, ANY)
  - `TargetingRequirements` dataclass with helper methods
  - `get_spell_targeting_requirements()` function
  - `get_item_targeting_requirements()` function
- Refactor `dnd_engine/ui/cli.py` to use targeting service in 4 locations
- Add `tests/systems/test_targeting.py` with 21 unit tests

## Test plan
- [x] All 21 new targeting service tests pass
- [x] All 151 related combat/spell/item tests pass
- [x] Ruff linting passes on new files
- [x] Code review completed

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)