### PR TITLE
Add #360: --dev MCP tools for spawning characters and monsters

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "dnd-game": {
       "type": "stdio",
-      "command": "/Users/joec/git/rpggame/client-2d/scripts/run_mcp_proxy.sh"
+      "command": "/Users/joec/git-dnd/rpggame/client-2d/scripts/run_mcp_proxy.sh",
+      "env": {
+        "DND_DEBUG": "1"
+      }
     }
   }
 }

--- a/client-2d/src/client_2d/embedded_mcp_server.py
+++ b/client-2d/src/client_2d/embedded_mcp_server.py
@@ -60,6 +60,7 @@ class EmbeddedMCPServer:
         bridge: MCPBridge,
         host: str = "127.0.0.1",
         port: int = 8765,
+        dev_mode: bool = False,
     ) -> None:
         """Initialize the embedded MCP server.
 
@@ -67,10 +68,15 @@ class EmbeddedMCPServer:
             bridge: MCPBridge for communication with GameWindow.
             host: Host to bind to (default localhost only).
             port: Port to listen on.
+            dev_mode: When True, additionally register the --dev spawn/setup
+                tools (spawn_monster, spawn_character, set_position,
+                clear_enemies, set_seed). Gated upstream by the --dev CLI
+                flag or DND_DEBUG=1 so these never leak into normal play.
         """
         self._bridge = bridge
         self._host = host
         self._port = port
+        self._dev_mode = dev_mode
         self._server_thread: threading.Thread | None = None
         self._shutdown_event = threading.Event()
         self._mcp = self._create_mcp_server()
@@ -167,7 +173,115 @@ class EmbeddedMCPServer:
             request = CommandRequest(command_type=CommandType.WAIT)
             return bridge.submit_command(request, timeout=10.0)
 
+        if self._dev_mode:
+            self._register_dev_tools(mcp, bridge)
+
         return mcp
+
+    def _register_dev_tools(self, mcp: FastMCP, bridge: MCPBridge) -> None:
+        """Register the --dev spawn/setup tools on the FastMCP instance.
+
+        Only invoked when dev_mode=True. These tools let a developer (or
+        Claude playtesting via MCP) stand up exact entity layouts for
+        feature testing — e.g. spawn a ranged-weapon-equipped fighter and
+        a goblin at chosen tiles to exercise ranged-attack rules.
+        """
+
+        @mcp.tool()
+        def spawn_monster(monster_id: str, x: int, y: int) -> str:
+            """Spawn a monster at (x, y). Starts combat if not already in combat.
+
+            Args:
+                monster_id: SRD monster ID (e.g. 'goblin', 'giant_rat').
+                x: Tile X coordinate.
+                y: Tile Y coordinate.
+
+            Returns:
+                JSON-ish dict string with entity_id, name, hp, position.
+            """
+            request = CommandRequest(
+                command_type=CommandType.SPAWN_MONSTER,
+                args={"monster_id": monster_id, "x": x, "y": y},
+            )
+            return bridge.submit_command(request, timeout=5.0)
+
+        @mcp.tool()
+        def spawn_character(
+            class_name: str,
+            race: str,
+            weapons: list[str],
+            x: int,
+            y: int,
+            name: str | None = None,
+            level: int = 1,
+        ) -> str:
+            """Spawn a player character, equip first weapon, add to party.
+
+            Available classes: fighter, rogue, wizard.
+            Available races: halfling, high_elf, human, mountain_dwarf.
+
+            Args:
+                class_name: Class ID.
+                race: Race ID.
+                weapons: Ordered weapon IDs; first equipped, rest in pack.
+                x: Tile X.
+                y: Tile Y.
+                name: Optional name (random if omitted).
+                level: Starting level (default 1).
+
+            Returns:
+                Dict string with entity_id, name, hp, position.
+            """
+            request = CommandRequest(
+                command_type=CommandType.SPAWN_CHARACTER,
+                args={
+                    "class_name": class_name,
+                    "race": race,
+                    "weapons": weapons,
+                    "x": x,
+                    "y": y,
+                    "name": name,
+                    "level": level,
+                },
+            )
+            return bridge.submit_command(request, timeout=10.0)
+
+        @mcp.tool()
+        def set_position(entity_id: str, x: int, y: int) -> str:
+            """Move an entity to (x, y) on the visual map.
+
+            Useful for tweaking distance between an attacker and a target
+            without re-spawning either.
+
+            Args:
+                entity_id: Entity ID as shown on the ASCII map.
+                x: New tile X.
+                y: New tile Y.
+            """
+            request = CommandRequest(
+                command_type=CommandType.SET_POSITION,
+                args={"entity_id": entity_id, "x": x, "y": y},
+            )
+            return bridge.submit_command(request, timeout=5.0)
+
+        @mcp.tool()
+        def clear_enemies() -> str:
+            """Remove all active enemies and end combat. Useful between tests."""
+            request = CommandRequest(command_type=CommandType.CLEAR_ENEMIES)
+            return bridge.submit_command(request, timeout=5.0)
+
+        @mcp.tool()
+        def set_seed(seed: int) -> str:
+            """Reseed the dice roller for reproducible rolls from this point.
+
+            Args:
+                seed: Integer seed.
+            """
+            request = CommandRequest(
+                command_type=CommandType.SET_SEED,
+                args={"seed": seed},
+            )
+            return bridge.submit_command(request, timeout=5.0)
 
     def start(self) -> None:
         """Start HTTP server in background thread."""

--- a/client-2d/src/client_2d/game.py
+++ b/client-2d/src/client_2d/game.py
@@ -129,6 +129,7 @@ class GameWindow(arcade.Window):
         fullscreen: bool = False,
         enable_mcp: bool = False,
         mcp_port: int = 8765,
+        dev_mode: bool = False,
     ):
         """Initialize the game window.
 
@@ -138,6 +139,7 @@ class GameWindow(arcade.Window):
             fullscreen: Whether to run in fullscreen mode.
             enable_mcp: Whether to start embedded MCP server.
             mcp_port: Port for MCP HTTP server.
+            dev_mode: Whether to register --dev spawn/setup MCP tools.
         """
         super().__init__(width, height, WINDOW_TITLE, fullscreen=fullscreen)
         arcade.set_background_color(UIColors.PANEL_BG_DARK)
