### PR TITLE
Add #327: Reference-based Entity system for 2D client

### DIFF
--- a/client-2d/src/client_2d/entities/__init__.py
+++ b/client-2d/src/client_2d/entities/__init__.py
@@ -1,0 +1,22 @@
+# ABOUTME: Entity module exports for the 2D client.
+# ABOUTME: Provides Entity classes with engine references for live state sync.
+
+from client_2d.entities.entity import (
+    Entity,
+    EntityType,
+    ItemEntity,
+    MonsterEntity,
+    PartyMemberEntity,
+    VisualState,
+)
+from client_2d.entities.entity_manager import EntityManager
+
+__all__ = [
+    "Entity",
+    "EntityManager",
+    "EntityType",
+    "ItemEntity",
+    "MonsterEntity",
+    "PartyMemberEntity",
+    "VisualState",
+]

--- a/client-2d/src/client_2d/entities/entity.py
+++ b/client-2d/src/client_2d/entities/entity.py
@@ -1,0 +1,204 @@
+# ABOUTME: Entity classes representing game objects with live engine references.
+# ABOUTME: Enables visual state sync from engine Creatures for rendering and animation.
+
+"""Entity classes for the 2D client with engine references.
+
+This module provides Entity classes that maintain references to engine
+Creature objects, enabling live synchronization between engine state
+and visual representation.
+
+Architecture:
+    Engine Creature <--reference--> Entity <--managed by--> EntityManager
+         │                            │
+         ├── current_hp               ├── hp (cached)
+         ├── is_alive                 ├── is_alive (cached)
+         └── active_conditions        └── visual (VisualState)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import TYPE_CHECKING
+
+import arcade
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+
+
+class EntityType(Enum):
+    """Types of entities that can exist on the map."""
+
+    MONSTER = auto()
+    PARTY_MEMBER = auto()
+    ITEM = auto()
+    DECORATION = auto()
+
+
+@dataclass
+class VisualState:
+    """Visual state for rendering and animation.
+
+    Tracks the visual representation of an entity, including
+    position offsets for smooth movement animations.
+
+    Attributes:
+        offset_x: Pixel offset from grid position (for animation).
+        offset_y: Pixel offset from grid position (for animation).
+        alpha: Transparency (0-255) for fade effects.
+        scale: Scale multiplier for size effects.
+        tint: RGB tint color for effects like damage flash.
+        is_animating: Whether entity is currently animating.
+    """
+
+    offset_x: float = 0.0
+    offset_y: float = 0.0
+    alpha: int = 255
+    scale: float = 1.0
+    tint: tuple[int, int, int] = (255, 255, 255)
+    is_animating: bool = False
+
+
+@dataclass
+class Entity:
+    """Base entity class with engine creature reference.
+
+    Represents any entity on the game map that may be linked to
+    an engine Creature object. Caches frequently-accessed state
+    for rendering and provides sync methods to update from engine.
+
+    Attributes:
+        entity_id: Unique identifier for this entity.
+        grid_x: X position in grid coordinates.
+        grid_y: Y position in grid coordinates.
+        entity_type: Type of entity (monster, party_member, item, etc.).
+        sub_type: Specific subtype (e.g., "giant_rat", "longsword").
+        visual: Visual state for rendering/animation.
+        texture: Loaded arcade texture for rendering.
+        hp: Cached current HP from engine creature.
+        max_hp: Cached max HP from engine creature.
+        is_alive: Cached alive status from engine creature.
+        conditions: Cached active conditions from engine creature.
+    """
+
+    entity_id: str
+    grid_x: int
+    grid_y: int
+    entity_type: EntityType
+    sub_type: str = ""
+    visual: VisualState = field(default_factory=VisualState)
+    texture: arcade.Texture | None = None
+    _creature_ref: Creature | None = field(default=None, repr=False)
+    hp: int = 0
+    max_hp: int = 0
+    is_alive: bool = True
+    conditions: set[str] = field(default_factory=set)
+
+    def sync_from_creature(self) -> bool:
+        """Sync cached state from the engine creature reference.
+
+        Updates cached HP, is_alive, and conditions from the referenced
+        engine Creature. This allows efficient rendering without
+        constantly querying the engine.
+
+        Returns:
+            True if any state changed, False if unchanged.
+            Use this to trigger animations on state changes.
+        """
+        if self._creature_ref is None:
+            return False
+
+        changed = False
+        creature = self._creature_ref
+
+        if self.hp != creature.current_hp:
+            self.hp = creature.current_hp
+            changed = True
+
+        if self.max_hp != creature.max_hp:
+            self.max_hp = creature.max_hp
+            changed = True
+
+        if self.is_alive != creature.is_alive:
+            self.is_alive = creature.is_alive
+            changed = True
+
+        new_conditions = set(creature.active_conditions.keys())
+        if self.conditions != new_conditions:
+            self.conditions = new_conditions
+            changed = True
+
+        return changed
+
+    @property
+    def creature(self) -> Creature | None:
+        """Access the referenced engine Creature."""
+        return self._creature_ref
+
+    @creature.setter
+    def creature(self, value: Creature | None) -> None:
+        """Set the engine Creature reference and sync state."""
+        self._creature_ref = value
+        if value is not None:
+            self.sync_from_creature()
+
+
+@dataclass
+class MonsterEntity(Entity):
+    """Entity representing an enemy monster.
+
+    Extends Entity with enemy-specific attributes for combat
+    targeting and turn order tracking.
+
+    Attributes:
+        enemy_index: Index into GameState.active_enemies for attack targeting.
+    """
+
+    enemy_index: int = -1
+
+    def __post_init__(self) -> None:
+        """Ensure entity_type is set to MONSTER."""
+        self.entity_type = EntityType.MONSTER
+
+
+@dataclass
+class PartyMemberEntity(Entity):
+    """Entity representing a party member character.
+
+    Extends Entity with party-specific attributes for combat
+    formation and turn highlighting.
+
+    Attributes:
+        party_index: Index into Party.characters (0-3 for 4-member party).
+        is_current_turn: Whether this character is taking their turn.
+        character_class: Character's class (fighter, wizard, etc.) for sprite.
+    """
+
+    party_index: int = -1
+    is_current_turn: bool = False
+    character_class: str = ""
+
+    def __post_init__(self) -> None:
+        """Ensure entity_type is set to PARTY_MEMBER."""
+        self.entity_type = EntityType.PARTY_MEMBER
+
+
+@dataclass
+class ItemEntity(Entity):
+    """Entity representing an item on the ground.
+
+    Extends Entity with item-specific attributes for
+    collection tracking.
+
+    Attributes:
+        collected: Whether the item has been picked up.
+        item_category: Category like "weapons", "potions", "misc".
+    """
+
+    collected: bool = False
+    item_category: str = ""
+
+    def __post_init__(self) -> None:
+        """Ensure entity_type is set to ITEM."""
+        self.entity_type = EntityType.ITEM

--- a/client-2d/src/client_2d/entities/entity_manager.py
+++ b/client-2d/src/client_2d/entities/entity_manager.py
@@ -1,0 +1,364 @@
+# ABOUTME: Manages Entity lifecycle and synchronization with engine state.
+# ABOUTME: Creates entities from engine state and handles sync, death removal, combat formation.
+
+"""EntityManager for managing game entities.
+
+This module provides the EntityManager class that handles:
+- Creating entities from engine state during room load
+- Synchronizing entity state from engine creatures
+- Removing dead entities after combat
+- Spreading party members into combat formation
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import arcade
+
+from client_2d.entities.entity import (
+    Entity,
+    EntityType,
+    ItemEntity,
+    MonsterEntity,
+    PartyMemberEntity,
+)
+
+if TYPE_CHECKING:
+
+    from client_2d.integration.engine_adapter import EngineAdapter
+    from client_2d.integration.layout_loader import RoomLayout
+
+
+class EntityManager:
+    """Manages entity lifecycle and synchronization with engine state.
+
+    The EntityManager is responsible for:
+    - Creating entities when loading a room (monsters from active_enemies, items from room data)
+    - Syncing entity state from engine creatures (HP, conditions, alive status)
+    - Removing dead entities and returning them for death animations
+    - Creating party member entities for combat spread formation
+
+    Usage:
+        manager = EntityManager()
+        manager.load_from_room(engine, layout, room_data, textures)
+
+        # After combat actions:
+        changed = manager.sync_from_engine(engine)
+        dead = manager.remove_dead_entities()
+
+        # Get entities for rendering:
+        for entity in manager.get_all():
+            draw(entity)
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty EntityManager."""
+        self._entities: dict[str, Entity] = {}
+        self._monsters: dict[str, MonsterEntity] = {}
+        self._party_members: dict[str, PartyMemberEntity] = {}
+        self._items: dict[str, ItemEntity] = {}
+
+    def clear(self) -> None:
+        """Remove all entities. Call on room transitions."""
+        self._entities.clear()
+        self._monsters.clear()
+        self._party_members.clear()
+        self._items.clear()
+
+    def load_from_room(
+        self,
+        engine: EngineAdapter,
+        layout: RoomLayout,
+        room_data: dict[str, Any] | None,
+        monster_textures: dict[str, arcade.Texture | None],
+        item_textures: dict[str, arcade.Texture | None],
+    ) -> None:
+        """Create entities from engine state and room layout.
+
+        Creates MonsterEntity objects for each active enemy in engine state,
+        and ItemEntity objects for visible items in room_data.
+
+        Args:
+            engine: EngineAdapter providing access to game state.
+            layout: RoomLayout with entity spawn positions.
+            room_data: Room JSON data with items and decoration info.
+            monster_textures: Dict mapping monster IDs to loaded textures.
+            item_textures: Dict mapping item IDs to loaded textures.
+        """
+        self.clear()
+
+        game_state = engine.game_state
+        if game_state is None:
+            return
+
+        # Create entities for active enemies from engine
+        enemy_positions = layout.entity_positions.enemies
+        for i, enemy in enumerate(game_state.active_enemies):
+            if i < len(enemy_positions):
+                ex, ey = enemy_positions[i]
+            else:
+                ex = layout.width // 2 + i
+                ey = layout.height // 2
+
+            # Extract monster type from name (e.g., "Giant Rat 1" -> "giant_rat")
+            monster_type = enemy.name.lower().replace(" ", "_")
+            # Strip trailing numbers for texture lookup
+            base_type = monster_type.rstrip("0123456789").rstrip("_")
+
+            entity_id = f"monster_{i}"
+            monster = MonsterEntity(
+                entity_id=entity_id,
+                grid_x=ex,
+                grid_y=ey,
+                entity_type=EntityType.MONSTER,
+                sub_type=base_type,
+                enemy_index=i,
+                texture=monster_textures.get(base_type),
+            )
+            monster.creature = enemy  # Sets reference and syncs state
+            self._add_entity(monster)
+
+        # Create entities for items from room data
+        if room_data:
+            room_items = room_data.get("items", [])
+            item_positions = layout.entity_positions.items
+            visible_idx = 0
+            for item_data in room_items:
+                if not item_data.get("visible", True):
+                    continue
+
+                item_id = item_data.get("id", f"item_{visible_idx}")
+                if visible_idx < len(item_positions):
+                    ix, iy = item_positions[visible_idx]
+                else:
+                    ix = 3 + (visible_idx * 2) % (layout.width - 6)
+                    iy = 3 + (visible_idx * 3) % (layout.height - 6)
+
+                entity = ItemEntity(
+                    entity_id=f"item_{item_id}",
+                    grid_x=ix,
+                    grid_y=iy,
+                    entity_type=EntityType.ITEM,
+                    sub_type=item_id,
+                    item_category=item_data.get("category", "misc"),
+                    texture=item_textures.get(item_id),
+                )
+                self._add_entity(entity)
+                visible_idx += 1
+
+    def sync_from_engine(self, engine: EngineAdapter) -> list[Entity]:
+        """Sync all entities with engine creature state.
+
+        Updates cached state (HP, conditions, alive) for all entities
+        that have creature references.
+
+        Args:
+            engine: EngineAdapter (currently unused, entities have direct refs).
+
+        Returns:
+            List of entities whose state changed (for animation triggers).
+        """
+        changed: list[Entity] = []
+
+        for monster in self._monsters.values():
+            if monster.sync_from_creature():
+                changed.append(monster)
+
+        for party_member in self._party_members.values():
+            if party_member.sync_from_creature():
+                changed.append(party_member)
+
+        return changed
+
+    def remove_dead_entities(self) -> list[Entity]:
+        """Remove dead entities from the manager.
+
+        Checks all monster entities and removes those that are no longer alive.
+        Party members are NOT removed when dead (they remain for resurrection).
+
+        Returns:
+            List of removed entities (for death animation triggers).
+        """
+        removed: list[Entity] = []
+
+        # Find dead monsters
+        dead_monster_ids = [
+            entity_id
+            for entity_id, monster in self._monsters.items()
+            if not monster.is_alive
+        ]
+
+        # Remove them
+        for entity_id in dead_monster_ids:
+            monster = self._monsters.pop(entity_id)
+            self._entities.pop(entity_id, None)
+            removed.append(monster)
+
+        return removed
+
+    def spread_party_for_combat(
+        self,
+        engine: EngineAdapter,
+        center_x: int,
+        center_y: int,
+        layout: RoomLayout,
+        character_textures: dict[str, arcade.Texture | None],
+    ) -> list[tuple[int, int]]:
+        """Create party member entities in combat formation.
+
+        Spreads the party into a 2x2 formation around the center point,
+        with front-row fighters and back-row casters.
+
+        Formation (assuming enemies to the north):
+            Back row:  [2] [3]  (wizard, rogue)
+            Front row: [0] [1]  (fighters)
+
+        Args:
+            engine: EngineAdapter providing party data.
+            center_x: Center X position for formation.
+            center_y: Center Y position for formation.
+            layout: RoomLayout to check for blocking tiles.
+            character_textures: Dict mapping class names to textures.
+
+        Returns:
+            List of (x, y) positions for each party member, in formation order.
+        """
+        # Clear any existing party member entities
+        for entity_id in list(self._party_members.keys()):
+            self._entities.pop(entity_id, None)
+        self._party_members.clear()
+
+        party_data = engine.get_party_for_rendering()
+        if not party_data:
+            return []
+
+        # Formation offsets: front row closer to enemies (north = lower y)
+        offsets = [
+            (-1, 0),   # Front-left
+            (1, 0),    # Front-right
+            (-1, 1),   # Back-left
+            (1, 1),    # Back-right
+        ]
+
+        positions: list[tuple[int, int]] = []
+
+        for i, char_data in enumerate(party_data[:4]):  # Max 4 party members
+            if i < len(offsets):
+                dx, dy = offsets[i]
+            else:
+                dx, dy = 0, i
+
+            px, py = center_x + dx, center_y + dy
+
+            # Clamp to room bounds and avoid walls
+            px = max(1, min(px, layout.width - 2))
+            py = max(1, min(py, layout.height - 2))
+
+            # If blocked, try the center position
+            if layout.is_blocking(px, py):
+                px, py = center_x, center_y
+
+            positions.append((px, py))
+
+            # Get creature reference from engine
+            creature_ref = None
+            party = engine.party
+            if party and i < len(party.characters):
+                creature_ref = party.characters[i]
+
+            char_class = char_data["class"].lower()
+            entity = PartyMemberEntity(
+                entity_id=f"party_{i}",
+                grid_x=px,
+                grid_y=py,
+                entity_type=EntityType.PARTY_MEMBER,
+                sub_type=char_class,
+                party_index=i,
+                is_current_turn=char_data.get("is_current_turn", False),
+                character_class=char_class,
+                texture=character_textures.get(char_class),
+            )
+            if creature_ref is not None:
+                entity.creature = creature_ref
+            self._add_entity(entity)
+
+        return positions
+
+    def collapse_party(self) -> None:
+        """Remove party member entities after combat ends.
+
+        Called when combat ends to remove the spread party members.
+        The player returns to single-unit representation.
+        """
+        for entity_id in list(self._party_members.keys()):
+            self._entities.pop(entity_id, None)
+        self._party_members.clear()
+
+    def update_party_turn_status(self, engine: EngineAdapter) -> None:
+        """Update is_current_turn for all party member entities.
+
+        Args:
+            engine: EngineAdapter to get current combatant info.
+        """
+        current = engine.get_current_combatant()
+        current_creature = current.get("creature") if current else None
+
+        for party_member in self._party_members.values():
+            party_member.is_current_turn = (
+                party_member._creature_ref is not None
+                and party_member._creature_ref is current_creature
+            )
+
+    def _add_entity(self, entity: Entity) -> None:
+        """Add an entity to the appropriate collections."""
+        self._entities[entity.entity_id] = entity
+
+        if isinstance(entity, MonsterEntity):
+            self._monsters[entity.entity_id] = entity
+        elif isinstance(entity, PartyMemberEntity):
+            self._party_members[entity.entity_id] = entity
+        elif isinstance(entity, ItemEntity):
+            self._items[entity.entity_id] = entity
+
+    def get_all(self) -> list[Entity]:
+        """Get all entities for rendering."""
+        return list(self._entities.values())
+
+    def get_monsters(self) -> list[MonsterEntity]:
+        """Get all monster entities."""
+        return list(self._monsters.values())
+
+    def get_party_members(self) -> list[PartyMemberEntity]:
+        """Get all party member entities."""
+        return list(self._party_members.values())
+
+    def get_items(self) -> list[ItemEntity]:
+        """Get all item entities."""
+        return list(self._items.values())
+
+    def get_at_position(self, x: int, y: int) -> Entity | None:
+        """Get entity at a specific grid position.
+
+        Args:
+            x: Grid X coordinate.
+            y: Grid Y coordinate.
+
+        Returns:
+            Entity at that position, or None if empty.
+        """
+        for entity in self._entities.values():
+            if entity.grid_x == x and entity.grid_y == y:
+                return entity
+        return None
+
+    def get_by_id(self, entity_id: str) -> Entity | None:
+        """Get an entity by its ID.
+
+        Args:
+            entity_id: The entity's unique identifier.
+
+        Returns:
+            The entity, or None if not found.
+        """
+        return self._entities.get(entity_id)

