### PR TITLE
feat: Add character vault sync and campaign preparation (#257)

### DIFF
--- a/dnd_engine/core/character.py
+++ b/dnd_engine/core/character.py
@@ -51,7 +51,8 @@ class Character(Creature):
         armor_proficiencies: list[str] | None = None,
         spellcasting_ability: str | None = None,
         known_spells: list[str] | None = None,
-        prepared_spells: list[str] | None = None
+        prepared_spells: list[str] | None = None,
+        vault_id: str | None = None
     ):
         """
         Initialize a player character.
@@ -76,6 +77,7 @@ class Character(Creature):
             spellcasting_ability: The ability used for spellcasting (e.g., "int", "wis", "cha")
             known_spells: List of spell IDs the character knows
             prepared_spells: List of spell IDs the character has prepared
+            vault_id: UUID linking this character to their vault entry (for syncing progression)
         """
         super().__init__(
             name=name,
@@ -103,6 +105,9 @@ class Character(Creature):
         self.spellcasting_ability = spellcasting_ability
         self.known_spells = known_spells if known_spells is not None else []
         self.prepared_spells = prepared_spells if prepared_spells is not None else []
+
+        # Vault tracking for syncing character progression across campaigns
+        self.vault_id = vault_id
 
         # Death saving throw state
         self.death_save_successes: int = 0
@@ -473,6 +478,48 @@ class Character(Creature):
             amount: XP to add
         """
         self.xp += amount
+
+    def prepare_for_new_campaign(self) -> dict[str, list[str]]:
+        """
+        Prepare character for a new campaign by resetting transient state.
+
+        Following traditional D&D conventions, characters are restored between
+        adventures as if they took a long rest:
+        - HP restored to max
+        - All resource pools restored (spell slots, rage, ki, etc.)
+        - Conditions cleared
+        - Quest items removed (campaign-specific items don't transfer)
+
+        XP, level, gold, and permanent items are preserved.
+
+        Returns:
+            Dictionary with lists of removed items by category:
+            {"quest_items": [...], "conditions": [...]}
+        """
+        removed = {"quest_items": [], "conditions": []}
+
+        # Restore HP to max
+        self.current_hp = self.max_hp
+
+        # Restore all resource pools (spell slots, rage, ki, etc.)
+        for pool in self.resource_pools.values():
+            pool.recover()  # Recovers to maximum
+
+        # Clear conditions
+        conditions_to_remove = list(self.conditions)
+        for condition in conditions_to_remove:
+            self.remove_condition(condition)
+            removed["conditions"].append(condition)
+
+        # Reset death saves
+        self.death_save_successes = 0
+        self.death_save_failures = 0
+        self.stabilized = False
+
+        # Remove quest items
+        removed["quest_items"] = self.inventory.remove_quest_items()
+
+        return removed
 
     def check_for_level_up(self, data_loader, event_bus=None) -> bool:
         """

--- a/dnd_engine/core/character_vault.py
+++ b/dnd_engine/core/character_vault.py
@@ -444,7 +444,8 @@ class CharacterVault:
                 {
                     "item_id": item.item_id,
                     "category": item.category,
-                    "quantity": item.quantity
+                    "quantity": item.quantity,
+                    "quest_item": item.quest_item
                 }
                 for item in inventory.items.values()
             ],
@@ -541,7 +542,8 @@ class CharacterVault:
             inventory.add_item(
                 item_id=item_data["item_id"],
                 category=item_data["category"],
-                quantity=item_data["quantity"]
+                quantity=item_data["quantity"],
+                quest_item=item_data.get("quest_item", False)
             )
 
         # Restore equipped items

--- a/dnd_engine/core/character_vault_v2.py
+++ b/dnd_engine/core/character_vault_v2.py
@@ -147,7 +147,7 @@ class CharacterVaultV2:
             character_id: UUID of the character
 
         Returns:
-            Character instance
+            Character instance with vault_id set for progression tracking
 
         Raises:
             FileNotFoundError: If character doesn't exist
@@ -159,7 +159,9 @@ class CharacterVaultV2:
             raise FileNotFoundError(f"Character not found: {character_id}")
 
         character_entry = vault_data["characters"][character_id]
-        return self._deserialize_character(character_entry["character"])
+        character = self._deserialize_character(character_entry["character"])
+        character.vault_id = character_id
+        return character
 
     def update_character(self, character_id: str, character: Character) -> None:
         """
@@ -410,7 +412,8 @@ class CharacterVaultV2:
                 {
                     "item_id": item.item_id,
                     "category": item.category,
-                    "quantity": item.quantity
+                    "quantity": item.quantity,
+                    "quest_item": item.quest_item
                 }
                 for item in inventory.items.values()
             ],
@@ -496,7 +499,8 @@ class CharacterVaultV2:
             inventory.add_item(
                 item_id=item_data["item_id"],
                 category=item_data["category"],
-                quantity=item_data["quantity"]
+                quantity=item_data["quantity"],
+                quest_item=item_data.get("quest_item", False)
             )
 
         # Restore equipped items

--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -1580,8 +1580,11 @@ class GameState:
             if not category:
                 return False  # Unknown item category
 
+            # Check if this is a quest item (doesn't transfer between campaigns)
+            is_quest_item = item_to_take.get("quest_item", False)
+
             # Add item to the specified character's inventory
-            character.inventory.add_item(item_id, category)
+            character.inventory.add_item(item_id, category, quest_item=is_quest_item)
 
             # Emit item acquired event
             self.event_bus.emit(Event(

--- a/dnd_engine/core/save_slot_manager.py
+++ b/dnd_engine/core/save_slot_manager.py
@@ -1,11 +1,16 @@
 # ABOUTME: Save slot manager for the new 10-slot save system
 # ABOUTME: Handles save/load operations, slot management, and game state persistence
 
+from __future__ import annotations
+
 import json
 from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dnd_engine.core.character_vault_v2 import CharacterVaultV2
 
 from dnd_engine.core.campaign_progress import CampaignProgress
 from dnd_engine.core.character import Character, CharacterClass
@@ -149,7 +154,8 @@ class SaveSlotManager:
         slot_number: int,
         game_state: GameState,
         playtime_delta: int = 0,
-        campaign_progress: CampaignProgress | None = None
+        campaign_progress: CampaignProgress | None = None,
+        character_vault: CharacterVaultV2 | None = None
     ) -> Path:
         """
         Save game state to a specific slot.
@@ -159,6 +165,7 @@ class SaveSlotManager:
             game_state: Current game state to save
             playtime_delta: Seconds to add to playtime (for this session)
             campaign_progress: Optional campaign progress for multi-dungeon campaigns
+            character_vault: Optional vault to sync character progression to
 
         Returns:
             Path to the saved file
@@ -189,6 +196,10 @@ class SaveSlotManager:
         # Extract party info
         slot.party_composition = [char.name for char in game_state.party.characters]
         slot.party_levels = [char.level for char in game_state.party.characters]
+
+        # Sync character progression to vault if provided
+        if character_vault:
+            self._sync_characters_to_vault(game_state, character_vault)
 
         # Save to file
         return self._save_slot_file(slot_number, slot, game_state, campaign_progress)
@@ -414,7 +425,8 @@ class SaveSlotManager:
             "resource_pools": self._serialize_resource_pools(character),
             "spellcasting_ability": character.spellcasting_ability,
             "known_spells": character.known_spells,
-            "prepared_spells": character.prepared_spells
+            "prepared_spells": character.prepared_spells,
+            "vault_id": character.vault_id
         }
 
     def _serialize_inventory(self, inventory: Inventory) -> dict[str, Any]:
