### PR TITLE
fix: Preserve character proficiencies and cleanup UI

### DIFF
--- a/dnd_engine/core/save_slot_manager.py
+++ b/dnd_engine/core/save_slot_manager.py
@@ -423,10 +423,16 @@ class SaveSlotManager:
             "inventory": self._serialize_inventory(character.inventory),
             "conditions": list(character.conditions),
             "resource_pools": self._serialize_resource_pools(character),
+            "saving_throw_proficiencies": character.saving_throw_proficiencies,
+            "skill_proficiencies": character.skill_proficiencies,
+            "expertise_skills": character.expertise_skills,
+            "weapon_proficiencies": character.weapon_proficiencies,
+            "armor_proficiencies": character.armor_proficiencies,
             "spellcasting_ability": character.spellcasting_ability,
             "known_spells": character.known_spells,
             "prepared_spells": character.prepared_spells,
-            "vault_id": character.vault_id
+            "vault_id": character.vault_id,
+            "darkvision_range": character.darkvision_range
         }
 
     def _serialize_inventory(self, inventory: Inventory) -> dict[str, Any]:
@@ -537,11 +543,19 @@ class SaveSlotManager:
             inventory=inventory,
             race=char_data["race"],
             subclass=char_data.get("subclass"),
+            saving_throw_proficiencies=char_data.get("saving_throw_proficiencies", []),
+            skill_proficiencies=char_data.get("skill_proficiencies", []),
+            expertise_skills=char_data.get("expertise_skills", []),
+            weapon_proficiencies=char_data.get("weapon_proficiencies", []),
+            armor_proficiencies=char_data.get("armor_proficiencies", []),
             spellcasting_ability=char_data.get("spellcasting_ability"),
             known_spells=char_data.get("known_spells"),
             prepared_spells=char_data.get("prepared_spells"),
             vault_id=char_data.get("vault_id")
         )
+
+        # Restore darkvision range
+        character.darkvision_range = char_data.get("darkvision_range", 0)
 
         # Restore conditions
         for condition in char_data.get("conditions", []):

--- a/dnd_engine/ui/inventory_ui.py
+++ b/dnd_engine/ui/inventory_ui.py
@@ -88,7 +88,7 @@ class InventoryUI:
             )
             choices.append(questionary.Choice(title=display, value=char))
 
-        choices.append(questionary.Choice(title="← Back", value=None))
+        choices.append(questionary.Choice(title="← Back", value="__BACK__"))
 
         try:
             result = questionary.select(
@@ -96,6 +96,8 @@ class InventoryUI:
                 choices=choices,
                 use_arrow_keys=True
             ).ask()
+            if result == "__BACK__" or result is None:
+                return None
             return result
         except (EOFError, KeyboardInterrupt):
             return None
@@ -297,9 +299,9 @@ class InventoryUI:
             item_data = self._get_item_data(inv_item.item_id, category)
             name = item_data.get("name", inv_item.item_id) if item_data else inv_item.item_id
 
-            # Build display with proficiency status
-            prof_marker = self._get_proficiency_marker(char, item_data, slot_name)
-            equipped_marker = " [green][equipped][/green]" if inv_item.item_id == currently_equipped else ""
+            # Build display with proficiency status (plain text for questionary)
+            prof_marker = self._get_proficiency_marker_plain(char, item_data, slot_name)
+            equipped_marker = " [equipped]" if inv_item.item_id == currently_equipped else ""
 
             display = f"{name}{equipped_marker}{prof_marker}"
             choices.append(questionary.Choice(title=display, value=inv_item.item_id))
@@ -390,7 +392,7 @@ class InventoryUI:
         item_type: str
     ) -> str:
         """
-        Get proficiency marker for an item.
+        Get proficiency marker for an item (Rich markup version for panels).
 
         Args:
             char: Character to check proficiency for
@@ -398,7 +400,7 @@ class InventoryUI:
             item_type: "weapon" or "armor"
 
         Returns:
-            Formatted proficiency marker string
+            Formatted proficiency marker string with Rich markup
         """
         if not item_data:
             return ""
@@ -419,5 +421,44 @@ class InventoryUI:
             if armor_type in char.armor_proficiencies:
                 return " [green]✓[/green]"
             return " [red]✗ not proficient[/red]"
