### PR TITLE
feat: Add Temple of Durgon dungeon content (#207)

### DIFF
--- a/dnd_engine/data/content/dungeons/temple_of_durgon.json
+++ b/dnd_engine/data/content/dungeons/temple_of_durgon.json
@@ -1,0 +1,452 @@
+{
+  "id": "temple_of_durgon",
+  "name": "The Unquiet Dead: Temple of Durgon",
+  "campaign_id": "the_unquiet_dead",
+  "description": "An abandoned temple in the swamps outside of town, sealed away centuries ago by the cleric Davos. The cult leader has fled here to complete the ritual to resurrect the devil Durgon using Davos's stolen skull.",
+  "start_room": "temple_of_durgon.entrance_hall",
+  "level_range": "2-3",
+  "estimated_playtime": "60-90 minutes",
+  "focus": "combat, exploration, final boss",
+  "notes": "Final part of The Unquiet Dead campaign. Features the resurrection ritual and confrontation with Durgon. Pitch black throughout - players need light sources or darkvision. Silvered weapons found in reliquaries are effective against Durgon.",
+  "rooms": {
+    "temple_of_durgon.entrance_hall": {
+      "id": "temple_of_durgon.entrance_hall",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Entrance Hall",
+      "description": "Massive stone doors hang partially open, revealing a grand entrance hall choked with centuries of decay. Cobwebs hang from the vaulted ceiling like tattered curtains, and the air is thick with moisture from the surrounding swamp. The stone floor is slick with moss and condensation. Faded murals on the walls depict angelic figures locked in combat with horned devils.",
+      "lighting": "dark",
+      "hidden_features": [
+        {
+          "type": "passive_perception",
+          "dc": 12,
+          "on_success": "Fresh footprints in the moss lead deeper into the temple - the cultists passed through here recently.",
+          "on_failure": null,
+          "trigger": "on_enter",
+          "once_per_room": true
+        }
+      ],
+      "exits": {
+        "south": {
+          "destination": "cult_hideout.dark_altar",
+          "label": "Back to Cult Hideout",
+          "locked": true,
+          "unlock_methods": [
+            {
+              "skill": "athletics",
+              "dc": 12,
+              "description": "force open the heavy stone door"
+            }
+          ]
+        },
+        "north": "temple_of_durgon.northern_chamber",
+        "east": "temple_of_durgon.southern_chamber"
+      },
+      "enemies": [],
+      "items": [],
+      "searched": false,
+      "searchable": false
+    },
+    "temple_of_durgon.northern_chamber": {
+      "id": "temple_of_durgon.northern_chamber",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Northern Chamber",
+      "description": "This circular chamber features elaborate murals depicting robed clerics battling shadowy creatures. The paint has faded but the artistry remains impressive. Three passages lead away from this room - to the west, north, and east. The northern passage shows signs of recent use.",
+      "lighting": "dark",
+      "examinable_objects": [
+        {
+          "id": "northern_murals",
+          "name": "murals",
+          "description": "Faded murals showing robed clerics in battle against dark creatures.",
+          "examine_checks": [
+            {
+              "skill": "religion",
+              "dc": 12,
+              "on_success": "The murals depict the Order of the Silver Dawn, holy warriors who sealed Durgon away centuries ago. The central figure appears to be Davos himself, wielding a silver mace against a bearded devil.",
+              "on_failure": "The murals show some kind of holy order fighting against devils, but the specific details are unclear."
+            }
+          ]
+        }
+      ],
+      "exits": {
+        "south": "temple_of_durgon.entrance_hall",
+        "west": "temple_of_durgon.chamber_of_warrior",
+        "north": "temple_of_durgon.chamber_of_thief",
+        "east": "temple_of_durgon.chamber_of_cleric"
+      },
+      "enemies": [],
+      "items": [],
+      "searched": false,
+      "searchable": false
+    },
+    "temple_of_durgon.chamber_of_warrior": {
+      "id": "temple_of_durgon.chamber_of_warrior",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Chamber of the Warrior",
+      "description": "A suit of ornate plate armor stands on a pedestal in the center of this chamber, posed as if ready for battle. Ancient weapon racks line the walls, though most have long since rotted away. As you enter, the armor begins to move, animated by ancient magic to defend this sacred place.",
+      "lighting": "dark",
+      "exits": {
+        "east": "temple_of_durgon.northern_chamber",
+        "north": "temple_of_durgon.reliquary_of_warrior"
+      },
+      "enemies": [
+        "animated_armor"
+      ],
+      "items": [],
+      "searched": false,
+      "searchable": false
+    },
+    "temple_of_durgon.reliquary_of_warrior": {
+      "id": "temple_of_durgon.reliquary_of_warrior",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Reliquary of the Warrior",
+      "description": "This small chamber served as a shrine to martial prowess. A stone altar bears the faded symbol of a crossed sword and shield. Behind the altar, a silver longsword rests in a crystal case, untouched by time. The weapon gleams with an inner light.",
+      "lighting": "dark",
+      "exits": {
+        "south": "temple_of_durgon.chamber_of_warrior"
+      },
+      "enemies": [],
+      "items": [
+        {
+          "type": "item",
+          "id": "silvered_longsword"
+        }
+      ],
+      "searched": false,
+      "searchable": true
+    },
+    "temple_of_durgon.chamber_of_thief": {
+      "id": "temple_of_durgon.chamber_of_thief",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Chamber of the Thief",
+      "description": "Shadow seems to cling to the corners of this chamber despite any light source. The walls are carved with intricate patterns that seem to shift when viewed from the corner of your eye. A hooded figure emerges from the darkness, blade drawn - a guardian spirit taking the form of a master spy.",
+      "lighting": "dark",
+      "exits": {
+        "south": "temple_of_durgon.northern_chamber",
+        "north": "temple_of_durgon.reliquary_of_thief"
+      },
+      "enemies": [
+        "spy"
+      ],
+      "items": [],
+      "searched": false,
+      "searchable": false
+    },
+    "temple_of_durgon.reliquary_of_thief": {
+      "id": "temple_of_durgon.reliquary_of_thief",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Reliquary of the Thief",
+      "description": "This chamber is dedicated to cunning and stealth. Faded tapestries depict hooded figures moving through shadows. On a velvet cushion atop a marble pedestal rests a silver dagger, its blade etched with prayers against evil.",
+      "lighting": "dark",
+      "exits": {
+        "south": "temple_of_durgon.chamber_of_thief"
+      },
+      "enemies": [],
+      "items": [
+        {
+          "type": "item",
+          "id": "silvered_dagger"
+        }
+      ],
+      "searched": false,
+      "searchable": true
+    },
+    "temple_of_durgon.southern_chamber": {
+      "id": "temple_of_durgon.southern_chamber",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Southern Chamber",
+      "description": "This chamber mirrors the northern one, with murals depicting clerics summoning celestial beings to aid in their battle against darkness. A sense of faded holiness lingers here. Passages lead west and north.",
+      "lighting": "dark",
+      "examinable_objects": [
+        {
+          "id": "southern_murals",
+          "name": "murals",
+          "description": "Murals showing clerics summoning angels and celestial beings.",
+          "examine_checks": [
+            {
+              "skill": "religion",
+              "dc": 12,
+              "on_success": "These murals show the final battle against Durgon. The clerics called upon celestial aid to bind the devil beneath this very temple. The binding required three sacred weapons - a sword, a dagger, and a mace - all coated in silver.",
+              "on_failure": "The murals depict some kind of summoning ritual, but the details are unclear."
+            }
+          ]
+        }
+      ],
+      "exits": {
+        "west": "temple_of_durgon.entrance_hall",
+        "north": "temple_of_durgon.chamber_of_cleric"
+      },
+      "enemies": [],
+      "items": [],
+      "searched": false,
+      "searchable": false
+    },
+    "temple_of_durgon.chamber_of_cleric": {
+      "id": "temple_of_durgon.chamber_of_cleric",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Chamber of the Cleric",
+      "description": "An altar to forgotten gods dominates this chamber. Candles have been recently lit - the cult has been here. A robed acolyte leads a prayer to dark powers, surrounded by six spectral cultists whose forms flicker like dying flames. They turn as you enter, eyes blazing with unholy light.",
+      "lighting": "dim",
+      "exits": {
+        "west": "temple_of_durgon.northern_chamber",
+        "south": "temple_of_durgon.southern_chamber",
+        "north": "temple_of_durgon.reliquary_of_cleric"
+      },
+      "enemies": [
+        "acolyte",
+        "cultist",
+        "cultist",
+        "cultist",
+        "cultist",
+        "cultist",
+        "cultist"
+      ],
+      "items": [
+        {
+          "type": "currency",
+          "gold": 0,
+          "silver": 25,
+          "copper": 0
+        }
+      ],
+      "searched": false,
+      "searchable": true,
+      "notes": "The six cultists are 'spirit cultists' with only 1 HP each per the module."
+    },
+    "temple_of_durgon.reliquary_of_cleric": {
+      "id": "temple_of_durgon.reliquary_of_cleric",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Reliquary of the Cleric",
+      "description": "This sacred chamber holds the weapons of faith. A silver mace rests upon the altar, its head shaped like a clenched fist. Holy symbols of long-forgotten gods are carved into every surface. A passage to the north leads deeper into the temple.",
+      "lighting": "dark",
+      "exits": {
+        "south": "temple_of_durgon.chamber_of_cleric",
+        "north": "temple_of_durgon.chamber_of_mage"
+      },
+      "enemies": [],
+      "items": [
+        {
+          "type": "item",
+          "id": "silvered_mace"
+        }
+      ],
+      "searched": false,
+      "searchable": true
+    },
+    "temple_of_durgon.chamber_of_mage": {
+      "id": "temple_of_durgon.chamber_of_mage",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Chamber of the Mage",
+      "description": "Arcane symbols cover the walls and floor of this chamber, forming complex magical diagrams. Bookshelves line the walls, though most volumes have crumbled to dust. A haggard mage in tattered robes stands among the ruins, clearly exhausted from casting powerful spells. He raises his hands defensively as you approach.",
+      "lighting": "dark",
+      "exits": {
+        "south": "temple_of_durgon.reliquary_of_cleric",
+        "north": "temple_of_durgon.reliquary_of_mage"
+      },
+      "enemies": [
+        "mage_weakened"
+      ],
+      "items": [
+        {
+          "type": "currency",
+          "gold": 15,
+          "silver": 0,
+          "copper": 0
+        }
+      ],
+      "searched": false,
+      "searchable": true
+    },
+    "temple_of_durgon.reliquary_of_mage": {
+      "id": "temple_of_durgon.reliquary_of_mage",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Reliquary of the Mage",
+      "description": "This chamber once held arcane treasures, but it has been thoroughly ransacked. Broken glass and scattered papers cover the floor. A hidden door in the north wall stands slightly ajar - the cultists came through here. Shards of glass from broken vials crunch underfoot.",
+      "lighting": "dark",
+      "hidden_features": [
+        {
+          "type": "passive_perception",
+          "dc": 12,
+          "on_success": "The glass shards on the floor will make noise if walked upon carelessly. You could try to move quietly (DC 12 Stealth) to avoid alerting anyone in the next room.",
+          "on_failure": null,
+          "trigger": "on_enter",
+          "once_per_room": true
+        }
+      ],
+      "exits": {
+        "south": "temple_of_durgon.chamber_of_mage",
+        "north": {
+          "destination": "temple_of_durgon.antechamber",
+          "hidden": true,
+          "label": "Hidden Door"
+        }
+      },
+      "enemies": [],
+      "items": [],
+      "searched": false,
+      "searchable": false,
+      "notes": "Moving through this room without DC 12 Stealth check alerts Room 12 (antechamber)."
+    },
+    "temple_of_durgon.antechamber": {
+      "id": "temple_of_durgon.antechamber",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Antechamber",
+      "description": "This narrow passage serves as the final approach to the inner sanctum. Torches in iron sconces have been recently lit. A single cultist stands guard, alert for any intruders. Beyond the northern door, you can hear chanting in Infernal.",
+      "lighting": "dim",
+      "exits": {
+        "south": "temple_of_durgon.reliquary_of_mage",
+        "north": "temple_of_durgon.hidden_shrine"
+      },
+      "enemies": [
+        "cultist"
+      ],
+      "items": [],
+      "searched": false,
+      "searchable": false
+    },
+    "temple_of_durgon.hidden_shrine": {
+      "id": "temple_of_durgon.hidden_shrine",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Hidden Shrine",
+      "description": "The cult leader stands before a blood-stained altar, the skull of Davos clutched in his hands. Two robed cultists flank him, chanting in Infernal. The air crackles with dark energy as the ritual nears completion. The cult leader turns, his eyes blazing with fanatical fervor. 'You're too late! The seal is breaking!'",
+      "lighting": "dim",
+      "examinable_objects": [
+        {
+          "id": "ritual_altar",
+          "name": "blood-stained altar",
+          "description": "An obsidian altar covered in infernal inscriptions and fresh blood.",
+          "examine_checks": [
+            {
+              "skill": "arcana",
+              "dc": 14,
+              "on_success": "The ritual is nearly complete. The skull of Davos is the final component needed to break the seal on Durgon's prison below. Destroying the skull or killing the cult leader would stop the ritual.",
+              "on_failure": "Dark magic is clearly at work here, but the specifics elude you."
+            }
+          ]
+        }
+      ],
+      "exits": {
+        "south": "temple_of_durgon.antechamber",
+        "down": {
+          "destination": "temple_of_durgon.main_chamber",
+          "hidden": true,
+          "label": "Descending Stairs",
+          "examine_checks": [
+            {
+              "skill": "investigation",
+              "dc": 12,
+              "action": "search the altar area",
+              "on_success": "Behind the altar, you find a hidden trapdoor leading down into darkness. Ancient stairs descend into the depths.",
+              "on_failure": "Nothing unusual catches your eye."
+            }
+          ]
+        }
+      },
+      "enemies": [
+        "cult_fanatic",
+        "cultist",
+        "cultist"
+      ],
+      "items": [
+        {
+          "type": "item",
+          "id": "profane_skull"
+        },
+        {
+          "type": "currency",
+          "gold": 42,
+          "silver": 0,
+          "copper": 0
+        }
+      ],
+      "searched": false,
+      "searchable": true,
+      "boss_room": true
+    },
+    "temple_of_durgon.main_chamber": {
+      "id": "temple_of_durgon.main_chamber",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Main Chamber",
+      "description": "The stairs descend into a vast underground chamber. The walls glow with infernal runes, and the temperature rises noticeably. In the center of the chamber, a pillar of hellfire erupts from a broken seal in the floor. Within the flames, a bearded devil takes shape - Durgon himself, finally freed from centuries of imprisonment. The devil appears disoriented, still reforming after so long in magical stasis.",
+      "lighting": "bright",
+      "hidden_features": [
+        {
+          "type": "passive_perception",
+          "dc": 10,
+          "on_success": "Durgon seems disoriented from his long imprisonment. He might be vulnerable to negotiation or intimidation, or you could press the attack while he's still recovering.",
+          "on_failure": null,
+          "trigger": "on_enter",
+          "once_per_room": true
+        }
+      ],
+      "examinable_objects": [
+        {
+          "id": "broken_seal",
+          "name": "broken seal",
+          "description": "The magical seal that imprisoned Durgon for centuries, now shattered.",
+          "examine_checks": [
+            {
+              "skill": "arcana",
+              "dc": 16,
+              "on_success": "The seal was created by Davos using the three silvered weapons as anchors. Though Durgon is free, he is weakened and disoriented. His first round of attacks will be at disadvantage.",
+              "on_failure": "The seal's magic is beyond your understanding."
+            }
+          ]
+        }
+      ],
+      "exits": {
+        "up": "temple_of_durgon.hidden_shrine",
+        "east": "temple_of_durgon.treasure_chamber"
+      },
+      "enemies": [
+        "bearded_devil"
+      ],
+      "items": [],
+      "searched": false,
+      "searchable": false,
+      "boss_room": true,
+      "notes": "Durgon (bearded devil) attacks at disadvantage on his first round due to disorientation. DC 18 Charisma check can negotiate or intimidate to avoid combat."
+    },
+    "temple_of_durgon.treasure_chamber": {
+      "id": "temple_of_durgon.treasure_chamber",
+      "location_type": "dungeon",
+      "parent": "temple_of_durgon",
+      "name": "Treasure Chamber",
+      "description": "This chamber served as the temple's vault. Ancient treasure sits in piles - offerings to the gods who once protected this place. Among the valuables, you spot a strange iron rod and a collection of silver coins. A holy symbol hangs on the wall, still radiating faint divine energy after all these centuries.",
+      "lighting": "dark",
+      "exits": {
+        "west": "temple_of_durgon.main_chamber"
+      },
+      "enemies": [],
+      "items": [
+        {
+          "type": "item",
+          "id": "immovable_rod"
+        },
+        {
+          "type": "currency",
+          "gold": 50,
+          "silver": 200,
+          "copper": 0
+        }
+      ],
+      "searched": false,
+      "searchable": true,
+      "safe_rest": true,
+      "notes": "Holy symbol worth 50gp. Campaign completion bonus of 250gp awarded upon returning to town."
+    }
+  }
+}

--- a/dnd_engine/data/srd/items.json
+++ b/dnd_engine/data/srd/items.json
@@ -179,6 +179,44 @@
       "rarity": "uncommon",
       "value": 150,
       "description": "You have a +1 bonus to attack and damage rolls made with this magic weapon. This weapon was found in the coffin of Davos the cleric, and still carries a faint divine aura."
+    },
+    "silvered_longsword": {
+      "name": "Silvered Longsword",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "weapon",
+      "weapon_type": "martial",
+      "category": "melee",
+      "damage": "1d8",
+      "damage_type": "slashing",
+      "properties": ["versatile", "silvered"],
+      "versatile_damage": "1d10",
+      "value": 115,
+      "description": "This longsword has been coated with silver, making it effective against creatures with resistance to non-silvered weapons such as devils and werewolves."
+    },
+    "silvered_dagger": {
+      "name": "Silvered Dagger",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "weapon",
+      "weapon_type": "simple",
+      "category": "melee",
+      "damage": "1d4",
+      "damage_type": "piercing",
+      "properties": ["finesse", "light", "thrown", "silvered"],
+      "range": "20/60",
+      "value": 102,
+      "description": "This dagger has been coated with silver, making it effective against creatures with resistance to non-silvered weapons such as devils and werewolves."
+    },
+    "silvered_mace": {
+      "name": "Silvered Mace",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "weapon",
+      "weapon_type": "simple",
+      "category": "melee",
+      "damage": "1d6",
+      "damage_type": "bludgeoning",
+      "properties": ["silvered"],
+      "value": 105,
+      "description": "This mace has been coated with silver, making it effective against creatures with resistance to non-silvered weapons such as devils and werewolves."
     }
   },
   "armor": {
@@ -528,6 +566,38 @@
       "description": "A rough map found among the belongings of the cult's second-in-command. It shows a route to an abandoned temple outside of town, along with notes about 'the final ritual' and 'the bones of Durgon sealed beneath.' A letter accompanying it requests the acolyte join the cult leader at the temple the following night. The symbol of Durgon - a horned skull wreathed in flames - is stamped in red wax at the bottom.",
       "value": 0,
       "notes": "This quest item unlocks the Temple of Durgon dungeon location."
+    }
+  },
+  "magical_items": {
+    "profane_skull": {
+      "name": "Profane Skull",
+      "source": "The Unquiet Dead (Adventures Await Studios, OGL)",
+      "type": "wondrous_item",
+      "rarity": "uncommon",
+      "requires_attunement": true,
+      "description": "This bone-white humanoid skull is inscribed with infernal runes that glow faintly red in darkness. The skull radiates an aura of malevolence. While attuned to this item, you can use a bonus action to sacrifice one of your Hit Dice, taking necrotic damage equal to the roll, to recover one expended spell slot of 3rd level or lower. Once you use this property, you can't use it again until you finish a long rest. The skull can be purified by soaking it in holy water for 24 hours, which destroys its magical properties.",
+      "value": 250,
+      "weight": 2
+    },
+    "immovable_rod": {
+      "name": "Immovable Rod",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "wondrous_item",
+      "rarity": "uncommon",
+      "requires_attunement": false,
+      "description": "This flat iron rod has a button on one end. You can use an action to press the button, which causes the rod to become magically fixed in place. Until you or another creature uses an action to push the button again, the rod doesn't move, even if it is defying gravity. The rod can hold up to 8,000 pounds of weight. More weight causes the rod to deactivate and fall. A creature can use an action to make a DC 30 Strength check, moving the fixed rod up to 10 feet on a success.",
+      "value": 500,
+      "weight": 2
+    },
+    "jar_of_ointment": {
+      "name": "Jar of Ointment",
+      "source": "The Unquiet Dead (Adventures Await Studios, OGL)",
+      "type": "wondrous_item",
+      "rarity": "common",
+      "requires_attunement": false,
+      "description": "This small clay jar contains a pungent healing salve. The jar has 5 uses. As an action, you can apply the ointment to a creature within 5 feet, restoring 2d8+2 hit points. The jar regains 1d4+1 uses daily at dawn.",
+      "value": 100,
+      "weight": 0.5
     }
   }
 }