@@ -424,7 +436,8 @@ class SaveSlotManager:
                 {
                     "item_id": item.item_id,
                     "category": item.category,
-                    "quantity": item.quantity
+                    "quantity": item.quantity,
+                    "quest_item": item.quest_item
                 }
                 for item in inventory.items.values()
             ],
@@ -526,7 +539,8 @@ class SaveSlotManager:
             subclass=char_data.get("subclass"),
             spellcasting_ability=char_data.get("spellcasting_ability"),
             known_spells=char_data.get("known_spells"),
-            prepared_spells=char_data.get("prepared_spells")
+            prepared_spells=char_data.get("prepared_spells"),
+            vault_id=char_data.get("vault_id")
         )
 
         # Restore conditions
@@ -549,7 +563,8 @@ class SaveSlotManager:
             inventory.add_item(
                 item_id=item_data["item_id"],
                 category=item_data["category"],
-                quantity=item_data["quantity"]
+                quantity=item_data["quantity"],
+                quest_item=item_data.get("quest_item", False)
             )
 
         # Restore equipped items
@@ -564,6 +579,29 @@ class SaveSlotManager:
         inventory.currency = Currency(**currency_data)
 
         return inventory
+
+    def _sync_characters_to_vault(
+        self,
+        game_state: GameState,
+        character_vault: CharacterVaultV2
+    ) -> None:
+        """
+        Sync character progression to the vault.
+
+        Updates vault entries for characters that have vault_ids with their
+        current XP, level, gold, and permanent items.
+
+        Args:
+            game_state: Current game state with party
+            character_vault: Vault to sync to
+        """
+        for character in game_state.party.characters:
+            if character.vault_id:
+                try:
+                    character_vault.update_character(character.vault_id, character)
+                except FileNotFoundError:
+                    # Character was deleted from vault, skip sync
+                    pass
 
     def _validate_slot_data(self, slot_data: dict[str, Any]) -> None:
         """

--- a/dnd_engine/main_v2.py
+++ b/dnd_engine/main_v2.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from dotenv import load_dotenv
 
+from dnd_engine.core.character_vault_v2 import CharacterVaultV2
 from dnd_engine.core.game_state import GameState
 from dnd_engine.core.save_slot_manager import SaveSlotManager
 from dnd_engine.llm.enhancer import LLMEnhancer
@@ -98,7 +99,13 @@ class SaveSlotCLIAdapter:
     This provides a compatible interface for CLI while using the new save slot system.
     """
 
