### PR TITLE
fix: Improve party status display clarity (#239, #242, #244)

### DIFF
--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -200,7 +200,9 @@ class CLI:
                 "ac": effective_ac,
                 "xp": char.xp,
                 "active_effects": active_effects,
-                "spell_slots": char.get_spell_slots_display() if char.has_spell_slots() else None
+                "spell_slots": char.get_spell_slots_display() if char.has_spell_slots() else None,
+                "is_dead": char.is_dead,
+                "conditions": char.active_conditions
             })
 
         table = create_party_status_table(party_data)
@@ -3861,7 +3863,23 @@ class CLI:
                 if char_result.hp_after == 0:
                     print_message("  ⚠️  Still unconscious (0 HP)")
                 else:
-                    print_message("  Already at full health and resources")
+                    # Check if character has depleted spell slots (not recovered on short rest)
+                    character = self.game_state.party.get_character_by_name(
+                        char_result.character_name
+                    )
+                    has_depleted_slots = False
+                    if character and character.has_spell_slots():
+                        slots = character.spell_slots
+                        has_depleted_slots = any(
+                            slots.get(level, 0) < character.get_max_spell_slots(level)
+                            for level in range(1, 10)
+                            if character.get_max_spell_slots(level) > 0
+                        )
+
+                    if has_depleted_slots and result.rest_type == "short":
+                        print_message("  ✓ HP at full (spell slots require long rest)")
+                    else:
+                        print_message("  Already at full health and resources")
 
             print_message("")
 

--- a/dnd_engine/ui/rich_ui.py
+++ b/dnd_engine/ui/rich_ui.py
@@ -103,38 +103,53 @@ def create_party_status_table(party_data: list[dict[str, Any]]) -> Table:
     table.add_column("XP", justify="right")
 
     for char in party_data:
-        # Color HP based on status
-        hp = char.get("hp", 0)
-        max_hp = char.get("max_hp", 1)
-        hp_percent = hp / max_hp
+        # Check if character is dead first
+        is_dead = char.get("is_dead", False)
 
-        if hp_percent <= 0.25:
-            hp_color = "red"
-            hp_symbol = "⚠ "
-        elif hp_percent <= 0.5:
-            hp_color = "yellow"
-            hp_symbol = "● "
+        if is_dead:
+            hp_text = "[red bold]💀 DEAD[/red bold]"
         else:
-            hp_color = "green"
-            hp_symbol = "✓ "
+            # Color HP based on status
+            hp = char.get("hp", 0)
+            max_hp = char.get("max_hp", 1)
+            hp_percent = hp / max_hp if max_hp > 0 else 0
 
-        hp_text = f"[{hp_color}]{hp_symbol}{hp}/{max_hp}[/{hp_color}]"
+            if hp_percent <= 0.25:
+                hp_color = "red"
+                hp_symbol = "⚠ "
+            elif hp_percent <= 0.5:
+                hp_color = "yellow"
+                hp_symbol = "● "
+            else:
+                hp_color = "green"
+                hp_symbol = "✓ "
 
-        # Format active effects
+            hp_text = f"[{hp_color}]{hp_symbol}{hp}/{max_hp}[/{hp_color}]"
+
+        # Format active effects and conditions
+        effects_text = []
+
+        # Add spell effects from time_manager
         active_effects = char.get("active_effects", [])
-        if active_effects:
-            effects_text = []
-            for effect in active_effects:
-                # Build effect display: "Name (duration)"
-                effect_name = effect.source
-                time_remaining = effect.get_time_remaining_display()
-                concentration_marker = " 🎯" if effect.concentration else ""
+        for effect in active_effects:
+            # Build effect display: "Name (duration)"
+            effect_name = effect.source
+            time_remaining = effect.get_time_remaining_display()
+            concentration_marker = " 🎯" if effect.concentration else ""
 
-                effects_text.append(f"[magenta]{effect_name}[/magenta] ({time_remaining}){concentration_marker}")
+            effects_text.append(f"[magenta]{effect_name}[/magenta] ({time_remaining}){concentration_marker}")
 
-            effects_display = "\n".join(effects_text)
-        else:
-            effects_display = "—"
+        # Add conditions (paralyzed, stunned, etc.)
+        conditions = char.get("conditions", {})
+        for condition_name, metadata in conditions.items():
+            # Format condition with duration if available
+            duration = metadata.get("duration_remaining")
+            if duration is not None:
+                effects_text.append(f"[red]{condition_name.upper()}[/red] ({duration})")
+            else:
+                effects_text.append(f"[red]{condition_name.upper()}[/red]")
+
+        effects_display = "\n".join(effects_text) if effects_text else "—"
 
         # Build row data
         row_data = [


### PR DESCRIPTION
## Summary
- Dead characters now display "💀 DEAD" instead of confusing "0/X HP" in the party status table
- Short rest messages now clarify when spellcasters have depleted spell slots that require a long rest to recover
- Active conditions (paralyzed, stunned, frightened, etc.) now appear in the Active Effects column with duration indicators

## Changes
- **cli.py**: Added `is_dead` and `conditions` to party_data; improved short rest message logic
- **rich_ui.py**: Updated `create_party_status_table` to display DEAD status and conditions in red

## Test plan
- [x] Run existing death save tests - all 46 pass
- [x] Run rest-related tests - all 59 pass
- [ ] Manual test: Kill a character and verify "💀 DEAD" appears
- [ ] Manual test: Short rest with full HP spellcaster with depleted slots
- [ ] Manual test: Apply paralyzed condition and verify it shows in Active Effects

Fixes #239, fixes #242, fixes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)