### PR TITLE
fix: Prevent LLM from describing enemies as defeated when still alive (#240)

### DIFF
--- a/dnd_engine/llm/prompts.py
+++ b/dnd_engine/llm/prompts.py
@@ -340,20 +340,25 @@ def build_combat_action_prompt(action_data: dict[str, Any]) -> str:
                 f"2-3 vivid sentences. {pov_constraint}"
             )
         elif is_critical:
+            # Critical hit but NOT a killing blow - enemy still alive
             prompt = (
                 f"Narrate this critical hit:\n\n"
                 f"{location_context}{history_context}"
                 f"{attacker} lands a devastating blow on {defender} "
-                f"with their {weapon_desc}.\n\n"
-                f"One visceral sentence (15-25 words). {pov_constraint}"
+                f"with their {weapon_desc}. The {defender} staggers but remains standing.\n\n"
+                f"One visceral sentence (15-25 words). Do NOT describe {defender} as "
+                f"defeated, dying, or dead. {pov_constraint}"
             )
         else:
             # Regular hit - minimal context, tight output
+            # IMPORTANT: Explicitly state enemy survives to prevent death-like language
             prompt = (
                 f"Narrate this combat hit:\n\n"
                 f"{location_context}"
-                f"{attacker} hits {defender} with their {weapon_desc}.\n\n"
-                f"One sentence, under 20 words. {pov_constraint}"
+                f"{attacker} hits {defender} with their {weapon_desc}. "
+                f"The {defender} is wounded but still fighting.\n\n"
+                f"One sentence, under 20 words. Do NOT describe {defender} as "
+                f"defeated, dying, or dead. {pov_constraint}"
             )
     else:
         # Misses are always brief - don't dwell on failure


### PR DESCRIPTION
## Summary
Adds explicit constraints to combat hit prompts preventing the LLM from generating death-like language when the enemy survives the attack.

## Problem
During playtest, Bilbo landed a critical hit on a Ghoul (4 HP remaining). The LLM generated:
> "With a final, desperate gurgle, the ghoul crumples to the ground, its lifeless body thudding against the cold stone floor..."

The Ghoul then attacked Tim on its next turn, dealing 8 damage and paralyzing him. This creates confusing narrative whiplash.

## Fix
For both regular hits and critical hits (non-killing blows), the prompt now:
1. States the enemy is "wounded but still fighting" or "staggers but remains standing"
2. Explicitly instructs: "Do NOT describe [defender] as defeated, dying, or dead"

Killing blows continue to use dramatic death language as before.

## Test plan
- [x] LLM tests pass (25 tests)
- [ ] Manual test: Land a non-killing hit and verify narrative doesn't describe death

Fixes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)