### PR TITLE
Fix #252: Handle all item categories in _get_item_category()

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -2462,9 +2462,23 @@ class GameState:
             Category name or None if not found
         """
         items_data = self.data_loader.load_items()
-        for category in ["weapons", "armor", "consumables", "magical_items"]:
+
+        # Direct category matches
+        for category in [
+            "weapons",
+            "armor",
+            "consumables",
+            "magical_items",
+            "tools",
+            "equipment",
+        ]:
             if item_id in items_data.get(category, {}):
                 return category
+
+        # Ammunition is stored in inventory as consumables (arrows/bolts are consumed)
+        if item_id in items_data.get("ammunition", {}):
+            return "consumables"
+
         return None
 
     def get_room_description(self) -> str:

--- a/tests/test_item_category.py
+++ b/tests/test_item_category.py
@@ -1,0 +1,65 @@
+# ABOUTME: Unit tests for _get_item_category method in GameState
+# ABOUTME: Ensures all item types from items.json can be properly categorized
+
+import pytest
+
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+
+
+@pytest.fixture
+def game_state():
+    """Create a minimal game state for testing item categories."""
+    abilities = Abilities(10, 10, 10, 10, 10, 10)
+    char = Character(
+        name="Test",
+        race="human",
+        character_class=CharacterClass.FIGHTER,
+        abilities=abilities,
+        level=1,
+        max_hp=10,
+        ac=10,
+    )
+    party = Party([char])
+    return GameState(party=party, dungeon_name="the_unquiet_dead_crypt")
+
+
+class TestGetItemCategory:
+    """Tests for GameState._get_item_category method."""
+
+    def test_weapons_category(self, game_state):
+        """Weapons should return 'weapons' category."""
+        assert game_state._get_item_category("longsword") == "weapons"
+        assert game_state._get_item_category("shortbow") == "weapons"
+
+    def test_armor_category(self, game_state):
+        """Armor should return 'armor' category."""
+        assert game_state._get_item_category("chain_mail") == "armor"
+        assert game_state._get_item_category("hide") == "armor"
+
+    def test_consumables_category(self, game_state):
+        """Consumables should return 'consumables' category."""
+        assert game_state._get_item_category("potion_of_healing") == "consumables"
+
+    def test_magical_items_category(self, game_state):
+        """Magical items should return 'magical_items' category."""
+        assert game_state._get_item_category("immovable_rod") == "magical_items"
+
+    def test_tools_category(self, game_state):
+        """Tools should return 'tools' category."""
+        assert game_state._get_item_category("thieves_tools") == "tools"
+
+    def test_equipment_category(self, game_state):
+        """Equipment should return 'equipment' category."""
+        assert game_state._get_item_category("backpack") == "equipment"
+
+    def test_ammunition_maps_to_consumables(self, game_state):
+        """Ammunition should map to 'consumables' category (consumed on use)."""
+        assert game_state._get_item_category("arrows") == "consumables"
+        assert game_state._get_item_category("bolts") == "consumables"
+
+    def test_unknown_item_returns_none(self, game_state):
+        """Unknown items should return None."""
+        assert game_state._get_item_category("nonexistent_item_xyz") is None


### PR DESCRIPTION
## Summary
- Extends `_get_item_category()` to support all item types from items.json
- Maps ammunition to consumables since arrows/bolts are consumed on use
- Adds comprehensive unit tests covering all categories

## Changes
- **dnd_engine/core/game_state.py**: Added tools and equipment categories to direct matching; added ammunition → consumables mapping
- **tests/test_item_category.py**: New test file with 8 unit tests covering all category types and edge cases

## Testing
- [x] Unit tests pass (8/8 in test_item_category.py)
- [x] All category types verified: weapons, armor, consumables, magical_items, tools, equipment, ammunition
- [x] Unknown items correctly return None

## Related Issues
Fixes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)