### PR TITLE
feat: Add Phase 1 wizard spells (L1-L4)

### DIFF
--- a/dnd_engine/data/srd/spells.json
+++ b/dnd_engine/data/srd/spells.json
@@ -727,5 +727,248 @@
       "utility",
       "healing"
     ]
+  },
+  "thunderwave": {
+    "id": "thunderwave",
+    "name": "Thunderwave",
+    "level": 1,
+    "school": "evocation",
+    "casting_time": "1 action",
+    "range_ft": 0,
+    "target_type": "area",
+    "components": {
+      "verbal": true,
+      "somatic": true,
+      "material": false
+    },
+    "duration": "Instantaneous",
+    "concentration": false,
+    "ritual": false,
+    "description": "A wave of thunderous force sweeps out from you. Each creature in a 15-foot cube originating from you must make a Constitution saving throw. On a failed save, a creature takes 2d8 thunder damage and is pushed 10 feet away from you. On a successful save, the creature takes half as much damage and isn't pushed. The spell emits a thunderous boom audible out to 300 feet.",
+    "damage": {
+      "dice": "2d8",
+      "damage_type": "thunder",
+      "higher_levels": "When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st."
+    },
+    "saving_throw": {
+      "ability": "constitution",
+      "on_success": "half"
+    },
+    "area_of_effect": "15-foot cube",
+    "higher_levels": "When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.",
+    "classes": [
+      "wizard",
+      "sorcerer",
+      "bard",
+      "druid"
+    ],
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": [
+      "combat",
+      "damage",
+      "aoe"
+    ]
+  },
+  "shatter": {
+    "id": "shatter",
+    "name": "Shatter",
+    "level": 2,
+    "school": "evocation",
+    "casting_time": "1 action",
+    "range_ft": 60,
+    "target_type": "area",
+    "components": {
+      "verbal": true,
+      "somatic": true,
+      "material": true,
+      "material_description": "a chip of mica"
+    },
+    "duration": "Instantaneous",
+    "concentration": false,
+    "ritual": false,
+    "description": "A sudden loud ringing noise, painfully intense, erupts from a point of your choice within range. Each creature in a 10-foot-radius sphere centered on that point must make a Constitution saving throw. A creature takes 3d8 thunder damage on a failed save, or half as much damage on a successful one. A creature made of inorganic material such as stone, crystal, or metal has disadvantage on this saving throw.",
+    "damage": {
+      "dice": "3d8",
+      "damage_type": "thunder",
+      "higher_levels": "When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd."
+    },
+    "saving_throw": {
+      "ability": "constitution",
+      "on_success": "half"
+    },
+    "area_of_effect": "10-foot radius sphere",
+    "higher_levels": "When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.",
+    "classes": [
+      "wizard",
+      "sorcerer",
+      "bard"
+    ],
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": [
+      "combat",
+      "damage",
+      "aoe"
+    ]
+  },
+  "fear": {
+    "id": "fear",
+    "name": "Fear",
+    "level": 3,
+    "school": "illusion",
+    "casting_time": "1 action",
+    "range_ft": 0,
+    "target_type": "area",
+    "components": {
+      "verbal": true,
+      "somatic": true,
+      "material": true,
+      "material_description": "a white feather or the heart of a hen"
+    },
+    "duration": "Concentration",
+    "duration_value": "1 minute",
+    "concentration": true,
+    "ritual": false,
+    "description": "You project a phantasmal image of a creature's worst fears. Each creature in a 30-foot cone must succeed on a Wisdom saving throw or drop whatever it is holding and become frightened for the duration. While frightened by this spell, a creature must take the Dash action and move away from you by the safest available route on each of its turns, unless there is nowhere to move.",
+    "saving_throw": {
+      "ability": "wisdom",
+      "on_success": "negates"
+    },
+    "effect": {
+      "condition": "frightened",
+      "duration_rounds": 10,
+      "allow_repeat_save": true,
+      "repeat_timing": "end_of_turn"
+    },
+    "area_of_effect": "30-foot cone",
+    "classes": [
+      "wizard",
+      "sorcerer",
+      "bard"
+    ],
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": [
+      "combat",
+      "control",
+      "aoe"
+    ]
+  },
+  "stinking_cloud": {
+    "id": "stinking_cloud",
+    "name": "Stinking Cloud",
+    "level": 3,
+    "school": "conjuration",
+    "casting_time": "1 action",
+    "range_ft": 90,
+    "target_type": "area",
+    "components": {
+      "verbal": true,
+      "somatic": true,
+      "material": true,
+      "material_description": "a rotten egg or several skunk cabbage leaves"
+    },
+    "duration": "Concentration",
+    "duration_value": "1 minute",
+    "concentration": true,
+    "ritual": false,
+    "description": "You create a 20-foot-radius sphere of yellow, nauseating gas centered on a point within range. The cloud spreads around corners, and its area is heavily obscured. Each creature that is completely within the cloud at the start of its turn must make a Constitution saving throw against poison. On a failed save, the creature spends its action that turn retching and reeling. Creatures that don't need to breathe or are immune to poison automatically succeed on this saving throw.",
+    "saving_throw": {
+      "ability": "constitution",
+      "on_success": "negates"
+    },
+    "effect": {
+      "condition": "incapacitated",
+      "duration_rounds": 1
+    },
+    "area_of_effect": "20-foot radius sphere",
+    "classes": [
+      "wizard",
+      "sorcerer",
+      "bard"
+    ],
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": [
+      "combat",
+      "control",
+      "aoe"
+    ]
+  },
+  "ice_storm": {
+    "id": "ice_storm",
+    "name": "Ice Storm",
+    "level": 4,
+    "school": "evocation",
+    "casting_time": "1 action",
+    "range_ft": 300,
+    "target_type": "area",
+    "components": {
+      "verbal": true,
+      "somatic": true,
+      "material": true,
+      "material_description": "a pinch of dust and a few drops of water"
+    },
+    "duration": "Instantaneous",
+    "concentration": false,
+    "ritual": false,
+    "description": "A hail of rock-hard ice pounds to the ground in a 20-foot-radius, 40-foot-high cylinder centered on a point within range. Each creature in the cylinder must make a Dexterity saving throw. A creature takes 2d8 bludgeoning damage and 4d6 cold damage on a failed save, or half as much damage on a successful one. The storm's area becomes difficult terrain until the end of your next turn.",
+    "damage": {
+      "dice": "2d8+4d6",
+      "damage_type": "bludgeoning and cold",
+      "higher_levels": "When you cast this spell using a spell slot of 5th level or higher, the bludgeoning damage increases by 1d8 for each slot level above 4th."
+    },
+    "saving_throw": {
+      "ability": "dexterity",
+      "on_success": "half"
+    },
+    "area_of_effect": "20-foot radius cylinder",
+    "higher_levels": "When you cast this spell using a spell slot of 5th level or higher, the bludgeoning damage increases by 1d8 for each slot level above 4th.",
+    "classes": [
+      "wizard",
+      "sorcerer",
+      "druid"
+    ],
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": [
+      "combat",
+      "damage",
+      "aoe"
+    ]
+  },
+  "blight": {
+    "id": "blight",
+    "name": "Blight",
+    "level": 4,
+    "school": "necromancy",
+    "casting_time": "1 action",
+    "range_ft": 30,
+    "target_type": "enemy",
+    "components": {
+      "verbal": true,
+      "somatic": true,
+      "material": false
+    },
+    "duration": "Instantaneous",
+    "concentration": false,
+    "ritual": false,
+    "description": "Necromantic energy washes over a creature of your choice that you can see within range, draining moisture and vitality from it. The target must make a Constitution saving throw. The target takes 8d8 necrotic damage on a failed save, or half as much damage on a successful one. This spell has no effect on undead or constructs.",
+    "damage": {
+      "dice": "8d8",
+      "damage_type": "necrotic",
+      "higher_levels": "When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1d8 for each slot level above 4th."
+    },
+    "saving_throw": {
+      "ability": "constitution",
+      "on_success": "half"
+    },
+    "higher_levels": "When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1d8 for each slot level above 4th.",
+    "classes": [
+      "wizard",
+      "sorcerer",
+      "druid"
+    ],
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": [
+      "combat",
+      "damage"
+    ]
   }
 }