+
+        return ""
+
+    def _get_proficiency_marker_plain(
+        self,
+        char: Character,
+        item_data: dict[str, Any] | None,
+        item_type: str
+    ) -> str:
+        """
+        Get proficiency marker for an item (plain text version for questionary).
+
+        Args:
+            char: Character to check proficiency for
+            item_data: Item data dictionary
+            item_type: "weapon" or "armor"
+
+        Returns:
+            Plain text proficiency marker string (no Rich markup)
+        """
+        if not item_data:
+            return ""
+
+        if item_type == "weapon":
+            weapon_type = item_data.get("weapon_type", "")
+            # Check weapon type proficiency
+            if weapon_type in char.weapon_proficiencies:
+                return " ✓"
+            # Check specific weapon proficiency
+            item_id = item_data.get("name", "").lower().replace(" ", "_")
+            if item_id in char.weapon_proficiencies:
+                return " ✓"
+            return " ✗ not proficient"
+
+        elif item_type == "armor":
+            armor_type = item_data.get("armor_type", "")
+            if armor_type in char.armor_proficiencies:
+                return " ✓"
+            return " ✗ not proficient"
 
         return ""

--- a/tests/test_save_slot_manager.py
+++ b/tests/test_save_slot_manager.py
@@ -494,3 +494,196 @@ class TestVaultSync:
         vault_char = vault.get_character(char_id)
         assert vault_char.inventory.has_item("longsword")
         assert vault_char.inventory.gold == 500