--- a/client-2d/src/client_2d/game.py
+++ b/client-2d/src/client_2d/game.py
@@ -27,6 +27,7 @@ from client_2d.core.constants import (
     LightingState,
     UIColors,
 )
+from client_2d.entities import EntityManager, EntityType
 from client_2d.integration.engine_adapter import EngineAdapter
 from client_2d.integration.layout_loader import LayoutLoader
 from client_2d.systems.fog_of_war import FogOfWarSystem
@@ -100,8 +101,8 @@ class GameWindow(arcade.Window):
         self.fog: FogOfWarSystem | None = None
         self.lighting: LightingSystem | None = None
 
-        # Entities in current room (x, y, type_string, texture)
-        self.entities: list[tuple[int, int, str, arcade.Texture | None]] = []
+        # Entity manager for live-synced entities with engine references
+        self.entity_manager = EntityManager()
 
         # Game state
         self.running = True
@@ -317,26 +318,14 @@ class GameWindow(arcade.Window):
 
         cx, cy = self.player_x, self.player_y
 
-        # Formation offsets: front row closer to enemies (north = lower y)
-        # Index 0,1 = front row (fighters), Index 2,3 = back row (casters)
-        offsets = [
-            (-1, 0),   # Front-left
-            (1, 0),    # Front-right
-            (-1, 1),   # Back-left
-            (1, 1),    # Back-right
-        ]
-
-        # Calculate positions, checking for valid tiles
-        self.party_positions = []
-        for dx, dy in offsets:
-            px, py = cx + dx, cy + dy
-            # Clamp to room bounds and avoid walls
-            px = max(1, min(px, self.room_layout.width - 2))
-            py = max(1, min(py, self.room_layout.height - 2))
-            # If blocked, try the center position
-            if self.room_layout.is_blocking(px, py):
-                px, py = cx, cy
-            self.party_positions.append((px, py))
+        # Use EntityManager to create party member entities in formation
+        self.party_positions = self.entity_manager.spread_party_for_combat(
+            engine=self.engine,
+            center_x=cx,
+            center_y=cy,
+            layout=self.room_layout,
+            character_textures=self.character_textures,
+        )
 
         self.party_spread = True
         self._update_lighting()
