### PR TITLE
Add #306: Create monorepo directory structure and pyproject.toml files

### DIFF
--- a/client-2d/pyproject.toml
+++ b/client-2d/pyproject.toml
@@ -1,0 +1,35 @@
+# ABOUTME: Placeholder package configuration for the future 2D graphical client.
+# ABOUTME: This will depend on dnd-engine plus a 2D graphics framework (e.g., pygame, pyglet).
+
+[project]
+name = "dnd-2d-client"
+version = "0.1.0"
+description = "2D graphical client for the D&D 5E game engine (placeholder)"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [
+    { name = "Joe Cotellese" }
+]
+
+dependencies = [
+    "dnd-engine",
+    # TODO: Add 2D graphics dependencies when implementation begins
+    # e.g., "pygame>=2.5.0" or "pyglet>=2.0.0"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.1.0",
+    "mypy>=1.7.0",
+    "ruff>=0.1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/client-terminal/pyproject.toml
+++ b/client-terminal/pyproject.toml
@@ -1,0 +1,100 @@
+# ABOUTME: Package configuration for the terminal-based D&D game client.
+# ABOUTME: This package depends on dnd-engine and adds terminal UI dependencies.
+
+[project]
+name = "dnd-terminal-client"
+version = "0.1.0"
+description = "Terminal-based client for the D&D 5E game engine"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [
+    { name = "Joe Cotellese" }
+]
+
+dependencies = [
+    "dnd-engine",
+    "prompt-toolkit>=3.0.52",
+    "questionary>=2.0.0",
+    "rapidfuzz>=3.0.0",
+    "rich>=14.2.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.1.0",
+    "mypy>=1.7.0",
+    "ruff>=0.1.0",
+]
+
+[project.scripts]
+dnd-game = "terminal_client.main:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["terminal_client"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = [
+    "--verbose",
+    "--cov=terminal_client",
+    "--cov-report=term-missing",
+    "--cov-report=html",
+]
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+strict_equality = true
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "UP",  # pyupgrade
+]
+ignore = [
+    "E501",  # line too long (handled by formatter)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["D"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["terminal_client", "dnd_engine"]
+
+[tool.coverage.run]
+source = ["terminal_client"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]

--- a/dnd-engine/pyproject.toml
+++ b/dnd-engine/pyproject.toml
@@ -1,0 +1,96 @@
+# ABOUTME: Package configuration for the headless D&D 5E rules engine.
+# ABOUTME: This package has NO UI dependencies - it's a pure game logic library.
+
+[project]
+name = "dnd-engine"
+version = "0.1.0"
+description = "Headless D&D 5E rules engine library"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [
+    { name = "Joe Cotellese" }
+]
+
+dependencies = [
+    "anthropic>=0.18.0",
+    "openai>=1.0.0",
+    "pydantic>=2.5.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.1.0",
+    "mypy>=1.7.0",
+    "ruff>=0.1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["dnd_engine"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = [
+    "--verbose",
+    "--cov=dnd_engine",
+    "--cov-report=term-missing",
+    "--cov-report=html",
+]
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+strict_equality = true
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "UP",  # pyupgrade
+]
+ignore = [
+    "E501",  # line too long (handled by formatter)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["D"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["dnd_engine"]
+
+[tool.coverage.run]
+source = ["dnd_engine"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]


### PR DESCRIPTION
## Summary
- Create Phase 2 of monorepo restructuring: directory structure and package configurations
- Establish clean separation between headless engine and terminal UI client
- Prepare for future 2D graphical client development

## Changes
- **dnd-engine/pyproject.toml**: Headless rules engine package with NO UI dependencies (anthropic, openai, pydantic, python-dotenv only)
- **client-terminal/pyproject.toml**: Terminal client package that depends on dnd-engine plus UI dependencies (rich, questionary, prompt-toolkit, rapidfuzz)
- **client-2d/pyproject.toml**: Placeholder for future 2D graphical client

## Directory Structure Created
```
rpggame/
├── dnd-engine/
│   ├── pyproject.toml
│   ├── dnd_engine/      (empty - files move in Phase 4)
│   └── tests/           (empty - tests move in Phase 6)
├── client-terminal/
│   ├── pyproject.toml
│   ├── terminal_client/ (empty - files move in Phase 5)
│   └── tests/           (empty - tests move in Phase 6)
└── client-2d/
    ├── pyproject.toml
    └── src/             (placeholder)
```

## Testing
- [x] All pyproject.toml files are valid TOML (verified with tomllib)
- [x] dnd-engine has NO UI dependencies (verified with grep)
- [x] client-terminal has all required UI dependencies

## Related Issues
Fixes #306
Part of #304 (Monorepo restructuring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)