### PR TITLE
Refactor: Consolidate combat item use logic from CLI to game engine (#215)

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -103,6 +103,33 @@ class CombatItemResult:
 
 
 @dataclass
+class CombatItemUseResult:
+    """
+    Result of using a consumable item during combat (non-attack items).
+
+    Contains all information needed for UI display without requiring
+    the CLI to perform any game logic calculations.
+    """
+    success: bool
+    item_name: str
+    action_type: ActionType
+    user_name: str
+    target_name: str
+
+    # Effect details (from ItemEffectResult)
+    effect_type: str | None = None
+    effect_message: str | None = None
+    effect_amount: int = 0
+
+    # HP tracking for healing display
+    hp_before: int | None = None
+    hp_after: int | None = None
+
+    # Error handling
+    error_message: str | None = None
+
+
+@dataclass
 class CombatSpellResult:
     """
     Result of casting a spell in combat.
@@ -2951,4 +2978,150 @@ class GameState:
             item_name=item_name,
             action_type=action_required,
             special_effects=special_effects
+        )
+
+    def use_item_combat(
+        self,
+        user: Character,
+        item_id: str,
+        target: Character | Creature
+    ) -> CombatItemUseResult:
+        """
+        Use a consumable item during combat (non-attack items like potions).
+
+        Handles the complete flow of using consumable items:
+        1. Validates action economy
+        2. Consumes item from inventory
+        3. Applies item effect to target
+        4. Emits appropriate events
+
+        Args:
+            user: Character using the item
+            item_id: ID of the item to use
+            target: Target character/creature for the effect
+
+        Returns:
+            CombatItemUseResult with effect outcome and display information
+        """
+        from dnd_engine.systems.item_effects import apply_item_effect
+
+        # Load item data
+        items_data = self.data_loader.load_items()
+
+        # Find item in consumables category
+        item_data = items_data.get("consumables", {}).get(item_id)
+
+        if item_data is None:
+            return CombatItemUseResult(
+                success=False,
+                item_name=item_id,
+                action_type=ActionType.ACTION,
+                user_name=user.name,
+                target_name=target.name,
+                error_message=f"Item '{item_id}' not found in consumables"
+            )
+
+        item_name = item_data.get("name", item_id)
+
+        # Parse action required
+        action_required_str = item_data.get("action_required", "action")
+        action_type_map = {
+            "action": ActionType.ACTION,
+            "bonus_action": ActionType.BONUS_ACTION,
+            "free_object": ActionType.FREE_OBJECT,
+            "no_action": ActionType.NO_ACTION
+        }
+        action_required = action_type_map.get(action_required_str, ActionType.ACTION)
+
+        # Validate action economy
+        turn_state = self.initiative_tracker.get_current_turn_state() if self.initiative_tracker else None
+        if not turn_state:
+            return CombatItemUseResult(
+                success=False,
+                item_name=item_name,
+                action_type=action_required,
+                user_name=user.name,
+                target_name=target.name,
+                error_message="Unable to get current turn state"
+            )
+
+        if not turn_state.is_action_available(action_required):
+            action_name = action_required_str.replace("_", " ").title()
+            return CombatItemUseResult(
+                success=False,
+                item_name=item_name,
+                action_type=action_required,
+                user_name=user.name,
+                target_name=target.name,
+                error_message=f"No {action_name} available this turn"
+            )
+
+        # Consume the action
+        if not turn_state.consume_action(action_required):
+            return CombatItemUseResult(
+                success=False,
+                item_name=item_name,
+                action_type=action_required,
+                user_name=user.name,
+                target_name=target.name,
+                error_message=f"Failed to consume {action_required_str}"
+            )
+
+        # Track HP before for healing display
+        hp_before = target.current_hp
+
+        # Use the item from inventory (removes it)
+        inventory = user.inventory
+        success, used_item_data = inventory.use_item(item_id, items_data)
+
+        if not success:
+            # Restore the action since item use failed
+            turn_state.reset()
+            turn_state.consume_action(action_required)
+            return CombatItemUseResult(
+                success=False,
+                item_name=item_name,
+                action_type=action_required,
+                user_name=user.name,
+                target_name=target.name,
+                error_message=f"Failed to use {item_name} from inventory"
+            )
+
+        # Apply the item's effect
+        effect_result = apply_item_effect(
+            item_info=used_item_data,
+            target=target,
+            dice_roller=self.dice_roller,
+            event_bus=self.event_bus,
+            time_manager=self.time_manager
+        )
+
+        # Track HP after for healing display
+        hp_after = target.current_hp
+
+        # Emit item used event
+        self.event_bus.emit(Event(
+            type=EventType.ITEM_USED,
+            data={
+                "character": user.name,
+                "target": target.name,
+                "item_id": item_id,
+                "item_name": item_name,
+                "effect_type": effect_result.effect_type,
+                "action_cost": action_required_str,
+                "success": effect_result.success
+            }
+        ))
+
+        return CombatItemUseResult(
+            success=True,
+            item_name=item_name,
+            action_type=action_required,
+            user_name=user.name,
+            target_name=target.name,
+            effect_type=effect_result.effect_type,
+            effect_message=effect_result.message,
+            effect_amount=effect_result.amount,
+            hp_before=hp_before,
+            hp_after=hp_after
         )

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -3764,201 +3764,55 @@ class CLI:
         # Use the item via the direct handler
         self.handle_use_item_direct(target_item_id, target, owner)
 
-    def handle_use_item_combat_direct(self, item_id: str, item_data: dict[str, Any], character: Character) -> None:
-        """
-        Handle using a consumable item during combat with explicit item data.
-
-        Validates action economy, consumes action, and applies item effect.
-
-        Args:
-            item_id: The item ID to use
-            item_data: The item data dictionary
-            character: The character using the item
-        """
-        from dnd_engine.systems.action_economy import ActionType
-        from dnd_engine.systems.item_effects import apply_item_effect
-
-        inventory = character.inventory
-        items_data = self.game_state.data_loader.load_items()
-
-        item_name = item_data.get("name", item_id)
-        action_required_str = item_data.get("action_required", "action")
-
-        # Map string to ActionType
-        action_type_map = {
-            "action": ActionType.ACTION,
-            "bonus_action": ActionType.BONUS_ACTION,
-            "free_object": ActionType.FREE_OBJECT,
-            "no_action": ActionType.NO_ACTION
-        }
-        action_required = action_type_map.get(action_required_str, ActionType.ACTION)
-
-        # Check if action is available
-        turn_state = self.game_state.initiative_tracker.get_current_turn_state()
-        if not turn_state:
-            print_error("Unable to get current turn state!")
-            return
-
-        if not turn_state.is_action_available(action_required):
-            action_name = action_required_str.replace("_", " ").title()
-            print_error(f"You don't have a {action_name} available this turn!")
-            print_status_message(f"Available: {turn_state}", "info")
-            return
-
-        # Consume the action
-        if not turn_state.consume_action(action_required):
-            print_error(f"Failed to consume {action_required_str}!")
-            return
-
-        # Use the item from inventory (removes it)
-        success, used_item_data = inventory.use_item(item_id, items_data)
-
-        if not success:
-            print_error(f"Failed to use {item_name}")
-            # Restore the action since item use failed
-            turn_state.reset()
-            turn_state.consume_action(action_required)  # Put back what we consumed
-            return
-
-        # Apply the item's effect
-        result = apply_item_effect(
-            item_info=used_item_data,
-            target=character,
-            dice_roller=self.game_state.dice_roller,
-            event_bus=self.game_state.event_bus,
-            time_manager=self.game_state.time_manager
-        )
-
-        # Display the result
-        action_cost_msg = f"({action_required_str.replace('_', ' ')})"
-        print_status_message(f"{character.name} uses {item_name} {action_cost_msg}", "info")
-        print_message(result.message)
-
-        # Show remaining actions
-        remaining_actions = str(turn_state)
-        print_status_message(f"Remaining this turn: {remaining_actions}", "info")
-
-        # Suggest ending turn if player wants to skip remaining actions
-        if turn_state.has_any_action():
-            print_status_message("Type 'done' or 'pass' to end your turn", "info")
-
-        # Emit item used event
-        self.game_state.event_bus.emit(Event(
-            type=EventType.ITEM_USED,
-            data={
-                "character": character.name,
-                "item_id": item_id,
-                "item_name": item_name,
-                "effect_type": result.effect_type,
-                "action_cost": action_required_str,
-                "success": result.success
-            }
-        ))
-
     def handle_use_item_combat_with_target(self, item_id: str, item_data: dict[str, Any], user: Character, target: Character) -> None:
         """
         Handle using a consumable item during combat on a specified target.
 
-        Validates action economy, consumes action, and applies item effect to target.
+        Delegates game logic to game_state.use_item_combat() and handles display.
 
         Args:
             item_id: The item ID to use
-            item_data: The item data dictionary
+            item_data: The item data dictionary (unused, kept for API compatibility)
             user: The character using the item
             target: The character receiving the item's effect
         """
-        from dnd_engine.systems.action_economy import ActionType
-        from dnd_engine.systems.item_effects import apply_item_effect
+        # Use the game state method to handle all game logic
+        result = self.game_state.use_item_combat(user, item_id, target)
 
-        inventory = user.inventory
-        items_data = self.game_state.data_loader.load_items()
-
-        item_name = item_data.get("name", item_id)
-        action_required_str = item_data.get("action_required", "action")
-
-        # Map string to ActionType
-        action_type_map = {
-            "action": ActionType.ACTION,
-            "bonus_action": ActionType.BONUS_ACTION,
-            "free_object": ActionType.FREE_OBJECT,
-            "no_action": ActionType.NO_ACTION
-        }
-        action_required = action_type_map.get(action_required_str, ActionType.ACTION)
-
-        # Check if action is available
-        turn_state = self.game_state.initiative_tracker.get_current_turn_state()
-        if not turn_state:
-            print_error("Unable to get current turn state!")
+        # Handle failure cases
+        if not result.success:
+            # Action economy issues - show available actions
+            if result.error_message and "available" in result.error_message.lower():
+                turn_state = self.game_state.initiative_tracker.get_current_turn_state()
+                print_error(f"You don't have a {result.action_type.value.replace('_', ' ')} available this turn!")
+                if turn_state:
+                    print_status_message(f"Available: {turn_state}", "info")
+            else:
+                print_error(result.error_message or "Failed to use item")
             return
-
-        if not turn_state.is_action_available(action_required):
-            action_name = action_required_str.replace("_", " ").title()
-            print_error(f"You don't have a {action_name} available this turn!")
-            print_status_message(f"Available: {turn_state}", "info")
-            return
-
-        # Consume the action
-        if not turn_state.consume_action(action_required):
-            print_error(f"Failed to consume {action_required_str}!")
-            return
-
-        # Show HP before healing (if target is alive or unconscious)
-        hp_before = target.current_hp
-
-        # Use the item from inventory (removes it)
-        success, used_item_data = inventory.use_item(item_id, items_data)
-
-        if not success:
-            print_error(f"Failed to use {item_name}")
-            # Restore the action since item use failed
-            turn_state.reset()
-            turn_state.consume_action(action_required)  # Put back what we consumed
-            return
-
-        # Apply the item's effect to the target
-        result = apply_item_effect(
-            item_info=used_item_data,
-            target=target,
-            dice_roller=self.game_state.dice_roller,
-            event_bus=self.game_state.event_bus,
-            time_manager=self.game_state.time_manager
-        )
 
         # Display the result with target information
-        action_cost_msg = f"({action_required_str.replace('_', ' ')})"
-        if user == target:
-            print_status_message(f"{user.name} uses {item_name} {action_cost_msg}", "info")
+        action_cost_msg = f"({result.action_type.value.replace('_', ' ')})"
+        if result.user_name == result.target_name:
+            print_status_message(f"{result.user_name} uses {result.item_name} {action_cost_msg}", "info")
         else:
-            print_status_message(f"{user.name} uses {item_name} on {target.name} {action_cost_msg}", "info")
+            print_status_message(f"{result.user_name} uses {result.item_name} on {result.target_name} {action_cost_msg}", "info")
 
-        print_message(result.message)
+        if result.effect_message:
+            print_message(result.effect_message)
 
         # Show HP change if healing occurred
-        if result.effect_type == "healing" and target.current_hp > hp_before:
-            hp_gained = target.current_hp - hp_before
-            print_status_message(f"{target.name}: {hp_before} → {target.current_hp} HP (+{hp_gained})", "success")
+        if result.effect_type == "healing" and result.hp_after is not None and result.hp_before is not None:
+            if result.hp_after > result.hp_before:
+                hp_gained = result.hp_after - result.hp_before
+                print_status_message(f"{result.target_name}: {result.hp_before} → {result.hp_after} HP (+{hp_gained})", "success")
 
         # Show remaining actions
-        remaining_actions = str(turn_state)
-        print_status_message(f"Remaining this turn: {remaining_actions}", "info")
-
-        # Suggest ending turn if player wants to skip remaining actions
-        if turn_state.has_any_action():
-            print_status_message("Type 'done' or 'pass' to end your turn", "info")
-
-        # Emit item used event
-        self.game_state.event_bus.emit(Event(
-            type=EventType.ITEM_USED,
-            data={
-                "character": user.name,
-                "target": target.name,
-                "item_id": item_id,
-                "item_name": item_name,
-                "effect_type": result.effect_type,
-                "action_cost": action_required_str,
-                "success": result.success
-            }
-        ))
+        turn_state = self.game_state.initiative_tracker.get_current_turn_state()
+        if turn_state:
+            print_status_message(f"Remaining this turn: {turn_state}", "info")
+            if turn_state.has_any_action():
+                print_status_message("Type 'done' or 'pass' to end your turn", "info")
 
         # End player turn
         self.game_state.initiative_tracker.next_turn()
@@ -4026,127 +3880,6 @@ class CLI:
         if self.game_state.in_combat:
             # Process enemy turns
             self.process_enemy_turns()
-
-    def handle_use_item_combat(self, item_id: str) -> None:
-        """
-        Handle using a consumable item during combat (legacy method).
-
-        Validates action economy, consumes action, and applies item effect.
-
-        Args:
-            item_id: The item to use (ID or name)
-        """
-        from dnd_engine.systems.action_economy import ActionType
-        from dnd_engine.systems.item_effects import apply_item_effect
-
-        # Verify it's the player's turn
-        if not self.game_state.in_combat or not self.game_state.initiative_tracker:
-            print_error("Not in combat!")
-            return
-
-        current = self.game_state.initiative_tracker.get_current_combatant()
-        if not current:
-            print_error("No current combatant!")
-            return
-
-        # Check if current combatant is a party member
-        if current.creature not in self.game_state.party.characters:
-            print_error("It's not a party member's turn!")
-            return
-
-        character = current.creature
-        inventory = character.inventory
-        items_data = self.game_state.data_loader.load_items()
-
-        # Find the item in consumables
-        target_item = None
-        consumables = inventory.get_items_by_category("consumables")
-
-        for inv_item in consumables:
-            item_data = items_data["consumables"].get(inv_item.item_id, {})
-            if inv_item.item_id == item_id or item_data.get("name", "").lower() == item_id.lower():
-                target_item = inv_item.item_id
-                break
-
-        if not target_item:
-            print_error(f"{character.name} doesn't have a consumable '{item_id}' in inventory.")
-            return
-
-        # Get item data to check action cost
-        item_info = items_data["consumables"][target_item]
-        item_name = item_info.get("name", target_item)
-        action_required_str = item_info.get("action_required", "action")
-
-        # Map string to ActionType
-        action_type_map = {
-            "action": ActionType.ACTION,
-            "bonus_action": ActionType.BONUS_ACTION,
-            "free_object": ActionType.FREE_OBJECT,
-            "no_action": ActionType.NO_ACTION
-        }
-        action_required = action_type_map.get(action_required_str, ActionType.ACTION)
-
-        # Check if action is available
-        turn_state = self.game_state.initiative_tracker.get_current_turn_state()
-        if not turn_state:
-            print_error("Unable to get current turn state!")
-            return
-
-        if not turn_state.is_action_available(action_required):
-            action_name = action_required_str.replace("_", " ").title()
-            print_error(f"You don't have a {action_name} available this turn!")
-            print_status_message(f"Available: {turn_state}", "info")
-            return
-
-        # Consume the action
-        if not turn_state.consume_action(action_required):
-            print_error(f"Failed to consume {action_required_str}!")
-            return
-
-        # Use the item from inventory (removes it)
-        success, item_data = inventory.use_item(target_item, items_data)
-
-        if not success:
-            print_error(f"Failed to use {item_id}")
-            # Restore the action since item use failed
-            turn_state.reset()
-            turn_state.consume_action(action_required)  # Put back what we consumed
-            return
-
-        # Apply the item's effect
-        result = apply_item_effect(
-            item_info=item_data,
-            target=character,
-            dice_roller=self.game_state.dice_roller,
-            event_bus=self.game_state.event_bus,
-            time_manager=self.game_state.time_manager
-        )
-
-        # Display the result
-        action_cost_msg = f"({action_required_str.replace('_', ' ')})"
-        print_status_message(f"{character.name} uses {item_name} {action_cost_msg}", "info")
-        print_message(result.message)
-
-        # Show remaining actions
-        remaining_actions = str(turn_state)
-        print_status_message(f"Remaining this turn: {remaining_actions}", "info")
-
-        # Suggest ending turn if player wants to skip remaining actions
-        if turn_state.has_any_action():
-            print_status_message("Type 'done' or 'pass' to end your turn", "info")
-
-        # Emit item used event
-        self.game_state.event_bus.emit(Event(
-            type=EventType.ITEM_USED,
-            data={
-                "character": character.name,
-                "item_id": target_item,
-                "item_name": item_name,
-                "effect_type": result.effect_type,
-                "action_cost": action_required_str,
-                "success": result.success
-            }
-        ))
 
     def handle_save(self) -> None:
         """Handle manual named save command."""

--- a/tests/test_end_turn_command.py
+++ b/tests/test_end_turn_command.py
@@ -196,16 +196,15 @@ class TestEndTurnIntegration:
         """Test that a helpful hint is shown after using an item with actions remaining"""
         from unittest.mock import Mock, patch
 
-        from dnd_engine.systems.action_economy import TurnState
+        from dnd_engine.core.game_state import CombatItemUseResult
+        from dnd_engine.systems.action_economy import ActionType, TurnState
 
         # Create mocks
         mock_game_state = Mock()
-        mock_game_state.in_combat = True
+        mock_game_state.in_combat = False  # Set to False so process_enemy_turns exits quickly
         mock_game_state.initiative_tracker = Mock()
-        mock_game_state.data_loader = Mock()
-        mock_game_state.dice_roller = Mock()
-        mock_game_state.event_bus = Mock()
         mock_game_state.party = Mock()
+        mock_game_state.party.characters = []  # Empty list to avoid iteration issues
 
         mock_campaign_manager = Mock()
         cli = CLI(
@@ -214,52 +213,41 @@ class TestEndTurnIntegration:
             campaign_name="test_campaign"
         )
 
-        # Create character with inventory
+        # Create character
         character = Mock()
         character.name = "TestCharacter"
-        character.inventory = Mock()
 
-        # Create turn state with action available (will be consumed by potion use)
-        # After using the potion, bonus action should still be available
+        # Create turn state with bonus action still available after using action
         turn_state = TurnState()
-        turn_state.action_available = True  # Action available for potion
-        turn_state.bonus_action_available = True  # Bonus action will remain after potion use
+        turn_state.action_available = False  # Action consumed by potion use
+        turn_state.bonus_action_available = True  # Bonus action still available
 
-        # Setup initiative tracker
-        combatant = Mock()
-        combatant.creature = character
-        cli.game_state.initiative_tracker.get_current_combatant.return_value = combatant
         cli.game_state.initiative_tracker.get_current_turn_state.return_value = turn_state
-        cli.game_state.party.characters = [character]
 
-        # Mock inventory and item data
-        item_data = {
-            "name": "Potion of Healing",
-            "action_required": "action",
-            "effect": {"type": "healing", "dice": "2d4+2"}
-        }
-        cli.game_state.data_loader.load_items.return_value = {
-            "consumables": {"potion_of_healing": item_data}
-        }
-        character.inventory.use_item.return_value = (True, item_data)
-        character.inventory.get_items_by_category.return_value = [
-            Mock(item_id="potion_of_healing")
-        ]
+        # Mock the game_state.use_item_combat() to return a successful result
+        mock_result = CombatItemUseResult(
+            success=True,
+            item_name="Potion of Healing",
+            action_type=ActionType.ACTION,
+            user_name="TestCharacter",
+            target_name="TestCharacter",
+            effect_type="healing",
+            effect_message="You heal 6 HP",
+            effect_amount=6,
+            hp_before=10,
+            hp_after=16
+        )
+        mock_game_state.use_item_combat.return_value = mock_result
 
-        # Mock apply_item_effect
-        with patch('dnd_engine.systems.item_effects.apply_item_effect') as mock_apply:
-            mock_result = Mock()
-            mock_result.message = "You heal 6 HP"
-            mock_result.effect_type = "healing"
-            mock_result.success = True
-            mock_apply.return_value = mock_result
+        # Mock item data (unused but required for API)
+        item_data = {"name": "Potion of Healing", "action_required": "action"}
 
-            # Track status messages
-            with patch('dnd_engine.ui.cli.print_status_message') as mock_status:
-                cli.handle_use_item_combat("potion_of_healing")
+        # Track status messages
+        with patch('dnd_engine.ui.cli.print_status_message') as mock_status:
+            cli.handle_use_item_combat_with_target("potion_of_healing", item_data, character, character)
 
-                # Verify the hint was shown
-                calls = [str(call) for call in mock_status.call_args_list]
-                hint_shown = any("done" in str(call).lower() or "pass" in str(call).lower()
-                                 for call in calls)
-                assert hint_shown, "Hint about ending turn should be shown after item use with actions remaining"
+            # Verify the hint was shown
+            calls = [str(call) for call in mock_status.call_args_list]
+            hint_shown = any("done" in str(call).lower() or "pass" in str(call).lower()
+                             for call in calls)
+            assert hint_shown, "Hint about ending turn should be shown after item use with actions remaining"

--- a/tests/test_use_item_combat.py
+++ b/tests/test_use_item_combat.py
@@ -1,0 +1,356 @@
+# ABOUTME: Unit tests for GameState.use_item_combat() method
+# ABOUTME: Tests consumable item use during combat with action economy validation
+
+import pytest
+from unittest.mock import Mock, patch
+
+from dnd_engine.core.character import Character
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.game_state import CombatItemUseResult, GameState
+from dnd_engine.core.party import Party
+from dnd_engine.systems.action_economy import ActionType, TurnState
+from dnd_engine.systems.inventory import Inventory
+
+
+class TestUseItemCombat:
+    """Test GameState.use_item_combat() method"""
+
+    @pytest.fixture
+    def mock_data_loader(self):
+        """Create a mock data loader with potion data"""
+        from pathlib import Path
+        loader = Mock()
+        loader.load_items.return_value = {
+            "consumables": {
+                "potion_of_healing": {
+                    "name": "Potion of Healing",
+                    "effect_type": "healing",
+                    "healing": "2d4+2",
+                    "action_required": "action"
+                },
+                "antitoxin": {
+                    "name": "Antitoxin",
+                    "effect_type": "buff",
+                    "action_required": "bonus_action"
+                }
+            }
+        }
+        # Mock dungeon loading
+        loader.load_dungeon.return_value = {
+            "name": "Test Dungeon",
+            "rooms": {},
+            "start_room": "entrance"
+        }
+        # Mock data_path for room registry (return non-existent path to skip)
+        loader.data_path = Path("/nonexistent")
+        return loader
+
+    @pytest.fixture
+    def character_with_potion(self):
+        """Create a character with a potion in inventory"""
+        abilities = Abilities(
+            strength=10, dexterity=10, constitution=10,
+            intelligence=10, wisdom=10, charisma=10
+        )
+        character = Character(
+            name="TestHero",
+            character_class="fighter",
+            level=1,
+            abilities=abilities,
+            max_hp=20,
+            ac=14,
+            current_hp=10  # Damaged
+        )
+        character.inventory.add_item("potion_of_healing", "consumables", quantity=1)
+        return character
+
+    @pytest.fixture
+    def turn_state_with_action(self):
+        """Create a turn state with action available"""
+        turn_state = TurnState()
+        turn_state.action_available = True
+        turn_state.bonus_action_available = True
+        return turn_state
+
+    @pytest.fixture
+    def turn_state_no_action(self):
+        """Create a turn state with no action available"""
+        turn_state = TurnState()
+        turn_state.action_available = False
+        turn_state.bonus_action_available = True
+        return turn_state
+
+    def test_successful_item_use_healing(self, mock_data_loader, character_with_potion, turn_state_with_action):
+        """Test successfully using a healing potion during combat"""
+        # Setup game state
+        game_state = Mock(spec=GameState)
+        game_state.data_loader = mock_data_loader
+        game_state.initiative_tracker = Mock()
+        game_state.initiative_tracker.get_current_turn_state.return_value = turn_state_with_action
+        game_state.dice_roller = Mock()
+        game_state.event_bus = Mock()
+        game_state.time_manager = Mock()
+
+        # Call the actual method (need to use the real implementation)
+        with patch('dnd_engine.systems.item_effects.apply_item_effect') as mock_apply:
+            mock_effect_result = Mock()
+            mock_effect_result.success = True
+            mock_effect_result.effect_type = "healing"
+            mock_effect_result.message = "You heal 8 HP"
+            mock_effect_result.amount = 8
+            mock_apply.return_value = mock_effect_result
+
+            # Call the real method on a real GameState
+            party = Party()
+            party.add_character(character_with_potion)
+            real_game_state = GameState(party=party, dungeon_name="test_dungeon", data_loader=mock_data_loader)
+            real_game_state.initiative_tracker = Mock()
+            real_game_state.initiative_tracker.get_current_turn_state.return_value = turn_state_with_action
+
+            hp_before = character_with_potion.current_hp
+
+            result = real_game_state.use_item_combat(
+                user=character_with_potion,
+                item_id="potion_of_healing",
+                target=character_with_potion
+            )
+
+            assert result.success is True
+            assert result.item_name == "Potion of Healing"
+            assert result.action_type == ActionType.ACTION
+            assert result.user_name == "TestHero"
+            assert result.target_name == "TestHero"
+            assert result.effect_type == "healing"
+            assert result.hp_before == hp_before
+
+    def test_item_not_found(self, mock_data_loader, character_with_potion, turn_state_with_action):
+        """Test using an item that doesn't exist in data"""
+        party = Party()
+        party.add_character(character_with_potion)
+        game_state = GameState(party=party, dungeon_name="test_dungeon", data_loader=mock_data_loader)
+        game_state.initiative_tracker = Mock()
+        game_state.initiative_tracker.get_current_turn_state.return_value = turn_state_with_action
+
+        result = game_state.use_item_combat(
+            user=character_with_potion,
+            item_id="nonexistent_potion",
+            target=character_with_potion
+        )
+
+        assert result.success is False
+        assert "not found" in result.error_message.lower()
+
+    def test_no_action_available(self, mock_data_loader, character_with_potion, turn_state_no_action):
+        """Test that item use fails when no action is available"""
+        party = Party()
+        party.add_character(character_with_potion)
+        game_state = GameState(party=party, dungeon_name="test_dungeon", data_loader=mock_data_loader)
+        game_state.initiative_tracker = Mock()
+        game_state.initiative_tracker.get_current_turn_state.return_value = turn_state_no_action
+
+        result = game_state.use_item_combat(
+            user=character_with_potion,
+            item_id="potion_of_healing",
+            target=character_with_potion
+        )
+
+        assert result.success is False
+        assert "available" in result.error_message.lower()
+        # Potion should still be in inventory
+        assert character_with_potion.inventory.has_item("potion_of_healing")
+
+    def test_item_not_in_inventory(self, mock_data_loader, turn_state_with_action):
+        """Test using an item that's not in the character's inventory"""
+        abilities = Abilities(
+            strength=10, dexterity=10, constitution=10,
+            intelligence=10, wisdom=10, charisma=10
+        )
+        character = Character(
+            name="EmptyHero",
+            character_class="fighter",
+            level=1,
+            abilities=abilities,
+            max_hp=20,
+            ac=14
+        )
+        # No potion in inventory
+
+        party = Party()
+        party.add_character(character)
+        game_state = GameState(party=party, dungeon_name="test_dungeon", data_loader=mock_data_loader)
+        game_state.initiative_tracker = Mock()
+        game_state.initiative_tracker.get_current_turn_state.return_value = turn_state_with_action
+
+        result = game_state.use_item_combat(
+            user=character,
+            item_id="potion_of_healing",
+            target=character
+        )
+
+        assert result.success is False
+        assert "inventory" in result.error_message.lower()
+
+    def test_action_consumed_on_success(self, mock_data_loader, character_with_potion, turn_state_with_action):
+        """Test that action is consumed when item is successfully used"""
+        party = Party()
+        party.add_character(character_with_potion)
+        game_state = GameState(party=party, dungeon_name="test_dungeon", data_loader=mock_data_loader)
+        game_state.initiative_tracker = Mock()
+        game_state.initiative_tracker.get_current_turn_state.return_value = turn_state_with_action
+
+        with patch('dnd_engine.systems.item_effects.apply_item_effect') as mock_apply:
+            mock_effect_result = Mock()
+            mock_effect_result.success = True
+            mock_effect_result.effect_type = "healing"
+            mock_effect_result.message = "You heal 8 HP"
+            mock_effect_result.amount = 8
+            mock_apply.return_value = mock_effect_result
+
+            result = game_state.use_item_combat(
+                user=character_with_potion,
+                item_id="potion_of_healing",
+                target=character_with_potion
+            )
+
+            assert result.success is True
+            # Action should have been consumed
+            assert turn_state_with_action.action_available is False
+
+    def test_bonus_action_item(self, mock_data_loader, turn_state_with_action):
+        """Test using an item that requires a bonus action"""
+        abilities = Abilities(
+            strength=10, dexterity=10, constitution=10,
+            intelligence=10, wisdom=10, charisma=10
+        )
+        character = Character(
+            name="TestHero",
+            character_class="fighter",
+            level=1,
+            abilities=abilities,
+            max_hp=20,
+            ac=14
+        )
+        character.inventory.add_item("antitoxin", "consumables", quantity=1)
+
+        party = Party()
+        party.add_character(character)
+        game_state = GameState(party=party, dungeon_name="test_dungeon", data_loader=mock_data_loader)
+        game_state.initiative_tracker = Mock()
+        game_state.initiative_tracker.get_current_turn_state.return_value = turn_state_with_action
+
+        with patch('dnd_engine.systems.item_effects.apply_item_effect') as mock_apply:
+            mock_effect_result = Mock()
+            mock_effect_result.success = True
+            mock_effect_result.effect_type = "buff"
+            mock_effect_result.message = "You gain advantage on poison saves"
+            mock_effect_result.amount = 0
+            mock_apply.return_value = mock_effect_result
+
+            result = game_state.use_item_combat(
+                user=character,
+                item_id="antitoxin",
+                target=character
+            )
+
+            assert result.success is True
+            assert result.action_type == ActionType.BONUS_ACTION
+            # Bonus action should have been consumed
+            assert turn_state_with_action.bonus_action_available is False
+            # Regular action should still be available
+            assert turn_state_with_action.action_available is True
+
+    def test_item_used_event_emitted(self, mock_data_loader, character_with_potion, turn_state_with_action):
+        """Test that ITEM_USED event is emitted on successful use"""
+        party = Party()
+        party.add_character(character_with_potion)
+        game_state = GameState(party=party, dungeon_name="test_dungeon", data_loader=mock_data_loader)
+        game_state.initiative_tracker = Mock()
+        game_state.initiative_tracker.get_current_turn_state.return_value = turn_state_with_action
+
+        with patch('dnd_engine.systems.item_effects.apply_item_effect') as mock_apply:
+            mock_effect_result = Mock()
+            mock_effect_result.success = True
+            mock_effect_result.effect_type = "healing"
+            mock_effect_result.message = "You heal 8 HP"
+            mock_effect_result.amount = 8
+            mock_apply.return_value = mock_effect_result
+
+            # Track emitted events
+            emitted_events = []
+            game_state.event_bus.emit = lambda e: emitted_events.append(e)
+
+            result = game_state.use_item_combat(
+                user=character_with_potion,
+                item_id="potion_of_healing",
+                target=character_with_potion
+            )
+
+            assert result.success is True
+            assert len(emitted_events) == 1
+            event = emitted_events[0]
+            assert event.data["item_name"] == "Potion of Healing"
+            assert event.data["effect_type"] == "healing"
+
+    def test_use_on_different_target(self, mock_data_loader, character_with_potion, turn_state_with_action):
+        """Test using a potion on a different character"""
+        # Create a second character as target
+        abilities = Abilities(
+            strength=10, dexterity=10, constitution=10,
+            intelligence=10, wisdom=10, charisma=10
+        )
+        target_character = Character(
+            name="WoundedAlly",
+            character_class="wizard",
+            level=1,
+            abilities=abilities,
+            max_hp=15,
+            ac=12,
+            current_hp=5  # Very damaged
+        )
+
+        party = Party()
+        party.add_character(character_with_potion)
+        party.add_character(target_character)
+        game_state = GameState(party=party, dungeon_name="test_dungeon", data_loader=mock_data_loader)
+        game_state.initiative_tracker = Mock()
+        game_state.initiative_tracker.get_current_turn_state.return_value = turn_state_with_action
+
+        with patch('dnd_engine.systems.item_effects.apply_item_effect') as mock_apply:
+            mock_effect_result = Mock()
+            mock_effect_result.success = True
+            mock_effect_result.effect_type = "healing"
+            mock_effect_result.message = "WoundedAlly heals 8 HP"
+            mock_effect_result.amount = 8
+            mock_apply.return_value = mock_effect_result
+
+            result = game_state.use_item_combat(
+                user=character_with_potion,
+                item_id="potion_of_healing",
+                target=target_character
+            )
+
+            assert result.success is True
+            assert result.user_name == "TestHero"
+            assert result.target_name == "WoundedAlly"
+            assert result.hp_before == 5
+            # Item should be removed from user's inventory
+            assert not character_with_potion.inventory.has_item("potion_of_healing")
+
+    def test_no_turn_state_returns_error(self, mock_data_loader, character_with_potion):
+        """Test that missing turn state returns an error"""
+        party = Party()
+        party.add_character(character_with_potion)
+        game_state = GameState(party=party, dungeon_name="test_dungeon", data_loader=mock_data_loader)
+        game_state.initiative_tracker = Mock()
+        game_state.initiative_tracker.get_current_turn_state.return_value = None
+
+        result = game_state.use_item_combat(
+            user=character_with_potion,
+            item_id="potion_of_healing",
+            target=character_with_potion
+        )
+
+        assert result.success is False
+        assert "turn state" in result.error_message.lower()
+        # Potion should still be in inventory
+        assert character_with_potion.inventory.has_item("potion_of_healing")


### PR DESCRIPTION
## Summary
- Add `CombatItemUseResult` dataclass for non-attack consumable items
- Add `GameState.use_item_combat()` method handling action economy, item consumption, effect application, and event emission
- Refactor `handle_use_item_combat_with_target()` to delegate game logic to engine
- Remove dead code: `handle_use_item_combat_direct()` (was never called)
- Remove legacy `handle_use_item_combat()` method
- Add 9 unit tests for `use_item_combat()`

## Test plan
- [x] All 9 new unit tests pass
- [x] Existing `test_end_turn_command.py` updated and passes
- [x] All 31 item-related tests pass

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)