@@ -349,6 +338,9 @@ class GameWindow(arcade.Window):
             avg_y = sum(p[1] for p in self.party_positions) // len(self.party_positions)
             self.player_x = avg_x
             self.player_y = avg_y
+
+        # Remove party member entities
+        self.entity_manager.collapse_party()
 
         self.party_spread = False
         self.party_positions = []
@@ -404,37 +396,14 @@ class GameWindow(arcade.Window):
                 if self.room_layout.is_blocking(x, y):
                     self.lighting.add_obstacle(x, y)
 
-        # Load entities from room data
-        self.entities = []
-        if room_data:
-            # Add enemies
-            room_enemies = room_data.get("enemies", [])
-            enemy_positions = self.room_layout.entity_positions.enemies
-            for i, enemy_type in enumerate(room_enemies):
-                if i < len(enemy_positions):
-                    ex, ey = enemy_positions[i]
-                else:
-                    ex = self.room_layout.width // 2 + i
-                    ey = self.room_layout.height // 2
-                texture = self.monster_textures.get(enemy_type)
-                self.entities.append((ex, ey, f"monster:{enemy_type}", texture))
-
-            # Add visible items
-            room_items = room_data.get("items", [])
-            item_positions = self.room_layout.entity_positions.items
-            visible_idx = 0
-            for item_data in room_items:
-                if not item_data.get("visible", True):
-                    continue
-                item_id = item_data.get("id", f"item_{visible_idx}")
-                if visible_idx < len(item_positions):
-                    ix, iy = item_positions[visible_idx]
-                else:
-                    ix = 3 + (visible_idx * 2) % (self.room_layout.width - 6)
-                    iy = 3 + (visible_idx * 3) % (self.room_layout.height - 6)
-                texture = self.item_textures.get(item_id)
-                self.entities.append((ix, iy, f"item:{item_id}", texture))
-                visible_idx += 1
+        # Load entities from engine state using EntityManager
+        self.entity_manager.load_from_room(
+            engine=self.engine,
+            layout=self.room_layout,
+            room_data=room_data,
+            monster_textures=self.monster_textures,
+            item_textures=self.item_textures,
+        )
 
         # Initial lighting update
         self._update_lighting()
@@ -647,10 +616,18 @@ class GameWindow(arcade.Window):
                         tile_rect = arcade.LBWH(screen_x, screen_y, tile_size - 1, tile_size - 1)
                         arcade.draw_rect_filled(tile_rect, (40, 35, 30))
 
-        # Draw entities (monsters, items) with lighting
-        for ex, ey, entity_type, texture in self.entities:
+        # Draw entities (monsters, items) from EntityManager with lighting
+        for entity in self.entity_manager.get_all():
+            # Skip party members - they're drawn separately in combat
+            if entity.entity_type == EntityType.PARTY_MEMBER:
+                continue
+
+            # Skip dead entities
+            if not entity.is_alive:
+                continue
+
             if self.fog:
-                state = self.fog.get_visibility(ex, ey)
+                state = self.fog.get_visibility(entity.grid_x, entity.grid_y)
                 tint = LIGHTING_TINTS.get(state)
             else:
                 tint = (255, 255, 255)
@@ -659,16 +636,16 @@ class GameWindow(arcade.Window):
             if tint is None:
                 continue
 
-            screen_x = offset_x + ex * tile_size
-            screen_y = offset_y + (self.room_layout.height - 1 - ey) * tile_size
+            screen_x = offset_x + entity.grid_x * tile_size
+            screen_y = offset_y + (self.room_layout.height - 1 - entity.grid_y) * tile_size
 
-            if texture:
-                self._draw_texture(texture, screen_x, screen_y, tint)
+            if entity.texture:
+                self._draw_texture(entity.texture, screen_x, screen_y, tint)
             else:
                 # Fallback: colored squares based on entity type