-    def __init__(self, slot_manager: SaveSlotManager, slot_number: int, session_start: datetime):
+    def __init__(
+        self,
+        slot_manager: SaveSlotManager,
+        slot_number: int,
+        session_start: datetime,
+        character_vault: CharacterVaultV2 | None = None
+    ):
         """
         Initialize the adapter.
 
@@ -106,10 +113,12 @@ class SaveSlotCLIAdapter:
             slot_manager: SaveSlotManager instance
             slot_number: Current slot number (1-10)
             session_start: When the game session started (for playtime tracking)
+            character_vault: Optional vault to sync character progression to
         """
         self.slot_manager = slot_manager
         self.slot_number = slot_number
         self.session_start = session_start
+        self.character_vault = character_vault
 
     def save_campaign_state(
         self,
@@ -130,11 +139,12 @@ class SaveSlotCLIAdapter:
         # Calculate session playtime
         playtime_delta = int((datetime.now() - self.session_start).total_seconds())
 
-        # Save to current slot
+        # Save to current slot and sync character progression to vault
         self.slot_manager.save_game(
             slot_number=self.slot_number,
             game_state=game_state,
-            playtime_delta=playtime_delta
+            playtime_delta=playtime_delta,
+            character_vault=self.character_vault
         )
 
 
@@ -195,9 +205,12 @@ def main() -> None:
         game_state, slot_number = result
 
         # Create save slot adapter for CLI compatibility
+        # Use menu's vault to sync character progression on save
         session_start = datetime.now()
         slot_manager = SaveSlotManager()
-        save_adapter = SaveSlotCLIAdapter(slot_manager, slot_number, session_start)
+        save_adapter = SaveSlotCLIAdapter(
+            slot_manager, slot_number, session_start, character_vault=menu.vault
+        )
 
         # Initialize CLI with adapter (compatible with old interface)
         # Note: CLI expects campaign_manager and campaign_name, we provide adapter and slot number

--- a/dnd_engine/systems/inventory.py
+++ b/dnd_engine/systems/inventory.py
@@ -25,6 +25,7 @@ class InventoryItem:
     item_id: str
     category: str  # "weapons", "armor", "consumables"
     quantity: int = 1
+    quest_item: bool = False  # Quest items don't transfer between campaigns
 
     def __str__(self) -> str:
         """String representation of the inventory item"""
@@ -66,7 +67,8 @@ class Inventory:
         self,
         item_id: str,
         category: str,
-        quantity: int = 1
+        quantity: int = 1,
+        quest_item: bool = False
     ) -> bool:
         """
         Add an item to the inventory.
@@ -78,6 +80,7 @@ class Inventory:
             item_id: ID of the item from items.json
             category: Item category ("weapons", "armor", "consumables")
             quantity: Number to add (default 1)
+            quest_item: Whether this item is campaign-specific (won't transfer)
 
         Returns:
             True if item was added, False if inventory full
@@ -101,7 +104,8 @@ class Inventory:
         self.items[item_id] = InventoryItem(
             item_id=item_id,
             category=category,
-            quantity=quantity
+            quantity=quantity,
+            quest_item=quest_item
         )
         return True
 
@@ -144,6 +148,30 @@ class Inventory:
                     self.equipped[slot] = None
 
         return True
+
+    def remove_quest_items(self) -> list[str]:
+        """
+        Remove all quest items from inventory.
+
+        Called when preparing a character for a new campaign. Quest items
+        are campaign-specific and don't transfer between adventures.
+
+        Returns:
+            List of item IDs that were removed
+        """
+        quest_item_ids = [
+            item_id for item_id, item in self.items.items()
+            if item.quest_item
+        ]
+
+        for item_id in quest_item_ids:
+            # Unequip if it was equipped
+            for slot, equipped_id in self.equipped.items():
+                if equipped_id == item_id:
+                    self.equipped[slot] = None
+            del self.items[item_id]
+
+        return quest_item_ids
 
     def has_item(self, item_id: str, quantity: int = 1) -> bool:
         """

--- a/dnd_engine/ui/main_menu_v2.py
+++ b/dnd_engine/ui/main_menu_v2.py
@@ -327,12 +327,13 @@ class MainMenuV2:
             # Override to start at the campaign's specific starting room
             game_state.current_room_id = starting_room
 
-            # Step 5: Save to slot with campaign progress
+            # Step 5: Save to slot with campaign progress and sync vault
             self.slot_manager.save_game(
                 slot_number=slot_num,
                 game_state=game_state,
                 playtime_delta=0,
-                campaign_progress=campaign_progress
+                campaign_progress=campaign_progress,
+                character_vault=self.vault
             )
 
             # Step 6: Record character usage in vault
