### PR TITLE
chore: Cleanup UI with questionary patterns

### DIFF
--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -34,6 +34,7 @@ from dnd_engine.systems.targeting import (
     get_spell_targeting_requirements,
 )
 from dnd_engine.ui.shop_ui import ShopUI
+from dnd_engine.ui.inventory_ui import InventoryUI
 from dnd_engine.ui.debug_console import DebugConsole
 from dnd_engine.ui.rich_ui import (
     console,
@@ -539,7 +540,12 @@ class CLI:
                 filter_arg = " ".join(parts[1:])
                 self.display_inventory(filter_arg)
             else:
-                self.display_inventory()
+                # Launch interactive inventory management UI
+                inventory_ui = InventoryUI(
+                    party=self.game_state.party.characters,
+                    data_loader=self.game_state.data_loader
+                )
+                inventory_ui.run()
             return
 
         if command == "equip" or command.startswith("equip "):
@@ -4767,7 +4773,7 @@ class CLI:
             ("shop [npc]", "Open shop UI (e.g., 'shop gareth' or just 'shop' for menu)"),
             ("search", "Search the room for items"),
             ("take/get/pickup <item>", "Pick up an item (e.g., 'take dagger', 'get gold')"),
-            ("inventory / i [filter]", "Show inventory. Filter: summary, player name/number, or item type"),
+            ("inventory / i [filter]", "Manage inventory. No args: interactive UI. Filter: summary, player, item type"),
             ("equip <item> [on <player>]", "Equip weapon/armor (e.g., 'equip sword on 2')"),
             ("unequip <slot> [on <player>]", "Unequip weapon/armor (e.g., 'unequip weapon on gandalf')"),
             ("use <item> [on <player>]", "Use consumable (e.g., 'use potion on 2')"),

--- a/dnd_engine/ui/inventory_ui.py
+++ b/dnd_engine/ui/inventory_ui.py
@@ -1,0 +1,423 @@
+# ABOUTME: Questionary-based inventory management UI for character equipment and items
+# ABOUTME: Provides character selection, equipment management, item viewing, and proficiency display
+
+from typing import Any
+
+import questionary
+from rich.panel import Panel
+
+from dnd_engine.core.character import Character
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.systems.inventory import EquipmentSlot
+
+from .rich_ui import console, print_section, print_status_message
+
+
+class InventoryUI:
+    """
+    Interactive inventory management interface using questionary menus.
+
+    Provides a structured UI for viewing inventory, managing equipment,
+    and displaying proficiency information for party members.
+    """
+
+    def __init__(self, party: list[Character], data_loader: DataLoader | None = None):
+        """
+        Initialize inventory UI.
+
+        Args:
+            party: List of party member characters
+            data_loader: Optional data loader (creates one if not provided)
+        """
+        self.party = party
+        self.loader = data_loader or DataLoader()
+        self.items_data = self.loader.load_items()
+        self.active_character: Character | None = None
+
+    def run(self) -> None:
+        """Run the inventory management interface until the user exits."""
+        if not self.party:
+            print_status_message("No party members available.", "warning")
+            return
+
+        # Filter to living members only
+        living_members = [c for c in self.party if c.is_alive]
+        if not living_members:
+            print_status_message("No living party members.", "warning")
+            return
+
+        while True:
+            console.print()
+            print_section("INVENTORY MANAGEMENT")
+
+            # Select character if not selected
+            if not self.active_character:
+                self.active_character = self._select_character(living_members)
+                if not self.active_character:
+                    break
+
+            # Show main menu for selected character
+            action = self._show_main_menu()
+
+            if action == "view":
+                self._view_inventory()
+            elif action == "equipment":
+                self._manage_equipment()
+            elif action == "back":
+                self.active_character = None
+            elif action == "exit":
+                break
+
+    def _select_character(self, characters: list[Character]) -> Character | None:
+        """
+        Show character selection menu.
+
+        Args:
+            characters: List of characters to choose from
+
+        Returns:
+            Selected character or None if cancelled
+        """
+        choices = []
+        for char in characters:
+            gold = char.inventory.gold
+            item_count = char.inventory.item_count()
+            display = (
+                f"{char.name} ({char.character_class.value.title()} {char.level}) "
+                f"- {gold} GP - {item_count} items"
+            )
+            choices.append(questionary.Choice(title=display, value=char))
+
+        choices.append(questionary.Choice(title="← Back", value=None))
+
+        try:
+            result = questionary.select(
+                "Select a character:",
+                choices=choices,
+                use_arrow_keys=True
+            ).ask()
+            return result
+        except (EOFError, KeyboardInterrupt):
+            return None
+
+    def _show_main_menu(self) -> str:
+        """
+        Show main inventory menu for selected character.
+
+        Returns:
+            Selected action string
+        """
+        char = self.active_character
+        if not char:
+            return "exit"
+
+        gold = char.inventory.gold
+        hp_str = f"{char.current_hp}/{char.max_hp} HP"
+
+        choices = [
+            questionary.Choice(title="View All Items", value="view"),
+            questionary.Choice(title="Manage Equipment", value="equipment"),
+            questionary.Choice(title="← Back to Characters", value="back"),
+        ]
+
+        try:
+            result = questionary.select(
+                f"{char.name}'s Inventory ({gold} GP, {hp_str}):",
+                choices=choices,
+                use_arrow_keys=True
+            ).ask()
+            return result or "exit"
+        except (EOFError, KeyboardInterrupt):
+            return "exit"
+
+    def _view_inventory(self) -> None:
+        """Display character's full inventory in a formatted view."""
+        char = self.active_character
+        if not char:
+            return
+
+        inventory = char.inventory
+        console.print()
+
+        # Build inventory display
+        equipped_weapon = inventory.get_equipped_item(EquipmentSlot.WEAPON)
+        equipped_armor = inventory.get_equipped_item(EquipmentSlot.ARMOR)
+
+        # Create panel content
+        lines = []
+
+        # Equipped section
+        lines.append("[bold cyan]EQUIPPED:[/bold cyan]")
+        if equipped_weapon:
+            weapon_data = self._get_item_data(equipped_weapon, "weapons")
+            weapon_name = weapon_data.get("name", equipped_weapon) if weapon_data else equipped_weapon
+            weapon_info = self._get_weapon_info(weapon_data) if weapon_data else ""
+            lines.append(f"  Weapon: {weapon_name} {weapon_info}")
+        else:
+            lines.append("  Weapon: [dim]None[/dim]")
+
+        if equipped_armor:
+            armor_data = self._get_item_data(equipped_armor, "armor")
+            armor_name = armor_data.get("name", equipped_armor) if armor_data else equipped_armor
+            armor_info = self._get_armor_info(armor_data) if armor_data else ""
+            lines.append(f"  Armor:  {armor_name} {armor_info}")
+        else:
+            lines.append("  Armor:  [dim]None[/dim]")
+
+        lines.append("")
+
+        # Weapons section
+        weapons = inventory.get_items_by_category("weapons")
+        if weapons:
+            lines.append("[bold cyan]WEAPONS:[/bold cyan]")
+            for inv_item in weapons:
+                item_data = self._get_item_data(inv_item.item_id, "weapons")
+                name = item_data.get("name", inv_item.item_id) if item_data else inv_item.item_id
+                equipped_marker = " [green][equipped][/green]" if inv_item.item_id == equipped_weapon else ""
+                prof_marker = self._get_proficiency_marker(char, item_data, "weapon")
+                qty_str = f" (x{inv_item.quantity})" if inv_item.quantity > 1 else ""
+                lines.append(f"  {name}{qty_str}{equipped_marker}{prof_marker}")
+            lines.append("")
+
+        # Armor section
+        armor_items = inventory.get_items_by_category("armor")
+        if armor_items:
+            lines.append("[bold cyan]ARMOR:[/bold cyan]")
+            for inv_item in armor_items:
+                item_data = self._get_item_data(inv_item.item_id, "armor")
+                name = item_data.get("name", inv_item.item_id) if item_data else inv_item.item_id
+                equipped_marker = " [green][equipped][/green]" if inv_item.item_id == equipped_armor else ""
+                prof_marker = self._get_proficiency_marker(char, item_data, "armor")
+                lines.append(f"  {name}{equipped_marker}{prof_marker}")
+            lines.append("")
+
+        # Consumables section
+        consumables = inventory.get_items_by_category("consumables")
+        if consumables:
+            lines.append("[bold cyan]CONSUMABLES:[/bold cyan]")
+            for inv_item in consumables:
+                item_data = self._get_item_data(inv_item.item_id, "consumables")
+                name = item_data.get("name", inv_item.item_id) if item_data else inv_item.item_id
+                qty_str = f" (x{inv_item.quantity})" if inv_item.quantity > 1 else ""
+                quest_marker = " [yellow]⚿[/yellow]" if inv_item.quest_item else ""
+                lines.append(f"  {name}{qty_str}{quest_marker}")
+            lines.append("")
+
+        # Quest items note
+        if any(inv.quest_item for inv in inventory.get_all_items()):
+            lines.append("[dim]⚿ = Quest item (cannot be dropped or sold)[/dim]")
+
+        if not (weapons or armor_items or consumables):
+            lines.append("[dim]No items in inventory[/dim]")
+
+        panel = Panel(
+            "\n".join(lines),
+            title=f"[bold white]{char.name}'s Items[/bold white]",
+            subtitle=f"[dim]Gold: {inventory.gold} GP[/dim]",
+            border_style="cyan",
+            padding=(1, 2)
+        )
+        console.print(panel)
+
+        # Wait for user to continue
+        console.print("\n[dim]Press Enter to continue...[/dim]")
+        console.input()
+
+    def _manage_equipment(self) -> None:
+        """Equipment management submenu."""
+        char = self.active_character
+        if not char:
+            return
+
+        while True:
+            inventory = char.inventory
+            equipped_weapon = inventory.get_equipped_item(EquipmentSlot.WEAPON)
+            equipped_armor = inventory.get_equipped_item(EquipmentSlot.ARMOR)
+
+            # Get display names
+            weapon_name = "None"
+            if equipped_weapon:
+                weapon_data = self._get_item_data(equipped_weapon, "weapons")
+                weapon_name = weapon_data.get("name", equipped_weapon) if weapon_data else equipped_weapon
+
+            armor_name = "None"
+            if equipped_armor:
+                armor_data = self._get_item_data(equipped_armor, "armor")
+                armor_name = armor_data.get("name", equipped_armor) if armor_data else equipped_armor
+
+            choices = [
+                questionary.Choice(
+                    title=f"Change Weapon (current: {weapon_name})",
+                    value="weapon"
+                ),
+                questionary.Choice(
+                    title=f"Change Armor (current: {armor_name})",
+                    value="armor"
+                ),
+                questionary.Choice(title="← Back", value="__BACK__"),
+            ]
+
+            try:
+                action = questionary.select(
+                    f"Manage Equipment - {char.name}:",
+                    choices=choices,
+                    use_arrow_keys=True
+                ).ask()
+            except (EOFError, KeyboardInterrupt):
+                return
+
+            if action is None or action == "__BACK__":
+                return
+            elif action == "weapon":
+                self._change_equipment(EquipmentSlot.WEAPON)
+            elif action == "armor":
+                self._change_equipment(EquipmentSlot.ARMOR)
+
+    def _change_equipment(self, slot: EquipmentSlot) -> None:
+        """
+        Change equipment in a specific slot.
+
+        Args:
+            slot: The equipment slot to change
+        """
+        char = self.active_character
+        if not char:
+            return
+
+        inventory = char.inventory
+        category = "weapons" if slot == EquipmentSlot.WEAPON else "armor"
+        slot_name = "weapon" if slot == EquipmentSlot.WEAPON else "armor"
+
+        # Get available items
+        available_items = inventory.get_items_by_category(category)
+        currently_equipped = inventory.get_equipped_item(slot)
+
+        choices = []
+        for inv_item in available_items:
+            item_data = self._get_item_data(inv_item.item_id, category)
+            name = item_data.get("name", inv_item.item_id) if item_data else inv_item.item_id
+
+            # Build display with proficiency status
+            prof_marker = self._get_proficiency_marker(char, item_data, slot_name)
+            equipped_marker = " [green][equipped][/green]" if inv_item.item_id == currently_equipped else ""
+
+            display = f"{name}{equipped_marker}{prof_marker}"
+            choices.append(questionary.Choice(title=display, value=inv_item.item_id))
+
+        # Add unequip option if something is equipped
+        if currently_equipped:
+            choices.append(questionary.Choice(
+                title=f"Unequip {slot_name}",
+                value="__UNEQUIP__"
+            ))
+
+        choices.append(questionary.Choice(title="← Cancel", value="__CANCEL__"))
+
+        if len(choices) == 1:  # Only cancel option
+            print_status_message(f"No {category} available to equip.", "info")
+            return
+
+        try:
+            selected = questionary.select(
+                f"Select {slot_name} for {char.name}:",
+                choices=choices,
+                use_arrow_keys=True
+            ).ask()
+        except (EOFError, KeyboardInterrupt):
+            return
+
+        if selected is None or selected == "__CANCEL__":
+            return
+
+        if selected == "__UNEQUIP__":
+            unequipped_id = inventory.unequip_item(slot)
+            if unequipped_id:
+                item_data = self._get_item_data(unequipped_id, category)
+                name = item_data.get("name", unequipped_id) if item_data else unequipped_id
+                print_status_message(f"{char.name} unequipped {name}", "info")
+        else:
+            # Equip the selected item
+            inventory.equip_item(selected, slot)
+            item_data = self._get_item_data(selected, category)
+            name = item_data.get("name", selected) if item_data else selected
+            print_status_message(f"{char.name} equipped {name}", "success")
+
+    def _get_item_data(self, item_id: str, category: str) -> dict[str, Any] | None:
+        """
+        Look up item data from items.json.
+
+        Args:
+            item_id: The item ID to look up
+            category: The category to search in (weapons, armor, consumables)
+
+        Returns:
+            Item data dictionary or None if not found
+        """
+        if category in self.items_data and item_id in self.items_data[category]:
+            return self.items_data[category][item_id]
+        return None
+
+    def _get_weapon_info(self, item_data: dict[str, Any] | None) -> str:
+        """Get compact weapon info string."""
+        if not item_data:
+            return ""
+
+        parts = []
+        damage = item_data.get("damage")
+        if damage:
+            parts.append(damage)
+
+        damage_type = item_data.get("damage_type")
+        if damage_type:
+            parts.append(damage_type)
+
+        return f"[dim]({', '.join(parts)})[/dim]" if parts else ""
+
+    def _get_armor_info(self, item_data: dict[str, Any] | None) -> str:
+        """Get compact armor info string."""
+        if not item_data:
+            return ""
+
+        ac = item_data.get("ac_base")
+        if ac:
+            return f"[dim](AC {ac})[/dim]"
+        return ""
+
+    def _get_proficiency_marker(
+        self,
+        char: Character,
+        item_data: dict[str, Any] | None,
+        item_type: str
+    ) -> str:
+        """
+        Get proficiency marker for an item.
+
+        Args:
+            char: Character to check proficiency for
+            item_data: Item data dictionary
+            item_type: "weapon" or "armor"
+
+        Returns:
+            Formatted proficiency marker string
+        """
+        if not item_data:
+            return ""
+
+        if item_type == "weapon":
+            weapon_type = item_data.get("weapon_type", "")
+            # Check weapon type proficiency
+            if weapon_type in char.weapon_proficiencies:
+                return " [green]✓[/green]"
+            # Check specific weapon proficiency
+            item_id = item_data.get("name", "").lower().replace(" ", "_")
+            if item_id in char.weapon_proficiencies:
+                return " [green]✓[/green]"
+            return " [red]✗ not proficient[/red]"
+
+        elif item_type == "armor":
+            armor_type = item_data.get("armor_type", "")
+            if armor_type in char.armor_proficiencies:
+                return " [green]✓[/green]"
+            return " [red]✗ not proficient[/red]"
+
+        return ""

--- a/dnd_engine/ui/main_menu_v2.py
+++ b/dnd_engine/ui/main_menu_v2.py
@@ -141,6 +141,95 @@ class MainMenuV2:
 
         return choice_map.get(choice)
 
+    def _build_slot_choice_display(self, slot) -> str:
+        """
+        Build a display string for a save slot choice.
+
+        Args:
+            slot: SaveSlot instance
+
+        Returns:
+            Formatted display string for questionary choice
+        """
+        if slot.is_empty():
+            return f"Slot {slot.slot_number}: [Empty]"
+
+        # Build compact display: "Slot 1: Adventure - Party (Lvl X) - 2h 30m"
+        parts = [f"Slot {slot.slot_number}:"]
+
+        # Adventure name
+        if slot.adventure_name:
+            parts.append(slot.adventure_name)
+        else:
+            parts.append("Unknown Adventure")
+
+        # Party composition with levels
+        if slot.party_composition:
+            party_str = ", ".join(slot.party_composition)
+            if slot.party_levels:
+                avg_level = sum(slot.party_levels) // len(slot.party_levels)
+                party_str += f" (Lvl {avg_level})"
+            parts.append(f"- {party_str}")
+
+        # Playtime
+        parts.append(f"- {slot._format_playtime()}")
+
+        return " ".join(parts)
+
+    def _select_save_slot(
+        self,
+        prompt: str,
+        filter_empty: bool = False,
+        allow_empty: bool = True
+    ) -> int | None:
+        """
+        Select a save slot using questionary.
+
+        Args:
+            prompt: The selection prompt to display
+            filter_empty: If True, only show non-empty slots
+            allow_empty: If True, empty slots can be selected (for new game)
+
+        Returns:
+            Selected slot number (1-10) or None if cancelled
+        """
+        slots = self.slot_manager.list_slots()
+
+        if filter_empty:
+            slots = [s for s in slots if not s.is_empty()]
+
+        if not slots:
+            print_status_message("No saved games found.", "warning")
+            return None
+
+        # Build choices
+        choices = []
+        for slot in slots:
+            display = self._build_slot_choice_display(slot)
+            disabled = None
+
+            # Disable empty slots if not allowed
+            if not allow_empty and slot.is_empty():
+                disabled = "empty slot"
+
+            choices.append(questionary.Choice(
+                title=display,
+                value=slot.slot_number,
+                disabled=disabled
+            ))
+
+        choices.append(questionary.Choice(title="← Back", value=None))
+
+        try:
+            selected = questionary.select(
+                prompt,
+                choices=choices,
+                use_arrow_keys=True
+            ).ask()
+            return selected
+        except (EOFError, KeyboardInterrupt):
+            return None
+
     def show_save_slot_list(self, filter_empty: bool = False) -> None:
         """
         Display all save slots with their current state.
@@ -197,33 +286,20 @@ class MainMenuV2:
         Returns:
             Tuple of (GameState, slot_number) if successful, None otherwise
         """
-        self.show_save_slot_list(filter_empty=True)
-
-        slots = self.slot_manager.list_slots()
-        used_slots = [s for s in slots if not s.is_empty()]
-
-        if not used_slots:
-            console.print("\n[yellow]No saved games found.[/yellow]")
-            return None
-
         console.print()
-        choice = console.input("[bold cyan]Select slot number (1-10) or [B]ack:[/bold cyan] ").strip()
+        print_section("LOAD GAME")
 
-        if choice.lower() in ['b', 'back']:
+        slot_num = self._select_save_slot(
+            "Select a saved game to load:",
+            filter_empty=True,
+            allow_empty=False
+        )
+
+        if slot_num is None:
             return None
 
         try:
-            slot_num = int(choice)
-
-            if not 1 <= slot_num <= 10:
-                print_error("Invalid slot number. Must be between 1 and 10.")
-                return None
-
             slot = self.slot_manager.get_slot(slot_num)
-
-            if slot.is_empty():
-                print_error(f"Slot {slot_num} is empty.")
-                return None
 
             # Load game state - returns tuple of (game_state, campaign_progress)
             game_state, campaign_progress = self.slot_manager.load_game(slot_num)
@@ -239,9 +315,6 @@ class MainMenuV2:
 
             return (game_state, slot_num)
 
-        except ValueError:
-            print_error("Invalid input. Please enter a number.")
-            return None
         except Exception as e:
             print_error(f"Failed to load game: {e}")
             return None
@@ -279,43 +352,47 @@ class MainMenuV2:
         # Step 3: Select save slot
         console.print()
         print_section("SELECT SAVE SLOT")
-        self.show_save_slot_list(filter_empty=False)
-        console.print()
 
-        choice = console.input("[bold cyan]Select slot number (1-10):[/bold cyan] ").strip()
+        slot_num = self._select_save_slot(
+            "Select a save slot for your new game:",
+            filter_empty=False,
+            allow_empty=True
+        )
+
+        if slot_num is None:
+            return None
+
+        slot = self.slot_manager.get_slot(slot_num)
+
+        # Confirm overwrite if not empty
+        if not slot.is_empty():
+            try:
+                confirm = questionary.confirm(
+                    f"Slot {slot_num} contains: {slot.get_display_name()}. Overwrite?",
+                    default=False
+                ).ask()
+            except (EOFError, KeyboardInterrupt):
+                return None
+
+            if not confirm:
+                console.print("\n[yellow]Cancelled.[/yellow]")
+                return None
+
+        # Step 4: Create game state with campaign progress
+        party = Party(party_characters)
+        campaign_progress = campaign_info.get("campaign_progress")
+
+        # Use room registry to find the dungeon containing the starting room
+        starting_room = campaign_info["starting_room"]
+        dungeons_path = self.data_loader.data_path / "content" / "dungeons"
+        room_registry = RoomRegistry(dungeons_path)
+        starting_dungeon = room_registry.get_dungeon_for_room(starting_room)
+
+        if not starting_dungeon:
+            print_error(f"Could not find dungeon for room: {starting_room}")
+            return None
 
         try:
-            slot_num = int(choice)
-
-            if not 1 <= slot_num <= 10:
-                print_error("Invalid slot number. Must be between 1 and 10.")
-                return None
-
-            slot = self.slot_manager.get_slot(slot_num)
-
-            # Confirm overwrite if not empty
-            if not slot.is_empty():
-                console.print(f"\n[yellow]⚠  Slot {slot_num} contains:[/yellow] {slot.get_display_name()}")
-                confirm = console.input("[bold red]Overwrite this slot? (yes/no):[/bold red] ").strip().lower()
-
-                if confirm != 'yes':
-                    console.print("\n[yellow]Cancelled.[/yellow]")
-                    return None
-
-            # Step 4: Create game state with campaign progress
-            party = Party(party_characters)
-            campaign_progress = campaign_info.get("campaign_progress")
-
-            # Use room registry to find the dungeon containing the starting room
-            starting_room = campaign_info["starting_room"]
-            dungeons_path = self.data_loader.data_path / "content" / "dungeons"
-            room_registry = RoomRegistry(dungeons_path)
-            starting_dungeon = room_registry.get_dungeon_for_room(starting_room)
-
-            if not starting_dungeon:
-                print_error(f"Could not find dungeon for room: {starting_room}")
-                return None
-
             game_state = GameState(
                 party=party,
                 dungeon_name=starting_dungeon,
@@ -352,9 +429,6 @@ class MainMenuV2:
 
             return (game_state, slot_num)
 
-        except ValueError:
-            print_error("Invalid input. Please enter a number.")
-            return None
         except Exception as e:
             print_error(f"Failed to create game: {e}")
             return None
@@ -634,45 +708,64 @@ class MainMenuV2:
         """Handle save slot management menu."""
         while True:
             console.print()
-            self.show_save_slot_list(filter_empty=False)
+            print_section("MANAGE SAVE SLOTS")
 
-            console.print("\n[bold]Actions:[/bold]")
-            console.print("  [R] Rename slot")
-            console.print("  [C] Clear slot")
-            console.print("  [B] Back to main menu")
+            # Action selection
+            action_choices = [
+                questionary.Choice(title="Rename slot", value="rename"),
+                questionary.Choice(title="Clear slot", value="clear"),
+                questionary.Choice(title="← Back to main menu", value=None),
+            ]
 
-            console.print()
-            choice = console.input("[bold cyan]Select action:[/bold cyan] ").strip().upper()
-
-            if choice == 'B':
+            try:
+                action = questionary.select(
+                    "What would you like to do?",
+                    choices=action_choices,
+                    use_arrow_keys=True
+                ).ask()
+            except (EOFError, KeyboardInterrupt):
                 break
-            elif choice == 'R':
-                slot_num = console.input("\n[bold cyan]Slot number to rename:[/bold cyan] ").strip()
-                try:
-                    num = int(slot_num)
-                    if 1 <= num <= 10:
-                        new_name = console.input("[bold cyan]Enter custom name (empty for auto-name):[/bold cyan] ").strip()
-                        self.slot_manager.rename_slot(num, new_name)
-                        print_status_message(f"Renamed Slot {num}", "success")
-                except ValueError:
-                    print_error("Invalid slot number.")
-            elif choice == 'C':
-                slot_num = console.input("\n[bold cyan]Slot number to clear:[/bold cyan] ").strip()
-                try:
-                    num = int(slot_num)
-                    if 1 <= num <= 10:
-                        slot = self.slot_manager.get_slot(num)
-                        if slot.is_empty():
-                            print_status_message("Slot is already empty.", "info")
-                        else:
-                            confirm = console.input(f"[bold red]Clear slot {num}? This cannot be undone! (yes/no):[/bold red] ").strip().lower()
-                            if confirm == 'yes':
-                                self.slot_manager.clear_slot(num)
-                                print_status_message(f"Cleared Slot {num}", "success")
-                except ValueError:
-                    print_error("Invalid slot number.")
-            else:
-                print_error("Invalid action.")
+
+            if action is None:
+                break
+
+            elif action == "rename":
+                slot_num = self._select_save_slot(
+                    "Select slot to rename:",
+                    filter_empty=False,
+                    allow_empty=False
+                )
+
+                if slot_num is not None:
+                    new_name = console.input(
+                        "[bold cyan]Enter custom name (empty for auto-name):[/bold cyan] "
+                    ).strip()
+                    self.slot_manager.rename_slot(slot_num, new_name)
+                    print_status_message(f"Renamed Slot {slot_num}", "success")
+
+            elif action == "clear":
+                slot_num = self._select_save_slot(
+                    "Select slot to clear:",
+                    filter_empty=False,
+                    allow_empty=False
+                )
+
+                if slot_num is not None:
+                    slot = self.slot_manager.get_slot(slot_num)
+                    if slot.is_empty():
+                        print_status_message("Slot is already empty.", "info")
+                    else:
+                        try:
+                            confirm = questionary.confirm(
+                                f"Clear slot {slot_num}? This cannot be undone!",
+                                default=False
+                            ).ask()
+                        except (EOFError, KeyboardInterrupt):
+                            continue
+
+                        if confirm:
+                            self.slot_manager.clear_slot(slot_num)
+                            print_status_message(f"Cleared Slot {slot_num}", "success")
 
             console.print("\n[dim]Press Enter to continue...[/dim]")
             console.input()

--- a/tests/test_inventory_ui.py
+++ b/tests/test_inventory_ui.py
@@ -1,0 +1,439 @@
+# ABOUTME: Unit tests for InventoryUI class
+# ABOUTME: Tests character selection, equipment management, and inventory display logic
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.systems.inventory import EquipmentSlot, Inventory
+from dnd_engine.ui.inventory_ui import InventoryUI
+
+
+@pytest.fixture
+def mock_items_data():
+    """Sample items data for testing."""
+    return {
+        "weapons": {
+            "longsword": {
+                "name": "Longsword",
+                "type": "weapon",
+                "weapon_type": "martial",
+                "damage": "1d8",
+                "damage_type": "slashing"
+            },
+            "dagger": {
+                "name": "Dagger",
+                "type": "weapon",
+                "weapon_type": "simple",
+                "damage": "1d4",
+                "damage_type": "piercing"
+            }
+        },
+        "armor": {
+            "chain_mail": {
+                "name": "Chain Mail",
+                "type": "armor",
+                "armor_type": "heavy",
+                "ac_base": 16
+            },
+            "leather_armor": {
+                "name": "Leather Armor",
+                "type": "armor",
+                "armor_type": "light",
+                "ac_base": 11
+            }
+        },
+        "consumables": {
+            "healing_potion": {
+                "name": "Healing Potion",
+                "type": "consumable",
+                "effect": "heal"
+            }
+        }
+    }
+
+
+@pytest.fixture
+def mock_character():
+    """Create a mock character with inventory."""
+    char = Mock(spec=Character)
+    char.name = "TestHero"
+    char.character_class = CharacterClass.FIGHTER
+    char.level = 3
+    char.is_alive = True
+    char.current_hp = 25
+    char.max_hp = 30
+    char.weapon_proficiencies = {"martial", "simple"}
+    char.armor_proficiencies = {"light", "medium", "heavy"}
+
+    # Mock inventory
+    char.inventory = Mock(spec=Inventory)
+    char.inventory.gold = 50
+    char.inventory.item_count.return_value = 5
+    char.inventory.get_equipped_item.return_value = None
+    char.inventory.get_items_by_category.return_value = []
+    char.inventory.get_all_items.return_value = []
+
+    return char
+
+
+@pytest.fixture
+def mock_rogue():
+    """Create a mock rogue character (limited proficiencies)."""
+    char = Mock(spec=Character)
+    char.name = "Sneaky"
+    char.character_class = CharacterClass.ROGUE
+    char.level = 2
+    char.is_alive = True
+    char.current_hp = 15
+    char.max_hp = 18
+    char.weapon_proficiencies = {"simple", "rapier", "shortsword"}
+    char.armor_proficiencies = {"light"}
+
+    char.inventory = Mock(spec=Inventory)
+    char.inventory.gold = 30
+    char.inventory.item_count.return_value = 3
+    char.inventory.get_equipped_item.return_value = None
+    char.inventory.get_items_by_category.return_value = []
+    char.inventory.get_all_items.return_value = []
+
+    return char
+
+
+@pytest.fixture
+def mock_data_loader(mock_items_data):
+    """Create a mock data loader."""
+    loader = Mock()
+    loader.load_items.return_value = mock_items_data
+    return loader
+
+
+class TestInventoryUIInit:
+    """Test InventoryUI initialization."""
+
+    def test_init_with_party_and_loader(self, mock_character, mock_data_loader):
+        """Test initialization with provided party and loader."""
+        party = [mock_character]
+        ui = InventoryUI(party=party, data_loader=mock_data_loader)
+
+        assert ui.party == party
+        assert ui.loader == mock_data_loader
+        assert ui.active_character is None
+
+    def test_init_creates_default_loader(self, mock_character):
+        """Test that initialization creates default loader if not provided."""
+        with patch('dnd_engine.ui.inventory_ui.DataLoader') as mock_loader_class:
+            mock_loader_instance = Mock()
+            mock_loader_instance.load_items.return_value = {}
+            mock_loader_class.return_value = mock_loader_instance
+
+            InventoryUI(party=[mock_character])
+
+            mock_loader_class.assert_called_once()
+
+
+class TestCharacterSelection:
+    """Test character selection functionality."""
+
+    @patch('dnd_engine.ui.inventory_ui.questionary')
+    def test_select_character_shows_all_living_members(
+        self, mock_questionary, mock_character, mock_rogue, mock_data_loader
+    ):
+        """Test that character selection shows all living party members."""
+        party = [mock_character, mock_rogue]
+        ui = InventoryUI(party=party, data_loader=mock_data_loader)
+
+        mock_questionary.select.return_value.ask.return_value = mock_character
+
+        result = ui._select_character(party)
+
+        assert result == mock_character
+        mock_questionary.select.assert_called_once()
+        # Verify choices were built for both characters
+        call_kwargs = mock_questionary.select.call_args
+        assert "Select a character:" in str(call_kwargs)
+
+    @patch('dnd_engine.ui.inventory_ui.questionary')
+    def test_select_character_returns_none_on_back(
+        self, mock_questionary, mock_character, mock_data_loader
+    ):
+        """Test that selecting back returns None."""
+        party = [mock_character]
+        ui = InventoryUI(party=party, data_loader=mock_data_loader)
+
+        mock_questionary.select.return_value.ask.return_value = None
+
+        result = ui._select_character(party)
+
+        assert result is None
+
+    @patch('dnd_engine.ui.inventory_ui.questionary')
+    def test_select_character_handles_keyboard_interrupt(
+        self, mock_questionary, mock_character, mock_data_loader
+    ):
+        """Test that keyboard interrupt returns None."""
+        party = [mock_character]
+        ui = InventoryUI(party=party, data_loader=mock_data_loader)
+
+        mock_questionary.select.return_value.ask.side_effect = KeyboardInterrupt
+
+        result = ui._select_character(party)
+
+        assert result is None
+
+
+class TestMainMenu:
+    """Test main menu functionality."""
+
+    @patch('dnd_engine.ui.inventory_ui.questionary')
+    def test_show_main_menu_with_character(
+        self, mock_questionary, mock_character, mock_data_loader
+    ):
+        """Test main menu shows character info in prompt."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+        ui.active_character = mock_character
+
+        mock_questionary.select.return_value.ask.return_value = "view"
+
+        result = ui._show_main_menu()
+
+        assert result == "view"
+        # Verify prompt contains character name and gold
+        call_args = mock_questionary.select.call_args
+        prompt = call_args[0][0]
+        assert "TestHero" in prompt
+        assert "50 GP" in prompt
+
+    @patch('dnd_engine.ui.inventory_ui.questionary')
+    def test_show_main_menu_returns_exit_without_character(
+        self, mock_questionary, mock_character, mock_data_loader
+    ):
+        """Test main menu returns exit if no active character."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+        ui.active_character = None
+
+        result = ui._show_main_menu()
+
+        assert result == "exit"
+
+
+class TestEquipmentManagement:
+    """Test equipment management functionality."""
+
+    @patch('dnd_engine.ui.inventory_ui.questionary')
+    def test_change_equipment_shows_available_weapons(
+        self, mock_questionary, mock_character, mock_data_loader, mock_items_data
+    ):
+        """Test that change equipment shows available weapons."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+        ui.active_character = mock_character
+
+        # Setup inventory with weapons
+        inv_item = Mock()
+        inv_item.item_id = "longsword"
+        inv_item.quantity = 1
+        mock_character.inventory.get_items_by_category.return_value = [inv_item]
+        mock_character.inventory.get_equipped_item.return_value = None
+
+        mock_questionary.select.return_value.ask.return_value = None  # Cancel
+
+        ui._change_equipment(EquipmentSlot.WEAPON)
+
+        mock_questionary.select.assert_called_once()
+        # Verify weapons were included in choices
+        call_args = mock_questionary.select.call_args
+        assert "weapon" in call_args[0][0].lower()
+
+    @patch('dnd_engine.ui.inventory_ui.questionary')
+    @patch('dnd_engine.ui.inventory_ui.print_status_message')
+    def test_change_equipment_equips_selected_item(
+        self, mock_print, mock_questionary, mock_character, mock_data_loader
+    ):
+        """Test that selecting an item equips it."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+        ui.active_character = mock_character
+
+        inv_item = Mock()
+        inv_item.item_id = "longsword"
+        inv_item.quantity = 1
+        mock_character.inventory.get_items_by_category.return_value = [inv_item]
+        mock_character.inventory.get_equipped_item.return_value = None
+
+        mock_questionary.select.return_value.ask.return_value = "longsword"
+
+        ui._change_equipment(EquipmentSlot.WEAPON)
+
+        mock_character.inventory.equip_item.assert_called_once_with(
+            "longsword", EquipmentSlot.WEAPON
+        )
+
+    @patch('dnd_engine.ui.inventory_ui.questionary')
+    @patch('dnd_engine.ui.inventory_ui.print_status_message')
+    def test_change_equipment_unequips_on_unequip_selection(
+        self, mock_print, mock_questionary, mock_character, mock_data_loader
+    ):
+        """Test that selecting unequip removes current equipment."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+        ui.active_character = mock_character
+
+        inv_item = Mock()
+        inv_item.item_id = "longsword"
+        inv_item.quantity = 1
+        mock_character.inventory.get_items_by_category.return_value = [inv_item]
+        mock_character.inventory.get_equipped_item.return_value = "longsword"
+        mock_character.inventory.unequip_item.return_value = "longsword"
+
+        mock_questionary.select.return_value.ask.return_value = "__UNEQUIP__"
+
+        ui._change_equipment(EquipmentSlot.WEAPON)
+
+        mock_character.inventory.unequip_item.assert_called_once_with(
+            EquipmentSlot.WEAPON
+        )
+
+
+class TestProficiencyMarkers:
+    """Test proficiency marker functionality."""
+
+    def test_proficiency_marker_proficient_weapon(
+        self, mock_character, mock_data_loader, mock_items_data
+    ):
+        """Test proficiency marker shows checkmark for proficient weapon."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+
+        weapon_data = mock_items_data["weapons"]["longsword"]
+        result = ui._get_proficiency_marker(mock_character, weapon_data, "weapon")
+
+        assert "✓" in result
+        assert "not proficient" not in result
+
+    def test_proficiency_marker_not_proficient_weapon(
+        self, mock_rogue, mock_data_loader, mock_items_data
+    ):
+        """Test proficiency marker shows warning for non-proficient weapon."""
+        ui = InventoryUI(party=[mock_rogue], data_loader=mock_data_loader)
+
+        weapon_data = mock_items_data["weapons"]["longsword"]
+        result = ui._get_proficiency_marker(mock_rogue, weapon_data, "weapon")
+
+        assert "not proficient" in result
+
+    def test_proficiency_marker_proficient_armor(
+        self, mock_character, mock_data_loader, mock_items_data
+    ):
+        """Test proficiency marker shows checkmark for proficient armor."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+
+        armor_data = mock_items_data["armor"]["chain_mail"]
+        result = ui._get_proficiency_marker(mock_character, armor_data, "armor")
+
+        assert "✓" in result
+
+    def test_proficiency_marker_not_proficient_armor(
+        self, mock_rogue, mock_data_loader, mock_items_data
+    ):
+        """Test proficiency marker shows warning for non-proficient armor."""
+        ui = InventoryUI(party=[mock_rogue], data_loader=mock_data_loader)
+
+        armor_data = mock_items_data["armor"]["chain_mail"]
+        result = ui._get_proficiency_marker(mock_rogue, armor_data, "armor")
+
+        assert "not proficient" in result
+
+
+class TestItemDataLookup:
+    """Test item data lookup functionality."""
+
+    def test_get_item_data_found(self, mock_character, mock_data_loader, mock_items_data):
+        """Test that item data is returned when found."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+
+        result = ui._get_item_data("longsword", "weapons")
+
+        assert result is not None
+        assert result["name"] == "Longsword"
+
+    def test_get_item_data_not_found(self, mock_character, mock_data_loader):
+        """Test that None is returned when item not found."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+
+        result = ui._get_item_data("nonexistent_item", "weapons")
+
+        assert result is None
+
+    def test_get_item_data_wrong_category(
+        self, mock_character, mock_data_loader, mock_items_data
+    ):
+        """Test that None is returned when looking in wrong category."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+
+        result = ui._get_item_data("longsword", "armor")
+
+        assert result is None
+
+
+class TestWeaponArmorInfo:
+    """Test weapon and armor info display helpers."""
+
+    def test_get_weapon_info_with_damage(
+        self, mock_character, mock_data_loader, mock_items_data
+    ):
+        """Test weapon info includes damage."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+
+        weapon_data = mock_items_data["weapons"]["longsword"]
+        result = ui._get_weapon_info(weapon_data)
+
+        assert "1d8" in result
+        assert "slashing" in result
+
+    def test_get_weapon_info_none_data(self, mock_character, mock_data_loader):
+        """Test weapon info returns empty for None."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+
+        result = ui._get_weapon_info(None)
+
+        assert result == ""
+
+    def test_get_armor_info_with_ac(
+        self, mock_character, mock_data_loader, mock_items_data
+    ):
+        """Test armor info includes AC."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+
+        armor_data = mock_items_data["armor"]["chain_mail"]
+        result = ui._get_armor_info(armor_data)
+
+        assert "AC 16" in result
+
+    def test_get_armor_info_none_data(self, mock_character, mock_data_loader):
+        """Test armor info returns empty for None."""
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+
+        result = ui._get_armor_info(None)
+
+        assert result == ""
+
+
+class TestRunMethod:
+    """Test the main run method."""
+
+    @patch('dnd_engine.ui.inventory_ui.print_status_message')
+    def test_run_with_empty_party(self, mock_print, mock_data_loader):
+        """Test run exits early with empty party."""
+        ui = InventoryUI(party=[], data_loader=mock_data_loader)
+
+        ui.run()
+
+        mock_print.assert_called_with("No party members available.", "warning")
+
+    @patch('dnd_engine.ui.inventory_ui.print_status_message')
+    def test_run_with_all_dead_party(self, mock_print, mock_character, mock_data_loader):
+        """Test run exits early with all dead party members."""
+        mock_character.is_alive = False
+        ui = InventoryUI(party=[mock_character], data_loader=mock_data_loader)
+
+        ui.run()
+
+        mock_print.assert_called_with("No living party members.", "warning")

--- a/tests/test_save_slot_ui.py
+++ b/tests/test_save_slot_ui.py
@@ -1,0 +1,332 @@
+# ABOUTME: Unit tests for save slot UI functionality in MainMenuV2
+# ABOUTME: Tests questionary-based slot selection and display formatting
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from dnd_engine.core.save_slot import SaveSlot
+from dnd_engine.ui.main_menu_v2 import MainMenuV2
+
+
+@pytest.fixture
+def empty_slot():
+    """Create an empty save slot."""
+    slot = Mock(spec=SaveSlot)
+    slot.slot_number = 1
+    slot.is_empty.return_value = True
+    slot.adventure_name = None
+    slot.party_composition = []
+    slot.party_levels = []
+    slot._format_playtime.return_value = "0m"
+    return slot
+
+
+@pytest.fixture
+def used_slot():
+    """Create a save slot with game data."""
+    slot = Mock(spec=SaveSlot)
+    slot.slot_number = 2
+    slot.is_empty.return_value = False
+    slot.adventure_name = "Tomb of Horrors"
+    slot.party_composition = ["Aria", "Zephyr"]
+    slot.party_levels = [3, 3]
+    slot._format_playtime.return_value = "2h 30m"
+    slot.get_display_name.return_value = "Tomb of Horrors - Aria, Zephyr"
+    return slot
+
+
+@pytest.fixture
+def mock_slot_manager(empty_slot, used_slot):
+    """Create mock slot manager with test slots."""
+    manager = Mock()
+    slots = [empty_slot, used_slot]
+    # Add more empty slots to fill to 10
+    for i in range(3, 11):
+        slot = Mock(spec=SaveSlot)
+        slot.slot_number = i
+        slot.is_empty.return_value = True
+        slot.adventure_name = None
+        slot.party_composition = []
+        slot.party_levels = []
+        slot._format_playtime.return_value = "0m"
+        slots.append(slot)
+    manager.list_slots.return_value = slots
+    manager.get_slot.side_effect = lambda n: slots[n - 1]
+    return manager
+
+
+class TestBuildSlotChoiceDisplay:
+    """Test slot choice display string building."""
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    def test_empty_slot_display(self, empty_slot):
+        """Test display string for empty slot."""
+        menu = MainMenuV2()
+        result = menu._build_slot_choice_display(empty_slot)
+
+        assert "Slot 1" in result
+        assert "[Empty]" in result
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    def test_used_slot_display(self, used_slot):
+        """Test display string for slot with saved game."""
+        menu = MainMenuV2()
+        result = menu._build_slot_choice_display(used_slot)
+
+        assert "Slot 2" in result
+        assert "Tomb of Horrors" in result
+        assert "Aria, Zephyr" in result
+        assert "Lvl 3" in result
+        assert "2h 30m" in result
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    def test_used_slot_without_adventure_name(self, used_slot):
+        """Test display string when adventure name is missing."""
+        menu = MainMenuV2()
+        used_slot.adventure_name = None
+
+        result = menu._build_slot_choice_display(used_slot)
+
+        assert "Unknown Adventure" in result
+
+
+class TestSelectSaveSlot:
+    """Test questionary-based save slot selection."""
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    @patch('dnd_engine.ui.main_menu_v2.questionary')
+    def test_select_slot_shows_all_slots(self, mock_questionary, mock_slot_manager):
+        """Test that all slots are shown in selection."""
+        menu = MainMenuV2()
+        menu.slot_manager = mock_slot_manager
+
+        mock_questionary.select.return_value.ask.return_value = 2
+        mock_questionary.Choice = Mock(side_effect=lambda **kwargs: kwargs)
+
+        result = menu._select_save_slot("Select a slot:")
+
+        assert result == 2
+        mock_questionary.select.assert_called_once()
+        # Verify 10 slots + back option = 11 choices
+        choice_calls = mock_questionary.Choice.call_args_list
+        assert len(choice_calls) == 11
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    @patch('dnd_engine.ui.main_menu_v2.questionary')
+    def test_select_slot_filters_empty_when_requested(
+        self, mock_questionary, mock_slot_manager, used_slot
+    ):
+        """Test filtering to only non-empty slots."""
+        menu = MainMenuV2()
+        menu.slot_manager = mock_slot_manager
+        # Only return the used slot when filtering
+        mock_slot_manager.list_slots.return_value = [used_slot]
+
+        mock_questionary.select.return_value.ask.return_value = 2
+        mock_questionary.Choice = Mock(side_effect=lambda **kwargs: kwargs)
+
+        result = menu._select_save_slot("Select:", filter_empty=True)
+
+        assert result == 2
+        # Should have 1 slot + back = 2 choices
+        choice_calls = mock_questionary.Choice.call_args_list
+        assert len(choice_calls) == 2
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    @patch('dnd_engine.ui.main_menu_v2.questionary')
+    def test_select_slot_disables_empty_when_not_allowed(
+        self, mock_questionary, mock_slot_manager
+    ):
+        """Test that empty slots are disabled when allow_empty=False."""
+        menu = MainMenuV2()
+        menu.slot_manager = mock_slot_manager
+
+        mock_questionary.select.return_value.ask.return_value = 2
+        mock_questionary.Choice = Mock(side_effect=lambda **kwargs: kwargs)
+
+        menu._select_save_slot("Select:", allow_empty=False)
+
+        # Check that disabled='empty slot' was set for empty slots
+        choice_calls = mock_questionary.Choice.call_args_list
+        disabled_count = sum(
+            1 for call in choice_calls
+            if call.kwargs.get('disabled') == 'empty slot'
+        )
+        # Should have 9 disabled empty slots (slot 2 is used)
+        assert disabled_count == 9
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    @patch('dnd_engine.ui.main_menu_v2.questionary')
+    def test_select_slot_returns_none_on_back(self, mock_questionary, mock_slot_manager):
+        """Test that selecting back returns None."""
+        menu = MainMenuV2()
+        menu.slot_manager = mock_slot_manager
+
+        mock_questionary.select.return_value.ask.return_value = None
+        mock_questionary.Choice = Mock(side_effect=lambda **kwargs: kwargs)
+
+        result = menu._select_save_slot("Select:")
+
+        assert result is None
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    @patch('dnd_engine.ui.main_menu_v2.questionary')
+    def test_select_slot_handles_keyboard_interrupt(
+        self, mock_questionary, mock_slot_manager
+    ):
+        """Test that keyboard interrupt returns None."""
+        menu = MainMenuV2()
+        menu.slot_manager = mock_slot_manager
+
+        mock_questionary.select.return_value.ask.side_effect = KeyboardInterrupt
+        mock_questionary.Choice = Mock(side_effect=lambda **kwargs: kwargs)
+
+        result = menu._select_save_slot("Select:")
+
+        assert result is None
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    @patch('dnd_engine.ui.main_menu_v2.print_status_message')
+    def test_select_slot_shows_warning_when_no_slots(self, mock_print):
+        """Test warning message when no slots match filter."""
+        menu = MainMenuV2()
+        menu.slot_manager = Mock()
+        menu.slot_manager.list_slots.return_value = []
+
+        result = menu._select_save_slot("Select:", filter_empty=True)
+
+        assert result is None
+        mock_print.assert_called_with("No saved games found.", "warning")
+
+
+class TestHandleLoadGame:
+    """Test load game flow with questionary."""
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    @patch.object(MainMenuV2, '_select_save_slot')
+    @patch('dnd_engine.ui.main_menu_v2.print_section')
+    @patch('dnd_engine.ui.main_menu_v2.console')
+    def test_load_game_uses_slot_selector(
+        self, mock_console, mock_print_section, mock_select, used_slot
+    ):
+        """Test that load game uses the slot selector."""
+        menu = MainMenuV2()
+        menu.slot_manager = Mock()
+        menu.slot_manager.get_slot.return_value = used_slot
+        menu.slot_manager.load_game.return_value = (Mock(), None)
+        mock_select.return_value = 2
+
+        menu.handle_load_game()
+
+        mock_select.assert_called_once_with(
+            "Select a saved game to load:",
+            filter_empty=True,
+            allow_empty=False
+        )
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    @patch.object(MainMenuV2, '_select_save_slot')
+    @patch('dnd_engine.ui.main_menu_v2.print_section')
+    @patch('dnd_engine.ui.main_menu_v2.console')
+    def test_load_game_returns_none_on_cancel(
+        self, mock_console, mock_print_section, mock_select
+    ):
+        """Test that canceling slot selection returns None."""
+        menu = MainMenuV2()
+        mock_select.return_value = None
+
+        result = menu.handle_load_game()
+
+        assert result is None
+
+
+class TestHandleManageSlots:
+    """Test manage slots flow with questionary."""
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    @patch('dnd_engine.ui.main_menu_v2.questionary')
+    @patch('dnd_engine.ui.main_menu_v2.print_section')
+    @patch('dnd_engine.ui.main_menu_v2.console')
+    def test_manage_slots_shows_action_menu(
+        self, mock_console, mock_print_section, mock_questionary
+    ):
+        """Test that manage slots shows action selection."""
+        menu = MainMenuV2()
+
+        # Return None (back) immediately
+        mock_questionary.select.return_value.ask.return_value = None
+        mock_questionary.Choice = Mock(side_effect=lambda **kwargs: kwargs)
+
+        menu.handle_manage_slots()
+
+        mock_questionary.select.assert_called()
+        # Verify action choices were presented
+        call_args = mock_questionary.select.call_args
+        assert "What would you like to do?" in str(call_args)
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    @patch.object(MainMenuV2, '_select_save_slot')
+    @patch('dnd_engine.ui.main_menu_v2.questionary')
+    @patch('dnd_engine.ui.main_menu_v2.print_section')
+    @patch('dnd_engine.ui.main_menu_v2.print_status_message')
+    @patch('dnd_engine.ui.main_menu_v2.console')
+    def test_manage_slots_rename_uses_slot_selector(
+        self,
+        mock_console,
+        mock_print,
+        mock_print_section,
+        mock_questionary,
+        mock_select,
+        used_slot
+    ):
+        """Test that rename action uses slot selector."""
+        menu = MainMenuV2()
+        menu.slot_manager = Mock()
+
+        # First call: rename action, Second call: back
+        mock_questionary.select.return_value.ask.side_effect = ["rename", None]
+        mock_questionary.Choice = Mock(side_effect=lambda **kwargs: kwargs)
+        mock_select.return_value = 2
+        mock_console.input.return_value = "New Name"
+
+        menu.handle_manage_slots()
+
+        mock_select.assert_called_once_with(
+            "Select slot to rename:",
+            filter_empty=False,
+            allow_empty=False
+        )
+        menu.slot_manager.rename_slot.assert_called_once_with(2, "New Name")
+
+    @patch.object(MainMenuV2, '__init__', lambda x: None)
+    @patch.object(MainMenuV2, '_select_save_slot')
+    @patch('dnd_engine.ui.main_menu_v2.questionary')
+    @patch('dnd_engine.ui.main_menu_v2.print_section')
+    @patch('dnd_engine.ui.main_menu_v2.print_status_message')
+    @patch('dnd_engine.ui.main_menu_v2.console')
+    def test_manage_slots_clear_with_confirmation(
+        self,
+        mock_console,
+        mock_print,
+        mock_print_section,
+        mock_questionary,
+        mock_select,
+        used_slot
+    ):
+        """Test that clear action asks for confirmation."""
+        menu = MainMenuV2()
+        menu.slot_manager = Mock()
+        menu.slot_manager.get_slot.return_value = used_slot
+
+        # First select: clear, confirm: yes, Second select: back
+        mock_questionary.select.return_value.ask.side_effect = ["clear", None]
+        mock_questionary.confirm.return_value.ask.return_value = True
+        mock_questionary.Choice = Mock(side_effect=lambda **kwargs: kwargs)
+        mock_select.return_value = 2
+        mock_console.input.return_value = ""
+
+        menu.handle_manage_slots()
+
+        mock_questionary.confirm.assert_called_once()
+        menu.slot_manager.clear_slot.assert_called_once_with(2)


### PR DESCRIPTION
## Summary
- Refactored save slot selection to use questionary arrow-key menus instead of text input
- Created new `InventoryUI` class for interactive inventory management with character selection and equipment management
- Added proficiency markers (✓/✗) for weapons and armor throughout inventory display
- Integrated inventory UI with CLI `inventory` command

## Changes
- **Save Slot System**: Added `_build_slot_choice_display()` and `_select_save_slot()` methods to `MainMenuV2` for consistent questionary-based slot selection
- **Inventory UI**: New `dnd_engine/ui/inventory_ui.py` with full equipment management workflow
- **CLI Integration**: `inventory` command now launches interactive UI; `inventory <filter>` still works for quick views
- **Tests**: Added 37 new tests covering save slot UI (14) and inventory UI (23)

## Test plan
- [ ] Run `uv run pytest tests/test_save_slot_ui.py tests/test_inventory_ui.py -v`
- [ ] Manual test: Start game, type `inventory`, navigate through character selection and equipment management
- [ ] Manual test: Main menu → Load Game → verify arrow-key slot selection works
- [ ] Manual test: Main menu → Manage Saves → verify rename/clear flows work

🤖 Generated with [Claude Code](https://claude.com/claude-code)