### PR TITLE
Fix 22 failing tests after API changes

### DIFF
--- a/tests/test_debug_console.py
+++ b/tests/test_debug_console.py
@@ -840,6 +840,9 @@ class TestLLMToggleCommand:
             def get_provider_name(self):
                 return "Mock Provider"
 
+            async def chat_with_tools(self, messages, tools, temperature=0.7):
+                return {"content": "test", "tool_calls": [], "finish_reason": "stop"}
+
         # Create mock CLI with LLM enhancer
         party = Party([])
         game_state = GameState(party, "test_dungeon")
@@ -887,6 +890,9 @@ class TestLLMToggleCommand:
 
             def get_provider_name(self):
                 return "Mock Provider"
+
+            async def chat_with_tools(self, messages, tools, temperature=0.7):
+                return {"content": "test", "tool_calls": [], "finish_reason": "stop"}
 
         # Create mock CLI with LLM enhancer
         party = Party([])

--- a/tests/test_debug_provider.py
+++ b/tests/test_debug_provider.py
@@ -65,7 +65,7 @@ Add vivid sensory details."""
         assert provider.api_key == "debug"
         assert provider.model == "debug"
         assert provider.timeout == 10.0
-        assert provider.max_tokens == 150
+        assert provider.max_tokens == 1000
 
     def test_init_with_custom_args(self) -> None:
         """Test that custom initialization args are accepted but ignored."""

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -43,7 +43,7 @@ class TestProviderFactory:
                 assert isinstance(provider, OpenAIProvider)
                 assert provider.model == "gpt-4o-mini"  # Default
                 assert provider.timeout == 20.0  # Factory default from LLM_TIMEOUT env var
-                assert provider.max_tokens == 150
+                assert provider.max_tokens == 1000
 
     def test_create_openai_provider_missing_key(self) -> None:
         """Test that missing API key returns None."""

--- a/tests/test_item_persistence.py
+++ b/tests/test_item_persistence.py
@@ -101,7 +101,7 @@ def test_items_persist_after_save_load(save_manager, game_state_with_items, samp
     )
 
     # Load the game
-    loaded_game_state = save_manager.load_game(
+    loaded_game_state, _ = save_manager.load_game(
         slot_number=1,
         event_bus=game_state_with_items.event_bus,
         data_loader=game_state_with_items.data_loader,
@@ -134,7 +134,7 @@ def test_items_persist_across_multiple_save_load_cycles(save_manager, game_state
     save_manager.save_game(slot_number=2, game_state=game_state_with_items)
 
     # Load and verify
-    loaded_gs = save_manager.load_game(
+    loaded_gs, _ = save_manager.load_game(
         slot_number=2,
         event_bus=game_state_with_items.event_bus,
         data_loader=game_state_with_items.data_loader,
@@ -147,7 +147,7 @@ def test_items_persist_across_multiple_save_load_cycles(save_manager, game_state
     save_manager.save_game(slot_number=2, game_state=loaded_gs)
 
     # Load and verify
-    loaded_gs2 = save_manager.load_game(
+    loaded_gs2, _ = save_manager.load_game(
         slot_number=2,
         event_bus=game_state_with_items.event_bus,
         data_loader=game_state_with_items.data_loader,
@@ -160,7 +160,7 @@ def test_items_persist_across_multiple_save_load_cycles(save_manager, game_state
     save_manager.save_game(slot_number=2, game_state=loaded_gs2)
 
     # Final load and verify - room should be completely empty
-    final_gs = save_manager.load_game(
+    final_gs, _ = save_manager.load_game(
         slot_number=2,
         event_bus=game_state_with_items.event_bus,
         data_loader=game_state_with_items.data_loader,
@@ -187,7 +187,7 @@ def test_searched_flag_and_items_both_persist(save_manager, game_state_with_item
     save_manager.save_game(slot_number=3, game_state=game_state_with_items)
 
     # Load
-    loaded_gs = save_manager.load_game(
+    loaded_gs, _ = save_manager.load_game(
         slot_number=3,
         event_bus=game_state_with_items.event_bus,
         data_loader=game_state_with_items.data_loader,

--- a/tests/test_llm_enhancer_integration.py
+++ b/tests/test_llm_enhancer_integration.py
@@ -33,6 +33,15 @@ class MockLLMProvider(LLMProvider):
         """Return mock provider name."""
         return "Mock Provider"
 
+    async def chat_with_tools(
+        self,
+        messages: list[dict],
+        tools: list[dict],
+        temperature: float = 0.7
+    ) -> dict | None:
+        """Mock chat_with_tools method."""
+        return {"content": "test", "tool_calls": [], "finish_reason": "stop"}
+
 
 class TestLLMEnhancer:
     """Test LLM enhancer integration with event bus."""

--- a/tests/test_quest_system.py
+++ b/tests/test_quest_system.py
@@ -417,9 +417,10 @@ class TestQuestManagerGameStateIntegration:
         event_bus = EventBus()
         data_loader = DataLoader()
 
+        # Use test_dungeon which doesn't have a campaign_id in its data
         game_state = GameState(
             party=party,
-            dungeon_name="town_of_arden",
+            dungeon_name="test_dungeon",
             event_bus=event_bus,
             data_loader=data_loader
         )


### PR DESCRIPTION
## Summary
- Add `chat_with_tools` method to `MockProvider`/`MockLLMProvider` classes to satisfy the new abstract method in `LLMProvider` base class
- Update `max_tokens` test expectations from 150 to 1000 to match actual default in `LLMProvider`
- Fix `test_item_persistence` to unpack tuple from `load_game()` which now returns `(GameState, CampaignProgress | None)`
- Fix `test_quest_system` to use `test_dungeon` instead of `town_of_arden` since `town_of_arden` has `campaign_id` in its data which auto-creates a `QuestManager`

## Test plan
- [x] All 22 previously failing tests now pass
- [x] No regressions in other tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)