-                if entity_type.startswith("monster:"):
+                if entity.entity_type == EntityType.MONSTER:
                     fallback_color = (180, 50, 50)  # Red for monsters
-                elif entity_type.startswith("item:"):
+                elif entity.entity_type == EntityType.ITEM:
                     fallback_color = (50, 180, 50)  # Green for items
                 else:
                     fallback_color = (180, 140, 50)  # Gold for decorations
@@ -679,18 +656,14 @@ class GameWindow(arcade.Window):
 
         # Draw party/player
         if self.party_spread and self.party_positions:
-            # Combat formation - draw each party member separately
-            party_data = self.engine.get_party_for_rendering()
-            for i, (px, py) in enumerate(self.party_positions):
-                if i >= len(party_data):
-                    break
+            # Combat formation - draw each party member from EntityManager
+            for party_entity in self.entity_manager.get_party_members():
+                char_screen_x = offset_x + party_entity.grid_x * tile_size
+                char_screen_y = offset_y + (self.room_layout.height - 1 - party_entity.grid_y) * tile_size
 
-                char_screen_x = offset_x + px * tile_size
-                char_screen_y = offset_y + (self.room_layout.height - 1 - py) * tile_size
-
-                char_class = party_data[i]["class"].lower()
-                is_current_turn = party_data[i]["is_current_turn"]
-                texture = self.character_textures.get(char_class, self.player_texture)
+                char_class = party_entity.character_class
+                is_current_turn = party_entity.is_current_turn
+                texture = party_entity.texture or self.player_texture
 
                 # Draw current turn highlight (selection ring)
                 if is_current_turn:
@@ -1035,6 +1008,10 @@ class GameWindow(arcade.Window):
             else:
                 self._add_combat_log(f"{result['enemy_name']} takes no action.")
 
+        # Sync entity state from engine after enemy action
+        self.entity_manager.sync_from_engine(self.engine)
+        self.entity_manager.update_party_turn_status(self.engine)
+
         # Advance turn
         turn_result = self.engine.advance_turn()
 
@@ -1085,10 +1062,11 @@ class GameWindow(arcade.Window):
 
         # Number keys to select enemy
         if arcade.key.KEY_1 <= key <= arcade.key.KEY_9:
-            index = key - arcade.key.KEY_1
+            display_index = key - arcade.key.KEY_1
             enemies = self.engine.get_enemies()
-            if index < len(enemies):
-                self.selected_enemy = index
+            if display_index < len(enemies):
+                # Use actual enemy index from engine, not display position
+                self.selected_enemy = enemies[display_index]["index"]
 
         # A to attack
         elif key == arcade.key.A:
@@ -1129,6 +1107,11 @@ class GameWindow(arcade.Window):
                     f"(rolled {result['attack_roll']} vs AC {result['target_ac']})"
                 )
 
+            # Sync entity state from engine and remove dead enemies
+            self.entity_manager.sync_from_engine(self.engine)
+            self.entity_manager.remove_dead_entities()
+            self.entity_manager.update_party_turn_status(self.engine)
+
             # Advance turn
             turn_result = self.engine.advance_turn()
 
@@ -1146,6 +1129,9 @@ class GameWindow(arcade.Window):
         current = self.engine.get_current_combatant()
         if current:
             self._add_combat_log(f"{current['name']} waits...")
+
+        # Update turn status after passing
+        self.entity_manager.update_party_turn_status(self.engine)
 
         turn_result = self.engine.advance_turn()
 

--- a/client-2d/src/client_2d/mcp_server.py
+++ b/client-2d/src/client_2d/mcp_server.py
@@ -35,6 +35,7 @@ Tools:
 
 from mcp.server.fastmcp import FastMCP
 
+from client_2d.entities import EntityManager, EntityType
 from client_2d.integration.engine_adapter import EngineAdapter
 from client_2d.integration.layout_loader import LayoutLoader, RoomLayout
 from client_2d.systems.fog_of_war import FogOfWarSystem
@@ -51,8 +52,12 @@ _room_layout: RoomLayout | None = None
 _fog: FogOfWarSystem | None = None
 _lighting: LightingSystem | None = None
 _renderer: StateRenderer | None = None
+_entity_manager: EntityManager | None = None
 _player_x: int = 0
 _player_y: int = 0
+
+# Empty texture dict for EntityManager (MCP server doesn't render sprites)
+_empty_textures: dict = {}
 
 
 def _get_layout_loader() -> LayoutLoader:
@@ -65,7 +70,7 @@ def _get_layout_loader() -> LayoutLoader:
 
 def _load_room_layout() -> None:
     """Load the current room's tile layout for ASCII rendering."""
-    global _room_layout, _fog, _lighting, _renderer, _player_x, _player_y
+    global _room_layout, _fog, _lighting, _renderer, _entity_manager, _player_x, _player_y
 
     if _engine is None or _engine.game_state is None:
         return
@@ -117,6 +122,16 @@ def _load_room_layout() -> None:
     # Set player position from spawn point
     _player_x, _player_y = _room_layout.spawn_points.player
 
+    # Initialize EntityManager and load entities from engine state
+    _entity_manager = EntityManager()
+    _entity_manager.load_from_room(
+        engine=_engine,
+        layout=_room_layout,
+        room_data=room_data,
+        monster_textures=_empty_textures,
+        item_textures=_empty_textures,
+    )
+
     # Initialize renderer
     _renderer = StateRenderer(
         width=_room_layout.width,
@@ -139,31 +154,43 @@ def _update_lighting() -> None:
 
 
 def _build_entities() -> list[Entity]:
-    """Build entity list from engine state for ASCII rendering."""
+    """Build entity list from EntityManager for ASCII rendering.
+
+    Converts EntityManager entities to StateRenderer Entity objects
+    for ASCII map rendering.
+    """
     entities: list[Entity] = []
 
-    if _engine is None or _room_layout is None:
+    if _entity_manager is None:
         return entities
 
-    game_state = _engine.game_state
-    if game_state is None:
-        return entities
+    # Sync from engine and remove dead entities before rendering
+    if _engine:
+        _entity_manager.sync_from_engine(_engine)
+        _entity_manager.remove_dead_entities()
 
-    # Add enemies from engine
-    enemy_positions = _room_layout.entity_positions.enemies
-    for i, enemy in enumerate(game_state.active_enemies):
-        if enemy.is_alive:
-            if i < len(enemy_positions):
-                ex, ey = enemy_positions[i]
-            else:
-                ex = _room_layout.width // 2 + i
-                ey = _room_layout.height // 2
-            entities.append(Entity(
-                x=ex,
-                y=ey,
-                entity_type="monster",
-                entity_id=f"{enemy.name.lower().replace(' ', '_')}_{i + 1}",
-            ))
+    # Convert EntityManager entities to StateRenderer entities
+    for entity in _entity_manager.get_all():
+        # Skip dead entities
+        if not entity.is_alive:
+            continue
+
+        # Map EntityType to string type for StateRenderer
+        if entity.entity_type == EntityType.MONSTER:
+            type_str = "monster"
+        elif entity.entity_type == EntityType.ITEM:
+            type_str = "item"
+        elif entity.entity_type == EntityType.PARTY_MEMBER:
+            type_str = "party"
+        else:
+            type_str = "decoration"
+
+        entities.append(Entity(
+            x=entity.grid_x,
+            y=entity.grid_y,
+            entity_type=type_str,
+            entity_id=f"{entity.sub_type}_{entity.entity_id}",
+        ))
 
     return entities
 
@@ -258,14 +285,15 @@ def _format_state_response(state_dict: dict) -> str:
                     f"{member['hp']}/{member['max_hp']} HP - {conditions}"
                 )
 
-    # Add enemies in combat
-    if _engine and _engine.in_combat:
-        enemies = _engine.get_enemies()
-        if enemies:
+    # Add enemies in combat (from EntityManager for consistency with visual display)
+    if _engine and _engine.in_combat and _entity_manager:
+        monsters = _entity_manager.get_monsters()
+        if monsters:
             lines.append("")
             lines.append("Enemies:")