--- a/tests/test_area_effect_spells.py
+++ b/tests/test_area_effect_spells.py
@@ -214,3 +214,91 @@ def test_area_effect_detection():
 
     assert "area_of_effect" in burning_hands
     assert "area_of_effect" not in shield
+
+
+@pytest.fixture
+def thunderwave_spell():
+    """Thunderwave spell data - CON save, thunder damage."""
+    return {
+        "id": "thunderwave",
+        "name": "Thunderwave",
+        "level": 1,
+        "school": "evocation",
+        "casting_time": "1 action",
+        "range_ft": 0,
+        "damage": {
+            "dice": "2d8",
+            "damage_type": "thunder"
+        },
+        "saving_throw": {
+            "ability": "constitution",
+            "on_success": "half"
+        },
+        "area_of_effect": "15-foot cube",
+        "classes": ["wizard", "sorcerer", "bard", "druid"]
+    }
+
+
+def test_thunderwave_hits_multiple_enemies(wizard, thunderwave_spell, skeletons):
+    """Test that Thunderwave damages all enemies in area with CON save."""
+    combat = CombatEngine()
+    event_bus = EventBus()
+
+    # Cast Thunderwave on both skeletons
+    result = combat.resolve_spell_save(
+        caster=wizard,
+        targets=skeletons,
+        spell=thunderwave_spell,
+        apply_damage=True,
+        event_bus=event_bus
+    )
+
+    # Verify spell details in result
+    assert result["spell_name"] == "Thunderwave"
+    assert result["caster"] == "Tim"
+    assert result["save_dc"] == 13  # 8 + 2 (prof) + 3 (INT)
+    assert result["save_ability"] == "constitution"
+
+    # Verify both targets got hit
+    assert len(result["targets"]) == 2
+
+    # Each target should have results with thunder damage
+    for target_result in result["targets"]:
+        assert target_result["name"] == "Skeleton"
+        assert target_result["damage"] > 0
+        assert target_result["damage_type"] == "thunder"
+
+    # Verify damage was applied to both skeletons
+    for skeleton in skeletons:
+        assert skeleton.current_hp < skeleton.max_hp
+
+
+def test_thunderwave_uses_constitution_save(wizard, thunderwave_spell):
+    """Test that Thunderwave uses CON saves (different from Burning Hands DEX)."""
+    combat = CombatEngine()
+
+    # Create enemy with high CON but low DEX
+    tough_enemy = Creature(
+        name="Ogre",
+        max_hp=59,
+        ac=11,
+        abilities=Abilities(
+            strength=19,
+            dexterity=8,   # -1 DEX modifier
+            constitution=16,  # +3 CON modifier
+            intelligence=5,
+            wisdom=7,
+            charisma=7
+        )
+    )
+
+    result = combat.resolve_spell_save(
+        caster=wizard,
+        targets=[tough_enemy],
+        spell=thunderwave_spell,
+        apply_damage=False
+    )
+
+    # Verify the save used CON modifier (+3)
+    target_result = result["targets"][0]
+    assert target_result["modifier"] == 3  # CON modifier


