### PR TITLE
Move stabilize execution logic from CLI to game engine

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -210,6 +210,25 @@ class PlayerAttackResult:
     error: str | None = None
 
 
+@dataclass
+class StabilizeResult:
+    """
+    Result of attempting to stabilize a dying character.
+
+    Contains all information needed for UI display without requiring
+    the CLI to perform any game logic calculations.
+    """
+    success: bool
+    helper_name: str
+    target_name: str
+
+    # Skill check details
+    roll: int
+    modifier: int
+    total: int
+    dc: int
+
+
 class EnemyTurnAction(Enum):
     """Actions an enemy can take during their turn."""
     ATTACK = "attack"
@@ -1975,6 +1994,55 @@ class GameState:
             concentration_broken=concentration_broken,
             target_killed=not target.is_alive,
             narrative_context=narrative_context
+        )
+
+    def execute_stabilize(
+        self,
+        helper: Character,
+        target: Character
+    ) -> "StabilizeResult":
+        """
+        Execute an attempt to stabilize a dying character.
+
+        Handles the complete flow:
+        1. Loads skills data
+        2. Makes Medicine skill check (DC 10)
+        3. Stabilizes target on success
+        4. Emits stabilization event
+
+        Args:
+            helper: Character attempting to stabilize
+            target: Dying character to stabilize
+
+        Returns:
+            StabilizeResult with check details and outcome.
+        """
+        # Load skills data and make Medicine check (DC 10)
+        skills_data = self.data_loader.load_skills()
+        check_result = helper.make_skill_check("medicine", 10, skills_data)
+
+        if check_result["success"]:
+            # Stabilize the target
+            target.stabilize_character()
+
+            # Emit stabilization event
+            self.event_bus.emit(Event(
+                type=EventType.CHARACTER_STABILIZED,
+                data={
+                    "helper": helper.name,
+                    "target": target.name,
+                    "check_total": check_result["total"]
+                }
+            ))
+
+        return StabilizeResult(
+            success=check_result["success"],
+            helper_name=helper.name,
+            target_name=target.name,
+            roll=check_result["roll"],
+            modifier=check_result["modifier"],
+            total=check_result["total"],
+            dc=check_result["dc"]
         )
 
     def _resolve_combat_attack_spell(

--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -14,6 +14,7 @@ from dnd_engine.core.game_state import (
     EnemyTurnResult,
     GameState,
     PlayerAttackResult,
+    StabilizeResult,
 )
 from dnd_engine.llm.npc_chat import NPCChatManager
 from dnd_engine.systems.action_economy import ActionType
@@ -2376,34 +2377,18 @@ class CLI:
 
         print_section(f"{helper.name} attempts to stabilize {target.name}")
 
-        # Load skills data
-        skills_data = self.game_state.data_loader.load_skills()
-
-        # Make Medicine skill check (DC 10)
-        check_result = helper.make_skill_check("medicine", 10, skills_data)
+        # Execute stabilize through game engine
+        result = self.game_state.execute_stabilize(helper, target)
 
         # Display check result
-        modifier_str = f"+{check_result['modifier']}" if check_result['modifier'] >= 0 else str(check_result['modifier'])
+        modifier_str = f"+{result.modifier}" if result.modifier >= 0 else str(result.modifier)
         print_status_message(
-            f"Medicine check: {check_result['roll']}{modifier_str} = {check_result['total']} vs DC {check_result['dc']}",
+            f"Medicine check: {result.roll}{modifier_str} = {result.total} vs DC {result.dc}",
             "info"
         )
 
-        if check_result['success']:
-            # Stabilize the target
-            target.stabilize_character()
+        if result.success:
             print_status_message(f"Success! {target.name} is stabilized.", "success")
-
-            # Emit stabilization event
-            from dnd_engine.utils.events import Event, EventType
-            self.game_state.event_bus.emit(Event(
-                type=EventType.CHARACTER_STABILIZED,
-                data={
-                    "helper": helper.name,
-                    "target": target.name,
-                    "check_total": check_result['total']
-                }
-            ))
         else:
             print_error(f"Failed! {target.name} remains unstabilized.")
 


### PR DESCRIPTION
## Summary
- Added `StabilizeResult` dataclass following the pattern of `PlayerAttackResult`
- Added `execute_stabilize()` method to GameState that handles:
  - Loading skills data
  - Making Medicine skill check (DC 10)
  - Stabilizing target on success
  - Emitting stabilization event
- Simplified CLI `_execute_stabilize()` to call engine method and display results

## Changes
- `dnd_engine/core/game_state.py`: +53 lines (dataclass + method)
- `dnd_engine/ui/cli.py`: -15 lines (removed game logic)

## Test plan
- [x] All 6 stabilize-related tests pass
- [x] All 48 combat/death save tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)