### PR TITLE
Refactor: Move item assignment logic from CLI to game engine (#214)

### DIFF
--- a/dnd_engine/systems/item_assignment.py
+++ b/dnd_engine/systems/item_assignment.py
@@ -1,0 +1,205 @@
+# ABOUTME: Item assignment service for recommending which character should receive items.
+# ABOUTME: Encapsulates game rules for class-item suitability matching.
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dnd_engine.core.character import Character
+
+
+@dataclass
+class ItemRecommendation:
+    """
+    Recommendation for assigning an item to a character.
+
+    Attributes:
+        character: The recommended character
+        score: Suitability score from 0.0 to 1.0
+               1.0 = perfect match, 0.5 = acceptable, 0.0 = unsuitable
+    """
+    character: "Character"
+    score: float
+
+
+class ItemAssignmentService:
+    """
+    Handles intelligent item assignment recommendations for party members.
+
+    Encapsulates game rules for determining which character class should
+    receive which item types. The CLI calls this service to get recommendations
+    and handles user interaction separately.
+
+    Class-item suitability rules:
+    - Weapons: prefer martial classes (Fighter)
+    - Armor: prefer tank classes (Fighter, Cleric)
+    - Scrolls/wands/staves: prefer casters (Wizard, Cleric)
+    - Potions: prefer characters with lower HP percentage
+    """
+
+    # Classes that prefer martial weapons
+    MARTIAL_CLASSES = frozenset(["fighter"])
+
+    # Classes that prefer heavy armor
+    TANK_CLASSES = frozenset(["fighter", "cleric"])
+
+    # Classes that prefer magical items (scrolls, wands, staves)
+    CASTER_CLASSES = frozenset(["wizard", "cleric"])
+
+    def __init__(self, items_data: dict[str, Any] | None = None):
+        """
+        Initialize the item assignment service.
+
+        Args:
+            items_data: Full items data from items.json. If not provided,
+                       will be loaded on first use.
+        """
+        self._items_data = items_data
+
+    @property
+    def items_data(self) -> dict[str, Any]:
+        """Lazy-load items data if not provided."""
+        if self._items_data is None:
+            from dnd_engine.rules.loader import DataLoader
+            data_loader = DataLoader()
+            self._items_data = data_loader.load_items()
+        return self._items_data
+
+    def get_recommended_recipients(
+        self,
+        item_id: str,
+        party_members: list["Character"]
+    ) -> list[ItemRecommendation]:
+        """
+        Get recommended recipients for an item with suitability scores.
+
+        Args:
+            item_id: ID of the item to assign
+            party_members: List of living party members to consider
+
+        Returns:
+            List of ItemRecommendation objects sorted by score (highest first).
+            Empty list if no party members provided.
+        """
+        if not party_members:
+            return []
+
+        # Find item details and category
+        item_details, category = self._find_item_details(item_id)
+
+        recommendations = []
+        for character in party_members:
+            score = self._calculate_suitability_score(
+                character, item_id, item_details, category
+            )
+            recommendations.append(ItemRecommendation(character=character, score=score))
+
+        # Sort by score descending
+        recommendations.sort(key=lambda r: r.score, reverse=True)
+        return recommendations
+
+    def _find_item_details(
+        self,
+        item_id: str
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        """
+        Find item details and category from items data.
+
+        Args:
+            item_id: ID of the item to look up
+
+        Returns:
+            Tuple of (item_details dict, category string) or (None, None) if not found
+        """
+        for category, category_items in self.items_data.items():
+            if isinstance(category_items, dict) and item_id in category_items:
+                return category_items[item_id], category
+        return None, None
+
+    def _calculate_suitability_score(
+        self,
+        character: "Character",
+        item_id: str,
+        item_details: dict[str, Any] | None,
+        category: str | None
+    ) -> float:
+        """
+        Calculate how suitable a character is for an item.
+
+        Args:
+            character: The character to evaluate
+            item_id: ID of the item
+            item_details: Item details from items.json (may be None)
+            category: Item category (weapons, armor, consumables)
+
+        Returns:
+            Suitability score from 0.0 to 1.0
+        """
+        char_class = character.character_class.value.lower()
+
+        # If we have item details, use type-based scoring
+        if item_details:
+            item_type = item_details.get("type", "").lower()
+
+            # Weapons: prefer martial classes
+            if "weapon" in item_type or category == "weapons":
+                if char_class in self.MARTIAL_CLASSES:
+                    return 1.0
+                return 0.5
+
+            # Armor: prefer tank classes
+            if "armor" in item_type or category == "armor":
+                if char_class in self.TANK_CLASSES:
+                    return 1.0
+                return 0.5
+
+        # Scrolls/wands/staves: prefer casters (check item_id for keywords)
+        if any(keyword in item_id.lower() for keyword in ["scroll", "wand", "staff"]):
+            if char_class in self.CASTER_CLASSES:
+                return 1.0
+            return 0.3
+
+        # Potions/consumables: score based on HP percentage (lower HP = higher score)
+        if "potion" in item_id.lower() or category == "consumables":
+            if character.max_hp > 0:
+                hp_percentage = character.current_hp / character.max_hp
+                # Invert so lower HP = higher score, scale to 0.5-1.0 range
+                return 0.5 + (0.5 * (1.0 - hp_percentage))
+            return 0.5
+
+        # Default: all characters equally suitable
+        return 0.5
+
+    def should_auto_assign(
+        self,
+        recommendations: list[ItemRecommendation],
+        threshold: float = 0.8
+    ) -> "Character | None":
+        """
+        Determine if an item should be auto-assigned without user prompt.
+
+        Auto-assigns when:
+        - Only one party member exists
+        - Exactly one character has a score >= threshold and others are below
+
+        Args:
+            recommendations: List of recommendations from get_recommended_recipients
+            threshold: Minimum score for auto-assignment (default 0.8)
+
+        Returns:
+            Character to auto-assign to, or None if user should be prompted
+        """
+        if not recommendations:
+            return None
+
+        # Single party member: auto-assign
+        if len(recommendations) == 1:
+            return recommendations[0].character
+
+        # Check for single high-confidence match
+        high_scorers = [r for r in recommendations if r.score >= threshold]
+        if len(high_scorers) == 1:
+            return high_scorers[0].character
+
+        # Multiple matches or no clear winner: prompt user
+        return None

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -6,19 +6,20 @@ from typing import Any, Optional
 from rich.panel import Panel
 
 from dnd_engine.core.character import Character, CharacterClass
-from dnd_engine.llm.npc_chat import NPCChatManager
 from dnd_engine.core.dice import format_dice_with_modifier
 from dnd_engine.core.game_state import CombatEvent, CombatSpellResult, GameState
+from dnd_engine.llm.npc_chat import NPCChatManager
 from dnd_engine.systems.action_economy import ActionType
 from dnd_engine.systems.ai import EnemyAI
 from dnd_engine.systems.combat_context import CombatContextBuilder
 from dnd_engine.systems.combat_middleware import ActionResult, CombatActionExecutor
 from dnd_engine.systems.condition_manager import ConditionManager
 from dnd_engine.systems.inventory import EquipmentSlot
+from dnd_engine.systems.item_assignment import ItemAssignmentService
 from dnd_engine.systems.targeting import (
+    ValidTargets,
     get_item_targeting_requirements,
     get_spell_targeting_requirements,
-    ValidTargets,
 )
 from dnd_engine.ui.debug_console import DebugConsole
 from dnd_engine.ui.rich_ui import (
@@ -83,6 +84,9 @@ class CLI:
 
         # Enemy AI for combat decisions
         self.enemy_ai = EnemyAI()
+
+        # Item assignment service for intelligent item distribution
+        self.item_assignment = ItemAssignmentService()
 
         # Combat context builder for assembling narrative context
         self.context_builder = CombatContextBuilder(game_state.data_loader, game_state)
@@ -1612,6 +1616,9 @@ class CLI:
         """
         Intelligently assign an item to a character based on class and item type.
 
+        Uses ItemAssignmentService for recommendation logic, then handles user
+        interaction if needed.
+
         Args:
             item: The item to assign
             living_members: List of living party members
@@ -1621,64 +1628,22 @@ class CLI:
         """
         item_id = item.get("id", "")
 
-        # If only one character, auto-assign
-        if len(living_members) == 1:
-            return living_members[0]
+        # Get recommendations from the item assignment service
+        recommendations = self.item_assignment.get_recommended_recipients(
+            item_id, living_members
+        )
 
-        # Load items data to get item type
-        from dnd_engine.rules.loader import DataLoader
-        data_loader = DataLoader()
-        items_data = data_loader.load_items()
+        # Check if we can auto-assign
+        auto_recipient = self.item_assignment.should_auto_assign(recommendations)
+        if auto_recipient:
+            return auto_recipient
 
-        # Find item details
-        item_details = None
-        for category, category_items in items_data.items():
-            if item_id in category_items:
-                item_details = category_items[item_id]
-                break
-
-        # Intelligent assignment based on item type
-        best_matches = []
-
-        if item_details:
-            item_type = item_details.get("type", "").lower()
-
-            # Weapons: prefer martial classes
-            if "weapon" in item_type or category == "weapons":
-                for char in living_members:
-                    char_class = char.character_class.value.lower()
-                    if char_class in ["fighter", "barbarian", "ranger", "paladin"]:
-                        best_matches.append(char)
-
-            # Armor: prefer tank classes
-            elif "armor" in item_type or category == "armor":
-                for char in living_members:
-                    char_class = char.character_class.value.lower()
-                    if char_class in ["fighter", "paladin", "cleric"]:
-                        best_matches.append(char)
-
-            # Scrolls/wands: prefer casters
-            elif "scroll" in item_id or "wand" in item_id or "staff" in item_id:
-                for char in living_members:
-                    char_class = char.character_class.value.lower()
-                    if char_class in ["wizard", "sorcerer", "cleric", "druid"]:
-                        best_matches.append(char)
-
-            # Potions/consumables: distribute to anyone who needs them
-            elif "potion" in item_id or category == "consumables":
-                # Prefer characters with lower HP percentage
-                chars_by_hp = sorted(living_members, key=lambda c: c.current_hp / c.max_hp if c.max_hp > 0 else 0)
-                best_matches = chars_by_hp
-
-        # If we have clear best matches, auto-assign to first one
-        if len(best_matches) == 1:
-            return best_matches[0]
-
-        # If multiple good matches or no clear match, prompt user
+        # Multiple good matches or no clear match: prompt user
         import questionary
 
         choices = []
-        for character in living_members:
+        for rec in recommendations:
+            character = rec.character
             choice_text = f"{character.name} ({character.character_class.value.title()})"
             choices.append(questionary.Choice(title=choice_text, value=character))
 

--- a/tests/test_item_assignment.py
+++ b/tests/test_item_assignment.py
@@ -1,0 +1,435 @@
+# ABOUTME: Unit tests for item assignment service.
+# ABOUTME: Verifies class-item suitability matching and auto-assignment logic.
+
+from enum import Enum
+
+import pytest
+
+from dnd_engine.systems.item_assignment import ItemAssignmentService, ItemRecommendation
+
+
+class MockCharacterClass(Enum):
+    """Mock character class enum for testing."""
+    FIGHTER = "fighter"
+    ROGUE = "rogue"
+    WIZARD = "wizard"
+    CLERIC = "cleric"
+
+
+class MockCharacter:
+    """Mock character for testing item assignment."""
+
+    def __init__(
+        self,
+        name: str,
+        character_class: MockCharacterClass,
+        current_hp: int = 20,
+        max_hp: int = 20
+    ):
+        self.name = name
+        self.character_class = character_class
+        self.current_hp = current_hp
+        self.max_hp = max_hp
+
+
+class TestItemAssignmentServiceWeapons:
+    """Test cases for weapon item assignment recommendations."""
+
+    @pytest.fixture
+    def service(self):
+        """Create service with mock items data."""
+        items_data = {
+            "weapons": {
+                "longsword": {"name": "Longsword", "type": "weapon"},
+                "dagger": {"name": "Dagger", "type": "weapon"},
+            }
+        }
+        return ItemAssignmentService(items_data=items_data)
+
+    def test_fighter_gets_high_score_for_weapons(self, service):
+        """Test that fighter gets highest score for weapons."""
+        party = [
+            MockCharacter("Conan", MockCharacterClass.FIGHTER),
+            MockCharacter("Gandalf", MockCharacterClass.WIZARD),
+        ]
+
+        recommendations = service.get_recommended_recipients("longsword", party)
+
+        # Fighter should be first with score 1.0
+        assert recommendations[0].character.name == "Conan"
+        assert recommendations[0].score == 1.0
+        # Wizard should have lower score
+        assert recommendations[1].character.name == "Gandalf"
+        assert recommendations[1].score == 0.5
+
+    def test_all_non_martial_classes_get_equal_weapon_score(self, service):
+        """Test that non-martial classes all get same weapon score."""
+        party = [
+            MockCharacter("Gandalf", MockCharacterClass.WIZARD),
+            MockCharacter("Frodo", MockCharacterClass.ROGUE),
+            MockCharacter("Brother Marcus", MockCharacterClass.CLERIC),
+        ]
+
+        recommendations = service.get_recommended_recipients("longsword", party)
+
+        # All should have score 0.5
+        for rec in recommendations:
+            assert rec.score == 0.5
+
+
+class TestItemAssignmentServiceArmor:
+    """Test cases for armor item assignment recommendations."""
+
+    @pytest.fixture
+    def service(self):
+        """Create service with mock items data."""
+        items_data = {
+            "armor": {
+                "chainmail": {"name": "Chainmail", "type": "armor"},
+                "plate": {"name": "Plate", "type": "armor"},
+            }
+        }
+        return ItemAssignmentService(items_data=items_data)
+
+    def test_fighter_gets_high_score_for_armor(self, service):
+        """Test that fighter gets highest score for armor."""
+        party = [
+            MockCharacter("Conan", MockCharacterClass.FIGHTER),
+            MockCharacter("Gandalf", MockCharacterClass.WIZARD),
+        ]
+
+        recommendations = service.get_recommended_recipients("chainmail", party)
+
+        assert recommendations[0].character.name == "Conan"
+        assert recommendations[0].score == 1.0
+
+    def test_cleric_gets_high_score_for_armor(self, service):
+        """Test that cleric gets highest score for armor."""
+        party = [
+            MockCharacter("Brother Marcus", MockCharacterClass.CLERIC),
+            MockCharacter("Gandalf", MockCharacterClass.WIZARD),
+        ]
+
+        recommendations = service.get_recommended_recipients("chainmail", party)
+
+        assert recommendations[0].character.name == "Brother Marcus"
+        assert recommendations[0].score == 1.0
+
+    def test_rogue_wizard_get_lower_armor_score(self, service):
+        """Test that rogue and wizard get lower armor scores."""
+        party = [
+            MockCharacter("Shadow", MockCharacterClass.ROGUE),
+            MockCharacter("Gandalf", MockCharacterClass.WIZARD),
+        ]
+
+        recommendations = service.get_recommended_recipients("chainmail", party)
+
+        for rec in recommendations:
+            assert rec.score == 0.5
+
+
+class TestItemAssignmentServiceMagicItems:
+    """Test cases for magical item (scrolls, wands, staves) recommendations."""
+
+    @pytest.fixture
+    def service(self):
+        """Create service with mock items data."""
+        items_data = {
+            "consumables": {
+                "scroll_of_fireball": {"name": "Scroll of Fireball", "type": "scroll"},
+                "wand_of_magic_missiles": {"name": "Wand of Magic Missiles", "type": "wand"},
+            }
+        }
+        return ItemAssignmentService(items_data=items_data)
+
+    def test_wizard_gets_high_score_for_scroll(self, service):
+        """Test that wizard gets highest score for scrolls."""
+        party = [
+            MockCharacter("Conan", MockCharacterClass.FIGHTER),
+            MockCharacter("Gandalf", MockCharacterClass.WIZARD),
+        ]
+
+        recommendations = service.get_recommended_recipients("scroll_of_fireball", party)
+
+        assert recommendations[0].character.name == "Gandalf"
+        assert recommendations[0].score == 1.0
+
+    def test_cleric_gets_high_score_for_scroll(self, service):
+        """Test that cleric gets highest score for scrolls."""
+        party = [
+            MockCharacter("Conan", MockCharacterClass.FIGHTER),
+            MockCharacter("Brother Marcus", MockCharacterClass.CLERIC),
+        ]
+
+        recommendations = service.get_recommended_recipients("scroll_of_fireball", party)
+
+        assert recommendations[0].character.name == "Brother Marcus"
+        assert recommendations[0].score == 1.0
+
+    def test_wand_detected_by_item_id(self, service):
+        """Test that wands are detected by item_id keyword."""
+        party = [
+            MockCharacter("Conan", MockCharacterClass.FIGHTER),
+            MockCharacter("Gandalf", MockCharacterClass.WIZARD),
+        ]
+
+        recommendations = service.get_recommended_recipients("wand_of_magic_missiles", party)
+
+        assert recommendations[0].character.name == "Gandalf"
+        assert recommendations[0].score == 1.0
+
+    def test_staff_detected_by_item_id(self, service):
+        """Test that staves are detected by item_id keyword."""
+        service_with_staff = ItemAssignmentService(items_data={"weapons": {}})
+        party = [
+            MockCharacter("Conan", MockCharacterClass.FIGHTER),
+            MockCharacter("Gandalf", MockCharacterClass.WIZARD),
+        ]
+
+        recommendations = service_with_staff.get_recommended_recipients("staff_of_power", party)
+
+        assert recommendations[0].character.name == "Gandalf"
+        assert recommendations[0].score == 1.0
+
+    def test_non_caster_gets_low_score_for_magic_items(self, service):
+        """Test that non-casters get low score for magic items."""
+        party = [
+            MockCharacter("Conan", MockCharacterClass.FIGHTER),
+            MockCharacter("Shadow", MockCharacterClass.ROGUE),
+        ]
+
+        recommendations = service.get_recommended_recipients("scroll_of_fireball", party)
+
+        # Both should have low score (0.3)
+        for rec in recommendations:
+            assert rec.score == 0.3
+
+
+class TestItemAssignmentServicePotions:
+    """Test cases for potion/consumable assignment based on HP."""
+
+    @pytest.fixture
+    def service(self):
+        """Create service with mock items data."""
+        items_data = {
+            "consumables": {
+                "potion_of_healing": {"name": "Potion of Healing", "type": "potion"},
+            }
+        }
+        return ItemAssignmentService(items_data=items_data)
+
+    def test_lower_hp_character_gets_higher_potion_score(self, service):
+        """Test that character with lower HP gets higher potion score."""
+        party = [
+            MockCharacter("Healthy", MockCharacterClass.FIGHTER, current_hp=20, max_hp=20),
+            MockCharacter("Injured", MockCharacterClass.WIZARD, current_hp=5, max_hp=20),
+        ]
+
+        recommendations = service.get_recommended_recipients("potion_of_healing", party)
+
+        # Injured character should be first
+        assert recommendations[0].character.name == "Injured"
+        assert recommendations[0].score > recommendations[1].score
+
+    def test_full_hp_character_gets_baseline_potion_score(self, service):
+        """Test that full HP character gets baseline score of 0.5."""
+        party = [
+            MockCharacter("Healthy", MockCharacterClass.FIGHTER, current_hp=20, max_hp=20),
+        ]
+
+        recommendations = service.get_recommended_recipients("potion_of_healing", party)
+
+        assert recommendations[0].score == 0.5
+
+    def test_zero_hp_character_gets_max_potion_score(self, service):
+        """Test that 0 HP character gets maximum score of 1.0."""
+        party = [
+            MockCharacter("Down", MockCharacterClass.FIGHTER, current_hp=0, max_hp=20),
+        ]
+
+        recommendations = service.get_recommended_recipients("potion_of_healing", party)
+
+        assert recommendations[0].score == 1.0
+
+    def test_half_hp_character_gets_intermediate_score(self, service):
+        """Test that half HP character gets score of 0.75."""
+        party = [
+            MockCharacter("HalfHP", MockCharacterClass.FIGHTER, current_hp=10, max_hp=20),
+        ]
+
+        recommendations = service.get_recommended_recipients("potion_of_healing", party)
+
+        assert recommendations[0].score == 0.75
+
+
+class TestItemAssignmentServiceUnknownItems:
+    """Test cases for unknown or generic items."""
+
+    @pytest.fixture
+    def service(self):
+        """Create service with minimal items data."""
+        return ItemAssignmentService(items_data={})
+
+    def test_unknown_item_gives_equal_scores(self, service):
+        """Test that unknown items give equal scores to all characters."""
+        party = [
+            MockCharacter("Conan", MockCharacterClass.FIGHTER),
+            MockCharacter("Gandalf", MockCharacterClass.WIZARD),
+            MockCharacter("Shadow", MockCharacterClass.ROGUE),
+        ]
+
+        recommendations = service.get_recommended_recipients("mystery_item", party)
+
+        # All should have equal score of 0.5
+        for rec in recommendations:
+            assert rec.score == 0.5
+
+
+class TestItemAssignmentServiceAutoAssign:
+    """Test cases for auto-assignment decision logic."""
+
+    @pytest.fixture
+    def service(self):
+        """Create service with mock items data."""
+        items_data = {
+            "weapons": {
+                "longsword": {"name": "Longsword", "type": "weapon"},
+            }
+        }
+        return ItemAssignmentService(items_data=items_data)
+
+    def test_auto_assign_single_party_member(self, service):
+        """Test auto-assign when only one party member."""
+        party = [MockCharacter("Solo", MockCharacterClass.FIGHTER)]
+        recommendations = service.get_recommended_recipients("longsword", party)
+
+        result = service.should_auto_assign(recommendations)
+
+        assert result is not None
+        assert result.name == "Solo"
+
+    def test_auto_assign_single_high_scorer(self, service):
+        """Test auto-assign when one character has score >= threshold."""
+        party = [
+            MockCharacter("Conan", MockCharacterClass.FIGHTER),
+            MockCharacter("Gandalf", MockCharacterClass.WIZARD),
+        ]
+        recommendations = service.get_recommended_recipients("longsword", party)
+
+        result = service.should_auto_assign(recommendations)
+
+        # Fighter has 1.0, Wizard has 0.5 - should auto-assign to Fighter
+        assert result is not None
+        assert result.name == "Conan"
+
+    def test_no_auto_assign_multiple_high_scorers(self, service):
+        """Test no auto-assign when multiple characters have high scores."""
+        party = [
+            MockCharacter("Conan", MockCharacterClass.FIGHTER),
+            MockCharacter("Roland", MockCharacterClass.FIGHTER),
+        ]
+        recommendations = service.get_recommended_recipients("longsword", party)
+
+        result = service.should_auto_assign(recommendations)
+
+        # Both fighters have 1.0, should prompt user
+        assert result is None
+
+    def test_no_auto_assign_empty_recommendations(self, service):
+        """Test no auto-assign when no recommendations."""
+        result = service.should_auto_assign([])
+
+        assert result is None
+
+    def test_auto_assign_custom_threshold(self, service):
+        """Test auto-assign with custom threshold."""
+        party = [
+            MockCharacter("Gandalf", MockCharacterClass.WIZARD),
+            MockCharacter("Shadow", MockCharacterClass.ROGUE),
+        ]
+        recommendations = service.get_recommended_recipients("longsword", party)
+
+        # With default threshold 0.8, neither scores high enough
+        # Both have 0.5, so no auto-assign
+        result = service.should_auto_assign(recommendations)
+        assert result is None
+
+        # With threshold 0.4, first one qualifies
+        result_low_threshold = service.should_auto_assign(recommendations, threshold=0.4)
+        assert result_low_threshold is None  # Still None because BOTH are >= 0.4
+
+
+class TestItemAssignmentServiceEdgeCases:
+    """Test edge cases and error handling."""
+
+    @pytest.fixture
+    def service(self):
+        """Create service with mock items data."""
+        return ItemAssignmentService(items_data={"weapons": {}})
+
+    def test_empty_party_returns_empty_list(self, service):
+        """Test that empty party returns empty recommendations."""
+        recommendations = service.get_recommended_recipients("longsword", [])
+
+        assert recommendations == []
+
+    def test_recommendations_sorted_by_score_descending(self, service):
+        """Test that recommendations are sorted by score (highest first)."""
+        items_data = {
+            "consumables": {
+                "potion_of_healing": {"name": "Potion", "type": "potion"},
+            }
+        }
+        service = ItemAssignmentService(items_data=items_data)
+
+        party = [
+            MockCharacter("Full", MockCharacterClass.FIGHTER, current_hp=20, max_hp=20),
+            MockCharacter("Half", MockCharacterClass.WIZARD, current_hp=10, max_hp=20),
+            MockCharacter("Low", MockCharacterClass.ROGUE, current_hp=2, max_hp=20),
+        ]
+
+        recommendations = service.get_recommended_recipients("potion_of_healing", party)
+
+        # Should be sorted: Low (highest score) -> Half -> Full (lowest score)
+        assert recommendations[0].character.name == "Low"
+        assert recommendations[1].character.name == "Half"
+        assert recommendations[2].character.name == "Full"
+
+    def test_character_with_zero_max_hp_gets_default_potion_score(self):
+        """Test that character with 0 max_hp doesn't cause division by zero."""
+        items_data = {
+            "consumables": {
+                "potion_of_healing": {"name": "Potion", "type": "potion"},
+            }
+        }
+        service = ItemAssignmentService(items_data=items_data)
+
+        party = [
+            MockCharacter("ZeroMax", MockCharacterClass.FIGHTER, current_hp=0, max_hp=0),
+        ]
+
+        recommendations = service.get_recommended_recipients("potion_of_healing", party)
+
+        # Should not raise, should return default score
+        assert len(recommendations) == 1
+        assert recommendations[0].score == 0.5
+
+
+class TestItemRecommendationDataclass:
+    """Test ItemRecommendation dataclass."""
+
+    def test_item_recommendation_creation(self):
+        """Test creating an ItemRecommendation."""
+        char = MockCharacter("Test", MockCharacterClass.FIGHTER)
+        rec = ItemRecommendation(character=char, score=0.8)
+
+        assert rec.character == char
+        assert rec.score == 0.8
+
+    def test_item_recommendation_equality(self):
+        """Test ItemRecommendation equality based on content."""
+        char = MockCharacter("Test", MockCharacterClass.FIGHTER)
+        rec1 = ItemRecommendation(character=char, score=0.8)
+        rec2 = ItemRecommendation(character=char, score=0.8)
+
+        assert rec1 == rec2


### PR DESCRIPTION
## Summary
- Create `ItemAssignmentService` to encapsulate class-item suitability rules
- Follow the `EnemyAI` pattern for separation of concerns
- CLI delegates to service for recommendations, handles only user interaction
- Reduce `_auto_assign_item()` from 50 lines of game logic to 25 lines of UI code

## Changes
- **New**: `dnd_engine/systems/item_assignment.py` - Service with scoring logic
- **New**: `tests/test_item_assignment.py` - 25 unit tests
- **Modified**: `dnd_engine/ui/cli.py` - Use new service

## Test plan
- [x] All 25 new unit tests pass
- [x] Existing search/take integration tests pass
- [x] Ruff linting clean on new files
- [ ] Manual test: pick up items in game to verify behavior preserved

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)