### PR TITLE
improve: Tighten combat narrative prompts for faster, punchier output (#209)

### DIFF
--- a/dnd_engine/llm/prompts.py
+++ b/dnd_engine/llm/prompts.py
@@ -341,32 +341,23 @@ def build_combat_action_prompt(action_data: dict[str, Any]) -> str:
             )
         elif is_critical:
             # Critical hit but NOT a killing blow - enemy still alive
+            # More dramatic than regular hit, but still concise
             prompt = (
-                f"Narrate this critical hit:\n\n"
-                f"{location_context}{history_context}"
-                f"{attacker} lands a devastating blow on {defender} "
-                f"with their {weapon_desc}. The {defender} staggers but remains standing.\n\n"
-                f"One visceral sentence (15-25 words). Do NOT describe {defender} as "
-                f"defeated, dying, or dead. {pov_constraint}"
+                f"CRITICAL HIT! {attacker} devastates {defender} with {weapon_desc}. "
+                f"One visceral sentence, 15-20 words. Enemy staggers but survives. {pov_constraint}"
             )
         else:
-            # Regular hit - minimal context, tight output
+            # Regular hit - ultra-tight output for fast-paced combat
             # IMPORTANT: Explicitly state enemy survives to prevent death-like language
             prompt = (
-                f"Narrate this combat hit:\n\n"
-                f"{location_context}"
-                f"{attacker} hits {defender} with their {weapon_desc}. "
-                f"The {defender} is wounded but still fighting.\n\n"
-                f"One sentence, under 20 words. Do NOT describe {defender} as "
-                f"defeated, dying, or dead. {pov_constraint}"
+                f"{attacker} hits {defender} with {weapon_desc}. "
+                f"One punchy sentence, max 12 words. No death language. {pov_constraint}"
             )
     else:
         # Misses are always brief - don't dwell on failure
         prompt = (
-            f"Narrate this combat miss:\n\n"
-            f"{location_context}"
-            f"{attacker} swings at {defender} with their {weapon_desc} but misses.\n\n"
-            f"One sentence, under 15 words. {pov_constraint}"
+            f"{attacker} misses {defender} with {weapon_desc}. "
+            f"One brief sentence, max 10 words. {pov_constraint}"
         )
 
     return prompt


### PR DESCRIPTION
## Summary
UX improvements to make combat feel faster and punchier by reducing narrative verbosity.

## Changes
| Action Type | Before | After |
|-------------|--------|-------|
| Regular hit | "under 20 words" + location + survival warning | "max 12 words, punchy" |
| Critical hit | "15-25 words" + location + history + survival warning | "15-20 words, visceral" |
| Miss | "under 15 words" + location | "max 10 words" |

## UX Rationale
- Combat involves many hits per round; each LLM call adds latency
- Shorter prompts → faster responses → snappier combat feel
- Routine actions shouldn't slow the game; save drama for crits/kills
- Removed redundant context (location, history) for routine hits
- Kept full context for killing blows where dramatic payoff matters

## Before/After Prompt Size
- Regular hits: ~60% reduction
- Critical hits: ~50% reduction
- Miss prompts: ~40% reduction

## Test plan
- [x] LLM tests pass (25 tests)
- [ ] Manual playtest to verify narrative quality at shorter lengths

Fixes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)