### PR TITLE
feat(ui): Add exit directions to status bar

### DIFF
--- a/dnd_engine/ui/cli.py
+++ b/dnd_engine/ui/cli.py
@@ -446,12 +446,20 @@ class CLI:
         }
         icon, color, label = lighting_display.get(best_lighting, ("?", "white", "Unknown"))
 
+        # Get available exits (compact format: N, S, E, W)
+        direction_abbrev = {"north": "N", "south": "S", "east": "E", "west": "W", "up": "U", "down": "D"}
+        exits = self.game_state.get_available_exits()
+        exit_dirs = [direction_abbrev.get(d, d.upper()[:1]) for d in exits.keys()]
+        exits_str = ", ".join(exit_dirs) if exit_dirs else "None"
+
         return HTML(
             f'<style fg="cyan">{location_name}</style>'
             f' <style fg="white">│</style> '
             f'<style fg="white">{room_name}</style>'
             f' <style fg="white">│</style> '
             f'<style fg="{color}">{icon} {label}</style>'
+            f' <style fg="white">│</style> '
+            f'<style fg="green">Exits: {exits_str}</style>'
         )
 
     def get_player_command(self) -> str:

--- a/tests/test_cli_status_bar.py
+++ b/tests/test_cli_status_bar.py
@@ -1,0 +1,89 @@
+# ABOUTME: Tests for CLI status bar functionality
+# ABOUTME: Verifies status bar displays location, lighting, and exit directions
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from dnd_engine.ui.cli import CLI
+
+
+class TestStatusBar:
+    """Test CLI status bar functionality."""
+
+    @pytest.fixture
+    def mock_game_state(self):
+        """Create a mock game state for testing."""
+        game_state = Mock()
+        game_state.dungeon = {"name": "The Crypt"}
+        game_state.get_current_room.return_value = {"name": "Entrance Hall"}
+        game_state.get_effective_lighting.return_value = "bright"
+        game_state.party = Mock()
+        game_state.party.characters = [Mock()]
+        game_state.get_available_exits.return_value = {
+            "north": {"destination": "room_2"},
+            "east": {"destination": "room_3"},
+        }
+        return game_state
+
+    def test_status_bar_includes_exits(self, mock_game_state):
+        """Test that status bar includes available exit directions."""
+        cli = CLI(mock_game_state, Mock(), "test_campaign")
+
+        status_bar = cli._get_status_bar()
+
+        # Convert HTML to string for checking
+        status_str = str(status_bar)
+
+        # Verify exits are shown in compact format
+        assert "Exits:" in status_str
+        assert "N" in status_str  # north
+        assert "E" in status_str  # east
+
+    def test_status_bar_exits_compact_format(self, mock_game_state):
+        """Test that exits use compact abbreviations (N, S, E, W)."""
+        mock_game_state.get_available_exits.return_value = {
+            "north": {},
+            "south": {},
+            "west": {},
+        }
+
+        cli = CLI(mock_game_state, Mock(), "test_campaign")
+        status_bar = cli._get_status_bar()
+        status_str = str(status_bar)
+
+        # Should show abbreviated directions
+        assert "N" in status_str
+        assert "S" in status_str
+        assert "W" in status_str
+        # Should NOT show full words
+        assert "north" not in status_str.lower() or "Exits:" in status_str
+
+    def test_status_bar_no_exits(self, mock_game_state):
+        """Test status bar when no exits available."""
+        mock_game_state.get_available_exits.return_value = {}
+
+        cli = CLI(mock_game_state, Mock(), "test_campaign")
+        status_bar = cli._get_status_bar()
+        status_str = str(status_bar)
+
+        assert "Exits: None" in status_str
+
+    def test_status_bar_updates_with_room_change(self, mock_game_state):
+        """Test that exits update when player moves to new room."""
+        cli = CLI(mock_game_state, Mock(), "test_campaign")
+
+        # Initial room has north and east exits
+        status_bar1 = cli._get_status_bar()
+        status_str1 = str(status_bar1)
+        assert "N" in status_str1
+        assert "E" in status_str1
+
+        # Simulate moving to new room with different exits
+        mock_game_state.get_available_exits.return_value = {"south": {}, "down": {}}
+        mock_game_state.get_current_room.return_value = {"name": "Lower Chamber"}
+
+        status_bar2 = cli._get_status_bar()
+        status_str2 = str(status_bar2)
+        assert "S" in status_str2
+        assert "D" in status_str2  # down


### PR DESCRIPTION
## Summary

Fixes #277: Add available exit directions to status bar.

After a long combat round, players lose context on which directions they can move. This adds exit directions to the status bar so players always know their movement options without typing `look`.

## Changes

- **dnd_engine/ui/cli.py**: Add exit directions to `_get_status_bar()` using `get_available_exits()`
- **tests/test_cli_status_bar.py**: Add unit tests for status bar exit display

## Example

Before:
```
The Crypt │ Entrance Hall │ ☀️ Bright
```

After:
```
The Crypt │ Entrance Hall │ ☀️ Bright │ Exits: N, S, E
```

## Test plan

- [x] Unit tests pass (4 new tests)
- [ ] Manual testing: Start game and verify exits shown in status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)