@@ -397,6 +398,13 @@ class MainMenuV2:
                 if selected_ids:
                     for char_id in selected_ids:
                         character = self.vault.get_character(char_id)
+                        # Prepare character for new campaign (reset HP, resources, etc.)
+                        removed = character.prepare_for_new_campaign()
+                        if removed["quest_items"]:
+                            print_status_message(
+                                f"{character.name}: Quest items removed: {', '.join(removed['quest_items'])}",
+                                "info"
+                            )
                         selected_characters.append(character)
 
             except (EOFError, KeyboardInterrupt):

--- a/tests/test_character_campaign_prep.py
+++ b/tests/test_character_campaign_prep.py
@@ -1,0 +1,240 @@
+# ABOUTME: Unit tests for Character.prepare_for_new_campaign() method
+# ABOUTME: Tests HP restoration, resource pool recovery, condition clearing, and quest item removal
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.systems.resources import ResourcePool
+
+
+class TestPrepareForNewCampaign:
+    """Test Character.prepare_for_new_campaign() functionality."""
+
+    @pytest.fixture
+    def sample_character(self):
+        """Create a sample character for testing."""
+        abilities = Abilities(
+            strength=16,
+            dexterity=14,
+            constitution=15,
+            intelligence=8,
+            wisdom=10,
+            charisma=12
+        )
+
+        return Character(
+            name="Test Warrior",
+            character_class=CharacterClass.FIGHTER,
+            level=5,
+            abilities=abilities,
+            max_hp=45,
+            ac=18,
+            current_hp=45,
+            xp=6500,
+            race="Dwarf"
+        )
+
+    def test_restores_hp_to_max(self, sample_character):
+        """Test that prepare_for_new_campaign restores HP to max."""
+        sample_character.current_hp = 10  # Damaged
+
+        sample_character.prepare_for_new_campaign()
+
+        assert sample_character.current_hp == sample_character.max_hp
+        assert sample_character.current_hp == 45
+
+    def test_restores_resource_pools(self, sample_character):
+        """Test that prepare_for_new_campaign restores all resource pools."""
+        # Add some resource pools
+        second_wind = ResourcePool(
+            name="second_wind",
+            current=0,  # Used
+            maximum=1,
+            recovery_type="short_rest"
+        )
+        action_surge = ResourcePool(
+            name="action_surge",
+            current=0,  # Used
+            maximum=2,
+            recovery_type="short_rest"
+        )
+
+        sample_character.add_resource_pool(second_wind)
+        sample_character.add_resource_pool(action_surge)
+
+        sample_character.prepare_for_new_campaign()
+
+        assert sample_character.resource_pools["second_wind"].current == 1
+        assert sample_character.resource_pools["action_surge"].current == 2
+
+    def test_clears_conditions(self, sample_character):
+        """Test that prepare_for_new_campaign clears all conditions."""
+        sample_character.add_condition("poisoned")
+        sample_character.add_condition("frightened")
+        sample_character.add_condition("exhaustion")
+
+        removed = sample_character.prepare_for_new_campaign()
+
+        assert len(sample_character.conditions) == 0
+        assert "poisoned" in removed["conditions"]
+        assert "frightened" in removed["conditions"]
+        assert "exhaustion" in removed["conditions"]
+
+    def test_resets_death_saves(self, sample_character):
+        """Test that prepare_for_new_campaign resets death saving throws."""
+        sample_character.death_save_successes = 2
+        sample_character.death_save_failures = 1
+        sample_character.stabilized = True
+
+        sample_character.prepare_for_new_campaign()
+
+        assert sample_character.death_save_successes == 0
+        assert sample_character.death_save_failures == 0
+        assert sample_character.stabilized is False
+
+    def test_removes_quest_items(self, sample_character):
+        """Test that prepare_for_new_campaign removes quest items."""
+        # Add regular item and quest item
+        sample_character.inventory.add_item("longsword", "weapons", 1)
+        sample_character.inventory.add_item(
+            "ancient_key", "consumables", 1, quest_item=True
+        )
+        sample_character.inventory.add_item(
+            "magic_orb", "consumables", 1, quest_item=True
+        )
+
+        removed = sample_character.prepare_for_new_campaign()
+
+        # Regular item should remain
+        assert sample_character.inventory.has_item("longsword")
+
+        # Quest items should be gone
+        assert not sample_character.inventory.has_item("ancient_key")
+        assert not sample_character.inventory.has_item("magic_orb")
+
+        # Check return value
+        assert "ancient_key" in removed["quest_items"]
+        assert "magic_orb" in removed["quest_items"]
+
+    def test_preserves_xp_and_level(self, sample_character):
+        """Test that XP and level are preserved."""
+        original_xp = sample_character.xp
+        original_level = sample_character.level
+
+        sample_character.prepare_for_new_campaign()
+
+        assert sample_character.xp == original_xp
+        assert sample_character.level == original_level
+
+    def test_preserves_gold(self, sample_character):
+        """Test that gold is preserved."""
+        sample_character.inventory.add_gold(500)
+
+        sample_character.prepare_for_new_campaign()
+
+        assert sample_character.inventory.gold == 500
+
+    def test_preserves_permanent_items(self, sample_character):
+        """Test that non-quest items are preserved."""
+        sample_character.inventory.add_item("longsword", "weapons", 1)
+        sample_character.inventory.add_item("chain_mail", "armor", 1)
+        sample_character.inventory.add_item("potion_of_healing", "consumables", 3)
+
+        sample_character.prepare_for_new_campaign()
+
+        assert sample_character.inventory.has_item("longsword")
+        assert sample_character.inventory.has_item("chain_mail")
+        assert sample_character.inventory.has_item("potion_of_healing")
+        assert sample_character.inventory.get_item_quantity("potion_of_healing") == 3
+
+    def test_returns_removed_items_report(self, sample_character):
+        """Test that method returns dictionary with removed items."""
+        sample_character.add_condition("poisoned")
+        sample_character.inventory.add_item(
+            "quest_gem", "consumables", 1, quest_item=True
+        )
+
+        removed = sample_character.prepare_for_new_campaign()
+
+        assert isinstance(removed, dict)
+        assert "quest_items" in removed
+        assert "conditions" in removed
+        assert "quest_gem" in removed["quest_items"]
+        assert "poisoned" in removed["conditions"]
+
+    def test_returns_empty_report_when_nothing_to_remove(self, sample_character):
+        """Test return value when character has no conditions or quest items."""
+        removed = sample_character.prepare_for_new_campaign()
+
+        assert removed["quest_items"] == []
+        assert removed["conditions"] == []
+
+    def test_handles_equipped_quest_item_removal(self, sample_character):
+        """Test that equipped quest items are properly unequipped and removed."""
+        from dnd_engine.systems.inventory import EquipmentSlot
+
+        # Add and equip a quest weapon
+        sample_character.inventory.add_item(
+            "cursed_blade", "weapons", 1, quest_item=True
+        )
+        sample_character.inventory.equip_item("cursed_blade", EquipmentSlot.WEAPON)
+
+        # Verify it's equipped
+        assert (
+            sample_character.inventory.get_equipped_item(EquipmentSlot.WEAPON)
+            == "cursed_blade"
+        )
+
+        sample_character.prepare_for_new_campaign()
+
+        # Quest item should be gone and slot empty
+        assert not sample_character.inventory.has_item("cursed_blade")
+        assert (
+            sample_character.inventory.get_equipped_item(EquipmentSlot.WEAPON) is None
+        )
+
+    def test_full_scenario_damaged_exhausted_character(self, sample_character):
+        """Test complete scenario with damaged, exhausted character with quest items."""
+        # Damage character
+        sample_character.current_hp = 5
+
+        # Add conditions
+        sample_character.add_condition("exhaustion")
+        sample_character.add_condition("poisoned")
+
+        # Use resources
+        sample_character.add_resource_pool(
+            ResourcePool("second_wind", current=0, maximum=1, recovery_type="short_rest")
+        )
+
+        # Add inventory
+        sample_character.inventory.add_gold(1000)
+        sample_character.inventory.add_item("longsword", "weapons", 1)
+        sample_character.inventory.add_item(
+            "macguffin", "consumables", 1, quest_item=True
+        )
+
+        # Set death saves (from a close call)
+        sample_character.death_save_successes = 3
+        sample_character.stabilized = True
+
+        # Prepare for new campaign
+        removed = sample_character.prepare_for_new_campaign()
+
+        # Verify full restoration
+        assert sample_character.current_hp == 45
+        assert len(sample_character.conditions) == 0
+        assert sample_character.resource_pools["second_wind"].current == 1
+        assert sample_character.death_save_successes == 0
+        assert sample_character.stabilized is False
+
+        # Verify items
+        assert sample_character.inventory.gold == 1000
+        assert sample_character.inventory.has_item("longsword")
+        assert not sample_character.inventory.has_item("macguffin")
+
+        # Verify report
+        assert "macguffin" in removed["quest_items"]
+        assert "exhaustion" in removed["conditions"]
+        assert "poisoned" in removed["conditions"]

