### PR TITLE
fix: Show UNCONSCIOUS status for characters at 0 HP

### DIFF
--- a/dnd_engine/ui/rich_ui.py
+++ b/dnd_engine/ui/rich_ui.py
@@ -112,19 +112,24 @@ def create_party_status_table(party_data: list[dict[str, Any]]) -> Table:
             # Color HP based on status
             hp = char.get("hp", 0)
             max_hp = char.get("max_hp", 1)
-            hp_percent = hp / max_hp if max_hp > 0 else 0
 
-            if hp_percent <= 0.25:
-                hp_color = "red"
-                hp_symbol = "⚠ "
-            elif hp_percent <= 0.5:
-                hp_color = "yellow"
-                hp_symbol = "● "
+            if hp == 0:
+                # Unconscious - at 0 HP but not dead yet (making death saves)
+                hp_text = "[red bold]⚠ UNCONSCIOUS[/red bold]"
             else:
-                hp_color = "green"
-                hp_symbol = "✓ "
+                hp_percent = hp / max_hp if max_hp > 0 else 0
 
-            hp_text = f"[{hp_color}]{hp_symbol}{hp}/{max_hp}[/{hp_color}]"
+                if hp_percent <= 0.25:
+                    hp_color = "red"
+                    hp_symbol = "⚠ "
+                elif hp_percent <= 0.5:
+                    hp_color = "yellow"
+                    hp_symbol = "● "
+                else:
+                    hp_color = "green"
+                    hp_symbol = "✓ "
+
+                hp_text = f"[{hp_color}]{hp_symbol}{hp}/{max_hp}[/{hp_color}]"
 
         # Format active effects and conditions
         effects_text = []


### PR DESCRIPTION
## Summary
Characters at 0 HP (making death saves) now display "⚠ UNCONSCIOUS" instead of "⚠ 0/X", making the status clearer at a glance.

## Status Progression
- ✓ 12/12 (green) - healthy
- ● 6/12 (yellow) - wounded  
- ⚠ 3/12 (red) - critical
- ⚠ UNCONSCIOUS (red) - 0 HP, making death saves
- 💀 DEAD (red) - 3 failed death saves

## Test plan
- [ ] Manual test: Reduce character to 0 HP and verify "⚠ UNCONSCIOUS" appears
- [ ] Manual test: Fail 3 death saves and verify "💀 DEAD" appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)