### PR TITLE
Fix #332: MCP attack command advances turns and reports failures

### DIFF
--- a/client-2d/src/client_2d/game.py
+++ b/client-2d/src/client_2d/game.py
@@ -398,6 +398,17 @@ class GameWindow(arcade.Window):
         self.selected_enemy = target_index
         self._execute_attack()
 
+        # Check if attack actually succeeded by seeing if turn advanced
+        # If still same player's turn and not processing enemies, attack failed
+        if self.engine.is_player_turn() and not self.processing_enemy_turn:
+            current = self.engine.get_current_combatant()
+            name = current["name"] if current else "Character"
+            return f"Attack failed! {name} cannot reach the target. Use game_wait() to pass."
+
+        # Process enemy turns synchronously for MCP
+        while self.processing_enemy_turn:
+            self._process_enemy_turn()
+
         return self._mcp_get_state()
 
     def _mcp_wait(self) -> str:


### PR DESCRIPTION
## Summary
- Fixes turn not advancing after `game_attack()` MCP command
- Adds clear error messages when attacks fail (e.g., target out of range)
- Processes enemy turns synchronously for MCP integration

## Test plan
- [x] Start combat via `game_move("north")`
- [x] Attack with adjacent character → turn advances correctly
- [x] Attack with non-adjacent character → returns error message
- [x] `game_wait()` correctly passes turn for non-adjacent characters

## Related
- Closes #332
- Filed #336 for combat movement feature (discovered during testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)