--- a/tests/test_character_vault_v2.py
+++ b/tests/test_character_vault_v2.py
@@ -352,3 +352,32 @@ class TestCharacterVaultV2:
         # Verify can load character
         retrieved = vault2.get_character(char_id)
         assert retrieved.name == sample_character.name
+
+    def test_get_character_sets_vault_id(self, vault, sample_character):
+        """Test that get_character sets vault_id on the returned character."""
+        char_id = vault.add_character(sample_character)
+
+        retrieved = vault.get_character(char_id)
+
+        assert retrieved.vault_id == char_id
+
+    def test_vault_id_is_none_before_adding_to_vault(self, sample_character):
+        """Test that new characters don't have a vault_id by default."""
+        assert sample_character.vault_id is None
+
+    def test_vault_id_persists_across_updates(self, vault, sample_character):
+        """Test that vault_id remains consistent after character updates."""
+        char_id = vault.add_character(sample_character)
+
+        # Get character (sets vault_id)
+        retrieved = vault.get_character(char_id)
+        assert retrieved.vault_id == char_id
+
+        # Update character
+        retrieved.level = 10
+        vault.update_character(char_id, retrieved)
+
+        # Get again and verify vault_id is still set correctly
+        retrieved_again = vault.get_character(char_id)
+        assert retrieved_again.vault_id == char_id
+        assert retrieved_again.level == 10

