### PR TITLE
Add #313: Combat party spread with formation rendering

### DIFF
--- a/client-2d/src/client_2d/game.py
+++ b/client-2d/src/client_2d/game.py
@@ -1,0 +1,1107 @@
+# ABOUTME: Main entry point for the 2D graphical client.
+# ABOUTME: Launches the game window with real engine integration.
+
+"""2D graphical client for the D&D game.
+
+This module provides the entry point for the 2D client, which can be
+launched via `dnd-game --mode 2d`.
+"""
+
+from pathlib import Path
+
+import arcade
+from arcade.types import Color
+
+from client_2d.assets.asset_manager import AssetManager
+from client_2d.core.constants import (
+    FONT_SIZE_BODY,
+    FONT_SIZE_SMALL,
+    FONT_SIZE_TITLE,
+    NARRATIVE_HEIGHT_PCT,
+    TILE_SIZE,
+    UI_BORDER_WIDTH,
+    UI_PADDING,
+    VIEWPORT_WIDTH_PCT,
+    GameMode,
+    LightingState,
+    UIColors,
+)
+from client_2d.integration.engine_adapter import EngineAdapter
+from client_2d.integration.layout_loader import LayoutLoader
+from client_2d.systems.fog_of_war import FogOfWarSystem
+from client_2d.systems.lighting import LightingSystem
+
+# Window settings
+WINDOW_TITLE = "D&D 5E - 2D Client"
+WINDOW_SIZES = {
+    "small": (800, 600),
+    "medium": (1280, 900),
+    "large": (1600, 1000),
+}
+
+# Combat timing
+ENEMY_TURN_DELAY = 1.5  # Seconds before enemy acts
+
+# Assets directory
+ASSETS_DIR = Path(__file__).parent.parent.parent / "assets"
+
+# Lighting tint colors (RGB multipliers as 0-255)
+LIGHTING_TINTS = {
+    LightingState.UNEXPLORED: None,  # Don't render
+    LightingState.DARK: (60, 60, 80),  # Dark blue-gray (memory)
+    LightingState.DIM: (160, 160, 180),  # Dimmed
+    LightingState.BRIGHT: (255, 255, 255),  # Full brightness
+}
+
+
+class GameWindow(arcade.Window):
+    """Main game window with real engine integration."""
+
+    def __init__(
+        self,
+        width: int = 1280,
+        height: int = 900,
+        fullscreen: bool = False,
+    ):
+        """Initialize the game window.
+
+        Args:
+            width: Window width in pixels.
+            height: Window height in pixels.
+            fullscreen: Whether to run in fullscreen mode.
+        """
+        super().__init__(width, height, WINDOW_TITLE, fullscreen=fullscreen)
+        arcade.set_background_color(UIColors.PANEL_BG_DARK)
+
+        # Engine adapter
+        self.engine = EngineAdapter()
+        self.layout_loader = LayoutLoader()
+
+        # Asset manager and textures
+        self.assets = AssetManager(assets_path=ASSETS_DIR)
+        self._load_textures()
+
+        # Room/map state
+        self.room_layout = None
+        self.room_tiles: list[list[int]] = []
+        self.player_x = 0
+        self.player_y = 0
+
+        # Party position tracking for combat (spread formation)
+        self.party_spread = False
+        self.party_positions: list[tuple[int, int]] = []
+
+        # Fog of war and lighting systems (initialized per-room)
+        self.fog: FogOfWarSystem | None = None
+        self.lighting: LightingSystem | None = None
+
+        # Entities in current room (x, y, type_string, texture)
+        self.entities: list[tuple[int, int, str, arcade.Texture | None]] = []
+
+        # Game state
+        self.running = True
+        self.current_mode = GameMode.EXPLORATION
+        self.selected_enemy = 0
+        self.enemy_turn_timer = 0.0
+        self.processing_enemy_turn = False
+        self.combat_log: list[str] = []
+
+        # Initialize the game
+        self._initialize_game()
+
+    def _initialize_game(self) -> None:
+        """Initialize game with party and dungeon."""
+        print("Loading party from vault...")
+        party_info = self.engine.load_party_from_vault()
+        for char in party_info:
+            print(f"  - {char['name']} ({char['class']} L{char['level']})")
+
+        print("\nInitializing game in cellar dungeon...")
+        game_info = self.engine.initialize_game(
+            dungeon_name="cellar",
+            campaign_id="poisoned_laboratory",
+            start_room="cellar.stairs",  # Start in safe room, rats are north
+        )
+        print(f"  Starting room: {game_info['room_name']}")
+        print("  Hint: Go NORTH to find the rats!")
+
+        # Load room layout for rendering
+        self._load_room_layout()
+
+        print("\nStarting game...")
+        start_info = self.engine.start_game()
+        if start_info["in_combat"]:
+            print(f"  Combat started! Enemies: {', '.join(start_info['enemies'])}")
+            self.current_mode = GameMode.COMBAT
+            self._spread_party_for_combat()
+            self._add_combat_log(f"Combat begins! {len(start_info['enemies'])} enemies!")
+            # Show whose turn it is
+            current = self.engine.get_current_combatant()
+            if current:
+                self._add_combat_log(f"{current['name']}'s turn first!")
+            # If enemy goes first, start enemy turn processing
+            if not self.engine.is_player_turn():
+                self.processing_enemy_turn = True
+                self.enemy_turn_timer = ENEMY_TURN_DELAY
+        else:
+            print("  No enemies in starting room. Explore with WASD!")
+            self._add_combat_log("Use WASD to move. Go NORTH to find the rats!")
+
+    def _add_combat_log(self, message: str) -> None:
+        """Add a message to the combat log."""
+        self.combat_log.append(message)
+        # Keep only last 10 messages
+        if len(self.combat_log) > 10:
+            self.combat_log = self.combat_log[-10:]
+
+    def _load_textures(self) -> None:
+        """Load tile textures from Stone Soup assets."""
+        # Floor and wall textures
+        floor_path = self.assets.get_terrain_sprite_path("floor_stone")
+        wall_path = self.assets.get_terrain_sprite_path("wall_brick")
+        door_closed_path = self.assets.get_terrain_sprite_path("door_closed")
+        player_path = self.assets.get_character_sprite_path("fighter")
+
+        # Load terrain textures
+        self.floor_texture = self._try_load_texture(floor_path, "floor")
+        self.wall_texture = self._try_load_texture(wall_path, "wall")
+        self.door_texture = self._try_load_texture(door_closed_path, "door")
+        self.player_texture = self._try_load_texture(player_path, "player")
+
+        # Load per-class character textures for party rendering
+        self.character_textures: dict[str, arcade.Texture | None] = {}
+        classes_to_load = ["fighter", "rogue", "wizard", "cleric", "paladin", "barbarian"]
+        for char_class in classes_to_load:
+            path = self.assets.get_character_sprite_path(char_class)
+            texture = self._try_load_texture(path, f"character:{char_class}")
+            if texture:
+                self.character_textures[char_class] = texture
+
+        # Load monster textures
+        self.monster_textures: dict[str, arcade.Texture | None] = {}
+        monsters_to_load = [
+            ("skeleton", "undead"),
+            ("ghoul", "undead"),
+            ("goblin", "humanoid"),
+            ("wolf", "beast"),
+            ("giant_rat", "beast"),
+            ("cultist", "humanoid"),
+        ]
+        for monster_id, creature_type in monsters_to_load:
+            path = self.assets.get_monster_sprite_path(monster_id, creature_type)
+            texture = self._try_load_texture(path, f"monster:{monster_id}")
+            if texture:
+                self.monster_textures[monster_id] = texture
+
+        # Load item textures
+        self.item_textures: dict[str, arcade.Texture | None] = {}
+        items_to_load = [
+            ("longsword", "weapons"),
+            ("potion_of_healing", "potions"),
+            ("torch", "misc"),
+            ("chain_mail", "armor"),
+            ("alchemists_fire", "misc"),
+            ("acid_vial", "misc"),
+        ]
+        for item_id, item_category in items_to_load:
+            path = self.assets.get_item_sprite_path(item_id, item_category)
+            texture = self._try_load_texture(path, f"item:{item_id}")
+            if texture:
+                self.item_textures[item_id] = texture
+
+        # Load decoration textures
+        self.decoration_textures: dict[str, arcade.Texture | None] = {}
+        for deco_id in ["chest_closed", "bones"]:
+            path = self.assets.get_decoration_sprite_path(deco_id)
+            texture = self._try_load_texture(path, f"decoration:{deco_id}")
+            if texture:
+                self.decoration_textures[deco_id] = texture
+
+    def _try_load_texture(
+        self, path: Path | None, name: str
+    ) -> arcade.Texture | None:
+        """Try to load a texture, logging success or fallback."""
+        if path and path.exists():
+            print(f"Loaded {name}: {path.name}")
+            return arcade.load_texture(str(path))
+        else:
+            print(f"Using fallback for {name}")
+            return None
+
+    def _draw_texture(
+        self,
+        texture: arcade.Texture,
+        x: float,
+        y: float,
+        tint: tuple[int, int, int] | None = None,
+    ) -> None:
+        """Draw a texture at position with optional tint."""
+        if tint:
+            color = Color(*tint, 255)
+        else:
+            color = arcade.color.WHITE
+
+        arcade.draw_texture_rect(
+            texture,
+            arcade.XYWH(x + TILE_SIZE / 2, y + TILE_SIZE / 2, TILE_SIZE, TILE_SIZE),
+            color=color,
+        )
+
+    def _update_lighting(self) -> None:
+        """Recalculate lighting based on player/party positions."""
+        if self.fog is None or self.lighting is None:
+            return
+
+        # Reset fog to dark for explored tiles
+        self.fog.reset_to_dark()
+
+        # Use party positions if spread, otherwise single player position
+        if self.party_spread and self.party_positions:
+            light_positions = self.party_positions
+        else:
+            light_positions = [(self.player_x, self.player_y)]
+
+        self.lighting.update_party_lights(light_positions, "torch")
+        lit_tiles = self.lighting.calculate_lighting()
+        self.fog.apply_lighting(lit_tiles)
+
+    def _spread_party_for_combat(self) -> None:
+        """Spread party into formation around current position for combat.
+
+        Formation (assuming enemies to the north):
+            Back row:  [2] [3]  (wizard, rogue)
+            Front row: [0] [1]  (fighters)
+        """
+        if not self.room_layout:
+            return
+
+        cx, cy = self.player_x, self.player_y
+
+        # Formation offsets: front row closer to enemies (north = lower y)
+        # Index 0,1 = front row (fighters), Index 2,3 = back row (casters)
+        offsets = [
+            (-1, 0),   # Front-left
+            (1, 0),    # Front-right
+            (-1, 1),   # Back-left
+            (1, 1),    # Back-right
+        ]
+
+        # Calculate positions, checking for valid tiles
+        self.party_positions = []
+        for dx, dy in offsets:
+            px, py = cx + dx, cy + dy
+            # Clamp to room bounds and avoid walls
+            px = max(1, min(px, self.room_layout.width - 2))
+            py = max(1, min(py, self.room_layout.height - 2))
+            # If blocked, try the center position
+            if self.room_layout.is_blocking(px, py):
+                px, py = cx, cy
+            self.party_positions.append((px, py))
+
+        self.party_spread = True
+        self._update_lighting()
+
+    def _collapse_party_after_combat(self) -> None:
+        """Collapse party back to single unit after combat ends."""
+        # Set player position to center of formation
+        if self.party_positions:
+            avg_x = sum(p[0] for p in self.party_positions) // len(self.party_positions)
+            avg_y = sum(p[1] for p in self.party_positions) // len(self.party_positions)
+            self.player_x = avg_x
+            self.player_y = avg_y
+
+        self.party_spread = False
+        self.party_positions = []
+        self._update_lighting()
+
+    def _load_room_layout(self) -> None:
+        """Load the current room's layout for rendering."""
+        game_state = self.engine.game_state
+        if game_state is None:
+            return
+
+        room_id = game_state.current_room_id
+        dungeon_name = game_state.dungeon_name
+        campaign_id = game_state.campaign_id
+
+        # Get room data for exits and entities
+        room_data = self.layout_loader.get_room_data(dungeon_name, room_id, campaign_id)
+        exits = {}
+        if room_data:
+            raw_exits = room_data.get("exits", {})
+            for direction, dest in raw_exits.items():
+                if isinstance(dest, dict):
+                    exits[direction] = dest.get("destination", "")
+                else:
+                    exits[direction] = dest
+
+        # Load layout with fallback generation
+        self.room_layout = self.layout_loader.load_room_with_fallback(
+            dungeon_name=dungeon_name,
+            room_id=room_id,
+            campaign_id=campaign_id,
+            default_width=20,
+            default_height=15,
+            exits=exits,
+        )
+
+        self.room_tiles = self.room_layout.tiles
+        self.player_x, self.player_y = self.room_layout.spawn_points.player
+
+        # Initialize fog of war and lighting systems
+        self.fog = FogOfWarSystem(
+            width=self.room_layout.width,
+            height=self.room_layout.height,
+        )
+        self.lighting = LightingSystem(
+            map_width=self.room_layout.width,
+            map_height=self.room_layout.height,
+        )
+
+        # Set walls as obstacles for lighting
+        for y in range(self.room_layout.height):
+            for x in range(self.room_layout.width):
+                if self.room_layout.is_blocking(x, y):
+                    self.lighting.add_obstacle(x, y)
+
+        # Load entities from room data
+        self.entities = []
+        if room_data:
+            # Add enemies
+            room_enemies = room_data.get("enemies", [])
+            enemy_positions = self.room_layout.entity_positions.enemies
+            for i, enemy_type in enumerate(room_enemies):
+                if i < len(enemy_positions):
+                    ex, ey = enemy_positions[i]
+                else:
+                    ex = self.room_layout.width // 2 + i
+                    ey = self.room_layout.height // 2
+                texture = self.monster_textures.get(enemy_type)
+                self.entities.append((ex, ey, f"monster:{enemy_type}", texture))
+
+            # Add visible items
+            room_items = room_data.get("items", [])
+            item_positions = self.room_layout.entity_positions.items
+            visible_idx = 0
+            for item_data in room_items:
+                if not item_data.get("visible", True):
+                    continue
+                item_id = item_data.get("id", f"item_{visible_idx}")
+                if visible_idx < len(item_positions):
+                    ix, iy = item_positions[visible_idx]
+                else:
+                    ix = 3 + (visible_idx * 2) % (self.room_layout.width - 6)
+                    iy = 3 + (visible_idx * 3) % (self.room_layout.height - 6)
+                texture = self.item_textures.get(item_id)
+                self.entities.append((ix, iy, f"item:{item_id}", texture))
+                visible_idx += 1
+
+        # Initial lighting update
+        self._update_lighting()
+
+    def _get_available_exits(self) -> dict[str, str]:
+        """Get available exits from current room."""
+        game_state = self.engine.game_state
+        if game_state is None:
+            return {}
+
+        room = game_state.get_current_room()
+        exits = {}
+        raw_exits = room.get("exits", {})
+        for direction, dest in raw_exits.items():
+            if isinstance(dest, dict):
+                if not dest.get("hidden", False):  # Skip hidden exits
+                    exits[direction] = dest.get("destination", "")
+            else:
+                exits[direction] = dest
+        return exits
+
+    def _move_player(self, direction: str) -> None:
+        """Attempt to move the player in a direction."""
+        if self.engine.in_combat:
+            self._add_combat_log("Can't move during combat!")
+            return
+
+        # Check if this direction leads to an exit
+        exits = self._get_available_exits()
+        if direction in exits:
+            # Room transition!
+            self._add_combat_log(f"Moving {direction}...")
+            self._transition_room(direction)
+            return
+
+        # Otherwise, try to move within the room
+        dx, dy = {"north": (0, -1), "south": (0, 1), "east": (1, 0), "west": (-1, 0)}.get(
+            direction, (0, 0)
+        )
+        new_x = self.player_x + dx
+        new_y = self.player_y + dy
+
+        # Check bounds and walls
+        if self.room_layout and 0 <= new_x < self.room_layout.width and 0 <= new_y < self.room_layout.height:
+            if not self.room_layout.is_blocking(new_x, new_y):
+                self.player_x = new_x
+                self.player_y = new_y
+                self._update_lighting()
+
+    def _transition_room(self, direction: str) -> None:
+        """Transition to a new room via an exit."""
+        game_state = self.engine.game_state
+        if game_state is None:
+            return
+
+        # Use engine's move to transition rooms
+        result = game_state.move(direction)
+
+        if result:
+            # Reload room layout
+            self._load_room_layout()
+
+            room = game_state.get_current_room()
+            room_name = room.get("name", "Unknown")
+            self._add_combat_log(f"Entered: {room_name}")
+
+            # Check for combat
+            if game_state.in_combat:
+                enemies = [e.name for e in game_state.active_enemies]
+                self.current_mode = GameMode.COMBAT
+                self._spread_party_for_combat()
+                self._add_combat_log(f"Combat! {len(enemies)} enemies: {', '.join(enemies)}")
+                # Show whose turn it is
+                current = self.engine.get_current_combatant()
+                if current:
+                    if current["is_player"]:
+                        self._add_combat_log(f"{current['name']}'s turn - press 1-9 then A to attack!")
+                    else:
+                        self._add_combat_log(f"{current['name']} attacks first...")
+                # If enemy goes first, start enemy turn processing
+                if not self.engine.is_player_turn():
+                    self.processing_enemy_turn = True
+                    self.enemy_turn_timer = ENEMY_TURN_DELAY
+
+    # ========== Drawing Methods ==========
+
+    def on_draw(self) -> None:
+        """Render the game."""
+        self.clear()
+
+        # Calculate layout zones
+        viewport_w = int(self.width * VIEWPORT_WIDTH_PCT)
+        context_w = self.width - viewport_w
+        narrative_h = int(self.height * NARRATIVE_HEIGHT_PCT)
+        main_h = self.height - narrative_h
+
+        # Draw UI panels
+        self._draw_game_viewport(0, narrative_h, viewport_w, main_h)
+        self._draw_context_panel(viewport_w, narrative_h, context_w, main_h)
+        self._draw_narrative_panel(0, 0, self.width, narrative_h)
+
+    def _draw_game_viewport(self, x: float, y: float, w: float, h: float) -> None:
+        """Draw the main game viewport with dungeon tiles."""
+        # Background
+        rect = arcade.LBWH(x, y, w, h)
+        arcade.draw_rect_filled(rect, UIColors.PANEL_BG_DARK)
+        arcade.draw_rect_outline(rect, UIColors.BORDER, UI_BORDER_WIDTH)
+
+        # Room name
+        room_name = "Unknown"
+        if self.engine.game_state:
+            room = self.engine.game_state.get_current_room()
+            room_name = room.get("name", "Unknown")
+
+        arcade.draw_text(
+            room_name,
+            x + UI_PADDING,
+            y + h - UI_PADDING - FONT_SIZE_TITLE,
+            UIColors.TEXT_HIGHLIGHT,
+            FONT_SIZE_TITLE,
+            bold=True,
+        )
+
+        # Draw the dungeon tiles
+        if self.room_layout:
+            self._draw_dungeon_tiles(x, y, w, h)
+
+        # Combat overlay
+        if self.engine.in_combat:
+            self._draw_combat_overlay(x, y, w, h)
+        else:
+            # Exploration controls hint
+            arcade.draw_text(
+                "WASD: Move  |  Go NORTH to find the rats!",
+                x + w // 2,
+                y + UI_PADDING,
+                UIColors.TEXT_DIM,
+                FONT_SIZE_SMALL,
+                anchor_x="center",
+            )
+
+    def _draw_dungeon_tiles(self, vp_x: float, vp_y: float, vp_w: float, vp_h: float) -> None:
+        """Draw the dungeon tile grid with textures and lighting."""
+        if not self.room_layout:
+            return
+
+        # Calculate tile size to fit the viewport
+        margin = 50  # Space for title and controls
+        available_h = vp_h - margin * 2
+        available_w = vp_w - UI_PADDING * 2
+
+        tile_size = min(
+            available_w // self.room_layout.width,
+            available_h // self.room_layout.height,
+            TILE_SIZE,  # Cap at max tile size
+        )
+
+        # Center the map in the viewport
+        map_w = self.room_layout.width * tile_size
+        map_h = self.room_layout.height * tile_size
+        offset_x = vp_x + (vp_w - map_w) // 2
+        offset_y = vp_y + margin + (available_h - map_h) // 2
+
+        # Draw tiles with lighting
+        for ty in range(self.room_layout.height):
+            for tx in range(self.room_layout.width):
+                screen_x = offset_x + tx * tile_size
+                # Flip Y for screen coords (0,0 at bottom-left in arcade)
+                screen_y = offset_y + (self.room_layout.height - 1 - ty) * tile_size
+
+                # Get lighting state for this tile
+                if self.fog:
+                    state = self.fog.get_visibility(tx, ty)
+                    tint = LIGHTING_TINTS.get(state)
+                else:
+                    tint = (255, 255, 255)  # Full bright if no fog system
+
+                # Skip unexplored tiles (render black)
+                if tint is None:
+                    tile_rect = arcade.LBWH(screen_x, screen_y, tile_size, tile_size)
+                    arcade.draw_rect_filled(tile_rect, arcade.color.BLACK)
+                    continue
+
+                tile_val = self.room_tiles[ty][tx]
+                is_wall = tile_val == 1
+                is_door = tile_val == 2
+
+                # Draw tile with texture or fallback
+                if is_wall:
+                    if self.wall_texture:
+                        self._draw_texture(self.wall_texture, screen_x, screen_y, tint)
+                    else:
+                        tile_rect = arcade.LBWH(screen_x, screen_y, tile_size - 1, tile_size - 1)
+                        arcade.draw_rect_filled(tile_rect, (60, 50, 40))
+                elif is_door:
+                    if self.door_texture:
+                        self._draw_texture(self.door_texture, screen_x, screen_y, tint)
+                    else:
+                        tile_rect = arcade.LBWH(screen_x, screen_y, tile_size - 1, tile_size - 1)
+                        arcade.draw_rect_filled(tile_rect, (100, 80, 60))
+                        arcade.draw_rect_outline(tile_rect, UIColors.TEXT_HIGHLIGHT, 2)
+                else:  # Floor
+                    if self.floor_texture:
+                        self._draw_texture(self.floor_texture, screen_x, screen_y, tint)
+                    else:
+                        tile_rect = arcade.LBWH(screen_x, screen_y, tile_size - 1, tile_size - 1)
+                        arcade.draw_rect_filled(tile_rect, (40, 35, 30))
+
+        # Draw entities (monsters, items) with lighting
+        for ex, ey, entity_type, texture in self.entities:
+            if self.fog:
+                state = self.fog.get_visibility(ex, ey)
+                tint = LIGHTING_TINTS.get(state)
+            else:
+                tint = (255, 255, 255)
+
+            # Only draw visible entities
+            if tint is None:
+                continue
+
+            screen_x = offset_x + ex * tile_size
+            screen_y = offset_y + (self.room_layout.height - 1 - ey) * tile_size
+
+            if texture:
+                self._draw_texture(texture, screen_x, screen_y, tint)
+            else:
+                # Fallback: colored squares based on entity type
+                if entity_type.startswith("monster:"):
+                    fallback_color = (180, 50, 50)  # Red for monsters
+                elif entity_type.startswith("item:"):
+                    fallback_color = (50, 180, 50)  # Green for items
+                else:
+                    fallback_color = (180, 140, 50)  # Gold for decorations
+                tile_rect = arcade.LBWH(
+                    screen_x + 4, screen_y + 4, tile_size - 8, tile_size - 8
+                )
+                arcade.draw_rect_filled(tile_rect, fallback_color)
+
+        # Draw party/player
+        if self.party_spread and self.party_positions:
+            # Combat formation - draw each party member separately
+            party_data = self.engine.get_party_for_rendering()
+            for i, (px, py) in enumerate(self.party_positions):
+                if i >= len(party_data):
+                    break
+
+                char_screen_x = offset_x + px * tile_size
+                char_screen_y = offset_y + (self.room_layout.height - 1 - py) * tile_size
+
+                char_class = party_data[i]["class"].lower()
+                is_current_turn = party_data[i]["is_current_turn"]
+                texture = self.character_textures.get(char_class, self.player_texture)
+
+                # Draw current turn highlight (selection ring)
+                if is_current_turn:
+                    center_x = char_screen_x + tile_size // 2
+                    center_y = char_screen_y + tile_size // 2
+                    arcade.draw_circle_outline(
+                        center_x, center_y, tile_size // 2 + 2,
+                        UIColors.TEXT_HIGHLIGHT, 3
+                    )
+
+                # Draw character texture or fallback
+                if texture:
+                    self._draw_texture(texture, char_screen_x, char_screen_y)
+                else:
+                    center_x = char_screen_x + tile_size // 2
+                    center_y = char_screen_y + tile_size // 2
+                    color = UIColors.TEXT_HIGHLIGHT if is_current_turn else UIColors.HP_FULL
+                    arcade.draw_circle_filled(center_x, center_y, tile_size // 3, color)
+                    # Show first letter of class
+                    arcade.draw_text(
+                        char_class[0].upper(), center_x, center_y - 5,
+                        (255, 255, 255), 14, anchor_x="center"
+                    )
+
+                # Draw torch glow on current turn character
+                if is_current_turn:
+                    center_x = char_screen_x + tile_size // 2
+                    center_y = char_screen_y + tile_size // 2
+                    arcade.draw_circle_filled(center_x, center_y, 6, arcade.color.ORANGE)
+        else:
+            # Exploration mode - single unit
+            player_screen_x = offset_x + self.player_x * tile_size
+            player_screen_y = offset_y + (self.room_layout.height - 1 - self.player_y) * tile_size
+
+            if self.player_texture:
+                self._draw_texture(self.player_texture, player_screen_x, player_screen_y)
+            else:
+                # Fallback colored circle with @ symbol
+                center_x = player_screen_x + tile_size // 2
+                center_y = player_screen_y + tile_size // 2
+                arcade.draw_circle_filled(center_x, center_y, tile_size // 3, UIColors.HP_FULL)
+                arcade.draw_text("@", center_x, center_y - 5, (255, 255, 255), 14, anchor_x="center")
+
+            # Draw light indicator on player (torch glow)
+            center_x = player_screen_x + tile_size // 2
+            center_y = player_screen_y + tile_size // 2
+            arcade.draw_circle_filled(center_x, center_y, 6, arcade.color.ORANGE)
+
+        # Draw exit indicators
+        exits = self._get_available_exits()
+        for direction in exits:
+            if self.room_layout:
+                exit_pos = self.room_layout.spawn_points.exits.get(direction)
+                if exit_pos:
+                    exit_x, exit_y = exit_pos
+                    exit_screen_x = offset_x + exit_x * tile_size + tile_size // 2
+                    exit_screen_y = offset_y + (self.room_layout.height - 1 - exit_y) * tile_size + tile_size // 2
+                    arcade.draw_text(
+                        direction[0].upper(),  # N, S, E, W
+                        exit_screen_x,
+                        exit_screen_y - 5,
+                        UIColors.TEXT_HIGHLIGHT,
+                        12,
+                        anchor_x="center",
+                        bold=True,
+                    )
+
+    def _draw_combat_overlay(self, x: float, y: float, w: float, h: float) -> None:
+        """Draw combat mode overlay on the viewport."""
+        # Semi-transparent overlay
+        overlay_rect = arcade.LBWH(x + 2, y + 2, w - 4, 80)
+        arcade.draw_rect_filled(overlay_rect, (0, 0, 0, 180))
+
+        status = "COMBAT!"
+        if self.processing_enemy_turn:
+            status += " - Enemy turn..."
+        elif self.engine.is_player_turn():
+            current = self.engine.get_current_combatant()
+            if current:
+                status += f" - {current['name']}'s turn"
+
+        arcade.draw_text(
+            status,
+            x + w // 2,
+            y + 60,
+            UIColors.HP_LOW,
+            FONT_SIZE_TITLE,
+            anchor_x="center",
+            bold=True,
+        )
+
+        # Enemy list with selection
+        enemies = self.engine.get_enemies()
+        enemy_text = "  ".join(
+            f"{'>' if i == self.selected_enemy else ' '}{i + 1}.{e['name']}({e['hp']}hp)"
+            for i, e in enumerate(enemies)
+        )
+        arcade.draw_text(
+            enemy_text,
+            x + w // 2,
+            y + 30,
+            UIColors.TEXT,
+            FONT_SIZE_BODY,
+            anchor_x="center",
+        )
+
+        # Controls hint
+        arcade.draw_text(
+            "1-9: Select  |  A: Attack  |  Space: Wait",
+            x + w // 2,
+            y + UI_PADDING,
+            UIColors.TEXT_DIM,
+            FONT_SIZE_SMALL,
+            anchor_x="center",
+        )
+
+    def _draw_context_panel(self, x: float, y: float, w: float, h: float) -> None:
+        """Draw the context panel (party status / combat initiative)."""
+        # Background
+        rect = arcade.LBWH(x, y, w, h)
+        arcade.draw_rect_filled(rect, UIColors.PANEL_BG)
+        arcade.draw_rect_outline(rect, UIColors.BORDER, UI_BORDER_WIDTH)
+
+        if self.engine.in_combat:
+            self._draw_combat_panel(x, y, w, h)
+        else:
+            self._draw_party_panel(x, y, w, h)
+
+    def _draw_party_panel(self, x: float, y: float, w: float, h: float) -> None:
+        """Draw party status panel."""
+        arcade.draw_text(
+            "PARTY",
+            x + UI_PADDING,
+            y + h - UI_PADDING - FONT_SIZE_TITLE,
+            UIColors.TEXT_HIGHLIGHT,
+            FONT_SIZE_TITLE,
+            bold=True,
+        )
+
+        party_data = self.engine.get_party_data()
+        row_h = 50
+        start_y = y + h - 60
+
+        for i, member in enumerate(party_data):
+            row_y = start_y - (i * row_h)
+
+            # Name and class
+            arcade.draw_text(
+                f"{member['name']}",
+                x + UI_PADDING,
+                row_y,
+                UIColors.TEXT_HIGHLIGHT,
+                FONT_SIZE_BODY,
+                bold=True,
+            )
+            arcade.draw_text(
+                f"{member['class']}",
+                x + UI_PADDING,
+                row_y - 18,
+                UIColors.TEXT_DIM,
+                FONT_SIZE_SMALL,
+            )
+
+            # HP bar
+            hp_pct = member["hp"] / member["max_hp"] if member["max_hp"] > 0 else 0
+            bar_w = w - UI_PADDING * 4 - 60
+            bar_x = x + UI_PADDING
+            bar_y = row_y - 35
+
+            # Background
+            bg_rect = arcade.LBWH(bar_x, bar_y, bar_w, 8)
+            arcade.draw_rect_filled(bg_rect, UIColors.HP_BG)
+
+            # Fill
+            if hp_pct > 0:
+                if hp_pct > 0.5:
+                    color = UIColors.HP_FULL
+                elif hp_pct > 0.25:
+                    color = UIColors.HP_MEDIUM
+                else:
+                    color = UIColors.HP_LOW
+                fill_rect = arcade.LBWH(bar_x, bar_y, bar_w * hp_pct, 8)
+                arcade.draw_rect_filled(fill_rect, color)
+
+            # HP text
+            arcade.draw_text(
+                f"{member['hp']}/{member['max_hp']}",
+                bar_x + bar_w + 5,
+                bar_y - 2,
+                UIColors.TEXT,
+                FONT_SIZE_SMALL,
+            )
+
+    def _draw_combat_panel(self, x: float, y: float, w: float, h: float) -> None:
+        """Draw combat initiative panel."""
+        combat_data = self.engine.get_combat_data()
+        if not combat_data:
+            return
+
+        arcade.draw_text(
+            f"COMBAT - Round {combat_data['round']}",
+            x + UI_PADDING,
+            y + h - UI_PADDING - FONT_SIZE_TITLE,
+            UIColors.HP_LOW,
+            FONT_SIZE_TITLE,
+            bold=True,
+        )
+
+        row_h = 35
+        start_y = y + h - 60
+
+        for i, combatant in enumerate(combat_data["initiative"]):
+            row_y = start_y - (i * row_h)
+            is_current = i == combat_data["current_turn"]
+
+            # Highlight current turn
+            if is_current:
+                highlight_rect = arcade.LBWH(x + 2, row_y - 10, w - 4, row_h - 2)
+                arcade.draw_rect_filled(highlight_rect, UIColors.SELECTION)
+
+            # Initiative number
+            arcade.draw_text(
+                f"{combatant['init']:2d}",
+                x + UI_PADDING,
+                row_y,
+                UIColors.TEXT_DIM,
+                FONT_SIZE_BODY,
+            )
+
+            # Name
+            name_color = UIColors.TEXT_HIGHLIGHT if combatant["is_player"] else UIColors.HP_LOW
+            arcade.draw_text(
+                combatant["name"],
+                x + UI_PADDING + 35,
+                row_y,
+                name_color,
+                FONT_SIZE_BODY,
+                bold=is_current,
+            )
+
+            # HP
+            hp_pct = combatant["hp"] / combatant["max_hp"] if combatant["max_hp"] > 0 else 0
+            if hp_pct > 0.5:
+                hp_color = UIColors.HP_FULL
+            elif hp_pct > 0.25:
+                hp_color = UIColors.HP_MEDIUM
+            else:
+                hp_color = UIColors.HP_LOW
+
+            arcade.draw_text(
+                f"{combatant['hp']}/{combatant['max_hp']}",
+                x + w - UI_PADDING - 60,
+                row_y,
+                hp_color,
+                FONT_SIZE_BODY,
+            )
+
+    def _draw_narrative_panel(self, x: float, y: float, w: float, h: float) -> None:
+        """Draw the narrative/combat log panel."""
+        # Background
+        rect = arcade.LBWH(x, y, w, h)
+        arcade.draw_rect_filled(rect, UIColors.PANEL_BG)
+        arcade.draw_rect_outline(rect, UIColors.BORDER, UI_BORDER_WIDTH)
+
+        arcade.draw_text(
+            "COMBAT LOG",
+            x + UI_PADDING,
+            y + h - UI_PADDING - FONT_SIZE_TITLE,
+            UIColors.TEXT_HIGHLIGHT,
+            FONT_SIZE_TITLE,
+            bold=True,
+        )
+
+        # Display combat log
+        log_y = y + h - 50
+        for i, msg in enumerate(reversed(self.combat_log[-5:])):
+            arcade.draw_text(
+                msg,
+                x + UI_PADDING,
+                log_y - (i * 20),
+                UIColors.TEXT,
+                FONT_SIZE_BODY,
+            )
+
+    # ========== Update Loop ==========
+
+    def on_update(self, delta_time: float) -> None:
+        """Update game state."""
+        if not self.engine.in_combat:
+            return
+
+        # Handle enemy turn timing
+        if self.processing_enemy_turn:
+            self.enemy_turn_timer -= delta_time
+            if self.enemy_turn_timer <= 0:
+                self._process_enemy_turn()
+
+    def _process_enemy_turn(self) -> None:
+        """Process the current enemy's turn."""
+        result = self.engine.process_enemy_turn()
+
+        if result["success"]:
+            if result.get("hit") is not None:
+                if result["hit"]:
+                    self._add_combat_log(
+                        f"{result['enemy_name']} hits {result['target_name']} for {result['damage']} damage!"
+                    )
+                    if result.get("target_killed"):
+                        self._add_combat_log(f"{result['target_name']} is down!")
+                else:
+                    self._add_combat_log(f"{result['enemy_name']} misses {result['target_name']}!")
+            else:
+                self._add_combat_log(f"{result['enemy_name']} takes no action.")
+
+        # Advance turn
+        turn_result = self.engine.advance_turn()
+
+        if turn_result.get("combat_ended"):
+            self._handle_combat_end()
+        elif not turn_result.get("is_player_turn"):
+            # Another enemy's turn - continue timer
+            self.enemy_turn_timer = ENEMY_TURN_DELAY
+        else:
+            # Player's turn
+            self.processing_enemy_turn = False
+
+    def _handle_combat_end(self) -> None:
+        """Handle end of combat."""
+        self.processing_enemy_turn = False
+        self.current_mode = GameMode.EXPLORATION
+        self._collapse_party_after_combat()
+
+        check = self.engine.end_combat_check()
+        if check.get("victory"):
+            self._add_combat_log("Victory! All enemies defeated!")
+        elif check.get("party_wiped"):
+            self._add_combat_log("Defeat! Your party has fallen...")
+
+    # ========== Input Handling ==========
+
+    def on_key_press(self, key: int, modifiers: int) -> None:
+        """Handle key presses."""
+        # ESC to quit
+        if key == arcade.key.ESCAPE:
+            self.close()
+            return
+
+        if self.engine.in_combat and not self.processing_enemy_turn:
+            self._handle_combat_input(key)
+        else:
+            self._handle_exploration_input(key)
+
+    def _handle_combat_input(self, key: int) -> None:
+        """Handle combat-mode input."""
+        if not self.engine.is_player_turn():
+            return
+
+        # Number keys to select enemy
+        if arcade.key.KEY_1 <= key <= arcade.key.KEY_9:
+            index = key - arcade.key.KEY_1
+            enemies = self.engine.get_enemies()
+            if index < len(enemies):
+                self.selected_enemy = index
+
+        # A to attack
+        elif key == arcade.key.A:
+            self._execute_attack()
+
+        # Space to wait/pass
+        elif key == arcade.key.SPACE:
+            self._pass_turn()
+
+    def _handle_exploration_input(self, key: int) -> None:
+        """Handle exploration-mode input."""
+        # WASD / Arrow movement
+        if key == arcade.key.W or key == arcade.key.UP:
+            self._move_player("north")
+        elif key == arcade.key.S or key == arcade.key.DOWN:
+            self._move_player("south")
+        elif key == arcade.key.A or key == arcade.key.LEFT:
+            self._move_player("west")
+        elif key == arcade.key.D or key == arcade.key.RIGHT:
+            self._move_player("east")
+
+    def _execute_attack(self) -> None:
+        """Execute attack on selected enemy."""
+        result = self.engine.execute_attack(target_index=self.selected_enemy)
+
+        if result["success"]:
+            if result["hit"]:
+                crit = " CRITICAL!" if result.get("critical") else ""
+                self._add_combat_log(
+                    f"{result['attacker_name']} hits {result['target_name']} "
+                    f"for {result['damage']} damage!{crit}"
+                )
+                if result.get("target_killed"):
+                    self._add_combat_log(f"{result['target_name']} is defeated!")
+            else:
+                self._add_combat_log(
+                    f"{result['attacker_name']} misses {result['target_name']}! "
+                    f"(rolled {result['attack_roll']} vs AC {result['target_ac']})"
+                )
+
+            # Advance turn
+            turn_result = self.engine.advance_turn()
+
+            if turn_result.get("combat_ended"):
+                self._handle_combat_end()
+            elif not turn_result.get("is_player_turn"):
+                # Start enemy turn timer
+                self.processing_enemy_turn = True
+                self.enemy_turn_timer = ENEMY_TURN_DELAY
+        else:
+            self._add_combat_log(f"Attack failed: {result.get('error', 'Unknown error')}")
+
+    def _pass_turn(self) -> None:
+        """Pass the current turn."""
+        current = self.engine.get_current_combatant()
+        if current:
+            self._add_combat_log(f"{current['name']} waits...")
+
+        turn_result = self.engine.advance_turn()
+
+        if turn_result.get("combat_ended"):
+            self._handle_combat_end()
+        elif not turn_result.get("is_player_turn"):
+            self.processing_enemy_turn = True
+            self.enemy_turn_timer = ENEMY_TURN_DELAY
+
+
+def run_2d_client(size: str = "medium", fullscreen: bool = False) -> None:
+    """Entry point for the 2D client.
+
+    Args:
+        size: Window size preset (small, medium, large).
+        fullscreen: Whether to run in fullscreen mode.
+    """
+    width, height = WINDOW_SIZES.get(size, WINDOW_SIZES["medium"])
+
+    # For fullscreen, use large dimensions as starting point
+    if fullscreen:
+        width, height = WINDOW_SIZES["large"]
+
+    print("=" * 50)
+    print("D&D 5E - 2D Graphical Client")
+    print("=" * 50)
+    if fullscreen:
+        print("Mode: Fullscreen")
+    else:
+        print(f"Window: {width}x{height} ({size})")
+    print()
+
+    GameWindow(width=width, height=height, fullscreen=fullscreen)
+    arcade.run()
+
+
+if __name__ == "__main__":
+    run_2d_client()

--- a/client-2d/src/client_2d/integration/engine_adapter.py
+++ b/client-2d/src/client_2d/integration/engine_adapter.py
@@ -1,0 +1,650 @@
+# ABOUTME: Adapter wrapping dnd-engine for the 2D graphical client.
+# ABOUTME: Loads characters from vault, creates GameState, provides UI-friendly data access.
+
+"""Engine adapter for connecting client-2d to dnd-engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dnd_engine.core.character import Character
+
+# Default party - hardcoded character IDs from vault
+DEFAULT_PARTY_IDS = [
+    "a16c59f0-3818-45be-ba89-a26f5b9db472",  # Bob (Fighter)
+    "4b351815-e063-407f-b071-3d93290a675e",  # Larry (Rogue)
+    "ebcff030-e5e8-41d2-813a-829d0b6f83dd",  # Thim (Wizard)
+    "09bde739-8bbc-4691-ad09-fe804578b0c1",  # Vesataus (Fighter)
+]
+
+
+@dataclass
+class CombatantInfo:
+    """Information about a combatant for UI display."""
+
+    name: str
+    initiative: int
+    is_player: bool
+    hp: int
+    max_hp: int
+    is_current_turn: bool = False
+
+
+class EngineAdapter:
+    """Adapter wrapping dnd-engine GameState for the 2D client.
+
+    Provides a clean interface for:
+    - Loading characters from the vault
+    - Initializing game state with a dungeon
+    - Querying game state in UI-friendly formats
+    - Executing player actions (move, attack, etc.)
+
+    Usage:
+        adapter = EngineAdapter()
+        adapter.load_party_from_vault()
+        adapter.initialize_game("cellar", "poisoned_laboratory")
+
+        # Get UI data
+        party_data = adapter.get_party_data()
+        combat_data = adapter.get_combat_data()
+
+        # Execute actions
+        result = adapter.execute_attack(target_index=0)
+    """
+
+    def __init__(self) -> None:
+        """Initialize the engine adapter."""
+        self._game_state = None
+        self._party = None
+        self._event_bus = None
+        self._vault = None
+        self._initialized = False
+
+    def load_party_from_vault(
+        self, character_ids: list[str] | None = None
+    ) -> list[dict[str, Any]]:
+        """Load characters from the vault into a party.
+
+        Args:
+            character_ids: List of character UUIDs to load.
+                          Uses DEFAULT_PARTY_IDS if not provided.
+
+        Returns:
+            List of character info dicts for UI display.
+
+        Raises:
+            FileNotFoundError: If a character ID doesn't exist in vault.
+        """
+        from dnd_engine.core.character_vault_v2 import CharacterVaultV2
+        from dnd_engine.core.party import Party
+
+        if character_ids is None:
+            character_ids = DEFAULT_PARTY_IDS
+
+        self._vault = CharacterVaultV2()
+        characters: list[Character] = []
+
+        for char_id in character_ids:
+            character = self._vault.get_character(char_id)
+            characters.append(character)
+
+        self._party = Party(characters)
+
+        # Return summary for UI
+        return [
+            {
+                "id": char_id,
+                "name": char.name,
+                "class": char.character_class.value.title(),
+                "level": char.level,
+                "hp": char.current_hp,
+                "max_hp": char.max_hp,
+            }
+            for char_id, char in zip(character_ids, characters, strict=True)
+        ]
+
+    def initialize_game(
+        self,
+        dungeon_name: str = "cellar",
+        campaign_id: str = "poisoned_laboratory",
+        start_room: str | None = None,
+    ) -> dict[str, Any]:
+        """Initialize game state with a dungeon.
+
+        Args:
+            dungeon_name: Name of the dungeon file (without .json).
+            campaign_id: Campaign containing the dungeon.
+            start_room: Optional room ID to start in (uses dungeon default if not provided).
+
+        Returns:
+            Dict with initial game info (room_id, room_name, etc.)
+
+        Raises:
+            ValueError: If party not loaded yet.
+        """
+        if self._party is None:
+            raise ValueError("Must call load_party_from_vault() first")
+
+        from dnd_engine.core.game_state import GameState
+        from dnd_engine.rules.loader import DataLoader
+        from dnd_engine.utils.events import EventBus
+
+        self._event_bus = EventBus()
+        data_loader = DataLoader()
+
+        self._game_state = GameState(
+            party=self._party,
+            dungeon_name=dungeon_name,
+            event_bus=self._event_bus,
+            data_loader=data_loader,
+            campaign_id=campaign_id,
+        )
+
+        # Override start room if specified
+        if start_room:
+            self._game_state.current_room_id = start_room
+
+        self._initialized = True
+
+        return {
+            "room_id": self._game_state.current_room_id,
+            "room_name": self._game_state.get_current_room().get("name", "Unknown"),
+            "dungeon": dungeon_name,
+            "campaign": campaign_id,
+        }
+
+    def start_game(self) -> dict[str, Any]:
+        """Start the game (triggers enemy check in starting room).
+
+        Returns:
+            Dict with combat status and any enemies found.
+        """
+        if not self._initialized:
+            raise ValueError("Must call initialize_game() first")
+
+        # This triggers _check_for_enemies() in the starting room
+        self._game_state.start()
+
+        return {
+            "in_combat": self._game_state.in_combat,
+            "enemies": [e.name for e in self._game_state.active_enemies],
+        }
+
+    @property
+    def game_state(self):
+        """Access the underlying GameState (for advanced use)."""
+        return self._game_state
+
+    @property
+    def party(self):
+        """Access the Party object."""
+        return self._party
+
+    @property
+    def event_bus(self):
+        """Access the EventBus for subscribing to events."""
+        return self._event_bus
+
+    @property
+    def in_combat(self) -> bool:
+        """Check if currently in combat."""
+        if self._game_state is None:
+            return False
+        return self._game_state.in_combat
+
+    # ========== UI Data Methods ==========
+
+    def get_party_data(self) -> list[dict[str, Any]]:
+        """Get party data in MOCK_PARTY format for UI.
+
+        Returns:
+            List of dicts with: name, class, hp, max_hp, conditions
+        """
+        if self._party is None:
+            return []
+
+        result = []
+        for char in self._party.characters:
+            conditions = []
+            # Get active conditions from character
+            if hasattr(char, "active_conditions"):
+                conditions = list(char.active_conditions.keys())
+
+            result.append({
+                "name": char.name,
+                "class": char.character_class.value.title(),
+                "hp": char.current_hp,
+                "max_hp": char.max_hp,
+                "conditions": conditions,
+            })
+
+        return result
+
+    def get_party_for_rendering(self) -> list[dict[str, Any]]:
+        """Get party data ordered for combat formation rendering.
+
+        Returns party members in formation order:
+        - Index 0: Front-left (typically first fighter)
+        - Index 1: Front-right (typically second fighter)
+        - Index 2: Back-left (typically wizard/caster)
+        - Index 3: Back-right (typically rogue/ranged)
+
+        Returns:
+            List of dicts with: name, class, hp, max_hp, is_current_turn
+        """
+        if self._party is None:
+            return []
+
+        # Separate by role (fighters front, others back)
+        front_row = []
+        back_row = []
+
+        for char in self._party.characters:
+            char_class = char.character_class.value.lower()
+            if char_class in ("fighter", "paladin", "barbarian"):
+                front_row.append(char)
+            else:
+                back_row.append(char)
+
+        # Build formation order: front row first, then back row
+        formation = front_row[:2] + back_row[:2]
+
+        # Pad with remaining characters if needed
+        remaining = [c for c in self._party.characters if c not in formation]
+        formation.extend(remaining)
+        formation = formation[:4]  # Max 4 characters displayed
+
+        # Determine current turn character
+        current_creature = None
+        if self._game_state and self._game_state.in_combat:
+            tracker = self._game_state.initiative_tracker
+            if tracker:
+                current_entry = tracker.get_current_combatant()
+                if current_entry:
+                    current_creature = current_entry.creature
+
+        result = []
+        for char in formation:
+            result.append({
+                "name": char.name,
+                "class": char.character_class.value.title(),
+                "hp": char.current_hp,
+                "max_hp": char.max_hp,
+                "is_current_turn": char is current_creature,
+            })
+
+        return result
+
+    def get_combat_data(self) -> dict[str, Any] | None:
+        """Get combat data in MOCK_COMBAT format for UI.
+
+        Returns:
+            Dict with round, current_turn, initiative list, or None if not in combat.
+        """
+        if self._game_state is None or not self._game_state.in_combat:
+            return None
+
+        tracker = self._game_state.initiative_tracker
+        if tracker is None:
+            return None
+
+        current_index = tracker.current_turn_index
+
+        initiative = []
+        for entry in tracker.get_all_combatants():
+            creature = entry.creature
+            is_player = creature in self._party.characters
+
+            initiative.append({
+                "name": entry.display_name or creature.name,
+                "init": entry.initiative_total,
+                "is_player": is_player,
+                "hp": creature.current_hp,
+                "max_hp": creature.max_hp,
+            })
+
+        return {
+            "round": tracker.round_number,
+            "current_turn": current_index,
+            "initiative": initiative,
+        }
+
+    def get_character_data(self, name: str | None = None) -> dict[str, Any] | None:
+        """Get detailed character data in MOCK_CHARACTER format.
+
+        Args:
+            name: Character name. Uses first living character if not provided.
+
+        Returns:
+            Dict with full character details, or None if not found.
+        """
+        if self._party is None:
+            return None
+
+        # Find character
+        char = None
+        if name:
+            for c in self._party.characters:
+                if c.name == name:
+                    char = c
+                    break
+        else:
+            # Use first living character
+            living = self._party.get_living_members()
+            if living:
+                char = living[0]
+
+        if char is None:
+            return None
+
+        # Build stats dict
+        stats = {}
+        if hasattr(char, "abilities"):
+            stats = {
+                "STR": char.abilities.strength,
+                "DEX": char.abilities.dexterity,
+                "CON": char.abilities.constitution,
+                "INT": char.abilities.intelligence,
+                "WIS": char.abilities.wisdom,
+                "CHA": char.abilities.charisma,
+            }
+
+        # Build equipment dict
+        equipment = {}
+        if hasattr(char, "inventory"):
+            from dnd_engine.systems.inventory import EquipmentSlot
+
+            weapon = char.inventory.get_equipped_item(EquipmentSlot.WEAPON)
+            armor = char.inventory.get_equipped_item(EquipmentSlot.ARMOR)
+            shield = char.inventory.get_equipped_item(EquipmentSlot.SHIELD)
+
+            equipment = {
+                "weapon": weapon or "Unarmed",
+                "armor": armor or "None",
+                "shield": shield or "None",
+            }
+
+        return {
+            "name": char.name,
+            "class": char.character_class.value.title(),
+            "level": char.level,
+            "hp": char.current_hp,
+            "max_hp": char.max_hp,
+            "ac": char.armor_class,
+            "stats": stats,
+            "equipment": equipment,
+        }
+
+    def get_inventory_data(self, name: str) -> dict[str, Any] | None:
+        """Get inventory data for a character.
+
+        Args:
+            name: Character name.
+
+        Returns:
+            Dict with equipped, backpack, currency, or None if not found.
+        """
+        if self._party is None:
+            return None
+
+        # Find character
+        char = None
+        for c in self._party.characters:
+            if c.name == name:
+                char = c
+                break
+
+        if char is None or not hasattr(char, "inventory"):
+            return None
+
+        from dnd_engine.systems.inventory import EquipmentSlot
+
+        inv = char.inventory
+
+        # Equipped items
+        equipped = {
+            "weapon": None,
+            "armor": None,
+            "shield": None,
+        }
+
+        weapon_id = inv.get_equipped_item(EquipmentSlot.WEAPON)
+        if weapon_id:
+            equipped["weapon"] = {"item_id": weapon_id, "name": weapon_id.replace("_", " ").title()}
+
+        armor_id = inv.get_equipped_item(EquipmentSlot.ARMOR)
+        if armor_id:
+            equipped["armor"] = {"item_id": armor_id, "name": armor_id.replace("_", " ").title()}
+
+        shield_id = inv.get_equipped_item(EquipmentSlot.SHIELD)
+        if shield_id:
+            equipped["shield"] = {"item_id": shield_id, "name": shield_id.replace("_", " ").title()}
+
+        # Backpack items
+        backpack = []
+        for item in inv.get_all_items():
+            backpack.append({
+                "item_id": item.item_id,
+                "name": item.item_id.replace("_", " ").title(),
+                "category": item.category,
+                "quantity": item.quantity,
+            })
+
+        # Currency
+        currency = {
+            "gold": inv.gold,
+            "silver": 0,
+            "copper": 0,
+        }
+
+        return {
+            "equipped": equipped,
+            "backpack": backpack,
+            "currency": currency,
+        }
+
+    def get_all_inventories(self) -> dict[str, dict[str, Any]]:
+        """Get inventory data for all party members.
+
+        Returns:
+            Dict mapping character name to inventory data.
+        """
+        if self._party is None:
+            return {}
+
+        result = {}
+        for char in self._party.characters:
+            inv_data = self.get_inventory_data(char.name)
+            if inv_data:
+                result[char.name] = inv_data
+
+        return result
+
+    # ========== Combat Action Methods ==========
+
+    def get_enemies(self) -> list[dict[str, Any]]:
+        """Get list of active enemies for targeting.
+
+        Returns:
+            List of dicts with index, name, hp, max_hp for each enemy.
+        """
+        if self._game_state is None or not self._game_state.in_combat:
+            return []
+
+        result = []
+        for i, enemy in enumerate(self._game_state.active_enemies):
+            if enemy.is_alive:
+                result.append({
+                    "index": i,
+                    "name": enemy.name,
+                    "hp": enemy.current_hp,
+                    "max_hp": enemy.max_hp,
+                })
+
+        return result
+
+    def get_current_combatant(self) -> dict[str, Any] | None:
+        """Get info about whose turn it is.
+
+        Returns:
+            Dict with name, is_player, or None if not in combat.
+        """
+        if self._game_state is None or not self._game_state.in_combat:
+            return None
+
+        tracker = self._game_state.initiative_tracker
+        if tracker is None:
+            return None
+
+        current = tracker.get_current_combatant()
+        if current is None:
+            return None
+
+        creature = current.creature
+        is_player = creature in self._party.characters
+
+        return {
+            "name": creature.name,
+            "is_player": is_player,
+            "creature": creature,
+        }
+
+    def is_player_turn(self) -> bool:
+        """Check if it's currently a player's turn."""
+        current = self.get_current_combatant()
+        if current is None:
+            return False
+        return current["is_player"]
+
+    def execute_attack(
+        self,
+        target_index: int,
+        attacker: Character | None = None,
+    ) -> dict[str, Any]:
+        """Execute a melee attack against an enemy.
+
+        Args:
+            target_index: Index into active_enemies list.
+            attacker: Character making the attack. Uses current turn character if not provided.
+
+        Returns:
+            Dict with attack result info (hit, damage, target_killed, etc.)
+        """
+        if self._game_state is None or not self._game_state.in_combat:
+            return {"success": False, "error": "Not in combat"}
+
+        # Get attacker
+        if attacker is None:
+            current = self.get_current_combatant()
+            if current is None or not current["is_player"]:
+                return {"success": False, "error": "Not player's turn"}
+            attacker = current["creature"]
+
+        # Get target
+        enemies = self._game_state.active_enemies
+        if target_index < 0 or target_index >= len(enemies):
+            return {"success": False, "error": "Invalid target"}
+
+        target = enemies[target_index]
+        if not target.is_alive:
+            return {"success": False, "error": "Target is dead"}
+
+        # Execute attack through game state
+        try:
+            result = self._game_state.execute_player_attack(attacker, target)
+
+            return {
+                "success": True,
+                "hit": result.attack_result.hit if result.attack_result else False,
+                "damage": result.attack_result.damage if result.attack_result else 0,
+                "critical": result.attack_result.critical_hit if result.attack_result else False,
+                "target_name": target.name,
+                "target_killed": not target.is_alive,
+                "attacker_name": attacker.name,
+                "attack_roll": result.attack_result.attack_roll if result.attack_result else 0,
+                "target_ac": result.attack_result.target_ac if result.attack_result else 0,
+            }
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    def process_enemy_turn(self) -> dict[str, Any]:
+        """Process the current enemy's turn.
+
+        Returns:
+            Dict with enemy action result.
+        """
+        if self._game_state is None or not self._game_state.in_combat:
+            return {"success": False, "error": "Not in combat"}
+
+        current = self.get_current_combatant()
+        if current is None:
+            return {"success": False, "error": "No current combatant"}
+
+        if current["is_player"]:
+            return {"success": False, "error": "It's a player's turn"}
+
+        try:
+            result = self._game_state.process_enemy_turn()
+
+            if result is None:
+                return {"success": True, "action": "skipped", "reason": "No valid action"}
+
+            return {
+                "success": True,
+                "action": result.action_taken.name if hasattr(result, "action_taken") else "attack",
+                "enemy_name": result.enemy_display_name if hasattr(result, "enemy_display_name") else current["name"],
+                "target_name": getattr(result, "target_name", None),
+                "hit": result.attack_result.hit if hasattr(result, "attack_result") and result.attack_result else None,
+                "damage": result.attack_result.damage if hasattr(result, "attack_result") and result.attack_result else 0,
+                "target_killed": getattr(result, "target_killed", False),
+                "combat_ended": getattr(result, "combat_ended", False),
+            }
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    def advance_turn(self) -> dict[str, Any]:
+        """Advance to the next turn in combat.
+
+        Returns:
+            Dict with new turn info.
+        """
+        if self._game_state is None or not self._game_state.in_combat:
+            return {"success": False, "error": "Not in combat"}
+
+        tracker = self._game_state.initiative_tracker
+        if tracker is None:
+            return {"success": False, "error": "No initiative tracker"}
+
+        tracker.next_turn()
+
+        # Check if combat ended
+        self._game_state._check_combat_end()
+
+        current = self.get_current_combatant()
+
+        return {
+            "success": True,
+            "round": tracker.round_number,
+            "current_turn": current["name"] if current else None,
+            "is_player_turn": current["is_player"] if current else False,
+            "combat_ended": not self._game_state.in_combat,
+        }
+
+    def end_combat_check(self) -> dict[str, Any]:
+        """Check if combat should end and handle cleanup.
+
+        Returns:
+            Dict with combat_ended flag and victory status.
+        """
+        if self._game_state is None:
+            return {"combat_ended": True, "victory": False}
+
+        self._game_state._check_combat_end()
+
+        return {
+            "combat_ended": not self._game_state.in_combat,
+            "victory": len([e for e in self._game_state.active_enemies if e.is_alive]) == 0,
+            "party_wiped": self._party.is_wiped() if self._party else True,
+        }

--- a/client-terminal/terminal_client/main.py
+++ b/client-terminal/terminal_client/main.py
@@ -31,13 +31,35 @@ def parse_arguments() -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  dnd-game                          # Start with new menu system
+  dnd-game                          # Start terminal client (default)
+  dnd-game --mode 2d                # Start 2D graphical client
   dnd-game --no-llm                 # Disable LLM enhancement
   dnd-game --llm-provider openai    # Use OpenAI (default)
   dnd-game --llm-provider anthropic # Use Anthropic Claude
   dnd-game --llm-provider debug     # Debug mode
   dnd-game --debug                  # Enable debug logging
         """,
+    )
+
+    parser.add_argument(
+        "--mode",
+        choices=["terminal", "2d"],
+        default="terminal",
+        help="Client mode: terminal (text UI) or 2d (graphical)",
+    )
+
+    # 2D client options
+    parser.add_argument(
+        "--size",
+        choices=["small", "medium", "large"],
+        default="medium",
+        help="Window size for 2D client: small (800x600), medium (1280x900), large (1600x1000)",
+    )
+
+    parser.add_argument(
+        "--fullscreen",
+        action="store_true",
+        help="Run 2D client in fullscreen mode",
     )
 
     parser.add_argument("--no-llm", action="store_true", help="Disable LLM narrative enhancement")
@@ -161,6 +183,18 @@ def main() -> None:
 
     # Parse arguments
     args = parse_arguments()
+
+    # Dispatch to 2D client if requested
+    if args.mode == "2d":
+        try:
+            from client_2d.game import run_2d_client
+            run_2d_client(size=args.size, fullscreen=args.fullscreen)
+            return
+        except ImportError as e:
+            print("Error: 2D client not installed. Install client-2d package first.")
+            print("  cd client-2d && uv pip install -e .")
+            print(f"Details: {e}")
+            sys.exit(1)
 
     # Initialize console with debug logging
     init_console(debug_mode=args.debug)


### PR DESCRIPTION
## Summary
- Party members spread into 2x2 formation during combat (front row: fighters, back row: casters)
- Current turn character highlighted with ring indicator
- Party collapses back to single unit after combat ends
- Adds `--mode 2d` flag to `dnd-game` command for launching graphical client

## Test plan
- [ ] Run `uv run dnd-game --mode 2d`
- [ ] Walk north to storage room (combat with rats)
- [ ] Verify 4 party members appear in formation
- [ ] Verify current turn character has highlight ring
- [ ] Complete combat, verify party collapses to single unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)