### PR TITLE
Refactor: Extract room display logic to GameState context method (#219)

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -316,6 +316,77 @@ class PartyRestResult:
             return f"{hours}h {minutes}m"
 
 
+@dataclass
+class PartyMemberLighting:
+    """Lighting information for a single party member."""
+    character_name: str
+    effective_lighting: str  # "bright", "dim", or "dark"
+    has_darkvision: bool
+
+
+@dataclass
+class VisibleItem:
+    """Item visible in a room."""
+    item_type: str  # "gold", "currency", "item"
+    item_id: str | None = None
+    item_name: str | None = None
+    amount: int | None = None  # For gold type
+    gold: int = 0  # For currency type
+    silver: int = 0
+    copper: int = 0
+    platinum: int = 0
+
+
+@dataclass
+class RoomDisplayContext:
+    """
+    Complete context needed to display a room.
+
+    Encapsulates all game state queries for room display, allowing
+    the CLI to focus purely on presentation logic.
+    """
+    room_id: str
+    room_name: str
+    description: str
+    exits: dict[str, Any]
+    monster_names: list[str]
+    combat_starting: bool
+    base_lighting: str
+    party_lighting: list[PartyMemberLighting]
+    light_casters: list[str]
+    previous_room_id: str | None
+    visible_items: list[VisibleItem]
+    npc_display_names: list[str]
+    room_searched: bool
+
+    # Data for LLM enhancement
+    monsters_data: dict[str, Any]
+    party_size: int
+
+    def to_llm_dict(self) -> dict[str, Any]:
+        """Convert context to dict format for LLM enhancement."""
+        return {
+            "id": self.room_id,
+            "name": self.room_name,
+            "description": self.description,
+            "monsters": self.monster_names,
+            "combat_starting": self.combat_starting,
+            "monsters_data": self.monsters_data,
+            "party_size": self.party_size,
+            "base_lighting": self.base_lighting,
+            "party_lighting": [
+                {
+                    "character": pl.character_name,
+                    "lighting": pl.effective_lighting,
+                    "has_darkvision": pl.has_darkvision
+                }
+                for pl in self.party_lighting
+            ],
+            "light_casters": self.light_casters,
+            "previous_room_id": self.previous_room_id
+        }
+
+
 class GameState:
     """
     Central game state manager.
@@ -2771,6 +2842,184 @@ class GameState:
             current_turn=current_turn,
             in_combat=True
         )
+
+    def get_room_display_context(self) -> RoomDisplayContext:
+        """
+        Get complete context needed to display the current room.
+
+        Encapsulates all game state queries for room display, allowing
+        the CLI to focus purely on presentation logic. Follows the same
+        pattern as get_battlefield_state().
+
+        Returns:
+            RoomDisplayContext with all current room information
+        """
+        room = self.get_current_room()
+        room_id = room.get("id", room.get("name", "unknown").lower().replace(" ", "_"))
+        room_name = room.get("name", "Unknown Room")
+        description = room.get("description", self.get_room_description())
+        exits = self.get_available_exits()
+
+        # Get monster information
+        monster_names, monsters_data = self._get_room_monster_info(room)
+        combat_starting = self._is_combat_starting(room)
+
+        # Get lighting information
+        base_lighting = room.get("lighting", "bright")
+        party_lighting = self._calculate_party_lighting()
+        light_casters = self._get_active_light_casters()
+
+        # Get visible items
+        visible_items = self._get_visible_items(room)
+
+        # Get NPCs
+        npc_display_names = self._get_room_npc_names(room)
+
+        return RoomDisplayContext(
+            room_id=room_id,
+            room_name=room_name,
+            description=description,
+            exits=exits,
+            monster_names=monster_names,
+            combat_starting=combat_starting,
+            base_lighting=base_lighting,
+            party_lighting=party_lighting,
+            light_casters=light_casters,
+            previous_room_id=self.previous_room_id,
+            visible_items=visible_items,
+            npc_display_names=npc_display_names,
+            room_searched=room.get("searched", False),
+            monsters_data=monsters_data,
+            party_size=len(self.party.characters)
+        )
+
+    def _get_room_monster_info(
+        self, room: dict[str, Any]
+    ) -> tuple[list[str], dict[str, Any]]:
+        """
+        Get monster names and data for the current room.
+
+        Args:
+            room: Current room data dict
+
+        Returns:
+            Tuple of (monster_names list, monsters_data dict)
+        """
+        enemy_ids = room.get("enemies", [])
+        monster_names = []
+        monsters_data = {}
+
+        if enemy_ids:
+            monsters_data = self.data_loader.load_monsters()
+            for enemy_id in enemy_ids:
+                if enemy_id in monsters_data:
+                    monster_names.append(monsters_data[enemy_id]["name"])
+
+        return monster_names, monsters_data
+
+    def _is_combat_starting(self, room: dict[str, Any]) -> bool:
+        """
+        Check if combat is about to start in this room.
+
+        Combat starts if there are enemies and we're not already in combat.
+
+        Args:
+            room: Current room data dict
+
+        Returns:
+            True if combat is about to start
+        """
+        enemy_ids = room.get("enemies", [])
+        return bool(enemy_ids) and not self.in_combat
+
+    def _calculate_party_lighting(self) -> list[PartyMemberLighting]:
+        """
+        Calculate effective lighting for each party member.
+
+        Returns:
+            List of PartyMemberLighting for each character
+        """
+        party_lighting = []
+        for char in self.party.characters:
+            lighting = self.get_effective_lighting(char)
+            party_lighting.append(PartyMemberLighting(
+                character_name=char.name,
+                effective_lighting=lighting,
+                has_darkvision=char.darkvision_range > 0
+            ))
+        return party_lighting
+
+    def _get_active_light_casters(self) -> list[str]:
+        """
+        Get names of characters with active Light spells.
+
+        Returns:
+            List of character names who have cast Light
+        """
+        from dnd_engine.systems.time_manager import EffectType
+
+        light_casters = []
+        for effect in self.time_manager.active_effects:
+            if effect.effect_type == EffectType.SPELL and effect.source.lower() == "light":
+                if effect.caster_name and effect.caster_name not in light_casters:
+                    light_casters.append(effect.caster_name)
+        return light_casters
+
+    def _get_visible_items(self, room: dict[str, Any]) -> list[VisibleItem]:
+        """
+        Get visible items in the room.
+
+        Args:
+            room: Current room data dict
+
+        Returns:
+            List of VisibleItem objects
+        """
+        visible_items = []
+        for item in room.get("items", []):
+            if not item.get("visible", False):
+                continue
+
+            item_type = item["type"]
+            if item_type == "gold":
+                visible_items.append(VisibleItem(
+                    item_type="gold",
+                    amount=item.get("amount", 0)
+                ))
+            elif item_type == "currency":
+                visible_items.append(VisibleItem(
+                    item_type="currency",
+                    gold=item.get("gold", 0),
+                    silver=item.get("silver", 0),
+                    copper=item.get("copper", 0),
+                    platinum=item.get("platinum", 0)
+                ))
+            else:
+                item_id = item.get("id", "an item")
+                visible_items.append(VisibleItem(
+                    item_type="item",
+                    item_id=item_id,
+                    item_name=item_id.replace("_", " ").title()
+                ))
+
+        return visible_items
+
+    def _get_room_npc_names(self, room: dict[str, Any]) -> list[str]:
+        """
+        Get display names of NPCs in the current room.
+
+        Args:
+            room: Current room data dict
+
+        Returns:
+            List of NPC display names
+        """
+        if not self.npc_manager:
+            return []
+
+        room_id = room.get("id", "")
+        npcs = self.npc_manager.get_npcs_in_room(room_id)
+        return [npc.display_name for npc in npcs]
 
     def _get_enemy_display_name(self, enemy: Creature) -> str:
         """

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -130,107 +130,50 @@ class CLI:
 
     def display_room(self) -> None:
         """Display the current room description with LLM enhancement."""
-        room = self.game_state.get_current_room()
-
-        # Extract room name and basic description
-        room_name = room.get("name", "Unknown Room")
-        basic_desc = room.get("description", self.game_state.get_room_description())
-        exits = self.game_state.get_available_exits()
-
-        # Check for monsters in the room
-        enemy_ids = room.get("enemies", [])
-        monster_names = []
-        if enemy_ids:
-            # Load monster data to get display names
-            monsters_data = self.game_state.data_loader.load_monsters()
-            for enemy_id in enemy_ids:
-                if enemy_id in monsters_data:
-                    monster_names.append(monsters_data[enemy_id]["name"])
-
-        # Detect if combat is about to start
-        # Combat starts if there are enemies and we're not already in combat
-        combat_starting = bool(enemy_ids) and not self.game_state.in_combat
-
-        # Calculate effective lighting for each party member
-        # (used for both LLM enhancement and UI display)
-        # Also track who actually cast Light spells for narrative purposes
-        from dnd_engine.systems.time_manager import EffectType
-        light_casters = []
-        for effect in self.game_state.time_manager.active_effects:
-            if effect.effect_type == EffectType.SPELL and effect.source.lower() == "light":
-                if effect.caster_name and effect.caster_name not in light_casters:
-                    light_casters.append(effect.caster_name)
-
-        party_lighting = []
-        for char in self.game_state.party.characters:
-            lighting = self.game_state.get_effective_lighting(char)
-            party_lighting.append({
-                "character": char.name,
-                "lighting": lighting,
-                "has_darkvision": char.darkvision_range > 0
-            })
+        # Get all room context from game engine
+        context = self.game_state.get_room_display_context()
 
         # Try to get enhanced description from LLM
         enhanced_desc = None
         if self.llm_enhancer:
-            # Load full monster data for creature-aware prompts
-            monsters_data = self.game_state.data_loader.load_monsters()
-            party_size = len(self.game_state.party.characters)
-
-            room_data = {
-                "id": room.get("id", room_name.lower().replace(" ", "_")),
-                "name": room_name,
-                "description": basic_desc,
-                "monsters": monster_names,  # Include monster info for LLM
-                "combat_starting": combat_starting,  # Flag for combat initiation narrative
-                "monsters_data": monsters_data,  # Full monster definitions for creature-aware prompts
-                "party_size": party_size,  # Party size for combat context
-                "base_lighting": room.get("lighting", "bright"),  # Room's base lighting level
-                "party_lighting": party_lighting,  # Effective lighting for each party member
-                "light_casters": light_casters,  # Characters who cast Light spells
-                "previous_room_id": self.game_state.previous_room_id  # Previous room for transition narrative
-            }
             with console.status("", spinner="dots"):
-                enhanced_desc = self.llm_enhancer.get_room_description_sync(room_data, timeout=20.0)
+                enhanced_desc = self.llm_enhancer.get_room_description_sync(
+                    context.to_llm_dict(), timeout=20.0
+                )
 
         # Use enhanced description if available, otherwise use basic
-        room_text = enhanced_desc if enhanced_desc else basic_desc
+        room_text = enhanced_desc if enhanced_desc else context.description
 
-        # Lighting is now shown in the status bar, so we just use the room name
-        print_room_description(room_name, room_text, exits)
+        # Display room description
+        print_room_description(context.room_name, room_text, context.exits)
 
         # Show visible items in the room
-        visible_items = [item for item in room.get("items", []) if item.get("visible", False)]
-        if visible_items and not room.get("searched", False):
+        if context.visible_items and not context.room_searched:
             print_status_message("\nYou notice:", "info")
-            for item in visible_items:
-                if item["type"] == "gold":
-                    print_status_message(f"  • {item['amount']} gold pieces", "info")
-                elif item["type"] == "currency":
+            for item in context.visible_items:
+                if item.item_type == "gold":
+                    print_status_message(f"  • {item.amount} gold pieces", "info")
+                elif item.item_type == "currency":
                     currency_parts = []
-                    if item.get("gold", 0) > 0:
-                        currency_parts.append(f"{item['gold']} gold")
-                    if item.get("silver", 0) > 0:
-                        currency_parts.append(f"{item['silver']} silver")
-                    if item.get("copper", 0) > 0:
-                        currency_parts.append(f"{item['copper']} copper")
-                    if item.get("platinum", 0) > 0:
-                        currency_parts.append(f"{item['platinum']} platinum")
+                    if item.gold > 0:
+                        currency_parts.append(f"{item.gold} gold")
+                    if item.silver > 0:
+                        currency_parts.append(f"{item.silver} silver")
+                    if item.copper > 0:
+                        currency_parts.append(f"{item.copper} copper")
+                    if item.platinum > 0:
+                        currency_parts.append(f"{item.platinum} platinum")
                     print_status_message(f"  • {', '.join(currency_parts)}", "info")
                 else:
-                    item_name = item.get('id', 'an item').replace("_", " ").title()
-                    print_status_message(f"  • {item_name}", "info")
+                    print_status_message(f"  • {item.item_name}", "info")
             print_status_message("Use 'take <item>' or 'take all' to pick up items.", "info")
 
         # Show NPCs in the room
-        if self.game_state.npc_manager:
-            room_id = room.get("id", "")
-            npcs = self.game_state.npc_manager.get_npcs_in_room(room_id)
-            if npcs:
-                print_status_message("\nYou see:", "info")
-                for npc in npcs:
-                    print_status_message(f"  • {npc.display_name}", "info")
-                print_status_message("Use 'talk <name>' to start a conversation.", "info")
+        if context.npc_display_names:
+            print_status_message("\nYou see:", "info")
+            for npc_name in context.npc_display_names:
+                print_status_message(f"  • {npc_name}", "info")
+            print_status_message("Use 'talk <name>' to start a conversation.", "info")
 
         # Mark room as displayed so subsequent "look" commands show "already in room" narrative
         self.game_state.mark_room_displayed()

--- a/tests/test_room_display_context.py
+++ b/tests/test_room_display_context.py
@@ -1,0 +1,425 @@
+# ABOUTME: Unit tests for RoomDisplayContext and related game state methods
+# ABOUTME: Tests room display context generation, monster info, lighting, and item visibility
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.game_state import (
+    GameState,
+    RoomDisplayContext,
+    PartyMemberLighting,
+    VisibleItem,
+)
+from dnd_engine.core.party import Party
+from dnd_engine.systems.time_manager import ActiveEffect, EffectType
+
+
+def create_test_character(name: str, char_class: str = "fighter", level: int = 1) -> Character:
+    """Helper to create a test character with minimal setup."""
+    char_class_enum = CharacterClass.FIGHTER if char_class == "fighter" else CharacterClass.WIZARD
+    return Character(
+        name=name,
+        character_class=char_class_enum,
+        level=level,
+        abilities=Abilities(15, 14, 13, 10, 12, 8),
+        max_hp=10,
+        ac=15,
+        race="human"
+    )
+
+
+class TestRoomDisplayContext:
+    """Tests for the RoomDisplayContext dataclass and get_room_display_context()."""
+
+    @pytest.fixture
+    def basic_game_state(self):
+        """Create a basic game state for testing."""
+        char = create_test_character("Frodo", "fighter", 1)
+        party = Party([char])
+        game_state = GameState(party, "test_dungeon")
+        return game_state
+
+    @pytest.fixture
+    def game_state_with_party(self):
+        """Create game state with multiple party members."""
+        char1 = create_test_character("Frodo", "fighter", 1)
+        char2 = create_test_character("Gandalf", "wizard", 1)
+        # Give Gandalf darkvision
+        char2.darkvision_range = 60
+        party = Party([char1, char2])
+        game_state = GameState(party, "test_dungeon")
+        return game_state
+
+    def test_get_room_display_context_basic(self, basic_game_state):
+        """Test basic room display context generation."""
+        context = basic_game_state.get_room_display_context()
+
+        assert isinstance(context, RoomDisplayContext)
+        assert context.room_name is not None
+        assert context.description is not None
+        assert isinstance(context.exits, dict)
+        assert isinstance(context.monster_names, list)
+        assert isinstance(context.party_lighting, list)
+        assert context.party_size == 1
+
+    def test_room_display_context_has_correct_room_info(self, basic_game_state):
+        """Test that context contains correct room information."""
+        context = basic_game_state.get_room_display_context()
+
+        # Should have the start room info
+        room = basic_game_state.get_current_room()
+        assert context.room_name == room.get("name", "Unknown Room")
+        assert context.room_id is not None
+
+    def test_party_lighting_calculation(self, game_state_with_party):
+        """Test that party lighting is calculated for each member."""
+        context = game_state_with_party.get_room_display_context()
+
+        assert len(context.party_lighting) == 2
+
+        # Find each character's lighting info
+        frodo_lighting = next(
+            pl for pl in context.party_lighting if pl.character_name == "Frodo"
+        )
+        gandalf_lighting = next(
+            pl for pl in context.party_lighting if pl.character_name == "Gandalf"
+        )
+
+        assert isinstance(frodo_lighting, PartyMemberLighting)
+        assert frodo_lighting.has_darkvision is False
+        assert gandalf_lighting.has_darkvision is True
+
+    def test_combat_starting_detection_no_enemies(self, basic_game_state):
+        """Test that combat_starting is False when no enemies."""
+        context = basic_game_state.get_room_display_context()
+
+        assert context.combat_starting is False
+        assert context.monster_names == []
+
+    def test_combat_starting_detection_with_enemies(self, basic_game_state):
+        """Test that combat_starting is True when enemies present."""
+        # Add enemies to current room
+        room = basic_game_state.get_current_room()
+        room["enemies"] = ["goblin"]
+
+        context = basic_game_state.get_room_display_context()
+
+        assert context.combat_starting is True
+
+    def test_combat_starting_false_when_already_in_combat(self, basic_game_state):
+        """Test that combat_starting is False when already in combat."""
+        room = basic_game_state.get_current_room()
+        room["enemies"] = ["goblin"]
+        basic_game_state.in_combat = True
+
+        context = basic_game_state.get_room_display_context()
+
+        assert context.combat_starting is False
+
+    def test_visible_items_gold(self, basic_game_state):
+        """Test visible gold items are included."""
+        room = basic_game_state.get_current_room()
+        room["items"] = [{"type": "gold", "amount": 50, "visible": True}]
+
+        context = basic_game_state.get_room_display_context()
+
+        assert len(context.visible_items) == 1
+        item = context.visible_items[0]
+        assert item.item_type == "gold"
+        assert item.amount == 50
+
+    def test_visible_items_currency(self, basic_game_state):
+        """Test visible currency items are included."""
+        room = basic_game_state.get_current_room()
+        room["items"] = [{
+            "type": "currency",
+            "gold": 10,
+            "silver": 25,
+            "copper": 50,
+            "visible": True
+        }]
+
+        context = basic_game_state.get_room_display_context()
+
+        assert len(context.visible_items) == 1
+        item = context.visible_items[0]
+        assert item.item_type == "currency"
+        assert item.gold == 10
+        assert item.silver == 25
+        assert item.copper == 50
+
+    def test_visible_items_regular_item(self, basic_game_state):
+        """Test visible regular items are included."""
+        room = basic_game_state.get_current_room()
+        room["items"] = [{
+            "type": "item",
+            "id": "healing_potion",
+            "visible": True
+        }]
+
+        context = basic_game_state.get_room_display_context()
+
+        assert len(context.visible_items) == 1
+        item = context.visible_items[0]
+        assert item.item_type == "item"
+        assert item.item_id == "healing_potion"
+        assert item.item_name == "Healing Potion"
+
+    def test_hidden_items_not_included(self, basic_game_state):
+        """Test that hidden items are not included."""
+        room = basic_game_state.get_current_room()
+        room["items"] = [
+            {"type": "gold", "amount": 50, "visible": True},
+            {"type": "gold", "amount": 100, "visible": False},
+        ]
+
+        context = basic_game_state.get_room_display_context()
+
+        assert len(context.visible_items) == 1
+        assert context.visible_items[0].amount == 50
+
+    def test_room_searched_status(self, basic_game_state):
+        """Test that room searched status is included."""
+        room = basic_game_state.get_current_room()
+        room["searched"] = False
+
+        context = basic_game_state.get_room_display_context()
+        assert context.room_searched is False
+
+        room["searched"] = True
+        context = basic_game_state.get_room_display_context()
+        assert context.room_searched is True
+
+    def test_to_llm_dict_format(self, basic_game_state):
+        """Test that to_llm_dict() returns proper format for LLM."""
+        context = basic_game_state.get_room_display_context()
+        llm_dict = context.to_llm_dict()
+
+        # Check required fields for LLM
+        assert "id" in llm_dict
+        assert "name" in llm_dict
+        assert "description" in llm_dict
+        assert "monsters" in llm_dict
+        assert "combat_starting" in llm_dict
+        assert "monsters_data" in llm_dict
+        assert "party_size" in llm_dict
+        assert "base_lighting" in llm_dict
+        assert "party_lighting" in llm_dict
+        assert "light_casters" in llm_dict
+        assert "previous_room_id" in llm_dict
+
+    def test_to_llm_dict_party_lighting_format(self, game_state_with_party):
+        """Test that party lighting is formatted correctly for LLM."""
+        context = game_state_with_party.get_room_display_context()
+        llm_dict = context.to_llm_dict()
+
+        party_lighting = llm_dict["party_lighting"]
+        assert len(party_lighting) == 2
+
+        # Check each entry has required keys
+        for entry in party_lighting:
+            assert "character" in entry
+            assert "lighting" in entry
+            assert "has_darkvision" in entry
+
+
+class TestLightCasters:
+    """Tests for light caster tracking."""
+
+    @pytest.fixture
+    def game_state_with_light(self):
+        """Create game state with Light spell active."""
+        char = create_test_character("Gandalf", "wizard", 1)
+        party = Party([char])
+        game_state = GameState(party, "test_dungeon")
+
+        # Add Light spell effect
+        light_effect = ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="Light",
+            duration_type="minutes",
+            duration_value=60,
+            remaining_value=60,
+            target_name="Gandalf",
+            caster_name="Gandalf"
+        )
+        game_state.time_manager.active_effects.append(light_effect)
+
+        return game_state
+
+    def test_light_casters_detected(self, game_state_with_light):
+        """Test that Light spell casters are detected."""
+        context = game_state_with_light.get_room_display_context()
+
+        assert "Gandalf" in context.light_casters
+
+    def test_light_casters_empty_without_spell(self):
+        """Test that light_casters is empty without Light spell."""
+        char = create_test_character("Frodo", "fighter", 1)
+        party = Party([char])
+        game_state = GameState(party, "test_dungeon")
+
+        context = game_state.get_room_display_context()
+
+        assert context.light_casters == []
+
+    def test_multiple_light_casters(self):
+        """Test multiple Light spell casters."""
+        char1 = create_test_character("Gandalf", "wizard", 1)
+        char2 = create_test_character("Radagast", "wizard", 1)
+        party = Party([char1, char2])
+        game_state = GameState(party, "test_dungeon")
+
+        # Add Light spells from both
+        game_state.time_manager.active_effects.append(ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="Light",
+            duration_type="minutes",
+            duration_value=60,
+            remaining_value=60,
+            target_name="Gandalf",
+            caster_name="Gandalf"
+        ))
+        game_state.time_manager.active_effects.append(ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="Light",
+            duration_type="minutes",
+            duration_value=60,
+            remaining_value=60,
+            target_name="Radagast",
+            caster_name="Radagast"
+        ))
+
+        context = game_state.get_room_display_context()
+
+        assert len(context.light_casters) == 2
+        assert "Gandalf" in context.light_casters
+        assert "Radagast" in context.light_casters
+
+    def test_duplicate_light_caster_not_repeated(self):
+        """Test that same caster with multiple Light spells isn't repeated."""
+        char = create_test_character("Gandalf", "wizard", 1)
+        party = Party([char])
+        game_state = GameState(party, "test_dungeon")
+
+        # Add two Light spells from same caster
+        game_state.time_manager.active_effects.append(ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="Light",
+            duration_type="minutes",
+            duration_value=60,
+            remaining_value=60,
+            target_name="Gandalf",
+            caster_name="Gandalf"
+        ))
+        game_state.time_manager.active_effects.append(ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="Light",
+            duration_type="minutes",
+            duration_value=60,
+            remaining_value=60,
+            target_name="Gandalf",
+            caster_name="Gandalf"
+        ))
+
+        context = game_state.get_room_display_context()
+
+        assert context.light_casters == ["Gandalf"]
+
+
+class TestMonsterInfo:
+    """Tests for monster information in room context."""
+
+    def test_monster_names_from_data_loader(self):
+        """Test that monster names are loaded from data."""
+        char = create_test_character("Frodo", "fighter", 1)
+        party = Party([char])
+        game_state = GameState(party, "test_dungeon")
+
+        # Add enemies to room
+        room = game_state.get_current_room()
+        room["enemies"] = ["goblin", "skeleton"]
+
+        context = game_state.get_room_display_context()
+
+        # Should have loaded monster names (actual names depend on data files)
+        assert isinstance(context.monster_names, list)
+        assert isinstance(context.monsters_data, dict)
+
+    def test_empty_monster_info_without_enemies(self):
+        """Test that monster info is empty without enemies."""
+        char = create_test_character("Frodo", "fighter", 1)
+        party = Party([char])
+        game_state = GameState(party, "test_dungeon")
+
+        context = game_state.get_room_display_context()
+
+        assert context.monster_names == []
+        assert context.monsters_data == {}
+
+
+class TestNPCDisplay:
+    """Tests for NPC display in room context."""
+
+    def test_npc_names_empty_without_npc_manager(self):
+        """Test that NPC names are empty without NPC manager."""
+        char = create_test_character("Frodo", "fighter", 1)
+        party = Party([char])
+        game_state = GameState(party, "test_dungeon")
+        game_state.npc_manager = None
+
+        context = game_state.get_room_display_context()
+
+        assert context.npc_display_names == []
+
+    def test_npc_names_with_mocked_manager(self):
+        """Test NPC names are included when NPCs are present."""
+        char = create_test_character("Frodo", "fighter", 1)
+        party = Party([char])
+        game_state = GameState(party, "test_dungeon")
+
+        # Mock NPC manager
+        mock_npc = MagicMock()
+        mock_npc.display_name = "Bob the Merchant"
+        mock_npc_manager = MagicMock()
+        mock_npc_manager.get_npcs_in_room.return_value = [mock_npc]
+        game_state.npc_manager = mock_npc_manager
+
+        context = game_state.get_room_display_context()
+
+        assert "Bob the Merchant" in context.npc_display_names
+
+
+class TestPreviousRoomTracking:
+    """Tests for previous room ID tracking."""
+
+    def test_previous_room_id_initially_none(self):
+        """Test that previous_room_id starts as None."""
+        char = create_test_character("Frodo", "fighter", 1)
+        party = Party([char])
+        game_state = GameState(party, "test_dungeon")
+
+        context = game_state.get_room_display_context()
+
+        assert context.previous_room_id is None
+
+    def test_previous_room_id_after_transition(self):
+        """Test previous_room_id after room transition."""
+        char = create_test_character("Frodo", "fighter", 1)
+        party = Party([char])
+        game_state = GameState(party, "test_dungeon")
+
+        # Mark room as displayed (simulates viewing room)
+        game_state.mark_room_displayed()
+        start_room_id = game_state.current_room_id
+
+        # Move to a new room if possible
+        exits = game_state.get_available_exits()
+        if exits:
+            direction = list(exits.keys())[0]
+            game_state.move(direction)
+
+            context = game_state.get_room_display_context()
+            assert context.previous_room_id == start_room_id


### PR DESCRIPTION
## Summary
- Move game state queries from CLI `display_room()` to new `get_room_display_context()` method in GameState
- Follow the same pattern as `get_battlefield_state()` for combat display
- CLI now purely handles presentation while game engine encapsulates all logic

## Changes
- Add `RoomDisplayContext`, `PartyMemberLighting`, `VisibleItem` dataclasses
- Add `get_room_display_context()` method to GameState
- Add helper methods: `_get_room_monster_info()`, `_is_combat_starting()`, `_calculate_party_lighting()`, `_get_active_light_casters()`, `_get_visible_items()`, `_get_room_npc_names()`
- Simplify CLI `display_room()` from ~105 lines to ~50 lines
- Add 23 unit tests for room display context functionality

## Test plan
- [x] All 23 new unit tests pass
- [x] Existing combat infrastructure tests pass
- [ ] Manual testing of room display in game

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)