### PR TITLE
feat(spells): Add spell effect plugin system for utility cantrips (#274)

### DIFF
--- a/dnd_engine/core/game_state.py
+++ b/dnd_engine/core/game_state.py
@@ -1807,13 +1807,31 @@ class GameState:
             if not target_name:
                 target_name = caster_name
 
+            target = self.party.get_character_by_name(target_name)
+
             # Consume spell slot for non-cantrips
             if spell_level > 0:
                 caster.use_spell_slot(spell_level)
 
+            # Check for spell effect handler
+            effect_handler_result = None
+            effect_type = spell_data.get("effect", {}).get("effect_type")
+            if effect_type:
+                from dnd_engine.spells.effects import get_effect_handler
+
+                handler = get_effect_handler(effect_type)
+                if handler:
+                    effect_handler_result = handler.apply(
+                        spell_data, caster, target, self
+                    )
+
             # Create active effect if spell has duration
             effect = self._create_spell_effect(spell_data, caster_name, target_name)
             if effect:
+                # If handler provided effect_data, merge it into the effect
+                if effect_handler_result and effect_handler_result.effect_data:
+                    effect.effect_data.update(effect_handler_result.effect_data)
+
                 # If this is a concentration spell, break concentration on any previous spell
                 if effect.concentration:
                     self.time_manager.remove_concentration_effects(caster_name)
@@ -1832,8 +1850,11 @@ class GameState:
                 )
             )
 
