### PR TITLE
Refactor: Move enemy turn processing from CLI to game engine (#216)

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -3,6 +3,7 @@
 
 import logging
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
 from dnd_engine.core.campaign_progress import CampaignProgress, CampaignProgressTracker
@@ -16,6 +17,8 @@ from dnd_engine.core.quest import QuestManager
 from dnd_engine.core.room_registry import RoomRegistry
 from dnd_engine.rules.loader import DataLoader
 from dnd_engine.systems.action_economy import ActionType
+from dnd_engine.systems.ai import EnemyAI
+from dnd_engine.systems.condition_manager import ConditionManager
 from dnd_engine.systems.initiative import InitiativeTracker
 from dnd_engine.systems.time_manager import ActiveEffect, EffectType, TimeManager
 from dnd_engine.utils.events import Event, EventBus, EventType
@@ -176,6 +179,84 @@ class CombatSpellResult:
     error: str | None = None
 
 
+class EnemyTurnAction(Enum):
+    """Actions an enemy can take during their turn."""
+    ATTACK = "attack"
+    CONDITION_REMOVAL = "condition_removal"
+    INCAPACITATED = "incapacitated"
+    DIED_START_OF_TURN = "died_start_of_turn"
+    NO_TARGETS = "no_targets"
+    NO_VALID_ATTACK = "no_valid_attack"
+
+
+@dataclass
+class ConditionRemovalResult:
+    """Result of an enemy attempting to remove a condition."""
+    condition_id: str
+    attempted: bool
+    success: bool
+    message: str
+
+
+@dataclass
+class TurnEffectResult:
+    """Result of a turn-start or turn-end effect."""
+    effect_type: str  # "damage", "condition_expired", etc.
+    condition_id: str
+    message: str
+    damage: int = 0
+    creature_died: bool = False
+
+
+@dataclass
+class EnemyTurnResult:
+    """
+    Result of processing an enemy's turn.
+
+    Contains all information needed for UI display without requiring
+    the CLI to perform any game logic calculations.
+    """
+    enemy_name: str
+    enemy_display_name: str
+    action_taken: EnemyTurnAction
+
+    # Attack details (when action_taken == ATTACK)
+    attack_result: AttackResult | None = None
+    target_name: str | None = None
+    target_killed: bool = False
+    action_data: dict[str, Any] | None = None  # Monster action used
+
+    # Saving throw results from attack (e.g., poison effects)
+    saving_throw_triggered: bool = False
+    save_ability: str | None = None
+    save_dc: int | None = None
+    save_succeeded: bool | None = None
+    conditions_applied: list[str] = field(default_factory=list)
+
+    # Condition removal (when action_taken == CONDITION_REMOVAL)
+    condition_removal: ConditionRemovalResult | None = None
+
+    # Concentration break on target
+    concentration_broken: dict[str, Any] | None = None
+
+    # Turn effects
+    turn_start_effects: list[TurnEffectResult] = field(default_factory=list)
+    turn_end_effects: list[TurnEffectResult] = field(default_factory=list)
+
+    # Incapacitation details
+    incapacitating_conditions: list[str] = field(default_factory=list)
+
+    # Narrative context for LLM enhancement
+    narrative_context: dict[str, Any] = field(default_factory=dict)
+
+    # Turn management
+    turn_advanced: bool = True  # Whether initiative moved to next turn
+    combat_ended: bool = False  # Whether combat ended this turn
+
+    # Error handling
+    error: str | None = None
+
+
 class GameState:
     """
     Central game state manager.
@@ -281,6 +362,13 @@ class GameState:
         self.combat_engine = CombatEngine(self.dice_roller)
         self.combat_history: list[CombatEvent] = []
         self.max_combat_history_size = 50  # Configurable limit
+
+        # Enemy AI and condition management for enemy turn processing
+        self.enemy_ai = EnemyAI()
+        self.condition_manager = ConditionManager(
+            dice_roller=self.dice_roller,
+            event_bus=self.event_bus
+        )
 
         # Navigation tracking for flee mechanic
         self.last_entry_direction: str | None = None
@@ -2595,6 +2683,337 @@ class GameState:
             round_number=self.initiative_tracker.round_number,
             current_turn=current_turn,
             in_combat=True
+        )
+
+    def _get_enemy_display_name(self, enemy: Creature) -> str:
+        """
+        Get the display name for an enemy from the initiative tracker.
+
+        Args:
+            enemy: The enemy creature
+
+        Returns:
+            Display name with combat number if applicable (e.g., "Goblin 2")
+        """
+        if self.initiative_tracker:
+            for entry in self.initiative_tracker.get_all_combatants():
+                if entry.creature == enemy:
+                    return entry.display_name if entry.display_name else enemy.name
+        return enemy.name
+
+    def _should_enemy_attempt_condition_removal(
+        self,
+        enemy: Creature
+    ) -> ConditionRemovalResult | None:
+        """
+        Determine if enemy should attempt condition removal and execute it.
+
+        Args:
+            enemy: The enemy creature
+
+        Returns:
+            ConditionRemovalResult if attempted, None otherwise
+        """
+        for condition_id in list(enemy.conditions):
+            if not self.condition_manager.can_attempt_early_removal(condition_id):
+                continue
+
+            # Use AI to decide if condition should be removed
+            if condition_id == "on_fire" and self.enemy_ai.should_attempt_condition_removal(
+                enemy
+            ):
+                # Attempt removal
+                result = self.condition_manager.attempt_condition_removal(
+                    enemy, condition_id
+                )
+
+                if result:
+                    return ConditionRemovalResult(
+                        condition_id=condition_id,
+                        attempted=True,
+                        success=result.success,
+                        message=result.message
+                    )
+
+                return ConditionRemovalResult(
+                    condition_id=condition_id,
+                    attempted=True,
+                    success=False,
+                    message=f"{enemy.name} failed to remove {condition_id}"
+                )
+
+        return None
+
+    def process_enemy_turn(self) -> EnemyTurnResult | None:
+        """
+        Process the current enemy's turn and return result for display.
+
+        Handles all game logic for enemy turns:
+        - Turn start effects (ongoing damage, etc.)
+        - AI decisions (condition removal vs attack)
+        - Target selection
+        - Attack resolution
+        - Concentration checks
+        - Turn end effects
+
+        Returns:
+            EnemyTurnResult with all information needed for UI display,
+            or None if current turn is not an enemy's turn.
+        """
+        if not self.in_combat or not self.initiative_tracker:
+            return None
+
+        current = self.initiative_tracker.get_current_combatant()
+
+        # Check if it's a party member's turn
+        for character in self.party.characters:
+            if current.creature == character:
+                return None  # Not an enemy turn
+
+        enemy = current.creature
+        enemy_display_name = self._get_enemy_display_name(enemy)
+
+        # Build base result
+        turn_start_effects: list[TurnEffectResult] = []
+        turn_end_effects: list[TurnEffectResult] = []
+
+        # Check if enemy is alive
+        if not enemy.is_alive:
+            self.initiative_tracker.next_turn()
+            return EnemyTurnResult(
+                enemy_name=enemy.name,
+                enemy_display_name=enemy_display_name,
+                action_taken=EnemyTurnAction.DIED_START_OF_TURN,
+                turn_advanced=True
+            )
+
+        # Process turn-start effects (e.g., ongoing fire damage)
+        start_results = self.condition_manager.process_turn_start_effects(enemy)
+        for result in start_results:
+            turn_start_effects.append(TurnEffectResult(
+                effect_type=result.effect_type,
+                condition_id=result.condition_id,
+                message=result.message,
+                damage=result.amount,
+                creature_died=not enemy.is_alive
+            ))
+
+        # Check if enemy died from turn-start effects
+        if not enemy.is_alive:
+            self.initiative_tracker.next_turn()
+            return EnemyTurnResult(
+                enemy_name=enemy.name,
+                enemy_display_name=enemy_display_name,
+                action_taken=EnemyTurnAction.DIED_START_OF_TURN,
+                turn_start_effects=turn_start_effects,
+                turn_advanced=True
+            )
+
+        # Check if enemy can act (not incapacitated or surprised)
+        if not enemy.can_take_actions():
+            incapacitating = [c.upper() for c in enemy.conditions]
+            # Process end-of-turn conditions (will remove surprised, etc.)
+            end_results = enemy.process_end_of_turn_conditions(self.event_bus)
+            for result in end_results:
+                if result["type"] == "condition_expired":
+                    turn_end_effects.append(TurnEffectResult(
+                        effect_type="condition_expired",
+                        condition_id=result["condition"],
+                        message=f"{result['condition'].upper()} on {enemy.name} has expired!"
+                    ))
+
+            self.initiative_tracker.next_turn()
+            return EnemyTurnResult(
+                enemy_name=enemy.name,
+                enemy_display_name=enemy_display_name,
+                action_taken=EnemyTurnAction.INCAPACITATED,
+                incapacitating_conditions=incapacitating,
+                turn_start_effects=turn_start_effects,
+                turn_end_effects=turn_end_effects,
+                turn_advanced=True
+            )
+
+        # Enemy AI: Check if should attempt to remove conditions
+        condition_removal = self._should_enemy_attempt_condition_removal(enemy)
+        if condition_removal:
+            self.initiative_tracker.next_turn()
+            return EnemyTurnResult(
+                enemy_name=enemy.name,
+                enemy_display_name=enemy_display_name,
+                action_taken=EnemyTurnAction.CONDITION_REMOVAL,
+                condition_removal=condition_removal,
+                turn_start_effects=turn_start_effects,
+                turn_advanced=True
+            )
+
+        # Choose target from living party members using AI
+        living_party = self.party.get_living_members()
+        if not living_party:
+            # No conscious targets - check if combat should end
+            self._check_combat_end()
+            if not self.in_combat:
+                return EnemyTurnResult(
+                    enemy_name=enemy.name,
+                    enemy_display_name=enemy_display_name,
+                    action_taken=EnemyTurnAction.NO_TARGETS,
+                    turn_start_effects=turn_start_effects,
+                    combat_ended=True,
+                    turn_advanced=False
+                )
+            # Combat continues (e.g., stabilized characters), advance turn
+            self.initiative_tracker.next_turn()
+            return EnemyTurnResult(
+                enemy_name=enemy.name,
+                enemy_display_name=enemy_display_name,
+                action_taken=EnemyTurnAction.NO_TARGETS,
+                turn_start_effects=turn_start_effects,
+                turn_advanced=True
+            )
+
+        target = self.enemy_ai.select_target(living_party)
+
+        # Get monster data for attack
+        monsters = self.data_loader.load_monsters()
+        monster_data = None
+        for mid, mdata in monsters.items():
+            if mdata["name"] == enemy.name:
+                monster_data = mdata
+                break
+
+        if not monster_data or not monster_data.get("actions"):
+            self.initiative_tracker.next_turn()
+            return EnemyTurnResult(
+                enemy_name=enemy.name,
+                enemy_display_name=enemy_display_name,
+                action_taken=EnemyTurnAction.NO_VALID_ATTACK,
+                target_name=target.name,
+                turn_start_effects=turn_start_effects,
+                error="No monster data or actions found",
+                turn_advanced=True
+            )
+
+        # Find first weapon attack action (skip Multiattack, etc.)
+        action = None
+        for act in monster_data["actions"]:
+            if "attack_bonus" in act and "damage" in act:
+                action = act
+                break
+
+        if not action:
+            self.initiative_tracker.next_turn()
+            return EnemyTurnResult(
+                enemy_name=enemy.name,
+                enemy_display_name=enemy_display_name,
+                action_taken=EnemyTurnAction.NO_VALID_ATTACK,
+                target_name=target.name,
+                turn_start_effects=turn_start_effects,
+                error="No valid attack actions",
+                turn_advanced=True
+            )
+
+        # Track conditions before attack (for saving throw detection)
+        conditions_before = set()
+        if hasattr(target, 'active_conditions'):
+            conditions_before = set(target.active_conditions.keys())
+
+        # Resolve attack
+        attack_result = self.combat_engine.resolve_attack(
+            attacker=enemy,
+            defender=target,
+            attack_bonus=action["attack_bonus"],
+            damage_dice=action["damage"],
+            apply_damage=True,
+            event_bus=self.event_bus,
+            action=action,
+            game_state=self
+        )
+
+        # Check concentration if target was hit and took damage
+        concentration_broken = None
+        if attack_result.hit and attack_result.damage > 0:
+            conc_result = self.check_concentration_from_damage(
+                target.name,
+                attack_result.damage
+            )
+            if conc_result["concentration_broken"]:
+                concentration_broken = conc_result
+
+        # Detect saving throw results
+        saving_throw_triggered = False
+        save_ability = None
+        save_dc = None
+        save_succeeded = None
+        conditions_applied: list[str] = []
+
+        if attack_result.hit and "saving_throw" in action:
+            save_data = action["saving_throw"]
+            save_ability = save_data.get("ability", "constitution").title()
+            save_dc = save_data.get("dc")
+            saving_throw_triggered = True
+
+            # Check if condition was applied (save failed)
+            if hasattr(target, 'active_conditions'):
+                conditions_after = set(target.active_conditions.keys())
+                new_conditions = conditions_after - conditions_before
+                if new_conditions:
+                    save_succeeded = False
+                    conditions_applied = list(new_conditions)
+                else:
+                    save_succeeded = True
+
+        # Process end-of-turn conditions
+        end_results = enemy.process_end_of_turn_conditions(self.event_bus)
+        for result in end_results:
+            if result["type"] == "condition_expired":
+                turn_end_effects.append(TurnEffectResult(
+                    effect_type="condition_expired",
+                    condition_id=result["condition"],
+                    message=f"{result['condition'].upper()} on {enemy.name} has expired!"
+                ))
+
+        # Advance turn
+        self.initiative_tracker.next_turn()
+
+        # Check if party wiped
+        combat_ended = self.party.is_wiped()
+        if combat_ended:
+            self._check_combat_end()
+
+        # Build narrative context for LLM enhancement
+        narrative_context = {
+            "attacker": enemy.name,
+            "attacker_display_name": enemy_display_name,
+            "target": target.name,
+            "action_name": action.get("name", "attack"),
+            "hit": attack_result.hit,
+            "damage": attack_result.damage if attack_result.hit else 0,
+            "critical": attack_result.critical_hit,
+            "target_hp_before": target.current_hp + (
+                attack_result.damage if attack_result.hit else 0
+            ),
+            "target_hp_after": target.current_hp,
+            "target_killed": not target.is_alive,
+        }
+
+        return EnemyTurnResult(
+            enemy_name=enemy.name,
+            enemy_display_name=enemy_display_name,
+            action_taken=EnemyTurnAction.ATTACK,
+            attack_result=attack_result,
+            target_name=target.name,
+            target_killed=not target.is_alive,
+            action_data=action,
+            saving_throw_triggered=saving_throw_triggered,
+            save_ability=save_ability,
+            save_dc=save_dc,
+            save_succeeded=save_succeeded,
+            conditions_applied=conditions_applied,
+            concentration_broken=concentration_broken,
+            turn_start_effects=turn_start_effects,
+            turn_end_effects=turn_end_effects,
+            narrative_context=narrative_context,
+            turn_advanced=True,
+            combat_ended=combat_ended
         )
 
     def flee_combat(self) -> dict[str, Any]:

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -7,7 +7,13 @@ from rich.panel import Panel
 
 from dnd_engine.core.character import Character, CharacterClass
 from dnd_engine.core.dice import format_dice_with_modifier
-from dnd_engine.core.game_state import CombatEvent, CombatSpellResult, GameState
+from dnd_engine.core.game_state import (
+    CombatEvent,
+    CombatSpellResult,
+    EnemyTurnAction,
+    EnemyTurnResult,
+    GameState,
+)
 from dnd_engine.llm.npc_chat import NPCChatManager
 from dnd_engine.systems.action_economy import ActionType
 from dnd_engine.systems.ai import EnemyAI
@@ -2712,145 +2718,126 @@ class CLI:
     def process_enemy_turns(self) -> None:
         """Process all enemy turns until it's a party member's turn again."""
         while self.game_state.in_combat:
-            current = self.game_state.initiative_tracker.get_current_combatant()
+            # Process one enemy turn via game engine
+            result = self.game_state.process_enemy_turn()
 
-            # If it's a party member's turn, stop
-            is_party_turn = False
-            for character in self.game_state.party.characters:
-                if current.creature == character:
-                    is_party_turn = True
-                    break
-
-            if is_party_turn:
+            # None means it's a party member's turn
+            if result is None:
                 break
 
-            # Enemy turn
-            enemy = current.creature
-            if not enemy.is_alive:
-                self.game_state.initiative_tracker.next_turn()
-                continue
+            # Display the enemy turn result
+            self._display_enemy_turn_result(result)
 
-            print_status_message(f"{enemy.name}'s turn...", "info")
-
-            # Process turn-start effects (e.g., ongoing fire damage)
-            self._process_turn_start_effects(enemy)
-
-            # Check if enemy died from turn-start effects
-            if not enemy.is_alive:
-                self.game_state.initiative_tracker.next_turn()
-                continue
-
-            # Check if enemy can act (not incapacitated or surprised)
-            if not enemy.can_take_actions():
-                conditions = [c.upper() for c in enemy.conditions]
-                condition_text = ", ".join(conditions)
-                print_status_message(f"⚠️  {enemy.name} is {condition_text} and cannot act this turn!", "warning")
-                # Process end-of-turn conditions (will remove surprised, etc.)
-                enemy.process_end_of_turn_conditions(self.game_state.event_bus)
-                self.game_state.initiative_tracker.next_turn()
-                continue
-
-            # Enemy AI: Check if should attempt to remove conditions
-            if self._should_enemy_attempt_condition_removal(enemy):
-                # Enemy attempts to remove condition instead of attacking
-                self.game_state.initiative_tracker.next_turn()
-                continue
-
-            # Choose target from living party members using AI
-            living_party = self.game_state.party.get_living_members()
-            if not living_party:
-                # No conscious targets - check if combat should end (party defeated)
-                self.game_state._check_combat_end()
-                if not self.game_state.in_combat:
-                    break  # Combat ended (party wiped or all stabilized)
-                # Combat continues (e.g., stabilized characters), advance turn
-                self.game_state.initiative_tracker.next_turn()
+            # Check if combat ended
+            if result.combat_ended:
                 break
 
-            target = self.enemy_ai.select_target(living_party)
+            # Check if entire party is dead
+            if self.game_state.party.is_wiped():
+                break
 
-            # Get monster data for attack
-            monsters = self.game_state.data_loader.load_monsters()
-            monster_data = None
-            for mid, mdata in monsters.items():
-                if mdata["name"] == enemy.name:
-                    monster_data = mdata
-                    break
+    def _display_enemy_turn_result(self, result: EnemyTurnResult) -> None:
+        """
+        Display the result of an enemy turn to the player.
 
-            if monster_data and monster_data.get("actions"):
-                # Find first weapon attack action (skip Multiattack, etc.)
-                action = None
-                for act in monster_data["actions"]:
-                    if "attack_bonus" in act and "damage" in act:
-                        action = act
-                        break
+        Handles all UI output based on the action taken and results.
 
-                if not action:
-                    print_error(f"{enemy.name} has no valid attack actions!")
-                    self.game_state.initiative_tracker.next_turn()
-                    continue
+        Args:
+            result: The EnemyTurnResult from game_state.process_enemy_turn()
+        """
+        enemy_name = result.enemy_display_name
 
-                # Track conditions before attack
-                conditions_before = set(target.active_conditions.keys()) if hasattr(target, 'active_conditions') else set()
-
-                result = self.game_state.combat_engine.resolve_attack(
-                    attacker=enemy,
-                    defender=target,
-                    attack_bonus=action["attack_bonus"],
-                    damage_dice=action["damage"],
-                    apply_damage=True,
-                    event_bus=self.game_state.event_bus,
-                    action=action,  # Pass action data for saving throw processing
-                    game_state=self.game_state
+        # Display turn-start effects
+        for effect in result.turn_start_effects:
+            print_status_message(effect.message, "warning")
+            if effect.creature_died:
+                print_status_message(
+                    f"💀 {enemy_name} is killed by {effect.condition_id.replace('_', ' ')}!",
+                    "warning"
                 )
 
-                # Check concentration if target was hit and took damage
-                if result.hit and result.damage > 0:
-                    concentration_result = self.game_state.check_concentration_from_damage(
-                        target.name,
-                        result.damage
+        # Handle different action types
+        if result.action_taken == EnemyTurnAction.DIED_START_OF_TURN:
+            # Already displayed death message above if from effects
+            return
+
+        if result.action_taken == EnemyTurnAction.INCAPACITATED:
+            condition_text = ", ".join(result.incapacitating_conditions)
+            print_status_message(
+                f"⚠️  {enemy_name} is {condition_text} and cannot act this turn!",
+                "warning"
+            )
+            self._display_turn_end_effects(result)
+            return
+
+        if result.action_taken == EnemyTurnAction.CONDITION_REMOVAL:
+            if result.condition_removal:
+                # Display condition removal attempt
+                if result.condition_removal.condition_id == "on_fire":
+                    print_status_message(
+                        f"🔥 {enemy_name} is on fire with low HP! Attempting to extinguish...",
+                        "info"
                     )
-                    if concentration_result["concentration_broken"]:
-                        spell_name = concentration_result["spell_name"]
-                        save_result = concentration_result["save_result"]
-                        dc = concentration_result["dc"]
-                        console.print(
-                            f"[yellow]💫 {target.name}'s concentration on {spell_name} is broken! "
-                            f"(CON save: {save_result['total']} vs DC {dc})[/yellow]"
+                if result.condition_removal.success:
+                    print_status_message(result.condition_removal.message, "success")
+                else:
+                    print_status_message(result.condition_removal.message, "warning")
+            return
+
+        if result.action_taken == EnemyTurnAction.NO_TARGETS:
+            # No display needed - combat will end
+            return
+
+        if result.action_taken == EnemyTurnAction.NO_VALID_ATTACK:
+            if result.error:
+                print_error(f"{enemy_name} has no valid attack actions!")
+            return
+
+        # ATTACK action
+        if result.action_taken == EnemyTurnAction.ATTACK:
+            print_status_message(f"{enemy_name}'s turn...", "info")
+
+            # Display concentration break if applicable
+            if result.concentration_broken:
+                conc = result.concentration_broken
+                console.print(
+                    f"[yellow]💫 {result.target_name}'s concentration on "
+                    f"{conc['spell_name']} is broken! "
+                    f"(CON save: {conc['save_result']['total']} vs DC {conc['dc']})[/yellow]"
+                )
+
+            # Display saving throw results
+            if result.saving_throw_triggered and result.save_ability and result.save_dc:
+                if result.save_succeeded is False and result.conditions_applied:
+                    # Failed save - get duration from target if available
+                    for condition in result.conditions_applied:
+                        # Get the target to check duration metadata
+                        target = self._find_party_member_by_name(result.target_name)
+                        duration = 0
+                        if target and hasattr(target, 'active_conditions'):
+                            metadata = target.active_conditions.get(condition, {})
+                            duration = metadata.get('duration_remaining', 0)
+                        print_status_message(
+                            f"💀 {result.target_name} fails {result.save_ability} save "
+                            f"(DC {result.save_dc}) - {condition.upper()} for {duration} rounds!",
+                            "error"
                         )
+                elif result.save_succeeded is True:
+                    print_status_message(
+                        f"✓ {result.target_name} succeeds on {result.save_ability} save "
+                        f"(DC {result.save_dc})!",
+                        "success"
+                    )
 
-                # Display saving throw results if triggered
-                if result.hit and "saving_throw" in action:
-                    save_data = action["saving_throw"]
-                    ability = save_data.get("ability", "constitution").title()
-                    dc = save_data.get("dc")
+            # Get attack narrative (if LLM enabled and hit)
+            if self.llm_enhancer and result.attack_result and result.attack_result.hit:
+                # Get the enemy and target creatures for context building
+                enemy = self._find_enemy_by_name(result.enemy_name)
+                target = self._find_party_member_by_name(result.target_name)
 
-                    # Check if condition was applied (save failed)
-                    if hasattr(target, 'active_conditions'):
-                        conditions_after = set(target.active_conditions.keys())
-                        new_conditions = conditions_after - conditions_before
-
-                        if new_conditions:
-                            # Failed save
-                            for condition in new_conditions:
-                                metadata = target.active_conditions.get(condition, {})
-                                duration = metadata.get('duration_remaining', 0)
-                                print_status_message(
-                                    f"💀 {target.name} fails {ability} save (DC {dc}) - {condition.upper()} for {duration} rounds!",
-                                    "error"
-                                )
-                        else:
-                            # Passed save
-                            print_status_message(
-                                f"✓ {target.name} succeeds on {ability} save (DC {dc})!",
-                                "success"
-                            )
-
-                # Get and display attack narrative FIRST (if hit)
-                if self.llm_enhancer and result.hit:
-                    # Build complete attack context using service
+                if enemy and target:
                     attack_context = self.context_builder.build_attack_context(
-                        enemy, target, result, action_data=action
+                        enemy, target, result.attack_result, action_data=result.action_data
                     )
 
                     with console.status("", spinner="dots"):
@@ -2861,44 +2848,60 @@ class CLI:
                     if narrative:
                         self.display_narrative_panel(narrative)
 
-                # Record this action in combat history
-                self._record_combat_action(result)
+            # Record combat action in history
+            if result.attack_result:
+                self._record_combat_action(result.attack_result)
 
-                # Display mechanics after narrative
-                console.print(f"[cyan]⚔️  {str(result)}[/cyan]")
+            # Display attack mechanics
+            if result.attack_result:
+                console.print(f"[cyan]⚔️  {str(result.attack_result)}[/cyan]")
 
-                # Check if party member died - show death narrative then message
-                if not target.is_alive:
-                    if self.llm_enhancer:
-                        with console.status("", spinner="dots"):
-                            death_narrative = self.llm_enhancer.get_death_narrative_sync(
-                                character_data={
-                                    "name": target.name,
-                                    "is_player": isinstance(target, Character)
-                                },
-                                timeout=20.0
-                            )
-                        if death_narrative:
-                            self.display_narrative_panel(death_narrative)
-
-                    print_status_message(f"{target.name} has fallen!", "warning")
-
-            # Process end-of-turn conditions (repeat saves, duration countdown, remove surprised)
-            results = enemy.process_end_of_turn_conditions(self.game_state.event_bus)
-            for result in results:
-                if result["type"] == "condition_expired":
-                    if result["condition"] != "surprised":  # Don't announce surprised expiry
-                        print_status_message(
-                            f"⏱ {result['condition'].upper()} on {enemy.name} has expired!",
-                            "info"
+            # Display death if target killed
+            if result.target_killed:
+                target = self._find_party_member_by_name(result.target_name)
+                if self.llm_enhancer and target:
+                    with console.status("", spinner="dots"):
+                        death_narrative = self.llm_enhancer.get_death_narrative_sync(
+                            character_data={
+                                "name": result.target_name,
+                                "is_player": isinstance(target, Character)
+                            },
+                            timeout=20.0
                         )
+                    if death_narrative:
+                        self.display_narrative_panel(death_narrative)
 
-            # Next turn
-            self.game_state.initiative_tracker.next_turn()
+                print_status_message(f"{result.target_name} has fallen!", "warning")
 
-            # Check if entire party is dead
-            if self.game_state.party.is_wiped():
-                break
+            # Display turn-end effects
+            self._display_turn_end_effects(result)
+
+    def _display_turn_end_effects(self, result: EnemyTurnResult) -> None:
+        """Display turn-end condition effects."""
+        for effect in result.turn_end_effects:
+            if effect.effect_type == "condition_expired":
+                # Don't announce surprised expiry
+                if effect.condition_id != "surprised":
+                    print_status_message(
+                        f"⏱ {effect.condition_id.upper()} on {result.enemy_name} has expired!",
+                        "info"
+                    )
+
+    def _find_party_member_by_name(self, name: str | None) -> Character | None:
+        """Find a party member by name."""
+        if not name:
+            return None
+        for char in self.game_state.party.characters:
+            if char.name == name:
+                return char
+        return None
+
+    def _find_enemy_by_name(self, name: str) -> Any | None:
+        """Find an enemy creature by name."""
+        for enemy in self.game_state.active_enemies:
+            if enemy.name == name:
+                return enemy
+        return None
 
     def _get_enemy_display_name(self, enemy: Any) -> str:
         """

--- a/tests/test_process_enemy_turn.py
+++ b/tests/test_process_enemy_turn.py
@@ -1,0 +1,384 @@
+# ABOUTME: Unit tests for GameState.process_enemy_turn() method
+# ABOUTME: Tests enemy turn processing including attacks, conditions, and AI decisions
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.game_state import (
+    EnemyTurnAction,
+    EnemyTurnResult,
+    GameState,
+)
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.systems.action_economy import TurnState
+from dnd_engine.systems.initiative import InitiativeEntry, InitiativeTracker
+from dnd_engine.utils.events import EventBus
+
+
+class TestProcessEnemyTurn:
+    """Tests for GameState.process_enemy_turn() method."""
+
+    @pytest.fixture
+    def event_bus(self):
+        """Create event bus for testing."""
+        return EventBus()
+
+    @pytest.fixture
+    def data_loader(self):
+        """Create data loader."""
+        return DataLoader()
+
+    @pytest.fixture
+    def dice_roller(self):
+        """Create seeded dice roller for predictable results."""
+        return DiceRoller(seed=42)
+
+    @pytest.fixture
+    def fighter(self):
+        """Create a fighter character."""
+        return Character(
+            name="Conan",
+            character_class=CharacterClass.FIGHTER,
+            level=3,
+            abilities=Abilities(16, 12, 14, 10, 10, 10),
+            max_hp=28,
+            ac=16
+        )
+
+    @pytest.fixture
+    def goblin(self):
+        """Create a goblin enemy."""
+        return Creature(
+            name="Goblin",
+            max_hp=7,
+            ac=13,
+            abilities=Abilities(8, 14, 10, 10, 8, 8)
+        )
+
+    @pytest.fixture
+    def game_state(self, fighter, goblin, event_bus, data_loader, dice_roller):
+        """Create game state with party and enemies in combat."""
+        party = Party([fighter])
+        game_state = GameState(
+            party=party,
+            dungeon_name="test_dungeon",
+            event_bus=event_bus,
+            data_loader=data_loader,
+            dice_roller=dice_roller
+        )
+        game_state.active_enemies = [goblin]
+        game_state.in_combat = True
+
+        # Set up initiative with goblin going first (higher initiative)
+        game_state.initiative_tracker = InitiativeTracker(dice_roller=dice_roller)
+        # Directly add entries to control order (goblin first, then fighter)
+        goblin_entry = InitiativeEntry(creature=goblin, initiative_roll=20)
+        fighter_entry = InitiativeEntry(creature=fighter, initiative_roll=10)
+        game_state.initiative_tracker.combatants = [goblin_entry, fighter_entry]
+        game_state.initiative_tracker.turn_states[goblin] = TurnState()
+        game_state.initiative_tracker.turn_states[fighter] = TurnState()
+        game_state.initiative_tracker.round_number = 1  # Combat has started
+
+        return game_state
+
+
+class TestProcessEnemyTurnBasicAttack(TestProcessEnemyTurn):
+    """Test basic enemy attack turn processing."""
+
+    def test_returns_enemy_turn_result(self, game_state):
+        """process_enemy_turn returns EnemyTurnResult."""
+        result = game_state.process_enemy_turn()
+
+        assert isinstance(result, EnemyTurnResult)
+
+    def test_attack_action_type(self, game_state):
+        """Enemy performs attack action when able."""
+        result = game_state.process_enemy_turn()
+
+        assert result.action_taken == EnemyTurnAction.ATTACK
+
+    def test_enemy_name_populated(self, game_state, goblin):
+        """Enemy name is included in result."""
+        result = game_state.process_enemy_turn()
+
+        assert result.enemy_name == "Goblin"
+
+    def test_target_name_populated(self, game_state, fighter):
+        """Target name is included in result."""
+        result = game_state.process_enemy_turn()
+
+        assert result.target_name == "Conan"
+
+    def test_attack_result_populated(self, game_state):
+        """Attack result is populated when attacking."""
+        result = game_state.process_enemy_turn()
+
+        assert result.attack_result is not None
+        assert hasattr(result.attack_result, "hit")
+        assert hasattr(result.attack_result, "damage")
+
+    def test_turn_advanced(self, game_state):
+        """Turn is advanced after processing."""
+        result = game_state.process_enemy_turn()
+
+        assert result.turn_advanced is True
+
+    def test_initiative_advances_to_party_member(self, game_state, fighter):
+        """After enemy turn, initiative moves to party member."""
+        game_state.process_enemy_turn()
+
+        current = game_state.initiative_tracker.get_current_combatant()
+        assert current.creature == fighter
+
+
+class TestProcessEnemyTurnPartyTurn(TestProcessEnemyTurn):
+    """Test when it's a party member's turn."""
+
+    def test_returns_none_when_party_turn(self, game_state, fighter, goblin):
+        """Returns None when current turn is a party member."""
+        # Advance to fighter's turn
+        game_state.initiative_tracker.next_turn()
+
+        result = game_state.process_enemy_turn()
+
+        assert result is None
+
+
+class TestProcessEnemyTurnNoCombat(TestProcessEnemyTurn):
+    """Test when not in combat."""
+
+    def test_returns_none_when_not_in_combat(self, game_state):
+        """Returns None when not in combat."""
+        game_state.in_combat = False
+
+        result = game_state.process_enemy_turn()
+
+        assert result is None
+
+
+class TestProcessEnemyTurnDeadEnemy(TestProcessEnemyTurn):
+    """Test dead enemy handling."""
+
+    def test_dead_enemy_skipped(self, game_state, goblin, fighter):
+        """Dead enemy has turn skipped."""
+        goblin.current_hp = 0
+
+        result = game_state.process_enemy_turn()
+
+        assert result.action_taken == EnemyTurnAction.DIED_START_OF_TURN
+        # Turn should advance to fighter
+        current = game_state.initiative_tracker.get_current_combatant()
+        assert current.creature == fighter
+
+
+class TestProcessEnemyTurnIncapacitated(TestProcessEnemyTurn):
+    """Test incapacitated enemy handling."""
+
+    def test_incapacitated_enemy_cannot_act(self, game_state, goblin):
+        """Incapacitated enemy cannot take actions."""
+        goblin.add_condition("stunned")
+
+        result = game_state.process_enemy_turn()
+
+        assert result.action_taken == EnemyTurnAction.INCAPACITATED
+        assert "STUNNED" in result.incapacitating_conditions
+
+    def test_surprised_enemy_cannot_act(self, game_state, goblin):
+        """Surprised enemy cannot take actions."""
+        goblin.add_condition("surprised")
+
+        result = game_state.process_enemy_turn()
+
+        assert result.action_taken == EnemyTurnAction.INCAPACITATED
+        assert "SURPRISED" in result.incapacitating_conditions
+
+
+class TestProcessEnemyTurnNoTargets(TestProcessEnemyTurn):
+    """Test when no targets available."""
+
+    def test_no_targets_when_party_wiped(self, game_state, fighter):
+        """No targets action when party is wiped."""
+        fighter.current_hp = 0
+
+        result = game_state.process_enemy_turn()
+
+        assert result.action_taken == EnemyTurnAction.NO_TARGETS
+
+
+class TestProcessEnemyTurnConditionRemoval(TestProcessEnemyTurn):
+    """Test condition removal decision."""
+
+    def test_on_fire_low_hp_attempts_removal(self, game_state, goblin):
+        """Enemy on fire with low HP attempts to extinguish."""
+        goblin.add_condition("on_fire")
+        goblin.current_hp = 3  # Below threshold of 4
+
+        result = game_state.process_enemy_turn()
+
+        assert result.action_taken == EnemyTurnAction.CONDITION_REMOVAL
+        assert result.condition_removal is not None
+        assert result.condition_removal.condition_id == "on_fire"
+
+    def test_on_fire_high_hp_attacks_instead(self, game_state, goblin):
+        """Enemy on fire with high HP attacks instead of extinguishing."""
+        goblin.add_condition("on_fire")
+        goblin.current_hp = 7  # Full HP, above threshold
+
+        result = game_state.process_enemy_turn()
+
+        # Should attack instead of attempting removal
+        assert result.action_taken == EnemyTurnAction.ATTACK
+
+
+class TestProcessEnemyTurnNarrativeContext(TestProcessEnemyTurn):
+    """Test narrative context for LLM enhancement."""
+
+    def test_narrative_context_populated(self, game_state):
+        """Narrative context is populated for attacks."""
+        result = game_state.process_enemy_turn()
+
+        assert result.narrative_context is not None
+        assert "attacker" in result.narrative_context
+        assert "target" in result.narrative_context
+        assert "hit" in result.narrative_context
+
+
+class TestProcessEnemyTurnTargetKilled(TestProcessEnemyTurn):
+    """Test target killed detection."""
+
+    def test_target_killed_flag_set(self, game_state, fighter):
+        """target_killed flag is set when target dies."""
+        # Set fighter to very low HP so goblin can kill
+        fighter.current_hp = 1
+
+        # Run enemy turn - may or may not kill depending on hit/damage
+        result = game_state.process_enemy_turn()
+
+        if result.attack_result and result.attack_result.hit:
+            if fighter.current_hp <= 0:
+                assert result.target_killed is True
+
+
+class TestProcessEnemyTurnTurnStartEffects(TestProcessEnemyTurn):
+    """Test turn-start effect processing."""
+
+    def test_turn_start_effects_recorded(self, game_state, goblin):
+        """Turn-start effects are recorded in result."""
+        goblin.add_condition("on_fire")
+        goblin.current_hp = 7  # High HP so won't try to extinguish
+
+        result = game_state.process_enemy_turn()
+
+        # Fire damage should be recorded (even if enemy still attacks)
+        # Note: turn_start_effects may be empty if on_fire doesn't trigger
+        # damage at turn start in this implementation
+        assert isinstance(result.turn_start_effects, list)
+
+
+class TestProcessEnemyTurnMultipleEnemies:
+    """Test with multiple enemies."""
+
+    @pytest.fixture
+    def event_bus(self):
+        return EventBus()
+
+    @pytest.fixture
+    def data_loader(self):
+        return DataLoader()
+
+    @pytest.fixture
+    def dice_roller(self):
+        return DiceRoller(seed=42)
+
+    @pytest.fixture
+    def fighter(self):
+        return Character(
+            name="Conan",
+            character_class=CharacterClass.FIGHTER,
+            level=3,
+            abilities=Abilities(16, 12, 14, 10, 10, 10),
+            max_hp=28,
+            ac=16
+        )
+
+    @pytest.fixture
+    def goblin1(self):
+        return Creature(
+            name="Goblin",
+            max_hp=7,
+            ac=13,
+            abilities=Abilities(8, 14, 10, 10, 8, 8)
+        )
+
+    @pytest.fixture
+    def goblin2(self):
+        return Creature(
+            name="Goblin",
+            max_hp=7,
+            ac=13,
+            abilities=Abilities(8, 14, 10, 10, 8, 8)
+        )
+
+    @pytest.fixture
+    def game_state_multi(
+        self, fighter, goblin1, goblin2, event_bus, data_loader, dice_roller
+    ):
+        """Create game state with multiple enemies."""
+        party = Party([fighter])
+        game_state = GameState(
+            party=party,
+            dungeon_name="test_dungeon",
+            event_bus=event_bus,
+            data_loader=data_loader,
+            dice_roller=dice_roller
+        )
+        game_state.active_enemies = [goblin1, goblin2]
+        game_state.in_combat = True
+
+        game_state.initiative_tracker = InitiativeTracker(dice_roller=dice_roller)
+        # Directly add entries to control order
+        goblin1_entry = InitiativeEntry(creature=goblin1, initiative_roll=20)
+        goblin2_entry = InitiativeEntry(creature=goblin2, initiative_roll=15)
+        fighter_entry = InitiativeEntry(creature=fighter, initiative_roll=10)
+        game_state.initiative_tracker.combatants = [
+            goblin1_entry, goblin2_entry, fighter_entry
+        ]
+        game_state.initiative_tracker.turn_states[goblin1] = TurnState()
+        game_state.initiative_tracker.turn_states[goblin2] = TurnState()
+        game_state.initiative_tracker.turn_states[fighter] = TurnState()
+        game_state.initiative_tracker.round_number = 1  # Combat has started
+
+        return game_state
+
+    def test_processes_first_enemy(self, game_state_multi, goblin1):
+        """Processes first enemy in initiative order."""
+        result = game_state_multi.process_enemy_turn()
+
+        assert result.action_taken == EnemyTurnAction.ATTACK
+        # First goblin should have gone
+
+    def test_processes_second_enemy_after_first(self, game_state_multi, goblin2):
+        """Second enemy can be processed after first."""
+        # Process first goblin
+        game_state_multi.process_enemy_turn()
+
+        # Process second goblin
+        result = game_state_multi.process_enemy_turn()
+
+        assert result.action_taken == EnemyTurnAction.ATTACK
+
+    def test_returns_none_after_all_enemies(self, game_state_multi, fighter):
+        """Returns None when all enemies have gone and it's party's turn."""
+        # Process both goblins
+        game_state_multi.process_enemy_turn()
+        game_state_multi.process_enemy_turn()
+
+        # Should now be fighter's turn
+        result = game_state_multi.process_enemy_turn()
+
+        assert result is None
+        current = game_state_multi.initiative_tracker.get_current_combatant()
+        assert current.creature == fighter


### PR DESCRIPTION
## Summary
- Add `GameState.process_enemy_turn()` that encapsulates all enemy turn logic
- New `EnemyTurnResult` dataclass with all info needed for UI display
- CLI `process_enemy_turns()` simplified from 145 lines to 10 lines (display loop only)
- 21 new unit tests for enemy turn processing

## Changes
**game_state.py:**
- `EnemyTurnAction` enum (ATTACK, CONDITION_REMOVAL, INCAPACITATED, etc.)
- `EnemyTurnResult` dataclass with attack results, conditions, narrative context
- `process_enemy_turn()` handles turn-start effects, AI decisions, attacks, concentration, turn-end effects
- Added `enemy_ai` and `condition_manager` to GameState

**cli.py:**
- `process_enemy_turns()` now just calls game engine and displays results
- `_display_enemy_turn_result()` handles action-specific UI output
- Helper methods: `_find_party_member_by_name()`, `_find_enemy_by_name()`

## Test plan
- [x] 21 new unit tests pass (test_process_enemy_turn.py)
- [x] Full test suite passes (1863 tests)
- [ ] Manual testing of combat scenarios

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)