--- a/tests/test_debug_console.py
+++ b/tests/test_debug_console.py
@@ -439,33 +439,51 @@ class TestInventoryManipulation:
     """Test inventory manipulation commands"""
 
     def test_gold_add(self):
-        """Test /gold command adds gold to party"""
-        party = Party([])
+        """Test /gold command adds gold to character inventory"""
+        # Create a character to receive gold
+        character = Character(
+            name="TestHero",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=Abilities(10, 10, 10, 10, 10, 10),
+            max_hp=10,
+            ac=10
+        )
+        party = Party([character])
         game_state = GameState(party, "test_dungeon")
         console = DebugConsole(game_state, enabled=True)
 
-        initial_gold = game_state.party.currency.gold
+        initial_gold = character.inventory.currency.gold
 
-        # Add gold
+        # Add gold (distributed to party members)
         console.cmd_gold(["500"])
 
-        new_gold = game_state.party.currency.gold
+        new_gold = character.inventory.currency.gold
         assert new_gold == initial_gold + 500
 
     def test_gold_remove(self):
         """Test /gold command with negative value removes gold"""
-        party = Party([])
+        # Create a character with gold
+        character = Character(
+            name="TestHero",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=Abilities(10, 10, 10, 10, 10, 10),
+            max_hp=10,
+            ac=10
+        )
+        party = Party([character])
         game_state = GameState(party, "test_dungeon")
-        # Add some gold first
-        game_state.party.currency.gold = 1000
+        # Add some gold to the character first
+        character.inventory.currency.gold = 1000
         console = DebugConsole(game_state, enabled=True)
 
-        initial_gold = game_state.party.currency.gold
+        initial_gold = character.inventory.currency.gold
 
         # Remove gold
         console.cmd_gold(["-200"])
 
-        new_gold = game_state.party.currency.gold
+        new_gold = character.inventory.currency.gold
         assert new_gold == initial_gold - 200
 
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -31,6 +31,18 @@ class TestInventoryItem:
         assert "potion_of_healing" in str(item2)
         assert "x3" in str(item2)
 
+    def test_inventory_item_default_quest_item_false(self):
+        """Test that default quest_item is False"""
+        item = InventoryItem(item_id="sword", category="weapons")
+        assert item.quest_item is False
+
+    def test_inventory_item_quest_item_true(self):
+        """Test creating a quest item"""
+        item = InventoryItem(
+            item_id="ancient_key", category="consumables", quest_item=True
+        )
+        assert item.quest_item is True
+
 
 class TestInventory:
     """Test the Inventory class"""
@@ -96,6 +108,23 @@ class TestInventory:
         # But adding more of existing item should work
         assert limited_inventory.add_item("longsword", "weapons", 5) is True
         assert limited_inventory.get_item_quantity("longsword") == 6
+
+    def test_add_item_with_quest_item_flag(self):
+        """Test adding an item marked as a quest item"""
+        result = self.inventory.add_item(
+            "ancient_key", "consumables", 1, quest_item=True
+        )
+        assert result is True
+
+        item = self.inventory.items["ancient_key"]
+        assert item.quest_item is True
+
+    def test_add_item_without_quest_item_flag(self):
+        """Test that items default to non-quest items"""
+        self.inventory.add_item("potion_of_healing", "consumables", 1)
+
+        item = self.inventory.items["potion_of_healing"]
+        assert item.quest_item is False
 
     def test_remove_item(self):
         """Test removing an item"""
@@ -563,3 +592,102 @@ class TestAmmunitionTracking:
         # Now out of ammo
         result = self.inventory.consume_ammo("arrows")
         assert result is False