-            # Return spell description as flavor text
-            description = spell_data.get("description", f"{spell_name} takes effect.")
+            # Use handler message if available, otherwise fall back to description
+            if effect_handler_result and effect_handler_result.success:
+                description = effect_handler_result.message
+            else:
+                description = spell_data.get("description", f"{spell_name} takes effect.")
 
             return {
                 "success": True,

--- a/dnd_engine/data/srd/spells.json
+++ b/dnd_engine/data/srd/spells.json
@@ -131,7 +131,12 @@
     "source": "D&D 5E SRD (CC BY 4.0)",
     "tags": [
       "utility"
-    ]
+    ],
+    "effect": {
+      "effect_type": "illumination",
+      "light_level": "bright",
+      "radius_ft": 20
+    }
   },
   "mage_hand": {
     "id": "mage_hand",
@@ -158,7 +163,13 @@
     "source": "D&D 5E SRD (CC BY 4.0)",
     "tags": [
       "utility"
-    ]
+    ],
+    "effect": {
+      "effect_type": "manipulation",
+      "capabilities": ["interact_at_range", "trigger_pressure_plates", "retrieve_objects"],
+      "range_ft": 30,
+      "weight_limit_lb": 10
+    }
   },
   "prestidigitation": {
     "id": "prestidigitation",
@@ -185,7 +196,11 @@
     "source": "D&D 5E SRD (CC BY 4.0)",
     "tags": [
       "utility"
-    ]
+    ],
+    "effect": {
+      "effect_type": "utility",
+      "utility_type": "prestidigitation"
+    }
   },
   "magic_missile": {
     "id": "magic_missile",
@@ -352,7 +367,12 @@
     "tags": [
       "utility",
       "ritual"
-    ]
+    ],
+    "effect": {
+      "effect_type": "detection",
+      "reveals": ["magical_items", "magical_effects", "magical_auras"],
+      "range_ft": 30
+    }
   },
   "sleep": {
     "id": "sleep",

--- a/dnd_engine/spells/__init__.py
+++ b/dnd_engine/spells/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Spell system package for D&D 5E game engine.
+# ABOUTME: Contains spell effect handlers and registry for utility, combat, and exploration spells.

--- a/dnd_engine/spells/effects/__init__.py
+++ b/dnd_engine/spells/effects/__init__.py
@@ -1,0 +1,77 @@
+# ABOUTME: Spell effect registry and handler exports.
+# ABOUTME: Auto-registers effect handlers on import for the plugin architecture.
+
+from typing import TYPE_CHECKING
+
+from .base import SpellEffect, SpellEffectResult
+
+if TYPE_CHECKING:
+    pass
+
+# Registry mapping effect_type strings to handler instances
+_REGISTRY: dict[str, SpellEffect] = {}
+
+
+def register(effect: SpellEffect) -> None:
+    """
+    Register a spell effect handler.
+
+    Args:
+        effect: SpellEffect instance to register
+    """
+    _REGISTRY[effect.effect_type] = effect
+
+
+def get_effect_handler(effect_type: str) -> SpellEffect | None:
+    """
+    Get the handler for a spell effect type.
+
+    Args:
+        effect_type: The effect_type from spell JSON data
+
+    Returns:
+        SpellEffect handler instance, or None if not found
+    """
+    return _REGISTRY.get(effect_type)
+
+
+def list_effect_types() -> list[str]:
+    """
+    List all registered effect types.
+
+    Returns:
+        List of registered effect_type strings
+    """
+    return list(_REGISTRY.keys())
+
+
+# Import and register effect handlers
+# Each module registers its handler(s) when imported
+from .illumination import IlluminationEffect  # noqa: E402
+
+register(IlluminationEffect())
+
+from .manipulation import ManipulationEffect  # noqa: E402
+
+register(ManipulationEffect())
+
+from .detection import DetectionEffect  # noqa: E402
+
+register(DetectionEffect())
+
+from .utility import UtilityEffect  # noqa: E402
+
+register(UtilityEffect())
+
+
+__all__ = [
+    "SpellEffect",
+    "SpellEffectResult",
+    "register",
+    "get_effect_handler",
+    "list_effect_types",
+    "IlluminationEffect",
+    "ManipulationEffect",
+    "DetectionEffect",
+    "UtilityEffect",
+]

--- a/dnd_engine/spells/effects/base.py
+++ b/dnd_engine/spells/effects/base.py
@@ -1,0 +1,155 @@
+# ABOUTME: Base classes for spell effect handlers.
+# ABOUTME: Defines SpellEffect ABC and SpellEffectResult for the plugin architecture.
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+    from dnd_engine.core.game_state import GameState
+    from dnd_engine.systems.time_manager import ActiveEffect
+
+
+@dataclass
+class SpellEffectResult:
+    """Result of applying a spell effect."""
+
+    success: bool
+    message: str
+    effect_data: dict[str, Any] = field(default_factory=dict)
+
+
+class SpellEffect(ABC):
+    """
+    Base class for spell effect handlers.
+
+    Each handler manages a category of spell effects (e.g., illumination, detection).
+    Spell JSON data declares an effect_type that maps to a registered handler.
+
+    To add a new effect type:
+    1. Create a new module in dnd_engine/spells/effects/
+    2. Subclass SpellEffect and set the effect_type class attribute
+    3. Implement the apply() method
+    4. Register the handler in effects/__init__.py
+    5. Add effect_type to spell data in spells.json
+    """
+
+    effect_type: str  # Must match spell JSON "effect.effect_type"
+
+    @abstractmethod
+    def apply(
+        self,
+        spell_data: dict[str, Any],
+        caster: "Creature",
+        target: "Creature | None",
+        game_state: "GameState",
+    ) -> SpellEffectResult:
+        """
+        Called when the spell is cast.
+
+        Args:
+            spell_data: Full spell definition from spells.json
+            caster: The creature casting the spell
+            target: The target creature (may be None for self-targeted spells)
+            game_state: Current game state for accessing other systems
+
+        Returns:
+            SpellEffectResult with success status, message, and effect_data
+            to store in the ActiveEffect
+        """
+        ...
+
+    def query(
+        self,
+        game_state: "GameState",
+        query_type: str,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Called by game systems to check effect status.
+
+        Override this to provide custom query handling for your effect type.
+        Common query_type values might be:
+        - "get_light_level" for illumination effects
+        - "has_capability" for manipulation effects
+        - "get_revealed_info" for detection effects
+
+        Args:
+            game_state: Current game state
+            query_type: String identifying what information is requested
+            **kwargs: Additional context for the query
+
+        Returns:
+            Query-specific result, or None if query not supported
+        """
+        return None
+
+    def on_expire(
+        self,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+    ) -> str | None:
+        """
+        Called when the spell effect expires.
+
+        Override to perform cleanup or provide expiration message.
+
+        Args:
+            effect: The ActiveEffect that is expiring
+            game_state: Current game state
+
+        Returns:
+            Optional message to display, or None
+        """
+        return None
+
+    def get_available_actions(
+        self,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+    ) -> list[dict[str, Any]]:
+        """
+        Return actions this effect enables while active.
+
+        For spells like Mage Hand that grant new interaction options,
+        return a list of action definitions that the UI can present.
+
+        Args:
+            effect: The active spell effect
+            game_state: Current game state
+
+        Returns:
+            List of action dicts with keys:
+            - "id": Unique action identifier
+            - "name": Display name
+            - "description": What the action does
+            - "handler": Method name to call on this effect class
+        """
+        return []
+
+    def handle_action(
+        self,
+        action_id: str,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+        **kwargs: Any,
+    ) -> SpellEffectResult:
+        """
+        Handle a spell-granted action.
+
+        Called when player uses an action from get_available_actions().
+
+        Args:
+            action_id: The action identifier
+            effect: The active spell effect
+            game_state: Current game state
+            **kwargs: Action-specific parameters
+
+        Returns:
+            SpellEffectResult describing the outcome
+        """
+        return SpellEffectResult(
+            success=False,
+            message=f"Action '{action_id}' not implemented for {self.effect_type}",
+        )

--- a/dnd_engine/spells/effects/detection.py
+++ b/dnd_engine/spells/effects/detection.py
@@ -1,0 +1,328 @@
+# ABOUTME: Detection spell effect handler for Detect Magic, Identify, etc.
+# ABOUTME: Reveals magical properties, hidden information, and creature types.
+
+from typing import TYPE_CHECKING, Any
+
+from .base import SpellEffect, SpellEffectResult
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+    from dnd_engine.core.game_state import GameState
+    from dnd_engine.systems.time_manager import ActiveEffect
+
+
+class DetectionEffect(SpellEffect):
+    """
+    Handler for spells that detect or reveal information.
+
+    Supported spells:
+    - Detect Magic: Sense presence of magic, identify schools
+    - Identify: Learn properties of magical items
+    - See Invisibility: See invisible creatures and objects
+    - Detect Evil and Good: Sense aberrations, celestials, etc.
+
+    Effect data stored in ActiveEffect:
+    - reveals: List of what can be detected (e.g., "magical_items", "invisible")
+    - range_ft: Detection range
+    - requires_concentration: Whether caster must focus
+    """
+
+    effect_type = "detection"
+
+    def apply(
+        self,
+        spell_data: dict[str, Any],
+        caster: "Creature",
+        target: "Creature | None",
+        game_state: "GameState",
+    ) -> SpellEffectResult:
+        """Apply detection effect when spell is cast."""
+        effect_config = spell_data.get("effect", {})
+        spell_name = spell_data.get("name", "Unknown Spell")
+
+        # What this spell reveals
+        reveals = effect_config.get("reveals", ["magical_auras"])
+        range_ft = effect_config.get("range_ft", 30)
+
+        # Build message and perform initial detection
+        message, detected_items = self._perform_detection(
+            spell_name, caster, reveals, range_ft, game_state
+        )
+
+        return SpellEffectResult(
+            success=True,
+            message=message,
+            effect_data={
+                "spell_name": spell_name,
+                "reveals": reveals,
+                "range_ft": range_ft,
+                "caster_name": caster.name,
+                "detected_items": detected_items,
+            },
+        )
+
+    def _perform_detection(
+        self,
+        spell_name: str,
+        caster: "Creature",
+        reveals: list[str],
+        range_ft: int,
+        game_state: "GameState",
+    ) -> tuple[str, list[dict[str, Any]]]:
+        """
+        Perform the detection and build result message.
+
+        Returns:
+            Tuple of (message, list of detected items)
+        """
+        detected_items: list[dict[str, Any]] = []
+        messages: list[str] = []
+
+        spell_lower = spell_name.lower()
+
+        # Opening flavor text
+        if "detect magic" in spell_lower:
+            messages.append(
+                f"{caster.name}'s senses expand, becoming attuned to magical energies."
+            )
+        elif "identify" in spell_lower:
+            messages.append(
+                f"{caster.name} focuses intently, magical insights flooding their mind."
+            )
+        elif "see invisibility" in spell_lower:
+            messages.append(
+                f"{caster.name}'s eyes shimmer briefly as they gain supernatural sight."
+            )
+        else:
+            messages.append(
+                f"{caster.name} extends their magical senses outward."
+            )
+
+        # Check for magical items if that's what we reveal
+        if "magical_items" in reveals or "magical_auras" in reveals:
+            magical_items = self._detect_magical_items(caster, game_state)
+            if magical_items:
+                detected_items.extend(magical_items)
+                item_names = [item["name"] for item in magical_items]
+                messages.append(
+                    f"Magical auras detected: {', '.join(item_names)}."
+                )
+            else:
+                messages.append("No magical auras are detected nearby.")
+
+        # Check for magical effects in the room/area
+        if "magical_effects" in reveals or "magical_auras" in reveals:
+            magical_effects = self._detect_magical_effects(game_state)
+            if magical_effects:
+                detected_items.extend(magical_effects)
+                effect_names = [e["name"] for e in magical_effects]
+                messages.append(
+                    f"Active magical effects: {', '.join(effect_names)}."
+                )
+
+        # Check for invisible creatures
+        if "invisible_creatures" in reveals:
+            invisible = self._detect_invisible(game_state)
+            if invisible:
+                detected_items.extend(invisible)
+                messages.append(
+                    f"Invisible presences detected: {len(invisible)}."
+                )
+
+        return " ".join(messages), detected_items
+
+    def _detect_magical_items(
+        self,
+        caster: "Creature",
+        game_state: "GameState",
+    ) -> list[dict[str, Any]]:
+        """Detect magical items in party inventory."""
+        magical_items: list[dict[str, Any]] = []
+
+        # Check party members' inventories
+        for character in game_state.party.characters:
+            if not hasattr(character, "inventory"):
+                continue
+
+            # Inventory stores items in a dict keyed by item_id
+            inventory = character.inventory
+            if not hasattr(inventory, "items"):
+                continue
+
+            for item_id, inv_item in inventory.items.items():
+                # Try to load full item data to check if magical
+                item_data = game_state.data_loader.get_item_by_id(item_id)
+                if not item_data:
+                    continue
+
+                is_magical = (
+                    item_data.get("magical", False)
+                    or item_data.get("rarity", "common") != "common"
+                    or item_data.get("magic_bonus", 0) > 0
+                )
+
+                if is_magical:
+                    magical_items.append({
+                        "type": "item",
+                        "name": item_data.get("name", item_id),
+                        "owner": character.name,
+                        "school": item_data.get("school", "unknown"),
+                    })
+
+        return magical_items
+
+    def _detect_magical_effects(
+        self,
+        game_state: "GameState",
+    ) -> list[dict[str, Any]]:
+        """Detect active magical effects in the area."""
+        from dnd_engine.systems.time_manager import EffectType
+
+        magical_effects: list[dict[str, Any]] = []
+
+        for effect in game_state.time_manager.get_all_effects():
+            if effect.effect_type == EffectType.SPELL:
+                magical_effects.append({
+                    "type": "effect",
+                    "name": effect.source,
+                    "target": effect.target_name,
+                    "remaining": effect.remaining_value,
+                })
+
+        return magical_effects
+
+    def _detect_invisible(
+        self,
+        game_state: "GameState",
+    ) -> list[dict[str, Any]]:
+        """Detect invisible creatures."""
+        invisible: list[dict[str, Any]] = []
+
+        # Check monsters in current room
+        if hasattr(game_state, "current_room") and game_state.current_room:
+            room = game_state.current_room
+            monsters = getattr(room, "monsters", [])
+            for monster in monsters:
+                conditions = getattr(monster, "conditions", [])
+                if "invisible" in conditions:
+                    invisible.append({
+                        "type": "creature",
+                        "name": monster.name,
+                    })
+
+        return invisible
+
+    def query(
+        self,
+        game_state: "GameState",
+        query_type: str,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Query detection effects.
+
+        Supported queries:
+        - "can_detect": Check if caster can detect a specific type
+          kwargs: detection_type (str), character_name (str)
+        - "get_detected_items": Get list of detected magical items
+          kwargs: character_name (str, optional)
+        - "is_item_magical": Check if a specific item is detected as magical
+          kwargs: item_name (str)
+        """
+        if query_type == "can_detect":
+            return self._can_detect(
+                game_state,
+                kwargs.get("detection_type"),
+                kwargs.get("character_name"),
+            )
+        elif query_type == "get_detected_items":
+            return self._get_detected_items(
+                game_state,
+                kwargs.get("character_name"),
+            )
+        elif query_type == "is_item_magical":
+            return self._is_item_detected_magical(
+                game_state,
+                kwargs.get("item_name"),
+            )
+        return None
+
+    def _can_detect(
+        self,
+        game_state: "GameState",
+        detection_type: str | None,
+        character_name: str | None,
+    ) -> bool:
+        """Check if a character has a detection effect active."""
+        if not detection_type:
+            return False
+
+        from dnd_engine.systems.time_manager import EffectType
+
+        for effect in game_state.time_manager.get_all_effects():
+            if effect.effect_type != EffectType.SPELL:
+                continue
+
+            if character_name and effect.effect_data.get("caster_name") != character_name:
+                continue
+
+            reveals = effect.effect_data.get("reveals", [])
+            if detection_type in reveals:
+                return True
+
+        return False
+
+    def _get_detected_items(
+        self,
+        game_state: "GameState",
+        character_name: str | None,
+    ) -> list[dict[str, Any]]:
+        """Get all items detected by active detection spells."""
+        from dnd_engine.systems.time_manager import EffectType
+
+        all_detected: list[dict[str, Any]] = []
+
+        for effect in game_state.time_manager.get_all_effects():
+            if effect.effect_type != EffectType.SPELL:
+                continue
+
+            if character_name and effect.effect_data.get("caster_name") != character_name:
+                continue
+
+            detected = effect.effect_data.get("detected_items", [])
+            all_detected.extend(detected)
+
+        return all_detected
+
+    def _is_item_detected_magical(
+        self,
+        game_state: "GameState",
+        item_name: str | None,
+    ) -> bool:
+        """Check if a specific item has been detected as magical."""
+        if not item_name:
+            return False
+
+        detected_items = self._get_detected_items(game_state, None)
+        item_lower = item_name.lower()
+
+        for item in detected_items:
+            if item.get("type") == "item":
+                if item.get("name", "").lower() == item_lower:
+                    return True
+
+        return False
+
+    def on_expire(
+        self,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+    ) -> str | None:
+        """Return message when detection effect expires."""
+        spell_name = effect.effect_data.get("spell_name", "The detection spell")
+        caster_name = effect.effect_data.get("caster_name", "The caster")
+
+        return (
+            f"{caster_name}'s magical senses return to normal as "
+            f"{spell_name} ends."
+        )

--- a/dnd_engine/spells/effects/illumination.py
+++ b/dnd_engine/spells/effects/illumination.py
@@ -1,0 +1,120 @@
+# ABOUTME: Illumination spell effect handler for Light, Dancing Lights, etc.
+# ABOUTME: Provides light sources that modify effective lighting in areas.
+
+from typing import TYPE_CHECKING, Any
+
+from .base import SpellEffect, SpellEffectResult
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+    from dnd_engine.core.game_state import GameState
+    from dnd_engine.systems.time_manager import ActiveEffect
+
+
+class IlluminationEffect(SpellEffect):
+    """
+    Handler for spells that provide illumination.
+
+    Supported spells:
+    - Light: Provides bright light in 20ft radius
+    - Dancing Lights: Creates up to 4 dim light sources
+
+    Effect data stored in ActiveEffect:
+    - light_level: "bright" or "dim"
+    - radius_ft: Light radius in feet
+    """
+
+    effect_type = "illumination"
+
+    def apply(
+        self,
+        spell_data: dict[str, Any],
+        caster: "Creature",
+        target: "Creature | None",
+        game_state: "GameState",
+    ) -> SpellEffectResult:
+        """Apply illumination effect when spell is cast."""
+        effect_config = spell_data.get("effect", {})
+        light_level = effect_config.get("light_level", "bright")
+        radius_ft = effect_config.get("radius_ft", 20)
+
+        spell_name = spell_data.get("name", "Unknown Spell")
+        target_name = target.name if target else caster.name
+
+        # Build descriptive message based on light level
+        if light_level == "bright":
+            message = (
+                f"Bright light springs forth, illuminating a {radius_ft}-foot "
+                f"radius around {target_name}."
+            )
+        else:
+            message = (
+                f"A soft glow appears, providing dim light in a {radius_ft}-foot "
+                f"radius around {target_name}."
+            )
+
+        return SpellEffectResult(
+            success=True,
+            message=message,
+            effect_data={
+                "light_level": light_level,
+                "radius_ft": radius_ft,
+                "spell_name": spell_name,
+            },
+        )
+
+    def query(
+        self,
+        game_state: "GameState",
+        query_type: str,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Query illumination effects.
+
+        Supported queries:
+        - "get_light_level": Returns the highest light level from active effects
+        - "has_light_source": Returns True if any illumination effect is active
+        """
+        if query_type == "get_light_level":
+            return self._get_highest_light_level(game_state)
+        elif query_type == "has_light_source":
+            return self._has_light_source(game_state)
+        return None
+
+    def _get_highest_light_level(self, game_state: "GameState") -> str | None:
+        """Get the highest light level from active illumination effects."""
+        from dnd_engine.systems.time_manager import EffectType
+
+        best_level = None
+        for effect in game_state.time_manager.get_all_effects():
+            if effect.effect_type != EffectType.SPELL:
+                continue
+
+            light_level = effect.effect_data.get("light_level")
+            if light_level == "bright":
+                return "bright"  # Can't get better than bright
+            elif light_level == "dim" and best_level is None:
+                best_level = "dim"
+
+        return best_level
+
+    def _has_light_source(self, game_state: "GameState") -> bool:
+        """Check if any illumination spell effect is active."""
+        from dnd_engine.systems.time_manager import EffectType
+
+        for effect in game_state.time_manager.get_all_effects():
+            if effect.effect_type != EffectType.SPELL:
+                continue
+            if effect.effect_data.get("light_level"):
+                return True
+        return False
+
+    def on_expire(
+        self,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+    ) -> str | None:
+        """Return message when illumination effect expires."""
+        spell_name = effect.effect_data.get("spell_name", "The light")
+        return f"{spell_name} fades away, and darkness returns."

--- a/dnd_engine/spells/effects/manipulation.py
+++ b/dnd_engine/spells/effects/manipulation.py
@@ -1,0 +1,253 @@
+# ABOUTME: Manipulation spell effect handler for Mage Hand, Unseen Servant, etc.
+# ABOUTME: Provides remote interaction capabilities during exploration.
+
+from typing import TYPE_CHECKING, Any
+
+from .base import SpellEffect, SpellEffectResult
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+    from dnd_engine.core.game_state import GameState
+    from dnd_engine.systems.time_manager import ActiveEffect
+
+
+class ManipulationEffect(SpellEffect):
+    """
+    Handler for spells that enable remote manipulation.
+
+    Supported spells:
+    - Mage Hand: Spectral hand for manipulating objects at range
+    - Unseen Servant: Invisible force that performs simple tasks
+
+    Effect data stored in ActiveEffect:
+    - capabilities: List of granted capabilities (e.g., "interact_at_range")
+    - range_ft: Maximum range for manipulation
+    - weight_limit_lb: Maximum weight that can be manipulated
+    """
+
+    effect_type = "manipulation"
+
+    def apply(
+        self,
+        spell_data: dict[str, Any],
+        caster: "Creature",
+        target: "Creature | None",
+        game_state: "GameState",
+    ) -> SpellEffectResult:
+        """Apply manipulation effect when spell is cast."""
+        effect_config = spell_data.get("effect", {})
+        spell_name = spell_data.get("name", "Unknown Spell")
+
+        # Default capabilities based on spell
+        capabilities = effect_config.get(
+            "capabilities",
+            ["interact_at_range", "trigger_pressure_plates"],
+        )
+        range_ft = effect_config.get("range_ft", spell_data.get("range_ft", 30))
+        weight_limit_lb = effect_config.get("weight_limit_lb", 10)
+
+        # Build descriptive message
+        message = self._build_cast_message(spell_name, caster.name, range_ft)
+
+        return SpellEffectResult(
+            success=True,
+            message=message,
+            effect_data={
+                "spell_name": spell_name,
+                "capabilities": capabilities,
+                "range_ft": range_ft,
+                "weight_limit_lb": weight_limit_lb,
+                "caster_name": caster.name,
+            },
+        )
+
+    def _build_cast_message(
+        self, spell_name: str, caster_name: str, range_ft: int
+    ) -> str:
+        """Build a descriptive message for the spell cast."""
+        spell_lower = spell_name.lower()
+
+        if "mage hand" in spell_lower:
+            return (
+                f"A spectral, floating hand appears near {caster_name}. "
+                f"It can manipulate objects up to {range_ft} feet away."
+            )
+        elif "unseen servant" in spell_lower:
+            return (
+                f"An invisible force materializes, ready to serve {caster_name}. "
+                f"It can perform simple tasks within {range_ft} feet."
+            )
+        else:
+            return (
+                f"{caster_name} gains the ability to manipulate objects "
+                f"at a distance of up to {range_ft} feet."
+            )
+
+    def query(
+        self,
+        game_state: "GameState",
+        query_type: str,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Query manipulation effects.
+
+        Supported queries:
+        - "has_capability": Check if a specific capability is active
+          kwargs: capability (str), character_name (str, optional)
+        - "get_manipulation_range": Get max manipulation range
+          kwargs: character_name (str, optional)
+        """
+        if query_type == "has_capability":
+            capability = kwargs.get("capability")
+            character_name = kwargs.get("character_name")
+            return self._has_capability(game_state, capability, character_name)
+        elif query_type == "get_manipulation_range":
+            character_name = kwargs.get("character_name")
+            return self._get_manipulation_range(game_state, character_name)
+        return None
+
+    def _has_capability(
+        self,
+        game_state: "GameState",
+        capability: str | None,
+        character_name: str | None,
+    ) -> bool:
+        """Check if a manipulation capability is active."""
+        if not capability:
+            return False
+
+        from dnd_engine.systems.time_manager import EffectType
+
+        for effect in game_state.time_manager.get_all_effects():
+            if effect.effect_type != EffectType.SPELL:
+                continue
+
+            # Filter by character if specified
+            if character_name and effect.effect_data.get("caster_name") != character_name:
+                continue
+
+            capabilities = effect.effect_data.get("capabilities", [])
+            if capability in capabilities:
+                return True
+
+        return False
+
+    def _get_manipulation_range(
+        self,
+        game_state: "GameState",
+        character_name: str | None,
+    ) -> int:
+        """Get the maximum manipulation range from active effects."""
+        from dnd_engine.systems.time_manager import EffectType
+
+        max_range = 0
+        for effect in game_state.time_manager.get_all_effects():
+            if effect.effect_type != EffectType.SPELL:
+                continue
+
+            # Filter by character if specified
+            if character_name and effect.effect_data.get("caster_name") != character_name:
+                continue
+
+            range_ft = effect.effect_data.get("range_ft", 0)
+            if range_ft > max_range:
+                max_range = range_ft
+
+        return max_range
+
+    def get_available_actions(
+        self,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+    ) -> list[dict[str, Any]]:
+        """Return actions enabled by the manipulation effect."""
+        actions = []
+        capabilities = effect.effect_data.get("capabilities", [])
+        spell_name = effect.effect_data.get("spell_name", "manipulation spell")
+
+        if "interact_at_range" in capabilities:
+            actions.append({
+                "id": "manipulate_object",
+                "name": f"Use {spell_name}",
+                "description": (
+                    f"Manipulate a small object at range "
+                    f"(up to {effect.effect_data.get('weight_limit_lb', 10)} lbs)"
+                ),
+                "handler": "handle_manipulate_object",
+            })
+
+        if "trigger_pressure_plates" in capabilities:
+            actions.append({
+                "id": "trigger_trap",
+                "name": "Trigger from distance",
+                "description": "Safely trigger a pressure plate or trap from afar",
+                "handler": "handle_trigger_trap",
+            })
+
+        return actions
+
+    def handle_action(
+        self,
+        action_id: str,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+        **kwargs: Any,
+    ) -> SpellEffectResult:
+        """Handle a manipulation action."""
+        if action_id == "manipulate_object":
+            return self._handle_manipulate_object(effect, game_state, **kwargs)
+        elif action_id == "trigger_trap":
+            return self._handle_trigger_trap(effect, game_state, **kwargs)
+
+        return SpellEffectResult(
+            success=False,
+            message=f"Unknown action: {action_id}",
+        )
+
+    def _handle_manipulate_object(
+        self,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+        **kwargs: Any,
+    ) -> SpellEffectResult:
+        """Handle the manipulate_object action."""
+        target_object = kwargs.get("target_object", "an object")
+        spell_name = effect.effect_data.get("spell_name", "The spectral hand")
+
+        return SpellEffectResult(
+            success=True,
+            message=f"{spell_name} reaches out and manipulates {target_object}.",
+        )
+
+    def _handle_trigger_trap(
+        self,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+        **kwargs: Any,
+    ) -> SpellEffectResult:
+        """Handle the trigger_trap action."""
+        spell_name = effect.effect_data.get("spell_name", "The spectral hand")
+
+        return SpellEffectResult(
+            success=True,
+            message=(
+                f"{spell_name} carefully prods the suspicious area, "
+                "triggering any hidden mechanisms from a safe distance."
+            ),
+        )
+
+    def on_expire(
+        self,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+    ) -> str | None:
+        """Return message when manipulation effect expires."""
+        spell_name = effect.effect_data.get("spell_name", "The magical force")
+
+        if "mage hand" in spell_name.lower():
+            return "The spectral hand fades away into nothingness."
+        elif "unseen servant" in spell_name.lower():
+            return "The unseen servant dissipates, its service complete."
+        else:
+            return f"{spell_name} ends."

--- a/dnd_engine/spells/effects/utility.py
+++ b/dnd_engine/spells/effects/utility.py
@@ -1,0 +1,342 @@
+# ABOUTME: Utility spell effect handler for Prestidigitation, Mending, etc.
+# ABOUTME: Handles minor magical effects that are primarily flavor or have limited mechanical impact.
+
+from typing import TYPE_CHECKING, Any
+
+from .base import SpellEffect, SpellEffectResult
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+    from dnd_engine.core.game_state import GameState
+    from dnd_engine.systems.time_manager import ActiveEffect
+
+
+class UtilityEffect(SpellEffect):
+    """
+    Handler for minor utility spells with limited mechanical effects.
+
+    Supported spells:
+    - Prestidigitation: Minor magical tricks
+    - Mending: Repair small breaks in objects
+    - Druidcraft: Minor nature effects
+    - Thaumaturgy: Minor divine effects
+
+    These spells are primarily for flavor and roleplay, but may provide
+    minor circumstantial benefits tracked via effect_data.
+    """
+
+    effect_type = "utility"
+
+    def apply(
+        self,
+        spell_data: dict[str, Any],
+        caster: "Creature",
+        target: "Creature | None",
+        game_state: "GameState",
+    ) -> SpellEffectResult:
+        """Apply utility effect when spell is cast."""
+        effect_config = spell_data.get("effect", {})
+        spell_name = spell_data.get("name", "Unknown Spell")
+
+        # Get the utility type and any specific effect
+        utility_type = effect_config.get("utility_type", "general")
+        specific_effect = effect_config.get("specific_effect")
+
+        # Build message based on spell and utility type
+        message = self._build_cast_message(
+            spell_name, caster.name, utility_type, specific_effect
+        )
+
+        # Determine what capabilities this grants
+        capabilities = self._determine_capabilities(spell_name, utility_type)
+
+        return SpellEffectResult(
+            success=True,
+            message=message,
+            effect_data={
+                "spell_name": spell_name,
+                "utility_type": utility_type,
+                "capabilities": capabilities,
+                "caster_name": caster.name,
+            },
+        )
+
+    def _build_cast_message(
+        self,
+        spell_name: str,
+        caster_name: str,
+        utility_type: str,
+        specific_effect: str | None,
+    ) -> str:
+        """Build a descriptive message for the spell cast."""
+        spell_lower = spell_name.lower()
+
+        if "prestidigitation" in spell_lower:
+            effects = [
+                "A small sensory effect manifests - a spark, a puff of wind, "
+                "a faint musical note.",
+                "Colors shift and swirl briefly in the air around the caster.",
+                "A harmless sensory effect creates a moment of wonder.",
+            ]
+            # Could randomize, but for now use first
+            base_msg = effects[0]
+            return (
+                f"{caster_name} performs a minor magical trick. {base_msg} "
+                "The magic lingers, ready for more tricks."
+            )
+
+        elif "mending" in spell_lower:
+            return (
+                f"{caster_name} touches the broken object, and magical energy "
+                "flows into the damaged area. Small cracks seal, tears mend, "
+                "and breaks rejoin seamlessly."
+            )
+
+        elif "druidcraft" in spell_lower:
+            return (
+                f"{caster_name} channels the magic of nature. A flower blooms, "
+                "leaves rustle without wind, or the scent of rain fills the air."
+            )
+
+        elif "thaumaturgy" in spell_lower:
+            return (
+                f"{caster_name} invokes divine power. Flames flicker, a voice "
+                "booms unnaturally loud, or the ground trembles slightly."
+            )
+
+        else:
+            return (
+                f"{caster_name} weaves a minor magical effect. "
+                f"The {spell_name} takes hold."
+            )
+
+    def _determine_capabilities(
+        self,
+        spell_name: str,
+        utility_type: str,
+    ) -> list[str]:
+        """Determine what capabilities this utility spell grants."""
+        spell_lower = spell_name.lower()
+        capabilities: list[str] = []
+
+        if "prestidigitation" in spell_lower:
+            capabilities = [
+                "create_sensory_effect",
+                "light_or_snuff",
+                "clean_or_soil",
+                "warm_or_chill",
+                "flavor_food",
+                "create_trinket",
+                "create_mark",
+            ]
+
+        elif "mending" in spell_lower:
+            capabilities = ["repair_object"]
+
+        elif "druidcraft" in spell_lower:
+            capabilities = [
+                "predict_weather",
+                "bloom_flower",
+                "create_sensory_effect",
+                "light_or_snuff",
+            ]
+
+        elif "thaumaturgy" in spell_lower:
+            capabilities = [
+                "boom_voice",
+                "cause_tremors",
+                "create_sensory_effect",
+                "slam_door",
+                "alter_flames",
+                "alter_eye_appearance",
+            ]
+
+        return capabilities
+
+    def query(
+        self,
+        game_state: "GameState",
+        query_type: str,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Query utility effects.
+
+        Supported queries:
+        - "has_utility_capability": Check if a capability is available
+          kwargs: capability (str), character_name (str, optional)
+        - "get_available_tricks": Get list of available utility tricks
+          kwargs: character_name (str, optional)
+        """
+        if query_type == "has_utility_capability":
+            return self._has_capability(
+                game_state,
+                kwargs.get("capability"),
+                kwargs.get("character_name"),
+            )
+        elif query_type == "get_available_tricks":
+            return self._get_available_tricks(
+                game_state,
+                kwargs.get("character_name"),
+            )
+        return None
+
+    def _has_capability(
+        self,
+        game_state: "GameState",
+        capability: str | None,
+        character_name: str | None,
+    ) -> bool:
+        """Check if a utility capability is active."""
+        if not capability:
+            return False
+
+        from dnd_engine.systems.time_manager import EffectType
+
+        for effect in game_state.time_manager.get_all_effects():
+            if effect.effect_type != EffectType.SPELL:
+                continue
+
+            if character_name and effect.effect_data.get("caster_name") != character_name:
+                continue
+
+            capabilities = effect.effect_data.get("capabilities", [])
+            if capability in capabilities:
+                return True
+
+        return False
+
+    def _get_available_tricks(
+        self,
+        game_state: "GameState",
+        character_name: str | None,
+    ) -> list[str]:
+        """Get all available utility tricks from active effects."""
+        from dnd_engine.systems.time_manager import EffectType
+
+        all_capabilities: set[str] = set()
+
+        for effect in game_state.time_manager.get_all_effects():
+            if effect.effect_type != EffectType.SPELL:
+                continue
+
+            if character_name and effect.effect_data.get("caster_name") != character_name:
+                continue
+
+            capabilities = effect.effect_data.get("capabilities", [])
+            all_capabilities.update(capabilities)
+
+        return list(all_capabilities)
+
+    def get_available_actions(
+        self,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+    ) -> list[dict[str, Any]]:
+        """Return actions enabled by the utility effect."""
+        actions: list[dict[str, Any]] = []
+        capabilities = effect.effect_data.get("capabilities", [])
+        spell_name = effect.effect_data.get("spell_name", "utility spell")
+
+        # Map capabilities to user-friendly actions
+        action_map = {
+            "create_sensory_effect": {
+                "id": "sensory_effect",
+                "name": "Create sensory effect",
+                "description": "Create a harmless sensory effect (sound, smell, visual)",
+            },
+            "repair_object": {
+                "id": "repair",
+                "name": "Mend object",
+                "description": "Repair a single break or tear in an object",
+            },
+            "clean_or_soil": {
+                "id": "clean_soil",
+                "name": "Clean or soil",
+                "description": "Instantly clean or soil an object no larger than 1 cubic foot",
+            },
+            "flavor_food": {
+                "id": "flavor",
+                "name": "Flavor food",
+                "description": "Season or flavor up to 1 cubic foot of nonliving material",
+            },
+            "predict_weather": {
+                "id": "predict_weather",
+                "name": "Predict weather",
+                "description": "Know what the weather will be for the next 24 hours",
+            },
+            "boom_voice": {
+                "id": "boom_voice",
+                "name": "Boom voice",
+                "description": "Cause your voice to boom up to three times as loud",
+            },
+        }
+
+        for cap in capabilities:
+            if cap in action_map:
+                action = action_map[cap].copy()
+                action["handler"] = f"handle_{action['id']}"
+                actions.append(action)
+
+        return actions
+
+    def handle_action(
+        self,
+        action_id: str,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+        **kwargs: Any,
+    ) -> SpellEffectResult:
+        """Handle a utility action."""
+        spell_name = effect.effect_data.get("spell_name", "The spell")
+        caster_name = effect.effect_data.get("caster_name", "The caster")
+
+        # Generic handling for most utility actions - primarily flavor
+        action_messages = {
+            "sensory_effect": (
+                f"{caster_name} creates a brief magical sensation - "
+                "a flash of color, a whisper of sound, a momentary scent."
+            ),
+            "repair": (
+                f"{caster_name} touches the damaged object. Magical energy "
+                "knits the break together seamlessly."
+            ),
+            "clean_soil": (
+                f"{caster_name} waves a hand, and the target becomes "
+                "instantly clean (or dirty, as intended)."
+            ),
+            "flavor": (
+                f"{caster_name} adds a touch of magic to the food, "
+                "enhancing its flavor perfectly."
+            ),
+            "predict_weather": (
+                f"{caster_name} senses the natural rhythms of the world. "
+                "The weather for the next day becomes clear in their mind."
+            ),
+            "boom_voice": (
+                f"{caster_name}'s next words BOOM with supernatural volume!"
+            ),
+        }
+
+        message = action_messages.get(
+            action_id,
+            f"{caster_name} uses {spell_name} to create a minor magical effect.",
+        )
+
+        return SpellEffectResult(success=True, message=message)
+
+    def on_expire(
+        self,
+        effect: "ActiveEffect",
+        game_state: "GameState",
+    ) -> str | None:
+        """Return message when utility effect expires."""
+        spell_name = effect.effect_data.get("spell_name", "The magical effect")
+
+        # Most utility cantrips are instantaneous or have subtle endings
+        if "prestidigitation" in spell_name.lower():
+            return "The prestidigitation magic fades, any created marks or trinkets vanishing."
+        elif "mending" in spell_name.lower():
+            return None  # Mending is instantaneous, no expiration message
+        else:
+            return f"The {spell_name} effect fades away."

--- a/tests/test_spell_effects.py
+++ b/tests/test_spell_effects.py
@@ -1,0 +1,364 @@
+# ABOUTME: Unit tests for the spell effects plugin system.
+# ABOUTME: Tests effect handlers for illumination, manipulation, detection, and utility spells.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dnd_engine.spells.effects import (
+    SpellEffect,
+    SpellEffectResult,
+    get_effect_handler,
+    list_effect_types,
+    register,
+)
+from dnd_engine.spells.effects.base import SpellEffect as BaseSpellEffect
+from dnd_engine.spells.effects.detection import DetectionEffect
+from dnd_engine.spells.effects.illumination import IlluminationEffect
+from dnd_engine.spells.effects.manipulation import ManipulationEffect
+from dnd_engine.spells.effects.utility import UtilityEffect
+
+
+class TestSpellEffectRegistry:
+    """Tests for the spell effect registry."""
+
+    def test_list_effect_types_returns_registered_types(self):
+        """All expected effect types should be registered."""
+        effect_types = list_effect_types()
+
+        assert "illumination" in effect_types
+        assert "manipulation" in effect_types
+        assert "detection" in effect_types
+        assert "utility" in effect_types
+
+    def test_get_effect_handler_returns_correct_handler(self):
+        """get_effect_handler should return the correct handler type."""
+        assert isinstance(get_effect_handler("illumination"), IlluminationEffect)
+        assert isinstance(get_effect_handler("manipulation"), ManipulationEffect)
+        assert isinstance(get_effect_handler("detection"), DetectionEffect)
+        assert isinstance(get_effect_handler("utility"), UtilityEffect)
+
+    def test_get_effect_handler_returns_none_for_unknown(self):
+        """get_effect_handler should return None for unknown effect types."""
+        assert get_effect_handler("nonexistent_effect") is None
+
+    def test_register_adds_handler(self):
+        """register should add a new handler to the registry."""
+
+        class TestEffect(BaseSpellEffect):
+            effect_type = "test_effect_unique"
+
+            def apply(self, spell_data, caster, target, game_state):
+                return SpellEffectResult(success=True, message="Test")
+
+        handler = TestEffect()
+        register(handler)
+
+        assert get_effect_handler("test_effect_unique") is handler
+
+
+class TestIlluminationEffect:
+    """Tests for the IlluminationEffect handler."""
+
+    @pytest.fixture
+    def handler(self):
+        return IlluminationEffect()
+
+    @pytest.fixture
+    def mock_caster(self):
+        caster = MagicMock()
+        caster.name = "Gandalf"
+        return caster
+
+    @pytest.fixture
+    def mock_game_state(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def light_spell_data(self):
+        return {
+            "name": "Light",
+            "effect": {
+                "effect_type": "illumination",
+                "light_level": "bright",
+                "radius_ft": 20,
+            },
+        }
+
+    def test_apply_returns_success(self, handler, mock_caster, mock_game_state, light_spell_data):
+        """apply() should return a successful result."""
+        result = handler.apply(light_spell_data, mock_caster, None, mock_game_state)
+
+        assert result.success is True
+        assert "bright" in result.message.lower()
+        assert result.effect_data["light_level"] == "bright"
+        assert result.effect_data["radius_ft"] == 20
+
+    def test_apply_uses_default_light_level(self, handler, mock_caster, mock_game_state):
+        """apply() should use bright as default light level."""
+        spell_data = {"name": "Light", "effect": {"effect_type": "illumination"}}
+
+        result = handler.apply(spell_data, mock_caster, None, mock_game_state)
+
+        assert result.effect_data["light_level"] == "bright"
+
+    def test_apply_with_dim_light(self, handler, mock_caster, mock_game_state):
+        """apply() should handle dim light level."""
+        spell_data = {
+            "name": "Dancing Lights",
+            "effect": {"effect_type": "illumination", "light_level": "dim", "radius_ft": 10},
+        }
+
+        result = handler.apply(spell_data, mock_caster, None, mock_game_state)
+
+        assert result.effect_data["light_level"] == "dim"
+        assert "dim" in result.message.lower() or "soft" in result.message.lower()
+
+    def test_on_expire_returns_message(self, handler, mock_game_state):
+        """on_expire() should return an expiration message."""
+        effect = MagicMock()
+        effect.effect_data = {"spell_name": "Light"}
+
+        message = handler.on_expire(effect, mock_game_state)
+
+        assert message is not None
+        assert "Light" in message
+        assert "fades" in message.lower()
+
+
+class TestManipulationEffect:
+    """Tests for the ManipulationEffect handler."""
+
+    @pytest.fixture
+    def handler(self):
+        return ManipulationEffect()
+
+    @pytest.fixture
+    def mock_caster(self):
+        caster = MagicMock()
+        caster.name = "Merlin"
+        return caster
+
+    @pytest.fixture
+    def mock_game_state(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def mage_hand_spell_data(self):
+        return {
+            "name": "Mage Hand",
+            "range_ft": 30,
+            "effect": {
+                "effect_type": "manipulation",
+                "capabilities": ["interact_at_range", "trigger_pressure_plates"],
+                "range_ft": 30,
+                "weight_limit_lb": 10,
+            },
+        }
+
+    def test_apply_returns_success(self, handler, mock_caster, mock_game_state, mage_hand_spell_data):
+        """apply() should return a successful result with capabilities."""
+        result = handler.apply(mage_hand_spell_data, mock_caster, None, mock_game_state)
+
+        assert result.success is True
+        assert "spectral" in result.message.lower() or "hand" in result.message.lower()
+        assert "interact_at_range" in result.effect_data["capabilities"]
+        assert result.effect_data["weight_limit_lb"] == 10
+
+    def test_apply_stores_caster_name(self, handler, mock_caster, mock_game_state, mage_hand_spell_data):
+        """apply() should store the caster name in effect_data."""
+        result = handler.apply(mage_hand_spell_data, mock_caster, None, mock_game_state)
+
+        assert result.effect_data["caster_name"] == "Merlin"
+
+    def test_get_available_actions_returns_actions(self, handler, mock_game_state):
+        """get_available_actions() should return manipulation actions."""
+        effect = MagicMock()
+        effect.effect_data = {
+            "spell_name": "Mage Hand",
+            "capabilities": ["interact_at_range", "trigger_pressure_plates"],
+            "weight_limit_lb": 10,
+        }
+
+        actions = handler.get_available_actions(effect, mock_game_state)
+
+        assert len(actions) >= 1
+        action_ids = [a["id"] for a in actions]
+        assert "manipulate_object" in action_ids or "trigger_trap" in action_ids
+
+    def test_handle_action_manipulate_object(self, handler, mock_game_state):
+        """handle_action() should handle manipulate_object action."""
+        effect = MagicMock()
+        effect.effect_data = {"spell_name": "Mage Hand"}
+
+        result = handler.handle_action(
+            "manipulate_object", effect, mock_game_state, target_object="a lever"
+        )
+
+        assert result.success is True
+        assert "lever" in result.message
+
+    def test_on_expire_returns_message(self, handler, mock_game_state):
+        """on_expire() should return an expiration message."""
+        effect = MagicMock()
+        effect.effect_data = {"spell_name": "Mage Hand"}
+
+        message = handler.on_expire(effect, mock_game_state)
+
+        assert message is not None
+        assert "fades" in message.lower() or "vanishes" in message.lower()
+
+
+class TestDetectionEffect:
+    """Tests for the DetectionEffect handler."""
+
+    @pytest.fixture
+    def handler(self):
+        return DetectionEffect()
+
+    @pytest.fixture
+    def mock_caster(self):
+        caster = MagicMock()
+        caster.name = "Elminster"
+        return caster
+
+    @pytest.fixture
+    def mock_game_state(self):
+        game_state = MagicMock()
+        game_state.party.characters = []
+        game_state.time_manager.get_all_effects.return_value = []
+        return game_state
+
+    @pytest.fixture
+    def detect_magic_spell_data(self):
+        return {
+            "name": "Detect Magic",
+            "effect": {
+                "effect_type": "detection",
+                "reveals": ["magical_items", "magical_effects", "magical_auras"],
+                "range_ft": 30,
+            },
+        }
+
+    def test_apply_returns_success(self, handler, mock_caster, mock_game_state, detect_magic_spell_data):
+        """apply() should return a successful result."""
+        result = handler.apply(detect_magic_spell_data, mock_caster, None, mock_game_state)
+
+        assert result.success is True
+        assert "Elminster" in result.message
+        assert "magical_items" in result.effect_data["reveals"]
+
+    def test_apply_stores_caster_name(self, handler, mock_caster, mock_game_state, detect_magic_spell_data):
+        """apply() should store the caster name in effect_data."""
+        result = handler.apply(detect_magic_spell_data, mock_caster, None, mock_game_state)
+
+        assert result.effect_data["caster_name"] == "Elminster"
+
+    def test_on_expire_returns_message(self, handler, mock_game_state):
+        """on_expire() should return an expiration message."""
+        effect = MagicMock()
+        effect.effect_data = {"spell_name": "Detect Magic", "caster_name": "Elminster"}
+
+        message = handler.on_expire(effect, mock_game_state)
+
+        assert message is not None
+        assert "Elminster" in message
+
+
+class TestUtilityEffect:
+    """Tests for the UtilityEffect handler."""
+
+    @pytest.fixture
+    def handler(self):
+        return UtilityEffect()
+
+    @pytest.fixture
+    def mock_caster(self):
+        caster = MagicMock()
+        caster.name = "Rincewind"
+        return caster
+
+    @pytest.fixture
+    def mock_game_state(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def prestidigitation_spell_data(self):
+        return {
+            "name": "Prestidigitation",
+            "effect": {"effect_type": "utility", "utility_type": "prestidigitation"},
+        }
+
+    def test_apply_returns_success(self, handler, mock_caster, mock_game_state, prestidigitation_spell_data):
+        """apply() should return a successful result."""
+        result = handler.apply(prestidigitation_spell_data, mock_caster, None, mock_game_state)
+
+        assert result.success is True
+        assert "Rincewind" in result.message
+
+    def test_apply_stores_capabilities(self, handler, mock_caster, mock_game_state, prestidigitation_spell_data):
+        """apply() should store prestidigitation capabilities."""
+        result = handler.apply(prestidigitation_spell_data, mock_caster, None, mock_game_state)
+
+        capabilities = result.effect_data["capabilities"]
+        assert "create_sensory_effect" in capabilities
+        assert "clean_or_soil" in capabilities
+
+    def test_get_available_actions_returns_actions(self, handler, mock_game_state):
+        """get_available_actions() should return utility actions."""
+        effect = MagicMock()
+        effect.effect_data = {
+            "spell_name": "Prestidigitation",
+            "capabilities": ["create_sensory_effect", "clean_or_soil", "flavor_food"],
+        }
+
+        actions = handler.get_available_actions(effect, mock_game_state)
+
+        assert len(actions) >= 1
+
+    def test_handle_action_sensory_effect(self, handler, mock_game_state):
+        """handle_action() should handle sensory_effect action."""
+        effect = MagicMock()
+        effect.effect_data = {"spell_name": "Prestidigitation", "caster_name": "Rincewind"}
+
+        result = handler.handle_action("sensory_effect", effect, mock_game_state)
+
+        assert result.success is True
+
+    def test_on_expire_prestidigitation_returns_message(self, handler, mock_game_state):
+        """on_expire() should return message for prestidigitation."""
+        effect = MagicMock()
+        effect.effect_data = {"spell_name": "Prestidigitation"}
+
+        message = handler.on_expire(effect, mock_game_state)
+
+        assert message is not None
+        assert "prestidigitation" in message.lower()
+
+
+class TestSpellEffectResult:
+    """Tests for SpellEffectResult dataclass."""
+
+    def test_create_success_result(self):
+        """Should create a successful result."""
+        result = SpellEffectResult(
+            success=True, message="Spell cast successfully", effect_data={"key": "value"}
+        )
+
+        assert result.success is True
+        assert result.message == "Spell cast successfully"
+        assert result.effect_data == {"key": "value"}
+
+    def test_create_failure_result(self):
+        """Should create a failure result."""
+        result = SpellEffectResult(success=False, message="Spell failed")
+
+        assert result.success is False
+        assert result.message == "Spell failed"
+        assert result.effect_data == {}
+
+    def test_default_effect_data(self):
+        """effect_data should default to empty dict."""
+        result = SpellEffectResult(success=True, message="Test")
+
+        assert result.effect_data == {}

--- a/tests/test_spell_effects_integration.py
+++ b/tests/test_spell_effects_integration.py
@@ -1,0 +1,309 @@
+# ABOUTME: Integration tests for spell effects with GameState.
+# ABOUTME: Tests that spell effect handlers integrate correctly with cast_spell_exploration.
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.systems.resources import ResourcePool
+from dnd_engine.systems.time_manager import EffectType
+from dnd_engine.utils.events import EventBus
+
+
+class TestSpellEffectsIntegration:
+    """Integration tests for spell effects with GameState."""
+
+    @pytest.fixture
+    def event_bus(self):
+        """Create event bus for testing."""
+        return EventBus()
+
+    @pytest.fixture
+    def data_loader(self):
+        """Create data loader."""
+        return DataLoader()
+
+    @pytest.fixture
+    def dice_roller(self):
+        """Create seeded dice roller for predictable results."""
+        return DiceRoller(seed=42)
+
+    @pytest.fixture
+    def wizard_abilities(self):
+        """Create abilities for a wizard."""
+        return Abilities(
+            strength=8,
+            dexterity=14,
+            constitution=12,
+            intelligence=16,  # +3 modifier
+            wisdom=10,
+            charisma=10,
+        )
+
+    @pytest.fixture
+    def wizard_with_utility_spells(self, wizard_abilities):
+        """Create a wizard with utility spells."""
+        wizard = Character(
+            name="Elara",
+            character_class=CharacterClass.WIZARD,
+            level=3,
+            abilities=wizard_abilities,
+            max_hp=15,
+            ac=12,
+            spellcasting_ability="int",
+            known_spells=[
+                "fire_bolt",
+                "light",
+                "mage_hand",
+                "prestidigitation",
+                "detect_magic",
+            ],
+            prepared_spells=[
+                "fire_bolt",
+                "light",
+                "mage_hand",
+                "prestidigitation",
+                "detect_magic",
+            ],
+        )
+        # Set up spell slots
+        wizard.add_resource_pool(
+            ResourcePool(
+                name="spell_slots_level_1", current=4, maximum=4, recovery_type="long_rest"
+            )
+        )
+        wizard.add_resource_pool(
+            ResourcePool(
+                name="spell_slots_level_2", current=2, maximum=2, recovery_type="long_rest"
+            )
+        )
+        return wizard
+
+    @pytest.fixture
+    def game_state(self, wizard_with_utility_spells, event_bus, data_loader, dice_roller):
+        """Create game state with a wizard."""
+        party = Party([wizard_with_utility_spells])
+        return GameState(
+            party=party,
+            dungeon_name="test_dungeon",
+            event_bus=event_bus,
+            data_loader=data_loader,
+            dice_roller=dice_roller,
+        )
+
+
+class TestLightSpellIntegration(TestSpellEffectsIntegration):
+    """Integration tests for Light cantrip."""
+
+    def test_light_spell_returns_illumination_message(self, game_state):
+        """Casting Light should return a message about illumination."""
+        result = game_state.cast_spell_exploration("Elara", "light")
+
+        assert result["success"] is True
+        assert "bright" in result["description"].lower()
+
+    def test_light_spell_creates_active_effect(self, game_state):
+        """Casting Light should create an active effect."""
+        game_state.cast_spell_exploration("Elara", "light")
+
+        effects = game_state.time_manager.get_all_effects()
+        light_effects = [e for e in effects if e.source == "Light"]
+
+        assert len(light_effects) == 1
+        effect = light_effects[0]
+        assert effect.effect_type == EffectType.SPELL
+        assert effect.effect_data.get("light_level") == "bright"
+
+    def test_light_spell_does_not_consume_slot(self, game_state, wizard_with_utility_spells):
+        """Light is a cantrip and should not consume spell slots."""
+        initial_slots = wizard_with_utility_spells.get_available_spell_slots(1)
+
+        game_state.cast_spell_exploration("Elara", "light")
+
+        assert wizard_with_utility_spells.get_available_spell_slots(1) == initial_slots
+
+    def test_light_spell_affects_effective_lighting(self, game_state, wizard_with_utility_spells):
+        """Light spell should affect the effective lighting in the area."""
+        # First check lighting without spell
+        game_state.cast_spell_exploration("Elara", "light")
+
+        # The get_effective_lighting method should detect the Light spell
+        lighting = game_state.get_effective_lighting(wizard_with_utility_spells)
+        assert lighting == "bright"
+
+
+class TestMageHandIntegration(TestSpellEffectsIntegration):
+    """Integration tests for Mage Hand cantrip."""
+
+    def test_mage_hand_returns_manipulation_message(self, game_state):
+        """Casting Mage Hand should return a message about the spectral hand."""
+        result = game_state.cast_spell_exploration("Elara", "mage_hand")
+
+        assert result["success"] is True
+        assert "spectral" in result["description"].lower() or "hand" in result["description"].lower()
+
+    def test_mage_hand_creates_active_effect_with_capabilities(self, game_state):
+        """Casting Mage Hand should create an effect with manipulation capabilities."""
+        game_state.cast_spell_exploration("Elara", "mage_hand")
+
+        effects = game_state.time_manager.get_all_effects()
+        mage_hand_effects = [e for e in effects if e.source == "Mage Hand"]
+
+        assert len(mage_hand_effects) == 1
+        effect = mage_hand_effects[0]
+        assert "interact_at_range" in effect.effect_data.get("capabilities", [])
+        assert effect.effect_data.get("weight_limit_lb") == 10
+
+    def test_mage_hand_is_concentration(self, game_state):
+        """Mage Hand should be a concentration spell."""
+        game_state.cast_spell_exploration("Elara", "mage_hand")
+
+        effects = game_state.time_manager.get_all_effects()
+        mage_hand_effects = [e for e in effects if e.source == "Mage Hand"]
+
+        assert len(mage_hand_effects) == 1
+        assert mage_hand_effects[0].concentration is True
+
+    def test_casting_mage_hand_again_breaks_concentration(self, game_state):
+        """Casting Mage Hand again should break concentration on the first one."""
+        game_state.cast_spell_exploration("Elara", "mage_hand")
+
+        # Cast again
+        game_state.cast_spell_exploration("Elara", "mage_hand")
+
+        # Should only have one active Mage Hand effect
+        effects = game_state.time_manager.get_all_effects()
+        mage_hand_effects = [e for e in effects if e.source == "Mage Hand"]
+
+        assert len(mage_hand_effects) == 1
+
+
+class TestPrestidigitationIntegration(TestSpellEffectsIntegration):
+    """Integration tests for Prestidigitation cantrip."""
+
+    def test_prestidigitation_returns_utility_message(self, game_state):
+        """Casting Prestidigitation should return a message about minor magic."""
+        result = game_state.cast_spell_exploration("Elara", "prestidigitation")
+
+        assert result["success"] is True
+        assert "Elara" in result["description"]
+
+    def test_prestidigitation_creates_effect_with_capabilities(self, game_state):
+        """Casting Prestidigitation should create an effect with utility capabilities."""
+        game_state.cast_spell_exploration("Elara", "prestidigitation")
+
+        effects = game_state.time_manager.get_all_effects()
+        presti_effects = [e for e in effects if e.source == "Prestidigitation"]
+
+        assert len(presti_effects) == 1
+        effect = presti_effects[0]
+        capabilities = effect.effect_data.get("capabilities", [])
+        assert "create_sensory_effect" in capabilities
+        assert "clean_or_soil" in capabilities
+
+
+class TestDetectMagicIntegration(TestSpellEffectsIntegration):
+    """Integration tests for Detect Magic spell."""
+
+    def test_detect_magic_returns_detection_message(self, game_state):
+        """Casting Detect Magic should return a message about magical senses."""
+        result = game_state.cast_spell_exploration("Elara", "detect_magic")
+
+        assert result["success"] is True
+        assert "Elara" in result["description"]
+        assert "senses" in result["description"].lower() or "magic" in result["description"].lower()
+
+    def test_detect_magic_consumes_spell_slot(self, game_state, wizard_with_utility_spells):
+        """Detect Magic (level 1) should consume a spell slot."""
+        initial_slots = wizard_with_utility_spells.get_available_spell_slots(1)
+
+        game_state.cast_spell_exploration("Elara", "detect_magic")
+
+        assert wizard_with_utility_spells.get_available_spell_slots(1) == initial_slots - 1
+
+    def test_detect_magic_creates_active_effect(self, game_state):
+        """Casting Detect Magic should create an active effect with reveals list."""
+        game_state.cast_spell_exploration("Elara", "detect_magic")
+
+        effects = game_state.time_manager.get_all_effects()
+        detect_effects = [e for e in effects if e.source == "Detect Magic"]
+
+        assert len(detect_effects) == 1
+        effect = detect_effects[0]
+        assert effect.concentration is True
+        reveals = effect.effect_data.get("reveals", [])
+        assert "magical_items" in reveals
+
+    def test_detect_magic_is_concentration(self, game_state):
+        """Detect Magic should be a concentration spell."""
+        game_state.cast_spell_exploration("Elara", "detect_magic")
+
+        effects = game_state.time_manager.get_all_effects()
+        detect_effects = [e for e in effects if e.source == "Detect Magic"]
+
+        assert len(detect_effects) == 1
+        assert detect_effects[0].concentration is True
+
+    def test_casting_detect_magic_breaks_mage_hand_concentration(self, game_state):
+        """Casting Detect Magic should break concentration on Mage Hand."""
+        game_state.cast_spell_exploration("Elara", "mage_hand")
+
+        # Verify Mage Hand is active
+        effects_before = game_state.time_manager.get_all_effects()
+        mage_hand_before = [e for e in effects_before if e.source == "Mage Hand"]
+        assert len(mage_hand_before) == 1
+
+        # Cast Detect Magic (also concentration)
+        game_state.cast_spell_exploration("Elara", "detect_magic")
+
+        # Mage Hand should be gone, Detect Magic should be active
+        effects_after = game_state.time_manager.get_all_effects()
+        mage_hand_after = [e for e in effects_after if e.source == "Mage Hand"]
+        detect_after = [e for e in effects_after if e.source == "Detect Magic"]
+
+        assert len(mage_hand_after) == 0
+        assert len(detect_after) == 1
+
+
+class TestSpellEffectQueries(TestSpellEffectsIntegration):
+    """Tests for querying spell effects through handlers."""
+
+    def test_illumination_query_returns_light_level(self, game_state):
+        """Illumination handler query should return active light level."""
+        from dnd_engine.spells.effects import get_effect_handler
+
+        game_state.cast_spell_exploration("Elara", "light")
+
+        handler = get_effect_handler("illumination")
+        light_level = handler.query(game_state, "get_light_level")
+
+        assert light_level == "bright"
+
+    def test_manipulation_query_has_capability(self, game_state):
+        """Manipulation handler query should detect active capabilities."""
+        from dnd_engine.spells.effects import get_effect_handler
+
+        game_state.cast_spell_exploration("Elara", "mage_hand")
+
+        handler = get_effect_handler("manipulation")
+        has_capability = handler.query(
+            game_state, "has_capability", capability="interact_at_range"
+        )
+
+        assert has_capability is True
+
+    def test_manipulation_query_no_capability_when_not_cast(self, game_state):
+        """Manipulation handler query should return False when no effect active."""
+        from dnd_engine.spells.effects import get_effect_handler
+
+        # Don't cast mage hand
+        handler = get_effect_handler("manipulation")
+        has_capability = handler.query(
+            game_state, "has_capability", capability="interact_at_range"
+        )
+
+        assert has_capability is False


### PR DESCRIPTION
## Summary
- Implements a plugin-style architecture for spell effects where each effect type is handled by a dedicated module
- Gives utility cantrips (Light, Mage Hand, Prestidigitation, Detect Magic) actual gameplay effects
- Adds SpellEffect base class with `apply()`, `query()`, `on_expire()` methods and effect registry

## Changes
- **New files**: `dnd_engine/spells/effects/` with base.py, illumination.py, manipulation.py, detection.py, utility.py
- **Modified**: `game_state.py` to integrate spell effect handlers with `cast_spell_exploration()`
- **Modified**: `spells.json` to add `effect` blocks with `effect_type` for utility spells

## Test plan
- [x] 24 unit tests for spell effect handlers pass
- [x] 18 integration tests for spell effects with GameState pass
- [x] All 42 spell effect tests pass

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)