--- a/dnd_engine/data/srd/monsters.json
+++ b/dnd_engine/data/srd/monsters.json
@@ -582,5 +582,420 @@
         "damage_type": "piercing"
       }
     ]
+  },
+  "animated_armor": {
+    "name": "Animated Armor",
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "size": "medium",
+    "type": "construct",
+    "alignment": "unaligned",
+    "ac": 18,
+    "ac_source": "natural armor",
+    "hp": "6d8+6",
+    "hp_average": 33,
+    "speed": 25,
+    "abilities": {
+      "str": 14,
+      "dex": 11,
+      "con": 13,
+      "int": 1,
+      "wis": 3,
+      "cha": 1
+    },
+    "skills": {},
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "condition_immunities": [
+      "blinded",
+      "charmed",
+      "deafened",
+      "exhaustion",
+      "frightened",
+      "paralyzed",
+      "petrified",
+      "poisoned"
+    ],
+    "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 6",
+    "passive_perception": 6,
+    "languages": [],
+    "cr": "1",
+    "xp": 200,
+    "loot": {
+      "gold": 0,
+      "silver": 0
+    },
+    "traits": [
+      {
+        "name": "Antimagic Susceptibility",
+        "description": "The armor is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the armor must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+      },
+      {
+        "name": "False Appearance",
+        "description": "While the armor remains motionless, it is indistinguishable from a normal suit of armor."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "description": "The armor makes two melee attacks."
+      },
+      {
+        "name": "Slam",
+        "type": "melee-weapon-attack",
+        "attack_bonus": 4,
+        "reach": "5 ft.",
+        "damage": "1d6+2",
+        "damage_average": 5,
+        "damage_type": "bludgeoning"
+      }
+    ]
+  },
+  "spy": {
+    "name": "Spy",
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "size": "medium",
+    "type": "humanoid (any race)",
+    "alignment": "any alignment",
+    "ac": 12,
+    "ac_source": "natural armor",
+    "hp": "6d8",
+    "hp_average": 27,
+    "speed": 30,
+    "abilities": {
+      "str": 10,
+      "dex": 15,
+      "con": 10,
+      "int": 12,
+      "wis": 14,
+      "cha": 16
+    },
+    "skills": {
+      "deception": 5,
+      "insight": 4,
+      "investigation": 5,
+      "perception": 6,
+      "persuasion": 5,
+      "sleight_of_hand": 4,
+      "stealth": 4
+    },
+    "senses": "passive Perception 16",
+    "passive_perception": 16,
+    "languages": [
+      "any two languages"
+    ],
+    "cr": "1",
+    "xp": 200,
+    "loot": {
+      "gold": 5,
+      "silver": 15
+    },
+    "traits": [
+      {
+        "name": "Cunning Action",
+        "description": "On each of its turns, the spy can use a bonus action to take the Dash, Disengage, or Hide action."
+      },
+      {
+        "name": "Sneak Attack (1/Turn)",
+        "description": "The spy deals an extra 7 (2d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 feet of an ally of the spy that isn't incapacitated and the spy doesn't have disadvantage on the attack roll."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "description": "The spy makes two melee attacks."
+      },
+      {
+        "name": "Shortsword",
+        "type": "melee-weapon-attack",
+        "attack_bonus": 4,
+        "reach": "5 ft.",
+        "damage": "1d6+2",
+        "damage_average": 5,
+        "damage_type": "piercing"
+      },
+      {
+        "name": "Hand Crossbow",
+        "type": "ranged-weapon-attack",
+        "attack_bonus": 4,
+        "range": "30/120 ft.",
+        "damage": "1d6+2",
+        "damage_average": 5,
+        "damage_type": "piercing"
+      }
+    ]
+  },
+  "cult_fanatic": {
+    "name": "Cult Fanatic",
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "size": "medium",
+    "type": "humanoid (any race)",
+    "alignment": "any non-good alignment",
+    "ac": 13,
+    "ac_source": "leather armor",
+    "hp": "6d8+6",
+    "hp_average": 33,
+    "speed": 30,
+    "abilities": {
+      "str": 11,
+      "dex": 14,
+      "con": 12,
+      "int": 10,
+      "wis": 13,
+      "cha": 14
+    },
+    "skills": {
+      "deception": 4,
+      "persuasion": 4,
+      "religion": 2
+    },
+    "senses": "passive Perception 11",
+    "passive_perception": 11,
+    "languages": [
+      "any one language (usually Common)"
+    ],
+    "cr": "2",
+    "xp": 450,
+    "is_boss": true,
+    "loot": {
+      "gold": 10,
+      "silver": 25
+    },
+    "traits": [
+      {
+        "name": "Dark Devotion",
+        "description": "The fanatic has advantage on saving throws against being charmed or frightened."
+      }
+    ],
+    "spellcasting": {
+      "ability": "wisdom",
+      "spell_dc": 11,
+      "spell_attack": 3,
+      "slots": {
+        "1": 4,
+        "2": 3
+      },
+      "cantrips": [
+        "light",
+        "sacred_flame",
+        "thaumaturgy"
+      ],
+      "spells_known": [
+        "command",
+        "inflict_wounds",
+        "shield_of_faith",
+        "hold_person",
+        "spiritual_weapon"
+      ]
+    },
+    "actions": [
+      {
+        "name": "Multiattack",
+        "description": "The fanatic makes two melee attacks."
+      },
+      {
+        "name": "Dagger",
+        "type": "melee-weapon-attack",
+        "attack_bonus": 4,
+        "reach": "5 ft.",
+        "damage": "1d4+2",
+        "damage_average": 4,
+        "damage_type": "piercing"
+      },
+      {
+        "name": "Sacred Flame",
+        "type": "spell-attack",
+        "range": "60 ft.",
+        "damage": "1d8",
+        "damage_average": 4,
+        "damage_type": "radiant",
+        "special": "Target must succeed on a DC 11 Dexterity saving throw or take the damage. The target gains no benefit from cover for this saving throw."
+      }
+    ]
+  },
+  "mage_weakened": {
+    "name": "Mage (Weakened)",
+    "source": "D&D 5E SRD (CC BY 4.0) / The Unquiet Dead (Adventures Await Studios, OGL)",
+    "size": "medium",
+    "type": "humanoid (any race)",
+    "alignment": "any alignment",
+    "ac": 12,
+    "ac_source": "15 with mage armor",
+    "hp": "4d8",
+    "hp_average": 30,
+    "speed": 30,
+    "abilities": {
+      "str": 9,
+      "dex": 14,
+      "con": 11,
+      "int": 17,
+      "wis": 12,
+      "cha": 11
+    },
+    "skills": {
+      "arcana": 6,
+      "history": 6
+    },
+    "senses": "passive Perception 11",
+    "passive_perception": 11,
+    "languages": [
+      "any four languages"
+    ],
+    "cr": "2",
+    "xp": 450,
+    "loot": {
+      "gold": 15,
+      "silver": 30
+    },
+    "traits": [
+      {
+        "name": "Exhausted",
+        "description": "This mage has expended most of their magical power and can only cast 1st-level spells."
+      }
+    ],
+    "spellcasting": {
+      "ability": "intelligence",
+      "spell_dc": 14,
+      "spell_attack": 6,
+      "slots": {
+        "1": 4
+      },
+      "cantrips": [
+        "fire_bolt",
+        "light",
+        "mage_hand",
+        "prestidigitation"
+      ],
+      "spells_known": [
+        "detect_magic",
+        "mage_armor",
+        "magic_missile",
+        "shield"
+      ]
+    },
+    "actions": [
+      {
+        "name": "Dagger",
+        "type": "melee-or-ranged-weapon-attack",
+        "attack_bonus": 5,
+        "reach": "5 ft.",
+        "range": "20/60 ft.",
+        "damage": "1d4+2",
+        "damage_average": 4,
+        "damage_type": "piercing"
+      },
+      {
+        "name": "Fire Bolt",
+        "type": "spell-attack",
+        "range": "120 ft.",
+        "damage": "2d10",
+        "damage_average": 11,
+        "damage_type": "fire",
+        "special": "Ranged spell attack against the target."
+      }
+    ]
+  },
+  "bearded_devil": {
+    "name": "Bearded Devil",
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "size": "medium",
+    "type": "fiend (devil)",
+    "alignment": "lawful evil",
+    "ac": 13,
+    "ac_source": "natural armor",
+    "hp": "8d8+24",
+    "hp_average": 52,
+    "speed": 30,
+    "abilities": {
+      "str": 16,
+      "dex": 15,
+      "con": 15,
+      "int": 9,
+      "wis": 11,
+      "cha": 11
+    },
+    "skills": {},
+    "saving_throws": {
+      "str": 5,
+      "con": 4,
+      "wis": 2
+    },
+    "damage_resistances": [
+      "cold",
+      "bludgeoning, piercing, and slashing from nonmagical attacks that aren't silvered"
+    ],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": "darkvision 120 ft., passive Perception 10",
+    "passive_perception": 10,
+    "languages": [
+      "Infernal",
+      "telepathy 120 ft."
+    ],
+    "cr": "3",
+    "xp": 700,
+    "is_boss": true,
+    "loot": {
+      "gold": 25,
+      "silver": 0
+    },
+    "traits": [
+      {
+        "name": "Devil's Sight",
+        "description": "Magical darkness doesn't impede the devil's darkvision."
+      },
+      {
+        "name": "Magic Resistance",
+        "description": "The devil has advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Steadfast",
+        "description": "The devil can't be frightened while it can see an allied creature within 30 feet of it."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "description": "The devil makes two attacks: one with its beard and one with its glaive."
+      },
+      {
+        "name": "Beard",
+        "type": "melee-weapon-attack",
+        "attack_bonus": 5,
+        "reach": "5 ft.",
+        "damage": "1d8+2",
+        "damage_average": 6,
+        "damage_type": "piercing",
+        "special": "If the target is a creature other than an undead or a construct, it must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute. While poisoned in this way, the target can't regain hit points. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "saving_throw": {
+          "trigger": "on_hit",
+          "ability": "constitution",
+          "dc": 12,
+          "on_fail": {
+            "condition": "poisoned",
+            "duration_type": "rounds",
+            "duration": 10,
+            "allow_repeat_save": true,
+            "repeat_timing": "end_of_turn"
+          }
+        }
+      },
+      {
+        "name": "Glaive",
+        "type": "melee-weapon-attack",
+        "attack_bonus": 5,
+        "reach": "10 ft.",
+        "damage": "1d10+3",
+        "damage_average": 8,
+        "damage_type": "slashing",
+        "special": "If the target is a creature other than an undead or a construct, it must succeed on a DC 12 Constitution saving throw or lose 5 (1d10) hit points at the start of each of its turns due to an infernal wound. Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 5 (1d10). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing."
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Add 5 monsters: animated_armor, spy, cult_fanatic, mage_weakened, bearded_devil
- Add 6 items: silvered longsword/dagger/mace, profane_skull, immovable_rod, jar_of_ointment
- Create temple_of_durgon.json with 15 rooms for final campaign dungeon

## Details

This implements issue #207 - the final dungeon in "The Unquiet Dead" campaign where the cult leader attempts to resurrect the devil Durgon.

**Dungeon Layout:**
- Entrance Hall → Trial Chambers (Warrior/Thief/Cleric paths) → Mage Chamber → Hidden Shrine (cult leader boss) → Main Chamber (Durgon final boss) → Treasure Chamber

**Special Mechanics:**
- Glass shards stealth check (DC 12) to avoid alerting enemies
- Durgon attacks at disadvantage first round (disoriented)
- Silvered weapons in reliquaries are effective against Durgon
- Hidden doors and investigation checks throughout

## Test plan

- [ ] Load game and verify monsters can be spawned
- [ ] Verify items appear correctly in inventory
- [ ] Navigate through all 15 rooms of the dungeon
- [ ] Test combat encounters with new monsters
- [ ] Verify Durgon's damage resistance to non-silvered weapons

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)