-            for e in enemies:
-                lines.append(f"  [{e['index']}] {e['name']}: {e['hp']}/{e['max_hp']} HP")
+            for i, m in enumerate(monsters):
+                name = m._creature_ref.name if m._creature_ref else m.sub_type
+                lines.append(f"  [{i}] {name}: {m.hp}/{m.max_hp} HP")
 
     lines.append("")
     lines.append("Available Actions:")
@@ -458,7 +486,7 @@ def game_attack(target_index: int) -> str:
     """Attack an enemy in combat using real D&D 5E combat rules.
 
     Args:
-        target_index: Index of the enemy to attack (from enemies list)
+        target_index: Index of the enemy to attack (0 = first living enemy)
 
     Returns:
         Combat result with attack roll, damage, and updated state.
@@ -473,8 +501,18 @@ def game_attack(target_index: int) -> str:
         return "Not your turn! Wait for enemies to act."
 
     try:
+        # Map display index to actual engine index via EntityManager
+        if _entity_manager is None:
+            return "Entity manager not initialized."
+
+        monsters = _entity_manager.get_monsters()
+        if target_index < 0 or target_index >= len(monsters):
+            return f"Invalid target index {target_index}. Valid range: 0-{len(monsters) - 1}"
+
+        actual_index = monsters[target_index].enemy_index
+
         # Execute attack through engine
-        result = _engine.execute_attack(target_index=target_index)
+        result = _engine.execute_attack(target_index=actual_index)
 
         if not result["success"]:
             return f"Attack failed: {result.get('error', 'Unknown error')}"

--- a/client-2d/tests/test_entity.py
+++ b/client-2d/tests/test_entity.py
@@ -1,0 +1,484 @@
+# ABOUTME: Unit tests for Entity classes and sync logic.
+# ABOUTME: Tests Entity, MonsterEntity, PartyMemberEntity with creature references.
+
+"""Unit tests for the entity module."""
+
+
+from client_2d.entities import (
+    Entity,
+    EntityManager,
+    EntityType,
+    ItemEntity,
+    MonsterEntity,
+    PartyMemberEntity,
+    VisualState,
+)
+
+
+class MockCreature:
+    """Mock creature for testing entity sync without engine dependency."""
+
+    def __init__(
+        self,
+        name: str = "Test Creature",
+        current_hp: int = 10,
+        max_hp: int = 10,
+        is_alive: bool = True,
+        active_conditions: dict | None = None,
+    ):
+        self.name = name
+        self.current_hp = current_hp
+        self.max_hp = max_hp
+        self._is_alive = is_alive
+        self.active_conditions = active_conditions or {}
+
+    @property
+    def is_alive(self) -> bool:
+        """Return alive status based on HP or override."""
+        if self._is_alive is not None:
+            return self._is_alive and self.current_hp > 0
+        return self.current_hp > 0
+
+
+class TestVisualState:
+    """Tests for VisualState dataclass."""
+
+    def test_default_values(self):
+        """Test VisualState has sensible defaults."""
+        vs = VisualState()
+
+        assert vs.offset_x == 0.0
+        assert vs.offset_y == 0.0
+        assert vs.alpha == 255
+        assert vs.scale == 1.0
+        assert vs.tint == (255, 255, 255)
+        assert vs.is_animating is False
+
+    def test_custom_values(self):
+        """Test VisualState can be customized."""
+        vs = VisualState(
+            offset_x=5.0,
+            offset_y=-3.0,
+            alpha=128,
+            scale=1.5,
+            tint=(255, 0, 0),
+            is_animating=True,
+        )
+
+        assert vs.offset_x == 5.0
+        assert vs.offset_y == -3.0
+        assert vs.alpha == 128
+        assert vs.scale == 1.5
+        assert vs.tint == (255, 0, 0)
+        assert vs.is_animating is True
+
+
+class TestEntity:
+    """Tests for base Entity class."""
+
+    def test_entity_creation(self):
+        """Test basic entity creation."""
+        entity = Entity(
+            entity_id="test_1",
+            grid_x=5,
+            grid_y=10,
+            entity_type=EntityType.MONSTER,
+            sub_type="goblin",
+        )
+
+        assert entity.entity_id == "test_1"
+        assert entity.grid_x == 5
+        assert entity.grid_y == 10
+        assert entity.entity_type == EntityType.MONSTER
+        assert entity.sub_type == "goblin"
+        assert entity.is_alive is True
+        assert entity.hp == 0
+        assert entity.max_hp == 0
+
+    def test_entity_default_visual_state(self):
+        """Test entity has default visual state."""
+        entity = Entity(
+            entity_id="test",
+            grid_x=0,
+            grid_y=0,
+            entity_type=EntityType.ITEM,
+        )
+
+        assert isinstance(entity.visual, VisualState)
+        assert entity.visual.alpha == 255
+
+    def test_entity_without_creature_ref(self):
+        """Test sync_from_creature returns False without creature ref."""
+        entity = Entity(
+            entity_id="test",
+            grid_x=0,
+            grid_y=0,
+            entity_type=EntityType.MONSTER,
+        )
+
+        changed = entity.sync_from_creature()
+        assert changed is False
+
+    def test_entity_sync_from_creature(self):
+        """Test entity syncs state from creature reference."""
+        creature = MockCreature(
+            name="Goblin",
+            current_hp=7,
+            max_hp=12,
+            active_conditions={"poisoned": {}},
+        )
+
+        entity = Entity(
+            entity_id="goblin_1",
+            grid_x=5,
+            grid_y=5,
+            entity_type=EntityType.MONSTER,
+        )
+
+        # Set creature reference
+        entity.creature = creature
+
+        # State should be synced immediately
+        assert entity.hp == 7
+        assert entity.max_hp == 12
+        assert entity.is_alive is True
+        assert "poisoned" in entity.conditions
+
+    def test_entity_sync_detects_changes(self):
+        """Test sync_from_creature returns True when state changes."""
+        creature = MockCreature(current_hp=10, max_hp=10)
+
+        entity = Entity(
+            entity_id="test",
+            grid_x=0,
+            grid_y=0,
+            entity_type=EntityType.MONSTER,
+        )
+        entity.creature = creature
+
+        # Initial sync happened in setter
+        changed = entity.sync_from_creature()
+        assert changed is False  # No change since setter synced
+
+        # Modify creature
+        creature.current_hp = 5
+        changed = entity.sync_from_creature()
+        assert changed is True
+        assert entity.hp == 5
+
+        # Sync again with no changes
+        changed = entity.sync_from_creature()
+        assert changed is False
+
+    def test_entity_sync_tracks_death(self):
+        """Test entity tracks creature death."""
+        creature = MockCreature(current_hp=5, max_hp=10)
+
+        entity = Entity(
+            entity_id="dying",
+            grid_x=0,
+            grid_y=0,
+            entity_type=EntityType.MONSTER,
+        )
+        entity.creature = creature
+
+        assert entity.is_alive is True
+
+        # Kill creature
+        creature.current_hp = 0
+        changed = entity.sync_from_creature()
+
+        assert changed is True
+        assert entity.is_alive is False
+        assert entity.hp == 0
+
+    def test_entity_sync_tracks_conditions(self):
+        """Test entity tracks condition changes."""
+        creature = MockCreature(current_hp=10, max_hp=10)
+
+        entity = Entity(
+            entity_id="test",
+            grid_x=0,
+            grid_y=0,
+            entity_type=EntityType.MONSTER,
+        )
+        entity.creature = creature
+
+        assert len(entity.conditions) == 0
+
+        # Add condition
+        creature.active_conditions["stunned"] = {}
+        changed = entity.sync_from_creature()
+
+        assert changed is True
+        assert "stunned" in entity.conditions
+
+        # Remove condition
+        del creature.active_conditions["stunned"]
+        changed = entity.sync_from_creature()
+
+        assert changed is True
+        assert "stunned" not in entity.conditions
+
+
+class TestMonsterEntity:
+    """Tests for MonsterEntity class."""
+
+    def test_monster_entity_type(self):
+        """Test MonsterEntity has correct type after __post_init__."""
+        monster = MonsterEntity(
+            entity_id="goblin_1",
+            grid_x=10,
+            grid_y=5,
+            entity_type=EntityType.ITEM,  # Wrong type, should be corrected
+            enemy_index=0,
+        )
+
+        assert monster.entity_type == EntityType.MONSTER
+        assert monster.enemy_index == 0
+
+    def test_monster_entity_defaults(self):
+        """Test MonsterEntity default values."""
+        monster = MonsterEntity(
+            entity_id="test",
+            grid_x=0,
+            grid_y=0,
+            entity_type=EntityType.MONSTER,
+        )
+
+        assert monster.enemy_index == -1
+
+
+class TestPartyMemberEntity:
+    """Tests for PartyMemberEntity class."""
+
+    def test_party_member_entity_type(self):
+        """Test PartyMemberEntity has correct type after __post_init__."""
+        party_member = PartyMemberEntity(
+            entity_id="fighter_1",
+            grid_x=5,
+            grid_y=5,
+            entity_type=EntityType.ITEM,  # Wrong type, should be corrected
+            party_index=0,
+            character_class="fighter",
+        )
+
+        assert party_member.entity_type == EntityType.PARTY_MEMBER
+        assert party_member.party_index == 0
+        assert party_member.character_class == "fighter"
+
+    def test_party_member_turn_tracking(self):
+        """Test PartyMemberEntity tracks turn status."""
+        party_member = PartyMemberEntity(
+            entity_id="wizard_1",
+            grid_x=5,
+            grid_y=5,
+            entity_type=EntityType.PARTY_MEMBER,
+            is_current_turn=True,
+        )
+
+        assert party_member.is_current_turn is True
+
+
+class TestItemEntity:
+    """Tests for ItemEntity class."""
+
+    def test_item_entity_type(self):
+        """Test ItemEntity has correct type after __post_init__."""
+        item = ItemEntity(
+            entity_id="potion_1",
+            grid_x=3,
+            grid_y=3,
+            entity_type=EntityType.MONSTER,  # Wrong type, should be corrected
+            item_category="potions",
+        )
+
+        assert item.entity_type == EntityType.ITEM
+        assert item.item_category == "potions"
+        assert item.collected is False
+
+    def test_item_collection_tracking(self):
+        """Test ItemEntity tracks collection status."""
+        item = ItemEntity(
+            entity_id="sword_1",
+            grid_x=0,
+            grid_y=0,
+            entity_type=EntityType.ITEM,
+            collected=True,
+        )
+
+        assert item.collected is True
+
+
+class TestEntityManager:
+    """Tests for EntityManager class."""
+
+    def test_entity_manager_init_empty(self):
+        """Test EntityManager initializes empty."""
+        manager = EntityManager()
+
+        assert len(manager.get_all()) == 0
+        assert len(manager.get_monsters()) == 0
+        assert len(manager.get_party_members()) == 0
+        assert len(manager.get_items()) == 0
+
+    def test_entity_manager_clear(self):
+        """Test EntityManager clear removes all entities."""
+        manager = EntityManager()
+
+        # Add some entities manually
+        monster = MonsterEntity(
+            entity_id="test_monster",
+            grid_x=5,
+            grid_y=5,
+            entity_type=EntityType.MONSTER,
+        )
+        manager._add_entity(monster)
+
+        assert len(manager.get_all()) == 1
+
+        manager.clear()
+
+        assert len(manager.get_all()) == 0
+
+    def test_entity_manager_get_at_position(self):
+        """Test EntityManager can find entity by position."""
+        manager = EntityManager()
+
+        monster = MonsterEntity(
+            entity_id="goblin_1",
+            grid_x=10,
+            grid_y=15,
+            entity_type=EntityType.MONSTER,
+        )
+        manager._add_entity(monster)
+
+        found = manager.get_at_position(10, 15)
+        assert found is monster
+
+        not_found = manager.get_at_position(0, 0)
+        assert not_found is None
+
+    def test_entity_manager_get_by_id(self):
+        """Test EntityManager can find entity by ID."""
+        manager = EntityManager()
+
+        item = ItemEntity(
+            entity_id="sword_of_doom",
+            grid_x=3,
+            grid_y=3,
+            entity_type=EntityType.ITEM,
+        )
+        manager._add_entity(item)
+
+        found = manager.get_by_id("sword_of_doom")
+        assert found is item
+
+        not_found = manager.get_by_id("nonexistent")
+        assert not_found is None
+
+    def test_entity_manager_remove_dead_entities(self):
+        """Test EntityManager removes dead monster entities."""
+        manager = EntityManager()
+
+        # Create a living monster
+        living_creature = MockCreature(current_hp=10, max_hp=10)
+        living_monster = MonsterEntity(
+            entity_id="living",
+            grid_x=5,
+            grid_y=5,
+            entity_type=EntityType.MONSTER,
+        )
+        living_monster.creature = living_creature
+        manager._add_entity(living_monster)
+
+        # Create a dead monster
+        dead_creature = MockCreature(current_hp=0, max_hp=10)
+        dead_monster = MonsterEntity(
+            entity_id="dead",
+            grid_x=10,
+            grid_y=10,
+            entity_type=EntityType.MONSTER,
+        )
+        dead_monster.creature = dead_creature
+        manager._add_entity(dead_monster)
+
+        assert len(manager.get_monsters()) == 2
+
+        # Remove dead entities
+        removed = manager.remove_dead_entities()
+
+        assert len(removed) == 1
+        assert removed[0] is dead_monster
+        assert len(manager.get_monsters()) == 1
+        assert manager.get_by_id("living") is living_monster
+        assert manager.get_by_id("dead") is None
+
+    def test_entity_manager_sync_from_engine(self):
+        """Test EntityManager syncs all entities and returns changed ones."""
+        manager = EntityManager()
+
+        # Create monsters with creature refs
+        creature1 = MockCreature(current_hp=10, max_hp=10)
+        monster1 = MonsterEntity(
+            entity_id="m1",
+            grid_x=5,
+            grid_y=5,
+            entity_type=EntityType.MONSTER,
+        )
+        monster1.creature = creature1
+        manager._add_entity(monster1)
+
+        creature2 = MockCreature(current_hp=8, max_hp=8)
+        monster2 = MonsterEntity(
+            entity_id="m2",
+            grid_x=10,
+            grid_y=10,
+            entity_type=EntityType.MONSTER,
+        )
+        monster2.creature = creature2
+        manager._add_entity(monster2)
+
+        # No changes initially
+        changed = manager.sync_from_engine(None)
+        assert len(changed) == 0
+
+        # Modify one creature
+        creature1.current_hp = 5
+
+        changed = manager.sync_from_engine(None)
+        assert len(changed) == 1
+        assert changed[0] is monster1
+        assert monster1.hp == 5
+
+    def test_entity_manager_collapse_party(self):
+        """Test EntityManager removes party member entities."""
+        manager = EntityManager()
+
+        # Add party members
+        for i in range(4):
+            party_member = PartyMemberEntity(
+                entity_id=f"party_{i}",
+                grid_x=i,
+                grid_y=i,
+                entity_type=EntityType.PARTY_MEMBER,
+                party_index=i,
+            )
+            manager._add_entity(party_member)
+
+        # Add a monster (should not be removed)
+        monster = MonsterEntity(
+            entity_id="monster_1",
+            grid_x=10,
+            grid_y=10,
+            entity_type=EntityType.MONSTER,
+        )
+        manager._add_entity(monster)
+
+        assert len(manager.get_party_members()) == 4
+        assert len(manager.get_monsters()) == 1
+
+        manager.collapse_party()
+
+        assert len(manager.get_party_members()) == 0
+        assert len(manager.get_monsters()) == 1  # Monster still there

--- a/client-2d/tests/test_entity_integration.py
+++ b/client-2d/tests/test_entity_integration.py
@@ -1,0 +1,487 @@
+# ABOUTME: Integration tests for EntityManager with real engine state.
+# ABOUTME: Tests combat flow with entity sync, death removal, and party spread.
+
+"""Integration tests for entity system with engine integration."""
+
+import pytest
+from client_2d.entities import EntityManager, EntityType
+
+
+class TestEnemyIndexMapping:
+    """Tests for enemy index mapping between display and engine indices.
+
+    Bug context: When enemy at index 0 dies, get_enemies() returns remaining
+    enemies but their "index" field contains the actual engine index, not
+    their position in the filtered list. UI must use this index for attacks.
+    """
+
+    @pytest.fixture
+    def engine_in_combat(self):
+        """Create engine adapter already in combat with multiple enemies."""
+        from client_2d.integration.engine_adapter import EngineAdapter
+
+        adapter = EngineAdapter()
+        adapter.load_party_from_vault()
+        adapter.initialize_game(
+            dungeon_name="cellar",
+            campaign_id="poisoned_laboratory",
+            start_room="cellar.storage",  # Room with rats
+        )
+        adapter.start_game()
+
+        if not adapter.in_combat:
+            pytest.skip("Room did not start combat")
+
+        return adapter
+
+    def test_get_enemies_returns_actual_indices(self, engine_in_combat):
+        """Test that get_enemies() index field contains actual engine index."""
+        enemies = engine_in_combat.get_enemies()
+
+        assert len(enemies) > 0
+
+        # Each enemy should have an index matching their position in active_enemies
+        for enemy_info in enemies:
+            idx = enemy_info["index"]
+            actual_enemy = engine_in_combat.game_state.active_enemies[idx]
+            assert actual_enemy.name == enemy_info["name"]
+            assert actual_enemy.is_alive
+
+    def test_attack_with_display_index_after_kill(self, engine_in_combat):
+        """Test that using display index maps correctly after enemy dies.
+
+        This tests the bug fix: if enemy 0 dies, display shows remaining
+        enemies as [0, 1, 2...] but their actual indices might be [1, 2, 3...].
+        """
+        # Kill the first enemy by attacking repeatedly
+        max_attacks = 30
+        attacks = 0
+        killed_first = False
+
+        initial_enemies = engine_in_combat.get_enemies()
+        if len(initial_enemies) < 2:
+            pytest.skip("Need at least 2 enemies for this test")
+
+        first_enemy_original_index = initial_enemies[0]["index"]
+
+        while attacks < max_attacks and engine_in_combat.in_combat:
+            if engine_in_combat.is_player_turn():
+                # Always attack first enemy in display list
+                enemies = engine_in_combat.get_enemies()
+                if not enemies:
+                    break
+
+                # Use actual index from get_enemies, not display position
+                actual_index = enemies[0]["index"]
+                result = engine_in_combat.execute_attack(target_index=actual_index)
+                attacks += 1
+
+                if result["success"] and result.get("target_killed"):
+                    if actual_index == first_enemy_original_index:
+                        killed_first = True
+                        break
+
+                engine_in_combat.advance_turn()
+            else:
+                engine_in_combat.process_enemy_turn()
+                engine_in_combat.advance_turn()
+
+        if not killed_first:
+            pytest.skip("Could not kill first enemy")
+
+        # Now get remaining enemies
+        remaining = engine_in_combat.get_enemies()
+        if not remaining:
+            pytest.skip("All enemies died")
+
+        # The first enemy in display (index 0) should have actual index > 0
+        # because the original index 0 enemy is dead
+        first_remaining = remaining[0]
+
+        # Attack using the actual index should succeed
+        if engine_in_combat.in_combat and engine_in_combat.is_player_turn():
+            result = engine_in_combat.execute_attack(
+                target_index=first_remaining["index"]
+            )
+            # Should not fail with "Target is dead"
+            assert result["success"] or "dead" not in result.get("error", "").lower()
+
+    def test_display_index_zero_maps_to_correct_enemy(self, engine_in_combat):
+        """Test that display index 0 always targets first LIVING enemy."""
+        enemies = engine_in_combat.get_enemies()
+        if not enemies:
+            pytest.skip("No enemies")
+
+        # Display index 0 should map to first living enemy
+        display_zero_actual_index = enemies[0]["index"]
+        target = engine_in_combat.game_state.active_enemies[display_zero_actual_index]
+
+        assert target.is_alive
+        assert target.name == enemies[0]["name"]
+
+
+class TestEntityManagerEngineIntegration:
+    """Integration tests for EntityManager with real engine."""
+
+    @pytest.fixture
+    def engine_adapter(self):
+        """Create a real EngineAdapter for integration testing."""
+        from client_2d.integration.engine_adapter import EngineAdapter
+
+        adapter = EngineAdapter()
+        adapter.load_party_from_vault()
+        adapter.initialize_game(
+            dungeon_name="cellar",
+            campaign_id="poisoned_laboratory",
+            start_room="cellar.storage",  # Room with rats
+        )
+        adapter.start_game()
+        return adapter
+
+    @pytest.fixture
+    def layout_loader(self):
+        """Create a real LayoutLoader."""
+        from client_2d.integration.layout_loader import LayoutLoader
+
+        return LayoutLoader()
+
+    def test_load_from_room_creates_monster_entities(
+        self, engine_adapter, layout_loader
+    ):
+        """Test EntityManager creates monster entities from engine state."""
+        manager = EntityManager()
+
+        # Load room layout
+        room_data = layout_loader.get_room_data(
+            "cellar", "cellar.storage", "poisoned_laboratory"
+        )
+        layout = layout_loader.load_room_with_fallback(
+            dungeon_name="cellar",
+            room_id="cellar.storage",
+            campaign_id="poisoned_laboratory",
+            default_width=20,
+            default_height=15,
+            exits={"south": "cellar.stairs"},
+        )
+
+        # Load entities
+        manager.load_from_room(
+            engine=engine_adapter,
+            layout=layout,
+            room_data=room_data,
+            monster_textures={},
+            item_textures={},
+        )
+
+        # Should have monster entities for active enemies
+        monsters = manager.get_monsters()
+        assert len(monsters) > 0
+
+        # Each monster should have a creature reference
+        for monster in monsters:
+            assert monster.entity_type == EntityType.MONSTER
+            assert monster._creature_ref is not None
+            assert monster.hp > 0
+            assert monster.is_alive is True
+
+    def test_load_from_room_creates_item_entities(
+        self, engine_adapter, layout_loader
+    ):
+        """Test EntityManager creates item entities from room data."""
+        manager = EntityManager()
+
+        # Load room with items
+        room_data = layout_loader.get_room_data(
+            "cellar", "cellar.storage", "poisoned_laboratory"
+        )
+        layout = layout_loader.load_room_with_fallback(
+            dungeon_name="cellar",
+            room_id="cellar.storage",
+            campaign_id="poisoned_laboratory",
+            default_width=20,
+            default_height=15,
+            exits={"south": "cellar.stairs"},
+        )
+
+        manager.load_from_room(
+            engine=engine_adapter,
+            layout=layout,
+            room_data=room_data,
+            monster_textures={},
+            item_textures={},
+        )
+
+        # Check item entities exist if room has items
+        items = manager.get_items()
+        if room_data and room_data.get("items"):
+            visible_items = [i for i in room_data["items"] if i.get("visible", True)]
+            assert len(items) == len(visible_items)
+
+    def test_sync_from_engine_after_damage(self, engine_adapter, layout_loader):
+        """Test entity sync updates HP after combat damage."""
+        manager = EntityManager()
+
+        room_data = layout_loader.get_room_data(
+            "cellar", "cellar.storage", "poisoned_laboratory"
+        )
+        layout = layout_loader.load_room_with_fallback(
+            dungeon_name="cellar",
+            room_id="cellar.storage",
+            campaign_id="poisoned_laboratory",
+            default_width=20,
+            default_height=15,
+            exits={"south": "cellar.stairs"},
+        )
+
+        manager.load_from_room(
+            engine=engine_adapter,
+            layout=layout,
+            room_data=room_data,
+            monster_textures={},
+            item_textures={},
+        )
+
+        monsters = manager.get_monsters()
+        if not monsters:
+            pytest.skip("No monsters in room")
+
+        # Get initial HP from first monster
+        first_monster = monsters[0]
+        initial_hp = first_monster.hp
+
+        # Execute attack through engine
+        if engine_adapter.in_combat and engine_adapter.is_player_turn():
+            result = engine_adapter.execute_attack(target_index=0)
+
+            if result["success"] and result["hit"]:
+                # Sync should detect HP change
+                changed = manager.sync_from_engine(engine_adapter)
+                assert len(changed) > 0
+
+                # Monster HP should be updated
+                assert first_monster.hp < initial_hp
+
+    def test_remove_dead_after_kill(self, engine_adapter, layout_loader):
+        """Test dead entities are removed after being killed."""
+        manager = EntityManager()
+
+        room_data = layout_loader.get_room_data(
+            "cellar", "cellar.storage", "poisoned_laboratory"
+        )
+        layout = layout_loader.load_room_with_fallback(
+            dungeon_name="cellar",
+            room_id="cellar.storage",
+            campaign_id="poisoned_laboratory",
+            default_width=20,
+            default_height=15,
+            exits={"south": "cellar.stairs"},
+        )
+
+        manager.load_from_room(
+            engine=engine_adapter,
+            layout=layout,
+            room_data=room_data,
+            monster_textures={},
+            item_textures={},
+        )
+
+        initial_monster_count = len(manager.get_monsters())
+        if initial_monster_count == 0:
+            pytest.skip("No monsters in room")
+
+        # Attack until a monster dies or we run out of turns
+        max_attacks = 20
+        attacks = 0
+        killed_one = False
+
+        while attacks < max_attacks and engine_adapter.in_combat:
+            if engine_adapter.is_player_turn():
+                result = engine_adapter.execute_attack(target_index=0)
+                attacks += 1
+
+                if result["success"]:
+                    manager.sync_from_engine(engine_adapter)
+
+                    if result.get("target_killed"):
+                        killed_one = True
+                        removed = manager.remove_dead_entities()
+                        assert len(removed) > 0
+                        assert len(manager.get_monsters()) < initial_monster_count
+                        break
+
+                    engine_adapter.advance_turn()
+            else:
+                engine_adapter.process_enemy_turn()
+                engine_adapter.advance_turn()
+
+        if not killed_one:
+            pytest.skip("Could not kill monster in allowed attacks")
+
+    def test_spread_party_creates_party_entities(
+        self, engine_adapter, layout_loader
+    ):
+        """Test party spread creates PartyMemberEntity objects."""
+        manager = EntityManager()
+
+        room_data = layout_loader.get_room_data(
+            "cellar", "cellar.storage", "poisoned_laboratory"
+        )
+        layout = layout_loader.load_room_with_fallback(
+            dungeon_name="cellar",
+            room_id="cellar.storage",
+            campaign_id="poisoned_laboratory",
+            default_width=20,
+            default_height=15,
+            exits={"south": "cellar.stairs"},
+        )
+
+        manager.load_from_room(
+            engine=engine_adapter,
+            layout=layout,
+            room_data=room_data,
+            monster_textures={},
+            item_textures={},
+        )
+
+        # Spread party for combat
+        positions = manager.spread_party_for_combat(
+            engine=engine_adapter,
+            center_x=10,
+            center_y=7,
+            layout=layout,
+            character_textures={},
+        )
+
+        # Should have party member entities
+        party_members = manager.get_party_members()
+        assert len(party_members) > 0
+        assert len(positions) == len(party_members)
+
+        # Each should have creature reference
+        for pm in party_members:
+            assert pm.entity_type == EntityType.PARTY_MEMBER
+            assert pm._creature_ref is not None
+            assert pm.character_class != ""
+
+    def test_collapse_party_removes_party_entities(
+        self, engine_adapter, layout_loader
+    ):
+        """Test collapse_party removes all party member entities."""
+        manager = EntityManager()
+
+        room_data = layout_loader.get_room_data(
+            "cellar", "cellar.storage", "poisoned_laboratory"
+        )
+        layout = layout_loader.load_room_with_fallback(
+            dungeon_name="cellar",
+            room_id="cellar.storage",
+            campaign_id="poisoned_laboratory",
+            default_width=20,
+            default_height=15,
+            exits={"south": "cellar.stairs"},
+        )
+
+        manager.load_from_room(
+            engine=engine_adapter,
+            layout=layout,
+            room_data=room_data,
+            monster_textures={},
+            item_textures={},
+        )
+
+        # Spread party
+        manager.spread_party_for_combat(
+            engine=engine_adapter,
+            center_x=10,
+            center_y=7,
+            layout=layout,
+            character_textures={},
+        )
+
+        assert len(manager.get_party_members()) > 0
+        monster_count = len(manager.get_monsters())
+
+        # Collapse party
+        manager.collapse_party()
+
+        # Party members gone, monsters remain
+        assert len(manager.get_party_members()) == 0
+        assert len(manager.get_monsters()) == monster_count
+
+    def test_update_party_turn_status(self, engine_adapter, layout_loader):
+        """Test party turn status updates correctly."""
+        manager = EntityManager()
+
+        room_data = layout_loader.get_room_data(
+            "cellar", "cellar.storage", "poisoned_laboratory"
+        )
+        layout = layout_loader.load_room_with_fallback(
+            dungeon_name="cellar",
+            room_id="cellar.storage",
+            campaign_id="poisoned_laboratory",
+            default_width=20,
+            default_height=15,
+            exits={"south": "cellar.stairs"},
+        )
+
+        manager.load_from_room(
+            engine=engine_adapter,
+            layout=layout,
+            room_data=room_data,
+            monster_textures={},
+            item_textures={},
+        )
+
+        # Spread party for combat
+        manager.spread_party_for_combat(
+            engine=engine_adapter,
+            center_x=10,
+            center_y=7,
+            layout=layout,
+            character_textures={},
+        )
+
+        # Update turn status
+        manager.update_party_turn_status(engine_adapter)
+
+        # Check that at most one party member has is_current_turn=True
+        current_turn_count = sum(
+            1 for pm in manager.get_party_members() if pm.is_current_turn
+        )
+
+        # Either 0 (enemy turn) or 1 (player turn)
+        assert current_turn_count <= 1
+
+    def test_room_clear_on_transition(self, engine_adapter, layout_loader):
+        """Test clear() removes all entities for room transition."""
+        manager = EntityManager()
+
+        room_data = layout_loader.get_room_data(
+            "cellar", "cellar.storage", "poisoned_laboratory"
+        )
+        layout = layout_loader.load_room_with_fallback(
+            dungeon_name="cellar",
+            room_id="cellar.storage",
+            campaign_id="poisoned_laboratory",
+            default_width=20,
+            default_height=15,
+            exits={"south": "cellar.stairs"},
+        )
+
+        manager.load_from_room(
+            engine=engine_adapter,
+            layout=layout,
+            room_data=room_data,
+            monster_textures={},
+            item_textures={},
+        )
+
+        assert len(manager.get_all()) > 0
+
+        # Clear for room transition
+        manager.clear()
+
+        assert len(manager.get_all()) == 0
+        assert len(manager.get_monsters()) == 0
+        assert len(manager.get_items()) == 0
+        assert len(manager.get_party_members()) == 0


### PR DESCRIPTION
## Summary

- Replace tuple-based entity storage with Entity class hierarchy maintaining live references to engine Creatures
- EntityManager handles sync, dead entity removal, and combat party spread
- MCP server now uses EntityManager exclusively for enemy display/targeting (consistent with visual client)

## Changes

- **New**: `entities/entity.py` - Entity, MonsterEntity, PartyMemberEntity, ItemEntity classes with creature refs
- **New**: `entities/entity_manager.py` - Manager with load_from_room, sync_from_engine, remove_dead_entities
- **Modified**: `game.py` - Integrated EntityManager at all sync points
- **Modified**: `mcp_server.py` - Uses EntityManager for enemy display and attack targeting
- **New**: Unit and integration tests (33 tests)

## Test plan

- [x] All 266 tests pass
- [ ] Manual playtest in 2D client - verify enemies disappear when killed
- [ ] MCP playtest - verify enemy indices match between display and attack targeting

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)