@@ -148,6 +150,7 @@ class GameWindow(arcade.Window):
         self._state_renderer: StateRenderer | None = None
         self._enable_mcp = enable_mcp
         self._mcp_port = mcp_port
+        self._dev_mode = dev_mode
 
         # Engine adapter
         self.engine = EngineAdapter()
@@ -267,6 +270,7 @@ class GameWindow(arcade.Window):
         self._mcp_server = EmbeddedMCPServer(
             bridge=self._mcp_bridge,
             port=self._mcp_port,
+            dev_mode=self._dev_mode,
         )
         self._mcp_server.start()
 
@@ -300,6 +304,32 @@ class GameWindow(arcade.Window):
                 result = self._mcp_attack(target)
             elif request.command_type == CommandType.WAIT:
                 result = self._mcp_wait()
+            elif request.command_type == CommandType.SPAWN_MONSTER:
+                result = self._mcp_spawn_monster(
+                    request.args.get("monster_id", ""),
+                    request.args.get("x", 0),
+                    request.args.get("y", 0),
+                )
+            elif request.command_type == CommandType.SPAWN_CHARACTER:
+                result = self._mcp_spawn_character(
+                    request.args.get("class_name", ""),
+                    request.args.get("race", ""),
+                    request.args.get("weapons", []),
+                    request.args.get("x", 0),
+                    request.args.get("y", 0),
+                    name=request.args.get("name"),
+                    level=request.args.get("level", 1),
+                )
+            elif request.command_type == CommandType.SET_POSITION:
+                result = self._mcp_set_position(
+                    request.args.get("entity_id", ""),
+                    request.args.get("x", 0),
+                    request.args.get("y", 0),
+                )
+            elif request.command_type == CommandType.CLEAR_ENEMIES:
+                result = self._mcp_clear_enemies()
+            elif request.command_type == CommandType.SET_SEED:
+                result = self._mcp_set_seed(request.args.get("seed", 0))
             else:
                 result = f"Unknown command: {request.command_type}"
             request.response_future.set_result(result)
@@ -673,6 +703,105 @@ class GameWindow(arcade.Window):
             self._process_enemy_turn()
 
         return self._mcp_get_state()
+
+    # ========== Dev-mode MCP handlers (issue #360) ==========
+    # Only invoked when EmbeddedMCPServer was started with dev_mode=True
+    # (gated upstream by --dev or DND_DEBUG=1).
+
+    def _mcp_spawn_monster(self, monster_id: str, x: int, y: int) -> str:
+        """Spawn a monster via the engine, register it with the visual EntityManager."""
+        from client_2d.entities.entity import MonsterEntity
+
+        result = self.engine.spawn_monster(monster_id, x, y)
+        enemy_index = len(self.engine.game_state.active_enemies) - 1
+        creature_ref = self.engine.game_state.active_enemies[enemy_index]
+
+        entity = MonsterEntity(
+            entity_id=result["entity_id"],
+            grid_x=x,
+            grid_y=y,
+            entity_type=EntityType.MONSTER,
+            sub_type=monster_id,
+            enemy_index=enemy_index,
+            texture=None,
+        )
+        entity.creature = creature_ref
+        self.entity_manager._add_entity(entity)
+
+        if self.current_mode != GameMode.COMBAT:
+            self.current_mode = GameMode.COMBAT
+            self._spread_party_for_combat()
+
+        return (
+            f"Spawned {result['name']} at ({x},{y}) as {result['entity_id']}. "
+            + self._mcp_get_state()
+        )
+
+    def _mcp_spawn_character(
+        self,
+        class_name: str,
+        race: str,
+        weapons: list[str],
+        x: int,
+        y: int,
+        name: str | None = None,
+        level: int = 1,
+    ) -> str:
+        """Spawn a PC via the engine, register a party-member entity for visuals."""
+        from client_2d.entities.entity import PartyMemberEntity
+
+        result = self.engine.spawn_character(
+            class_name, race, weapons, x, y, name=name, level=level
+        )
+        party_index = len(self.engine.party.characters) - 1
+        creature_ref = self.engine.party.characters[party_index]
+
+        entity = PartyMemberEntity(
+            entity_id=result["entity_id"],
+            grid_x=x,
+            grid_y=y,
+            entity_type=EntityType.PARTY_MEMBER,
+            sub_type=class_name.lower(),
+            party_index=party_index,
+            character_class=class_name.lower(),
+            texture=None,
+        )
+        entity.creature = creature_ref
+        self.entity_manager._add_entity(entity)
+
+        return (
+            f"Spawned {result['name']} ({class_name}/{race}) at ({x},{y}) "
+            f"as {result['entity_id']}. " + self._mcp_get_state()
+        )
+
+    def _mcp_set_position(self, entity_id: str, x: int, y: int) -> str:
+        """Move an existing entity on the visual map."""
+        result = self.engine.set_position(entity_id, x, y)
+        target = self.entity_manager.get_by_id(entity_id)
+        if target is None:
+            return f"Entity '{entity_id}' not found on the map."
+        target.grid_x = x
+        target.grid_y = y
+        return (
+            f"Moved {entity_id} to {tuple(result['position'])}. " + self._mcp_get_state()
+        )
+
+    def _mcp_clear_enemies(self) -> str:
+        """Wipe enemies from engine and visual layer."""
+        result = self.engine.clear_enemies()
+        # Mark visual monsters dead so the standard removal path drops them.
+        for entity in list(self.entity_manager.get_all()):
+            if entity.entity_type == EntityType.MONSTER:
+                entity.is_alive = False
+        self.entity_manager.remove_dead_entities()
+        if self.current_mode == GameMode.COMBAT:
+            self.current_mode = GameMode.EXPLORATION
+        return f"Cleared {result['cleared']} enemies. " + self._mcp_get_state()
+
+    def _mcp_set_seed(self, seed: int) -> str:
+        """Reseed the engine dice roller."""
+        result = self.engine.set_seed(seed)
+        return f"Dice roller reseeded with {result['seed']}."
 
     # ========== End MCP Server Integration ==========
 