+
+
+class TestQuestItemRemoval:
+    """Test quest item removal functionality."""
+
+    def setup_method(self):
+        """Set up test fixtures"""
+        self.inventory = Inventory()
+
+    def test_remove_quest_items_removes_only_quest_items(self):
+        """Test that remove_quest_items only removes items with quest_item=True."""
+        # Add regular items
+        self.inventory.add_item("longsword", "weapons", 1)
+        self.inventory.add_item("potion_of_healing", "consumables", 3)
+
+        # Add quest items
+        self.inventory.add_item("ancient_key", "consumables", 1, quest_item=True)
+        self.inventory.add_item("magic_orb", "consumables", 1, quest_item=True)
+
+        removed = self.inventory.remove_quest_items()
+
+        # Regular items should remain
+        assert self.inventory.has_item("longsword")
+        assert self.inventory.has_item("potion_of_healing")
+        assert self.inventory.get_item_quantity("potion_of_healing") == 3
+
+        # Quest items should be gone
+        assert not self.inventory.has_item("ancient_key")
+        assert not self.inventory.has_item("magic_orb")
+
+        # Return value should list removed item IDs
+        assert "ancient_key" in removed
+        assert "magic_orb" in removed
+        assert len(removed) == 2
+
+    def test_remove_quest_items_returns_empty_list_when_none(self):
+        """Test that remove_quest_items returns empty list when no quest items."""
+        self.inventory.add_item("longsword", "weapons", 1)
+        self.inventory.add_item("potion_of_healing", "consumables", 3)
+
+        removed = self.inventory.remove_quest_items()
+
+        assert removed == []
+        assert self.inventory.has_item("longsword")
+        assert self.inventory.has_item("potion_of_healing")
+
+    def test_remove_quest_items_on_empty_inventory(self):
+        """Test that remove_quest_items works on empty inventory."""
+        removed = self.inventory.remove_quest_items()
+        assert removed == []
+
+    def test_remove_quest_items_unequips_equipped_quest_item(self):
+        """Test that equipped quest items are unequipped before removal."""
+        # Add and equip a quest weapon
+        self.inventory.add_item("cursed_blade", "weapons", 1, quest_item=True)
+        self.inventory.equip_item("cursed_blade", EquipmentSlot.WEAPON)
+
+        # Verify it's equipped
+        assert self.inventory.get_equipped_item(EquipmentSlot.WEAPON) == "cursed_blade"
+
+        removed = self.inventory.remove_quest_items()
+
+        # Item should be removed
+        assert "cursed_blade" in removed
+        assert not self.inventory.has_item("cursed_blade")
+
+        # Equipment slot should be empty
+        assert self.inventory.get_equipped_item(EquipmentSlot.WEAPON) is None
+
+    def test_remove_quest_items_preserves_equipped_non_quest_items(self):
+        """Test that equipped non-quest items remain equipped."""
+        # Add and equip regular items
+        self.inventory.add_item("longsword", "weapons", 1)
+        self.inventory.add_item("chain_mail", "armor", 1)
+        self.inventory.equip_item("longsword", EquipmentSlot.WEAPON)
+        self.inventory.equip_item("chain_mail", EquipmentSlot.ARMOR)
+
+        # Add a quest item
+        self.inventory.add_item("ancient_key", "consumables", 1, quest_item=True)
+
+        self.inventory.remove_quest_items()
+
+        # Regular equipment should remain equipped
+        assert self.inventory.get_equipped_item(EquipmentSlot.WEAPON) == "longsword"
+        assert self.inventory.get_equipped_item(EquipmentSlot.ARMOR) == "chain_mail"
+
+    def test_remove_quest_items_handles_multiple_equipped_slots(self):
+        """Test removal when both weapon and armor are quest items."""
+        # Add and equip quest items in both slots
+        self.inventory.add_item("quest_sword", "weapons", 1, quest_item=True)
+        self.inventory.add_item("quest_armor", "armor", 1, quest_item=True)
+        self.inventory.equip_item("quest_sword", EquipmentSlot.WEAPON)
+        self.inventory.equip_item("quest_armor", EquipmentSlot.ARMOR)
+
+        removed = self.inventory.remove_quest_items()
+
+        assert len(removed) == 2
+        assert self.inventory.get_equipped_item(EquipmentSlot.WEAPON) is None
+        assert self.inventory.get_equipped_item(EquipmentSlot.ARMOR) is None

--- a/tests/test_save_slot_manager.py
+++ b/tests/test_save_slot_manager.py
@@ -322,3 +322,175 @@ class TestSaveSlotManager:
         for filename, expected in test_cases:
             result = save_manager._get_adventure_display_name(filename)
             assert result == expected