+
+
+class TestProficiencySerialization:
+    """Test that character proficiencies are correctly saved and loaded."""
+
+    @pytest.fixture
+    def character_with_proficiencies(self):
+        """Create a character with full proficiency data."""
+        abilities = Abilities(
+            strength=17,
+            dexterity=16,
+            constitution=15,
+            intelligence=13,
+            wisdom=14,
+            charisma=12
+        )
+
+        char = Character(
+            name="Larry the Fighter",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=abilities,
+            max_hp=12,
+            ac=16,
+            current_hp=12,
+            xp=0,
+            race="Human",
+            weapon_proficiencies=["simple", "martial"],
+            armor_proficiencies=["light", "medium", "heavy", "shields"],
+            skill_proficiencies=["athletics", "perception"],
+            expertise_skills=[],
+            saving_throw_proficiencies=["strength", "constitution"]
+        )
+        char.darkvision_range = 60
+        return char
+
+    def test_serialize_character_includes_proficiencies(
+        self, save_manager, character_with_proficiencies
+    ):
+        """Test that _serialize_character includes all proficiency fields."""
+        serialized = save_manager._serialize_character(character_with_proficiencies)
+
+        assert serialized["weapon_proficiencies"] == ["simple", "martial"]
+        assert serialized["armor_proficiencies"] == ["light", "medium", "heavy", "shields"]
+        assert serialized["skill_proficiencies"] == ["athletics", "perception"]
+        assert serialized["expertise_skills"] == []
+        assert serialized["saving_throw_proficiencies"] == ["strength", "constitution"]
+        assert serialized["darkvision_range"] == 60
+
+    def test_deserialize_character_restores_proficiencies(
+        self, save_manager, character_with_proficiencies
+    ):
+        """Test that _deserialize_character restores all proficiency fields."""
+        serialized = save_manager._serialize_character(character_with_proficiencies)
+        deserialized = save_manager._deserialize_character(serialized)
+
+        assert deserialized.weapon_proficiencies == ["simple", "martial"]
+        assert deserialized.armor_proficiencies == ["light", "medium", "heavy", "shields"]
+        assert deserialized.skill_proficiencies == ["athletics", "perception"]
+        assert deserialized.expertise_skills == []
+        assert deserialized.saving_throw_proficiencies == ["strength", "constitution"]
+        assert deserialized.darkvision_range == 60
+
+    def test_save_and_load_preserves_proficiencies(
+        self, save_manager, character_with_proficiencies
+    ):
+        """Test full save/load cycle preserves proficiencies."""
+        party = Party([character_with_proficiencies])
+        data_loader = DataLoader()
+        game_state = GameState(
+            party=party,
+            dungeon_name="test_dungeon",
+            data_loader=data_loader
+        )
+
+        # Save
+        save_manager.save_game(slot_number=1, game_state=game_state)
+
+        # Load
+        loaded_state, _ = save_manager.load_game(slot_number=1)
+        loaded_char = loaded_state.party.characters[0]
+
+        # Verify all proficiencies preserved
+        assert loaded_char.weapon_proficiencies == ["simple", "martial"]
+        assert loaded_char.armor_proficiencies == ["light", "medium", "heavy", "shields"]
+        assert loaded_char.skill_proficiencies == ["athletics", "perception"]
+        assert loaded_char.expertise_skills == []
+        assert loaded_char.saving_throw_proficiencies == ["strength", "constitution"]
+        assert loaded_char.darkvision_range == 60
+
+    def test_deserialize_handles_missing_proficiencies_gracefully(self, save_manager):
+        """Test that loading old saves without proficiencies uses defaults."""
+        # Simulate an old save format without proficiency fields
+        old_format_char = {
+            "name": "Old Character",
+            "character_class": "fighter",
+            "level": 1,
+            "race": "Human",
+            "subclass": None,
+            "xp": 0,
+            "max_hp": 10,
+            "current_hp": 10,
+            "ac": 16,
+            "abilities": {
+                "strength": 15,
+                "dexterity": 14,
+                "constitution": 13,
+                "intelligence": 12,
+                "wisdom": 10,
+                "charisma": 8
+            },
+            "inventory": {
+                "items": [],
+                "equipped": {"weapon": None, "armor": None},
+                "currency": {"gold": 0, "silver": 0, "copper": 0, "electrum": 0, "platinum": 0}
+            },
+            "conditions": [],
+            "resource_pools": [],
+            "spellcasting_ability": None,
+            "known_spells": [],
+            "prepared_spells": [],
+            "vault_id": None
+            # Note: No proficiency fields - simulating old save format
+        }
+
+        deserialized = save_manager._deserialize_character(old_format_char)
+
+        # Should have empty defaults, not crash
+        assert deserialized.weapon_proficiencies == []
+        assert deserialized.armor_proficiencies == []
+        assert deserialized.skill_proficiencies == []
+        assert deserialized.expertise_skills == []
+        assert deserialized.saving_throw_proficiencies == []
+        assert deserialized.darkvision_range == 0
+
+    def test_rogue_expertise_skills_preserved(self, save_manager):
+        """Test that Rogue expertise skills are correctly saved and loaded."""
+        abilities = Abilities(10, 18, 12, 14, 10, 12)
+        rogue = Character(
+            name="Sneaky Pete",
+            character_class=CharacterClass.ROGUE,
+            level=1,
+            abilities=abilities,
+            max_hp=10,
+            ac=14,
+            race="Halfling",
+            weapon_proficiencies=["simple"],
+            armor_proficiencies=["light"],
+            skill_proficiencies=["stealth", "sleight_of_hand", "acrobatics", "perception"],
+            expertise_skills=["stealth", "sleight_of_hand"],
+            saving_throw_proficiencies=["dexterity", "intelligence"]
+        )
+
+        party = Party([rogue])
+        data_loader = DataLoader()
+        game_state = GameState(
+            party=party,
+            dungeon_name="test_dungeon",
+            data_loader=data_loader
+        )
+
+        save_manager.save_game(slot_number=2, game_state=game_state)
+        loaded_state, _ = save_manager.load_game(slot_number=2)
+        loaded_rogue = loaded_state.party.characters[0]
+
+        assert loaded_rogue.expertise_skills == ["stealth", "sleight_of_hand"]
+        assert loaded_rogue.skill_proficiencies == ["stealth", "sleight_of_hand", "acrobatics", "perception"]
+
+    def test_slot_file_contains_proficiencies(
+        self, save_manager, character_with_proficiencies, temp_saves_dir
+    ):
+        """Test that the JSON save file contains proficiency data."""
+        party = Party([character_with_proficiencies])
+        data_loader = DataLoader()
+        game_state = GameState(
+            party=party,
+            dungeon_name="test_dungeon",
+            data_loader=data_loader
+        )
+
+        save_manager.save_game(slot_number=3, game_state=game_state)
+
+        # Read the raw JSON file
+        slot_path = temp_saves_dir / "slot_03.json"
+        with open(slot_path) as f:
+            data = json.load(f)
+
+        char_data = data["party"][0]
+        assert char_data["weapon_proficiencies"] == ["simple", "martial"]
+        assert char_data["armor_proficiencies"] == ["light", "medium", "heavy", "shields"]
+        assert char_data["skill_proficiencies"] == ["athletics", "perception"]
+        assert char_data["saving_throw_proficiencies"] == ["strength", "constitution"]
+        assert char_data["darkvision_range"] == 60


### PR DESCRIPTION
## Summary
- Fix character proficiencies (weapon, armor, skill, expertise, saving throws) not being saved to save files
- Fix darkvision_range not persisting across saves
- Fix Rich markup tags showing raw in questionary menus
- Fix inventory UI crash when selecting "← Back" from character selection

## Test plan
- [x] Run proficiency serialization tests (`pytest tests/test_save_slot_manager.py::TestProficiencySerialization`)
- [x] All existing save_slot_manager tests pass
- [ ] Manual test: Load game, check inventory shows proficiency checkmarks
- [ ] Manual test: Exit inventory UI via "← Back" without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)