@@ -2154,6 +2283,7 @@ def run_2d_client(
     fullscreen: bool = False,
     enable_mcp: bool = False,
     mcp_port: int = 8765,
+    dev_mode: bool = False,
 ) -> None:
     """Entry point for the 2D client.
 
@@ -2162,6 +2292,7 @@ def run_2d_client(
         fullscreen: Whether to run in fullscreen mode.
         enable_mcp: Whether to start embedded MCP HTTP server.
         mcp_port: Port for MCP server (default 8765).
+        dev_mode: Whether to register --dev spawn/setup MCP tools.
     """
     width, height = WINDOW_SIZES.get(size, WINDOW_SIZES["medium"])
 
@@ -2178,6 +2309,8 @@ def run_2d_client(
         print(f"Window: {width}x{height} ({size})")
     if enable_mcp:
         print(f"MCP Server: http://127.0.0.1:{mcp_port}/sse")
+    if dev_mode:
+        print("Dev mode: ENABLED (spawn_monster/spawn_character/... available)")
     print()
 
     GameWindow(
@@ -2186,6 +2319,7 @@ def run_2d_client(
         fullscreen=fullscreen,
         enable_mcp=enable_mcp,
         mcp_port=mcp_port,
+        dev_mode=dev_mode,
     )
     arcade.run()
 

--- a/client-2d/src/client_2d/integration/engine_adapter.py
+++ b/client-2d/src/client_2d/integration/engine_adapter.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import random
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -735,6 +736,31 @@ class EngineAdapter:
             "is_player_turn": current["is_player"] if current else False,
             "combat_ended": not self._game_state.in_combat,
         }
+
+    # ========== Dev-Mode Spawn / Setup Methods ==========
+    # Backing implementations for the --dev MCP tools (issue #360).
+    # All raise ValueError if the game has not been initialized yet.
+
+    def set_seed(self, seed: int) -> dict[str, Any]:
+        """Reseed the live DiceRoller in place.
+
+        All combat / initiative / damage rolls share GameState.dice_roller,
+        so swapping its underlying random.Random gives reproducible rolls
+        without re-wiring CombatEngine or InitiativeTracker.
+
+        Args:
+            seed: New RNG seed.
+
+        Returns:
+            {"success": True, "seed": seed}
+
+        Raises:
+            ValueError: If initialize_game() has not been called yet.
+        """
+        if self._game_state is None:
+            raise ValueError("Must call initialize_game() first")
+        self._game_state.dice_roller.random = random.Random(seed)
+        return {"success": True, "seed": seed}
 
     def end_combat_check(self) -> dict[str, Any]:
         """Check if combat should end and handle cleanup.

--- a/client-2d/src/client_2d/integration/engine_adapter.py
+++ b/client-2d/src/client_2d/integration/engine_adapter.py
@@ -853,6 +853,54 @@ class EngineAdapter:
             "position": [x, y],
         }
 
+    def set_position(self, entity_id: str, x: int, y: int) -> dict[str, Any]:
+        """Return a placement directive for the GameWindow handler to apply.
+
+        Engine-side creature coordinates are not tracked today; the visual
+        EntityManager owns ``grid_x``/``grid_y``. The adapter validates
+        inputs and returns a structured dict that the dispatch layer
+        translates into ``entity_manager.get_by_id(entity_id)`` + assign.
+
+        Args:
+            entity_id: ID of the entity to move (as it appears in
+                EntityManager / on the ASCII map).
+            x: New tile X.
+            y: New tile Y.
+
+        Returns:
+            ``{"entity_id": entity_id, "position": [x, y]}``.
+
+        Raises:
+            ValueError: If initialize_game() has not been called.
+            TypeError: If ``x`` or ``y`` is not an int.
+        """
+        if self._game_state is None:
+            raise ValueError("Must call initialize_game() first")
+        if not isinstance(x, int) or not isinstance(y, int):
+            raise TypeError("x and y must be integers")
+        return {"entity_id": entity_id, "position": [x, y]}
+
+    def clear_enemies(self) -> dict[str, Any]:
+        """Remove all active enemies and end combat.
+
+        Useful between test scenarios. Wipes ``active_enemies``, ends
+        combat, and discards the initiative tracker so the next spawn
+        starts a fresh encounter.
+
+        Returns:
+            ``{"success": True, "cleared": <count of removed enemies>}``.
+
+        Raises:
+            ValueError: If initialize_game() has not been called.
+        """
+        if self._game_state is None:
+            raise ValueError("Must call initialize_game() first")
+        cleared = len(self._game_state.active_enemies)
+        self._game_state.active_enemies = []
+        self._game_state.in_combat = False
+        self._game_state.initiative_tracker = None
+        return {"success": True, "cleared": cleared}
+
     def set_seed(self, seed: int) -> dict[str, Any]:
         """Reseed the live DiceRoller in place.
 

--- a/client-2d/src/client_2d/integration/engine_adapter.py
+++ b/client-2d/src/client_2d/integration/engine_adapter.py
@@ -741,6 +741,48 @@ class EngineAdapter:
     # Backing implementations for the --dev MCP tools (issue #360).
     # All raise ValueError if the game has not been initialized yet.
 
+    def spawn_monster(self, monster_id: str, x: int, y: int) -> dict[str, Any]:
+        """Create a monster and place it on the map.
+
+        Appends to ``GameState.active_enemies`` and, if the party is not
+        already in combat, starts combat (matching the room-entry flow at
+        ``game_state.py:_check_for_enemies``). If combat is active, adds the
+        new creature to the existing initiative tracker.
+
+        Args:
+            monster_id: SRD monster ID (e.g. ``"goblin"``). Surfaces a
+                ``KeyError`` from DataLoader for unknown IDs.
+            x: Map tile X coordinate (validated/applied by the caller in the
+                GameWindow handler — engine has no creature position).
+            y: Map tile Y coordinate.
+
+        Returns:
+            ``{"entity_id": "<monster_id>_<index>", "name": str, "hp": int,
+            "position": [x, y]}``.
+
+        Raises:
+            ValueError: If initialize_game() has not been called.
+            KeyError: If ``monster_id`` is not in the SRD monster list.
+        """
+        if self._game_state is None:
+            raise ValueError("Must call initialize_game() first")
+
+        creature = self._game_state.data_loader.create_monster(monster_id)
+        index = len(self._game_state.active_enemies)
+        self._game_state.active_enemies.append(creature)
+
+        if self._game_state.in_combat and self._game_state.initiative_tracker is not None:
+            self._game_state.initiative_tracker.add_combatant(creature)
+        else:
+            self._game_state._start_combat()
+
+        return {
+            "entity_id": f"{monster_id}_{index}",
+            "name": creature.name,
+            "hp": creature.current_hp,
+            "position": [x, y],
+        }
+
     def set_seed(self, seed: int) -> dict[str, Any]:
         """Reseed the live DiceRoller in place.
 

--- a/client-2d/src/client_2d/integration/engine_adapter.py
+++ b/client-2d/src/client_2d/integration/engine_adapter.py
@@ -741,6 +741,76 @@ class EngineAdapter:
     # Backing implementations for the --dev MCP tools (issue #360).
     # All raise ValueError if the game has not been initialized yet.
 
+    def spawn_character(
+        self,
+        class_name: str,
+        race: str,
+        weapons: list[str],
+        x: int,
+        y: int,
+        name: str | None = None,
+        level: int = 1,
+    ) -> dict[str, Any]:
+        """Create a player character, equip weapons, add to the party.
+
+        Builds the PC via ``CharacterFactory.create_character`` (which sets
+        up proficiencies, default equipment, and resource pools). Each
+        weapon in ``weapons`` is added to the inventory; the first is moved
+        to the WEAPON slot, the rest stay in the pack. If combat is active,
+        the character joins the initiative tracker.
+
+        Args:
+            class_name: Class ID (e.g. ``"ranger"``).
+            race: Race ID (e.g. ``"elf"``).
+            weapons: Ordered list of item IDs from items.json. The first is
+                equipped; the rest go to the pack.
+            x: Map tile X (applied by the GameWindow handler — engine has
+                no PC position).
+            y: Map tile Y.
+            name: Optional name; CharacterFactory generates one if omitted.
+            level: Starting level (default 1).
+
+        Returns:
+            ``{"entity_id": "pc_<name>", "name": str, "hp": int,
+            "position": [x, y]}``.
+
+        Raises:
+            ValueError: If initialize_game() has not been called, or if the
+                class/race is unknown (surfaced from CharacterFactory).
+        """
+        if self._game_state is None:
+            raise ValueError("Must call initialize_game() first")
+
+        from dnd_engine.core.character_factory import CharacterFactory
+        from dnd_engine.systems.inventory import EquipmentSlot
+
+        factory = CharacterFactory()
+        character = factory.create_character(
+            class_name=class_name,
+            race_name=race,
+            data_loader=self._game_state.data_loader,
+            level=level,
+            name=name,
+        )
+
+        for i, weapon_id in enumerate(weapons):
+            character.inventory.add_item(weapon_id, category="weapons")
+            if i == 0:
+                character.inventory.equip_item(weapon_id, EquipmentSlot.WEAPON)
+
+        self._party.add_character(character)
+
+        if self._game_state.in_combat and self._game_state.initiative_tracker is not None:
+            self._game_state.initiative_tracker.add_combatant(character)
+
+        entity_id = f"pc_{character.name.lower().replace(' ', '_')}"
+        return {
+            "entity_id": entity_id,
+            "name": character.name,
+            "hp": character.current_hp,
+            "position": [x, y],
+        }
+
     def spawn_monster(self, monster_id: str, x: int, y: int) -> dict[str, Any]:
         """Create a monster and place it on the map.
 

--- a/client-2d/src/client_2d/main.py
+++ b/client-2d/src/client_2d/main.py
@@ -9,9 +9,12 @@ Usage:
     dnd-2d --fullscreen       # Fullscreen mode
     dnd-2d --mcp              # Enable embedded MCP server
     dnd-2d --mcp-port 9000    # Custom MCP port
+    dnd-2d --dev --mcp        # Expose dev spawn tools via MCP (issue #360)
+    DND_DEBUG=1 dnd-2d --mcp  # Env-var alias for --dev
 """
 
 import argparse
+import os
 import sys
 
 from client_2d.game import run_2d_client
@@ -59,7 +62,19 @@ Examples:
         help="Port for MCP server (default: 8765)",
     )
 
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help=(
+            "Enable dev-mode MCP tools (spawn_monster, spawn_character, "
+            "set_position, clear_enemies, set_seed). Also enabled by "
+            "setting DND_DEBUG=1 in the environment."
+        ),
+    )
+
     args = parser.parse_args()
+
+    dev_mode = args.dev or os.environ.get("DND_DEBUG") == "1"
 
     try:
         run_2d_client(
@@ -67,6 +82,7 @@ Examples:
             fullscreen=args.fullscreen,
             enable_mcp=args.mcp,
             mcp_port=args.mcp_port,
+            dev_mode=dev_mode,
         )
     except PartyLoadError as err:
         print("\nERROR: Cannot start the 2D client.", file=sys.stderr)

--- a/client-2d/src/client_2d/mcp_bridge.py
+++ b/client-2d/src/client_2d/mcp_bridge.py
@@ -29,6 +29,14 @@ class CommandType(Enum):
     ATTACK = auto()
     WAIT = auto()
 
+    # Dev-mode commands (only dispatched when EmbeddedMCPServer was started
+    # with dev_mode=True, gated upstream by --dev or DND_DEBUG=1).
+    SPAWN_MONSTER = auto()
+    SPAWN_CHARACTER = auto()
+    SET_POSITION = auto()
+    CLEAR_ENEMIES = auto()
+    SET_SEED = auto()
+
 
 @dataclass
 class CommandRequest:

--- a/client-2d/src/client_2d/mcp_proxy.py
+++ b/client-2d/src/client_2d/mcp_proxy.py
@@ -21,6 +21,7 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
@@ -31,8 +32,16 @@ from fastmcp import Client
 from fastmcp.client.transports import SSETransport
 from mcp.server.fastmcp import FastMCP
 
+# Dev-mode flag is read from the proxy's environment at import time. When the
+# proxy is launched with DND_DEBUG=1, it both (a) advertises the spawn/setup
+# tools to Claude and (b) launches the game with --dev so the upstream MCP
+# server actually registers them.
+DEV_MODE = os.environ.get("DND_DEBUG") == "1"
+
 # Game configuration
 GAME_COMMAND = [sys.executable, "-m", "client_2d.main", "--mcp"]
+if DEV_MODE:
+    GAME_COMMAND.append("--dev")
 GAME_MCP_URL = "http://127.0.0.1:8765"
 GAME_STARTUP_TIMEOUT = 10.0  # seconds to wait for game to start
 GAME_HEALTH_CHECK_INTERVAL = 0.5  # seconds between health checks
@@ -296,6 +305,93 @@ def create_proxy_server() -> FastMCP:
         if not game_manager.is_running:
             return "Game not running. Use game_start() first."
         return await proxy.call_tool_async("game_wait")
+
+    # === Dev-Mode Tools (only registered when DND_DEBUG=1) ===
+    # Forward to the matching tools on the game's embedded MCP server, which
+    # itself only registers them when launched with --dev / DND_DEBUG=1.
+
+    if DEV_MODE:
+
+        @mcp.tool()
+        async def spawn_monster(monster_id: str, x: int, y: int) -> str:
+            """Spawn a monster at (x, y). Starts combat if not already in combat.
+
+            Args:
+                monster_id: SRD monster ID (e.g. 'goblin', 'giant_rat').
+                x: Tile X coordinate.
+                y: Tile Y coordinate.
+            """
+            if not game_manager.is_running:
+                return "Game not running. Use game_start() first."
+            return await proxy.call_tool_async("spawn_monster", monster_id=monster_id, x=x, y=y)
+
+        @mcp.tool()
+        async def spawn_character(
+            class_name: str,
+            race: str,
+            weapons: list[str],
+            x: int,
+            y: int,
+            name: str | None = None,
+            level: int = 1,
+        ) -> str:
+            """Spawn a player character, equip first weapon, add to party.
+
+            Available classes: fighter, rogue, wizard.
+            Available races: halfling, high_elf, human, mountain_dwarf.
+
+            Args:
+                class_name: Class ID.
+                race: Race ID.
+                weapons: Ordered weapon IDs; first equipped, rest in pack.
+                x: Tile X.
+                y: Tile Y.
+                name: Optional name (random if omitted).
+                level: Starting level (default 1).
+            """
+            if not game_manager.is_running:
+                return "Game not running. Use game_start() first."
+            return await proxy.call_tool_async(
+                "spawn_character",
+                class_name=class_name,
+                race=race,
+                weapons=weapons,
+                x=x,
+                y=y,
+                name=name,
+                level=level,
+            )
+
+        @mcp.tool()
+        async def set_position(entity_id: str, x: int, y: int) -> str:
+            """Move an entity to (x, y) on the visual map.
+
+            Args:
+                entity_id: Entity ID as shown on the ASCII map.
+                x: New tile X.
+                y: New tile Y.
+            """
+            if not game_manager.is_running:
+                return "Game not running. Use game_start() first."
+            return await proxy.call_tool_async("set_position", entity_id=entity_id, x=x, y=y)
+
+        @mcp.tool()
+        async def clear_enemies() -> str:
+            """Remove all active enemies and end combat."""
+            if not game_manager.is_running:
+                return "Game not running. Use game_start() first."
+            return await proxy.call_tool_async("clear_enemies")
+
+        @mcp.tool()
+        async def set_seed(seed: int) -> str:
+            """Reseed the dice roller for reproducible rolls.
+
+            Args:
+                seed: Integer seed.
+            """
+            if not game_manager.is_running:
+                return "Game not running. Use game_start() first."
+            return await proxy.call_tool_async("set_seed", seed=seed)
 
     return mcp
 

--- a/client-2d/tests/test_dev_mode_mcp.py
+++ b/client-2d/tests/test_dev_mode_mcp.py
@@ -1,0 +1,64 @@
+# ABOUTME: Tests that the --dev MCP tools register on EmbeddedMCPServer iff dev_mode=True.
+# ABOUTME: Verifies the five spawn/setup tools never leak into normal play sessions.
+
+"""Tests for dev-mode gating on EmbeddedMCPServer.
+
+The five --dev tools (spawn_monster, spawn_character, set_position,
+clear_enemies, set_seed) must only register when EmbeddedMCPServer is
+constructed with dev_mode=True. The default (dev_mode=False) keeps them
+invisible to normal play sessions.
+"""
+
+from __future__ import annotations
+
+from client_2d.embedded_mcp_server import EmbeddedMCPServer
+from client_2d.mcp_bridge import MCPBridge
+
+DEV_TOOL_NAMES = {
+    "spawn_monster",
+    "spawn_character",
+    "set_position",
+    "clear_enemies",
+    "set_seed",
+}
+
+PLAY_TOOL_NAMES = {"game_state", "game_move", "game_attack", "game_wait"}
+
+
+def _registered_tool_names(server: EmbeddedMCPServer) -> set[str]:
+    """Return the set of tool names registered on the embedded FastMCP."""
+    return {tool.name for tool in server._mcp._tool_manager.list_tools()}
+
+
+def test_play_tools_always_present() -> None:
+    """The four play-mode tools register regardless of dev_mode."""
+    server = EmbeddedMCPServer(bridge=MCPBridge())
+    assert PLAY_TOOL_NAMES.issubset(_registered_tool_names(server))
+
+
+def test_spawn_tools_absent_when_dev_mode_false() -> None:
+    """Default construction (dev_mode=False) keeps spawn tools off the wire."""
+    server = EmbeddedMCPServer(bridge=MCPBridge())
+    names = _registered_tool_names(server)
+    assert names.isdisjoint(DEV_TOOL_NAMES)
+
+
+def test_spawn_tools_absent_when_dev_mode_explicitly_false() -> None:
+    """Explicit dev_mode=False matches the default."""
+    server = EmbeddedMCPServer(bridge=MCPBridge(), dev_mode=False)
+    names = _registered_tool_names(server)
+    assert names.isdisjoint(DEV_TOOL_NAMES)
+
+
+def test_spawn_tools_present_when_dev_mode_true() -> None:
+    """dev_mode=True registers all five spawn/setup tools."""
+    server = EmbeddedMCPServer(bridge=MCPBridge(), dev_mode=True)
+    names = _registered_tool_names(server)
+    assert DEV_TOOL_NAMES.issubset(names)
+
+
+def test_play_tools_still_present_in_dev_mode() -> None:
+    """Dev mode adds tools; it does not replace the play-mode set."""
+    server = EmbeddedMCPServer(bridge=MCPBridge(), dev_mode=True)
+    names = _registered_tool_names(server)
+    assert PLAY_TOOL_NAMES.issubset(names)

--- a/client-2d/tests/test_engine_adapter_spawn.py
+++ b/client-2d/tests/test_engine_adapter_spawn.py
@@ -1,0 +1,94 @@
+# ABOUTME: Tests for EngineAdapter dev-mode spawn/setup methods (#360).
+# ABOUTME: Covers set_seed, spawn_monster, spawn_character, set_position, clear_enemies.
+
+"""Tests for the engine adapter's dev-mode spawn primitives.
+
+These adapter methods back the --dev MCP tools. They run against a real
+EngineAdapter wired to a real GameState in the cellar/poisoned_laboratory
+campaign (deterministic content, no vault dependency).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def initialized_adapter():
+    """An EngineAdapter with a 1-member party and a real cellar GameState.
+
+    Bypasses load_party_from_vault() so tests don't depend on the user's
+    ~/.dnd_game/character_vault.json. Builds a fighter via CharacterFactory
+    and constructs GameState directly.
+    """
+    from client_2d.integration.engine_adapter import EngineAdapter
+
+    from dnd_engine.core.character_factory import CharacterFactory
+    from dnd_engine.core.game_state import GameState
+    from dnd_engine.core.party import Party
+    from dnd_engine.rules.loader import DataLoader
+    from dnd_engine.utils.events import EventBus
+
+    data_loader = DataLoader()
+    factory = CharacterFactory()
+    fighter = factory.create_character(
+        "fighter", "human", data_loader, name="Tester",
+    )
+    party = Party([fighter])
+    event_bus = EventBus()
+    game_state = GameState(
+        party=party,
+        dungeon_name="cellar",
+        event_bus=event_bus,
+        data_loader=data_loader,
+        campaign_id="poisoned_laboratory",
+    )
+
+    adapter = EngineAdapter()
+    adapter._party = party
+    adapter._event_bus = event_bus
+    adapter._game_state = game_state
+    adapter._initialized = True
+    return adapter
+
+
+class TestSetSeed:
+    """EngineAdapter.set_seed reseeds the live DiceRoller in place."""
+
+    def test_reseed_makes_rolls_reproducible(self, initialized_adapter) -> None:
+        """Same seed → same sequence of rolls."""
+        adapter = initialized_adapter
+        roller = adapter.game_state.dice_roller
+
+        adapter.set_seed(42)
+        first = [roller.roll("1d20").total for _ in range(5)]
+
+        adapter.set_seed(42)
+        second = [roller.roll("1d20").total for _ in range(5)]
+
+        assert first == second
+
+    def test_set_seed_returns_dict(self, initialized_adapter) -> None:
+        """Returns a structured dict echoing the seed."""
+        result = initialized_adapter.set_seed(123)
+
+        assert result == {"success": True, "seed": 123}
+
+    def test_set_seed_propagates_to_combat_engine(self, initialized_adapter) -> None:
+        """Combat engine holds the same DiceRoller, so reseed affects it too."""
+        adapter = initialized_adapter
+        adapter.set_seed(7)
+        a = adapter.game_state.combat_engine.dice_roller.roll("1d20").total
+
+        adapter.set_seed(7)
+        b = adapter.game_state.combat_engine.dice_roller.roll("1d20").total
+
+        assert a == b
+
+    def test_set_seed_raises_when_not_initialized(self) -> None:
+        """Raises ValueError if no GameState yet (parity with other adapter methods)."""
+        from client_2d.integration.engine_adapter import EngineAdapter
+
+        adapter = EngineAdapter()
+        with pytest.raises(ValueError, match="initialize_game"):
+            adapter.set_seed(1)

--- a/client-2d/tests/test_engine_adapter_spawn.py
+++ b/client-2d/tests/test_engine_adapter_spawn.py
@@ -227,3 +227,54 @@ class TestSpawnCharacter:
 
         with pytest.raises(ValueError, match="initialize_game"):
             EngineAdapter().spawn_character("fighter", "human", [], 0, 0)
+
+
+class TestSetPosition:
+    """EngineAdapter.set_position validates and returns a placement directive.
+
+    Engine-side creature position is not tracked today; the GameWindow handler
+    is responsible for applying the result to EntityManager.
+    """
+
+    def test_returns_position_dict(self, initialized_adapter) -> None:
+        result = initialized_adapter.set_position("goblin_0", 4, 9)
+        assert result == {"entity_id": "goblin_0", "position": [4, 9]}
+
+    def test_rejects_non_integer_coordinates(self, initialized_adapter) -> None:
+        with pytest.raises(TypeError):
+            initialized_adapter.set_position("goblin_0", "four", 9)
+
+    def test_raises_when_not_initialized(self) -> None:
+        from client_2d.integration.engine_adapter import EngineAdapter
+
+        with pytest.raises(ValueError, match="initialize_game"):
+            EngineAdapter().set_position("goblin_0", 0, 0)
+
+
+class TestClearEnemies:
+    """EngineAdapter.clear_enemies wipes active_enemies and ends combat."""
+
+    def test_clears_active_enemies_and_ends_combat(self, initialized_adapter) -> None:
+        adapter = initialized_adapter
+        adapter.spawn_monster("goblin", 12, 7)
+        adapter.spawn_monster("goblin", 14, 7)
+        assert adapter.in_combat
+        assert len(adapter.game_state.active_enemies) == 2
+
+        result = adapter.clear_enemies()
+
+        assert result == {"success": True, "cleared": 2}
+        assert adapter.game_state.active_enemies == []
+        assert not adapter.in_combat
+        assert adapter.game_state.initiative_tracker is None
+
+    def test_noop_when_no_enemies(self, initialized_adapter) -> None:
+        result = initialized_adapter.clear_enemies()
+        assert result == {"success": True, "cleared": 0}
+        assert not initialized_adapter.in_combat
+
+    def test_raises_when_not_initialized(self) -> None:
+        from client_2d.integration.engine_adapter import EngineAdapter
+
+        with pytest.raises(ValueError, match="initialize_game"):
+            EngineAdapter().clear_enemies()

--- a/client-2d/tests/test_engine_adapter_spawn.py
+++ b/client-2d/tests/test_engine_adapter_spawn.py
@@ -92,3 +92,64 @@ class TestSetSeed:
         adapter = EngineAdapter()
         with pytest.raises(ValueError, match="initialize_game"):
             adapter.set_seed(1)
+
+
+class TestSpawnMonster:
+    """EngineAdapter.spawn_monster places a monster and updates combat state."""
+
+    def test_appends_to_active_enemies_and_returns_entity_id(
+        self, initialized_adapter
+    ) -> None:
+        """Spawning adds the creature and returns its ASCII-map entity_id."""
+        adapter = initialized_adapter
+        before = len(adapter.game_state.active_enemies)
+
+        result = adapter.spawn_monster("goblin", 12, 7)
+
+        assert len(adapter.game_state.active_enemies) == before + 1
+        assert result["entity_id"] == f"goblin_{before}"
+        assert result["position"] == [12, 7]
+        assert result["hp"] > 0
+        assert result["name"]
+
+    def test_starts_combat_when_not_in_combat(self, initialized_adapter) -> None:
+        """First spawn outside combat triggers _start_combat."""
+        adapter = initialized_adapter
+        assert not adapter.in_combat
+
+        adapter.spawn_monster("goblin", 12, 7)
+
+        assert adapter.in_combat
+        assert adapter.game_state.initiative_tracker is not None
+
+    def test_adds_to_initiative_when_in_combat(self, initialized_adapter) -> None:
+        """Second spawn during combat appends to existing initiative."""
+        adapter = initialized_adapter
+        adapter.spawn_monster("goblin", 12, 7)
+        tracker = adapter.game_state.initiative_tracker
+        before = len(tracker.get_all_combatants())
+
+        adapter.spawn_monster("goblin", 14, 7)
+
+        after = len(tracker.get_all_combatants())
+        assert after == before + 1
+
+    def test_unknown_monster_raises(self, initialized_adapter) -> None:
+        """Unknown monster_id surfaces the DataLoader KeyError."""
+        with pytest.raises(KeyError):
+            initialized_adapter.spawn_monster("not_a_real_monster", 0, 0)
+
+    def test_entity_id_uses_running_index(self, initialized_adapter) -> None:
+        """Second goblin gets index 1, not a name collision."""
+        adapter = initialized_adapter
+        first = adapter.spawn_monster("goblin", 10, 7)
+        second = adapter.spawn_monster("goblin", 11, 7)
+
+        assert first["entity_id"] == "goblin_0"
+        assert second["entity_id"] == "goblin_1"
+
+    def test_raises_when_not_initialized(self) -> None:
+        from client_2d.integration.engine_adapter import EngineAdapter
+
+        with pytest.raises(ValueError, match="initialize_game"):
+            EngineAdapter().spawn_monster("goblin", 0, 0)

--- a/client-2d/tests/test_engine_adapter_spawn.py
+++ b/client-2d/tests/test_engine_adapter_spawn.py
@@ -153,3 +153,77 @@ class TestSpawnMonster:
 
         with pytest.raises(ValueError, match="initialize_game"):
             EngineAdapter().spawn_monster("goblin", 0, 0)
+
+
+class TestSpawnCharacter:
+    """EngineAdapter.spawn_character creates a PC, equips weapons, joins party."""
+
+    def test_adds_to_party(self, initialized_adapter) -> None:
+        """New character appears in party.characters."""
+        adapter = initialized_adapter
+        before = len(adapter.party.characters)
+
+        result = adapter.spawn_character(
+            "fighter", "high_elf", ["shortbow"], 5, 7, name="Robyn",
+        )
+
+        assert len(adapter.party.characters) == before + 1
+        assert result["name"] == "Robyn"
+        assert result["position"] == [5, 7]
+        assert result["entity_id"].startswith("pc_")
+
+    def test_equips_first_weapon_in_list(self, initialized_adapter) -> None:
+        """First weapon in the list is moved to the WEAPON slot."""
+        from dnd_engine.systems.inventory import EquipmentSlot
+
+        adapter = initialized_adapter
+        adapter.spawn_character(
+            "fighter", "high_elf", ["shortbow", "dagger"], 5, 7, name="Robyn",
+        )
+
+        # Find the newly added character
+        new_char = adapter.party.characters[-1]
+        equipped = new_char.inventory.get_equipped_item(EquipmentSlot.WEAPON)
+        assert equipped == "shortbow"
+        # Second weapon is in the pack, not equipped
+        assert new_char.inventory.has_item("dagger")
+
+    def test_adds_to_initiative_when_in_combat(self, initialized_adapter) -> None:
+        """Spawning during combat appends to existing initiative."""
+        adapter = initialized_adapter
+        adapter.spawn_monster("goblin", 12, 7)  # triggers combat
+        before = len(adapter.game_state.initiative_tracker.get_all_combatants())
+
+        adapter.spawn_character(
+            "fighter", "high_elf", ["shortbow"], 5, 7, name="LateJoiner",
+        )
+
+        after = len(adapter.game_state.initiative_tracker.get_all_combatants())
+        assert after == before + 1
+
+    def test_invalid_class_raises(self, initialized_adapter) -> None:
+        """CharacterFactory's ValueError surfaces unchanged."""
+        with pytest.raises(ValueError, match="Invalid class"):
+            initialized_adapter.spawn_character(
+                "not_a_class", "high_elf", ["dagger"], 0, 0, name="Bad",
+            )
+
+    def test_empty_weapons_list_is_allowed(self, initialized_adapter) -> None:
+        """No weapons → no WEAPON slot filled, character still spawns."""
+        from dnd_engine.systems.inventory import EquipmentSlot
+
+        adapter = initialized_adapter
+        adapter.spawn_character("wizard", "high_elf", [], 5, 7, name="Spellslinger")
+
+        new_char = adapter.party.characters[-1]
+        # CharacterFactory may equip a default weapon; we only assert no
+        # weapon from our (empty) list overrode that — spawn doesn't crash
+        # and the character is present.
+        assert new_char.name == "Spellslinger"
+        _ = new_char.inventory.get_equipped_item(EquipmentSlot.WEAPON)
+
+    def test_raises_when_not_initialized(self) -> None:
+        from client_2d.integration.engine_adapter import EngineAdapter
+
+        with pytest.raises(ValueError, match="initialize_game"):
+            EngineAdapter().spawn_character("fighter", "human", [], 0, 0)

--- a/client-2d/tests/test_mcp_bridge_dev_commands.py
+++ b/client-2d/tests/test_mcp_bridge_dev_commands.py
@@ -1,0 +1,44 @@
+# ABOUTME: Tests for the --dev MCP CommandType variants (spawn/setup tooling).
+# ABOUTME: Verifies the five dev-only command kinds exist and are distinct enum members.
+
+"""Tests for the dev-mode CommandType variants in mcp_bridge.
+
+These five variants exist to carry spawn/setup commands from the MCP server
+thread into the GameWindow main thread when --dev (or DND_DEBUG=1) is set.
+"""
+
+from __future__ import annotations
+
+from client_2d.mcp_bridge import CommandType
+
+DEV_COMMAND_NAMES = (
+    "SPAWN_MONSTER",
+    "SPAWN_CHARACTER",
+    "SET_POSITION",
+    "CLEAR_ENEMIES",
+    "SET_SEED",
+)
+
+
+def test_dev_command_types_exist() -> None:
+    """All five dev-mode CommandType variants are defined on the enum."""
+    for name in DEV_COMMAND_NAMES:
+        assert hasattr(CommandType, name), f"CommandType.{name} missing"
+
+
+def test_dev_command_types_unique() -> None:
+    """Each dev-mode variant has a unique value (no auto() collisions)."""
+    members = [getattr(CommandType, name) for name in DEV_COMMAND_NAMES]
+    assert len(members) == len(set(members))
+
+
+def test_dev_command_types_distinct_from_existing() -> None:
+    """Dev-mode variants don't collide with the four play-mode variants."""
+    existing = {
+        CommandType.GET_STATE,
+        CommandType.MOVE,
+        CommandType.ATTACK,
+        CommandType.WAIT,
+    }
+    dev = {getattr(CommandType, name) for name in DEV_COMMAND_NAMES}
+    assert existing.isdisjoint(dev)


### PR DESCRIPTION
## Summary
Phase 1 of the in-game testing toolkit (parent plan: `feature/in-game-testing-tools`). Adds five `--dev`-gated MCP tools so a developer (or Claude playtesting via MCP) can stand up an exact entity layout on demand — unblocking the stalled ranged-attack playtest where the vault party has only melee weapons.

- `spawn_monster(monster_id, x, y)` — create + place, start combat if needed
- `spawn_character(class_name, race, weapons, x, y, name?, level?)` — build PC via CharacterFactory, equip first weapon, add to party
- `set_position(entity_id, x, y)` — move any entity on the visual map
- `clear_enemies()` — wipe enemies + end combat between scenarios
- `set_seed(seed)` — reseed live DiceRoller for reproducible rolls

All five tools register **only** when `EmbeddedMCPServer` is started with `dev_mode=True`, which the CLI turns on for `--dev` or `DND_DEBUG=1`. Normal `--mcp` play sessions never see them.

## Changes
- **`mcp_bridge.py`** — five new `CommandType` variants for cross-thread dispatch.
- **`engine_adapter.py`** — `spawn_monster`, `spawn_character`, `set_position`, `clear_enemies`, `set_seed` adapter methods. Each raises `ValueError` if the game hasn't been initialized; `KeyError`/`ValueError` from `DataLoader`/`CharacterFactory` surface unchanged.
- **`embedded_mcp_server.py`** — adds `dev_mode: bool = False`; conditionally registers the five tools via `_register_dev_tools()`.
- **`main.py`** — adds `--dev` argparse flag, reads `DND_DEBUG=1` as alias.
- **`game.py`** — threads `dev_mode` through `run_2d_client`/`GameWindow`/`_initialize_mcp_server`; extends `_process_mcp_commands` dispatch; five new `_mcp_*` handlers that call the adapter and update `EntityManager` so spawned entities appear on the ASCII map immediately.

### Tests (TDD-first)
- `tests/test_mcp_bridge_dev_commands.py` — 3 tests for the new enum variants.
- `tests/test_engine_adapter_spawn.py` — 22 tests covering all five adapter methods, including combat-start, mid-combat initiative add, unknown-monster `KeyError`, invalid-class `ValueError`, reproducible reseed, and not-initialized guards.
- `tests/test_dev_mode_mcp.py` — 5 tests asserting tools register **iff** `dev_mode=True` (and that play-mode tools are never displaced).

The two TDD-exempt tasks (CLI argparse wiring and arcade-coupled GameWindow handlers) are flagged in the plan and covered by the manual acceptance script below — importing `GameWindow` requires arcade, which the unit-test scope excludes.

### Includes pre-req commit
Also in this PR: `fda9bd0 Refactor: Vault-content-first party loading with PartyLoadError`. The hardcoded `DEFAULT_PARTY_IDS` (four UUIDs from one specific developer's vault) broke any fresh checkout; load now defaults to the first `MAX_PARTY_SIZE` characters present in the vault and surfaces a structured `PartyLoadError` with available characters so the user can recover.

## Testing
- [x] 30 new unit tests pass
- [x] Full `client-2d/tests/` suite: 367 passed, no regressions
- [x] `ruff check` clean on all modified files
- [ ] Manual: `uv run dnd-2d --mcp` — confirm `spawn_*` tools NOT in tool list
- [ ] Manual: `uv run dnd-2d --dev --mcp` — confirm `spawn_*` tools present; drive: `spawn_character("fighter","high_elf",["shortbow"],5,7,name="Robyn")` + `spawn_monster("goblin",12,7)` + `game_attack("goblin_0")` resolves via ranged-attack rules
- [ ] Manual: `DND_DEBUG=1 uv run dnd-2d --mcp` — env-var alias enables tools

Note: SRD ships fighter/rogue/wizard + halfling/high_elf/human/mountain_dwarf — no plain `ranger`/`elf`, so the acceptance script uses `fighter`/`high_elf`/`shortbow`.

## Related Issues
Fixes #360
Phase 1 of #361, #362, #363 (parent plan: `~/.claude/plans/snug-swinging-reef.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)