+
+
+class TestVaultSync:
+    """Test vault sync functionality during save_game()."""
+
+    @pytest.fixture
+    def temp_vault_path(self, temp_saves_dir):
+        """Create a temporary path for vault file alongside saves."""
+        return temp_saves_dir.parent / "character_vault.json"
+
+    @pytest.fixture
+    def vault(self, temp_vault_path):
+        """Create a CharacterVaultV2 with temporary file."""
+        from dnd_engine.core.character_vault_v2 import CharacterVaultV2
+        return CharacterVaultV2(vault_path=temp_vault_path)
+
+    def test_save_game_syncs_characters_with_vault_id(
+        self, save_manager, vault, sample_character
+    ):
+        """Test that save_game syncs characters with vault_id to the vault."""
+        # Add character to vault and get the vault_id
+        char_id = vault.add_character(sample_character)
+        retrieved = vault.get_character(char_id)
+
+        # Create game state with the vault-linked character
+        party = Party([retrieved])
+        data_loader = DataLoader()
+        game_state = GameState(
+            party=party,
+            dungeon_name="test_dungeon",
+            data_loader=data_loader
+        )
+
+        # Modify character in game
+        game_state.party.characters[0].level = 10
+        game_state.party.characters[0].xp = 50000
+
+        # Save with vault sync
+        save_manager.save_game(
+            slot_number=1,
+            game_state=game_state,
+            character_vault=vault
+        )
+
+        # Verify vault was updated
+        vault_char = vault.get_character(char_id)
+        assert vault_char.level == 10
+        assert vault_char.xp == 50000
+
+    def test_save_game_without_vault_skips_sync(
+        self, save_manager, sample_character
+    ):
+        """Test that save_game works without vault (no sync)."""
+        party = Party([sample_character])
+        data_loader = DataLoader()
+        game_state = GameState(
+            party=party,
+            dungeon_name="test_dungeon",
+            data_loader=data_loader
+        )
+
+        # Save without vault - should not raise
+        slot_path = save_manager.save_game(
+            slot_number=2,
+            game_state=game_state
+        )
+
+        assert slot_path.exists()
+
+    def test_save_game_ignores_characters_without_vault_id(
+        self, save_manager, vault, sample_character
+    ):
+        """Test that characters without vault_id are not synced."""
+        # Add one character to vault
+        char_id = vault.add_character(sample_character)
+        vault_char = vault.get_character(char_id)
+
+        # Create a new character not in vault
+        new_char = Character(
+            name="New Hero",
+            character_class=CharacterClass.ROGUE,
+            level=5,
+            abilities=Abilities(10, 18, 12, 14, 10, 12),
+            max_hp=35,
+            ac=15,
+            current_hp=35,
+            xp=6500,
+            race="Halfling"
+        )
+
+        # Create party with both
+        party = Party([vault_char, new_char])
+        data_loader = DataLoader()
+        game_state = GameState(
+            party=party,
+            dungeon_name="test_dungeon",
+            data_loader=data_loader
+        )
+
+        # Save with vault sync
+        save_manager.save_game(
+            slot_number=3,
+            game_state=game_state,
+            character_vault=vault
+        )
+
+        # Vault should still only have one character
+        chars = vault.list_characters()
+        assert len(chars) == 1
+
+    def test_save_game_handles_deleted_vault_character(
+        self, save_manager, vault, sample_character
+    ):
+        """Test that sync handles characters deleted from vault gracefully."""
+        # Add and get character with vault_id
+        char_id = vault.add_character(sample_character)
+        retrieved = vault.get_character(char_id)
+
+        # Create game state
+        party = Party([retrieved])
+        data_loader = DataLoader()
+        game_state = GameState(
+            party=party,
+            dungeon_name="test_dungeon",
+            data_loader=data_loader
+        )
+
+        # Delete character from vault
+        vault.delete_character(char_id)
+
+        # Save should not raise error even though vault char is deleted
+        save_manager.save_game(
+            slot_number=4,
+            game_state=game_state,
+            character_vault=vault
+        )
+
+        # Slot should still be saved
+        slot = save_manager.get_slot(4)
+        assert not slot.is_empty()
+
+    def test_save_game_syncs_inventory_changes(
+        self, save_manager, vault, sample_character
+    ):
+        """Test that inventory changes are synced to vault."""
+        char_id = vault.add_character(sample_character)
+        retrieved = vault.get_character(char_id)
+
+        party = Party([retrieved])
+        data_loader = DataLoader()
+        game_state = GameState(
+            party=party,
+            dungeon_name="test_dungeon",
+            data_loader=data_loader
+        )
+
+        # Add items to character's inventory
+        game_state.party.characters[0].inventory.add_item(
+            "longsword", "weapons", 1
+        )
+        game_state.party.characters[0].inventory.add_gold(500)
+
+        save_manager.save_game(
+            slot_number=5,
+            game_state=game_state,
+            character_vault=vault
+        )
+
+        # Verify vault character has the items
+        vault_char = vault.get_character(char_id)
+        assert vault_char.inventory.has_item("longsword")
+        assert vault_char.inventory.gold == 500


### PR DESCRIPTION
## Summary
- Track `vault_id` on party members for syncing progression back to the character vault
- Sync characters to vault automatically on `save_game()` when vault is provided
- Add `quest_item` flag to `InventoryItem` for campaign-specific items that don't transfer
- Add `prepare_for_new_campaign()` method to reset transient state between adventures
- Fix debug console gold tests to use character inventory correctly

## Test plan
- [x] Unit tests for vault_id being set correctly (3 tests)
- [x] Integration tests for vault sync on save_game() (5 tests)
- [x] Unit tests for prepare_for_new_campaign() (12 tests)
- [x] Unit tests for quest item removal (10 tests)
- [x] All 30 new tests passing

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)