### PR DESCRIPTION
## Summary
- Add 6 new wizard spells using existing game mechanics (Phase 1 of #253)
- Adds Thunderwave (L1), Shatter (L2), Fear (L3), Stinking Cloud (L3), Ice Storm (L4), Blight (L4)
- Includes tests for Thunderwave spell mechanics
- First Level 4 spells added to the game!

## Spells Added

| Spell | Level | Type | Save | Damage/Effect |
|-------|-------|------|------|---------------|
| Thunderwave | 1 | AoE (15ft cube) | CON | 2d8 thunder |
| Shatter | 2 | AoE (10ft sphere) | CON | 3d8 thunder |
| Fear | 3 | AoE (30ft cone) | WIS | Frightened condition |
| Stinking Cloud | 3 | AoE (20ft sphere) | CON | Incapacitated condition |
| Ice Storm | 4 | AoE (20ft cylinder) | DEX | 2d8+4d6 bludgeoning/cold |
| Blight | 4 | Single target | CON | 8d8 necrotic |

## Skipped (needs new mechanics)
- Chromatic Orb - requires damage type choice UI
- Acid Arrow - requires damage-over-time mechanic

## Test plan
- [x] All 38 spell tests pass
- [x] New spells load correctly from JSON
- [ ] Manual testing of spells in combat

Closes #253 partially (Phase 1 complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)