### PR TITLE
Add #361: YAML scenario loader (dev-only load_scenario MCP tool)

### DIFF
--- a/client-2d/src/client_2d/embedded_mcp_server.py
+++ b/client-2d/src/client_2d/embedded_mcp_server.py
@@ -283,6 +283,28 @@ class EmbeddedMCPServer:
             )
             return bridge.submit_command(request, timeout=5.0)
 
+        @mcp.tool()
+        def load_scenario(path: str) -> str:
+            """Load a YAML scenario file: map, party, enemies, and seed.
+
+            Replaces the current game state with the one described in
+            the scenario. Useful for reproducible playtests — see
+            ``dnd-engine/tests/scenarios/yaml/_schema.md`` for the
+            expected format.
+
+            Args:
+                path: Filesystem path to the scenario YAML.
+
+            Returns:
+                Dict string with the scenario name, seed, and the new
+                game state.
+            """
+            request = CommandRequest(
+                command_type=CommandType.LOAD_SCENARIO,
+                args={"path": path},
+            )
+            return bridge.submit_command(request, timeout=15.0)
+
     def start(self) -> None:
         """Start HTTP server in background thread."""
         self._shutdown_event.clear()

--- a/client-2d/src/client_2d/game.py
+++ b/client-2d/src/client_2d/game.py
@@ -330,6 +330,8 @@ class GameWindow(arcade.Window):
                 result = self._mcp_clear_enemies()
             elif request.command_type == CommandType.SET_SEED:
                 result = self._mcp_set_seed(request.args.get("seed", 0))
+            elif request.command_type == CommandType.LOAD_SCENARIO:
+                result = self._mcp_load_scenario(request.args.get("path", ""))
             else:
                 result = f"Unknown command: {request.command_type}"
             request.response_future.set_result(result)
@@ -802,6 +804,91 @@ class GameWindow(arcade.Window):
         """Reseed the engine dice roller."""
         result = self.engine.set_seed(seed)
         return f"Dice roller reseeded with {result['seed']}."
+
+    def _mcp_load_scenario(self, path: str) -> str:
+        """Load a YAML scenario: swap engine state and rebuild the visual layer.
+
+        Mirrors the spawn-handler pattern (#360): the adapter does the
+        engine work, then this method rebuilds the entity_manager and
+        room layout so the visuals match the scenario's setup. After
+        load the game is in COMBAT mode with the scenario's enemies.
+        """
+        from client_2d.entities.entity import MonsterEntity, PartyMemberEntity
+
+        result = self.engine.load_scenario(path)
+
+        # New engine state means a new (possibly different) dungeon and
+        # room. Reload the layout, fog, and lighting before placing
+        # entities so coordinate math has the right dimensions.
+        self._load_room_layout()
+
+        # Wipe whatever entities the room layout pre-populated; the
+        # scenario is the source of truth for who is present and where.
+        self.entity_manager.clear()
+
+        game_state = self.engine.game_state
+        for entity_id, (x, y) in result["party_positions"].items():
+            # Entity IDs follow Phase 1's convention: pc_<name lowercased,
+            # spaces as underscores>. Match back to the live character
+            # the loader pushed into the party.
+            expected = entity_id.removeprefix("pc_")
+            character = next(
+                (
+                    c
+                    for c in game_state.party.characters
+                    if c.name.lower().replace(" ", "_") == expected
+                ),
+                None,
+            )
+            if character is None:
+                continue
+            entity = PartyMemberEntity(
+                entity_id=entity_id,
+                grid_x=x,
+                grid_y=y,
+                entity_type=EntityType.PARTY_MEMBER,
+                sub_type=character.character_class.value.lower(),
+                party_index=game_state.party.characters.index(character),
+                character_class=character.character_class.value.lower(),
+                texture=None,
+            )
+            entity.creature = character
+            self.entity_manager._add_entity(entity)
+
+        for entity_id, (x, y) in result["enemy_positions"].items():
+            # Entity IDs encode the active_enemies index as the trailing
+            # underscore-separated integer (e.g. "goblin_0", "giant_rat_1").
+            monster_id, _, index_str = entity_id.rpartition("_")
+            try:
+                enemy_index = int(index_str)
+            except ValueError:
+                continue
+            if enemy_index >= len(game_state.active_enemies):
+                continue
+            creature = game_state.active_enemies[enemy_index]
+            entity = MonsterEntity(
+                entity_id=entity_id,
+                grid_x=x,
+                grid_y=y,
+                entity_type=EntityType.MONSTER,
+                sub_type=monster_id,
+                enemy_index=enemy_index,
+                texture=None,
+            )
+            entity.creature = creature
+            self.entity_manager._add_entity(entity)
+
+        # Scenarios with enemies always boot into combat (the loader has
+        # already called _start_combat on the engine).
+        if game_state.in_combat:
+            self.current_mode = GameMode.COMBAT
+        else:
+            self.current_mode = GameMode.EXPLORATION
+
+        return (
+            f"Loaded scenario '{result['name']}' (seed={result['seed']}). "
+            + self._mcp_get_state()
+        )
 
     # ========== End MCP Server Integration ==========
 

--- a/client-2d/src/client_2d/integration/engine_adapter.py
+++ b/client-2d/src/client_2d/integration/engine_adapter.py
@@ -922,6 +922,45 @@ class EngineAdapter:
         self._game_state.dice_roller.random = random.Random(seed)
         return {"success": True, "seed": seed}
 
+    def load_scenario(self, path: str | Path) -> dict[str, Any]:
+        """Load a YAML scenario, replacing the adapter's party / state.
+
+        Thin wrapper around :class:`dnd_engine.scenarios.ScenarioLoader`
+        for the client side. Engine work happens in the loader; the
+        adapter swaps in the new ``Party`` / ``GameState`` / ``EventBus``
+        and returns the scenario's positions so the GameWindow handler
+        can rebuild the visual entity layer.
+
+        Args:
+            path: Path to a scenario YAML file.
+
+        Returns:
+            ``{"name": str, "seed": int,
+            "party_positions": {entity_id: (x, y)},
+            "enemy_positions": {entity_id: (x, y)}}``.
+
+        Raises:
+            ScenarioValidationError: For any schema, parse, or content
+                error in the scenario file (propagated unchanged from
+                the loader).
+        """
+        from dnd_engine.scenarios import ScenarioLoader
+
+        loaded = ScenarioLoader().load(path)
+
+        self._party = loaded.game_state.party
+        self._game_state = loaded.game_state
+        self._event_bus = loaded.game_state.event_bus
+        self._initialized = True
+
+        return {
+            "name": loaded.name,
+            "seed": loaded.seed,
+            "party_positions": dict(loaded.party_positions),
+            "enemy_positions": dict(loaded.enemy_positions),
+            "map_config": dict(loaded.map_config),
+        }
+
     def end_combat_check(self) -> dict[str, Any]:
         """Check if combat should end and handle cleanup.
 

--- a/client-2d/src/client_2d/mcp_bridge.py
+++ b/client-2d/src/client_2d/mcp_bridge.py
@@ -36,6 +36,7 @@ class CommandType(Enum):
     SET_POSITION = auto()
     CLEAR_ENEMIES = auto()
     SET_SEED = auto()
+    LOAD_SCENARIO = auto()
 
 
 @dataclass

--- a/client-2d/src/client_2d/mcp_proxy.py
+++ b/client-2d/src/client_2d/mcp_proxy.py
@@ -393,6 +393,21 @@ def create_proxy_server() -> FastMCP:
                 return "Game not running. Use game_start() first."
             return await proxy.call_tool_async("set_seed", seed=seed)
 
+        @mcp.tool()
+        async def load_scenario(path: str) -> str:
+            """Load a YAML scenario file (map, party, enemies, seed).
+
+            See dnd-engine/tests/scenarios/yaml/_schema.md for the
+            expected format. Replaces the current game state with the
+            scenario's state and boots into combat.
+
+            Args:
+                path: Filesystem path to the scenario YAML.
+            """
+            if not game_manager.is_running:
+                return "Game not running. Use game_start() first."
+            return await proxy.call_tool_async("load_scenario", path=path)
+
     return mcp
 
 

--- a/client-2d/tests/test_dev_mode_mcp.py
+++ b/client-2d/tests/test_dev_mode_mcp.py
@@ -20,6 +20,7 @@ DEV_TOOL_NAMES = {
     "set_position",
     "clear_enemies",
     "set_seed",
+    "load_scenario",
 }
 
 PLAY_TOOL_NAMES = {"game_state", "game_move", "game_attack", "game_wait"}

--- a/client-2d/tests/test_engine_adapter_scenario.py
+++ b/client-2d/tests/test_engine_adapter_scenario.py
@@ -1,0 +1,65 @@
+# ABOUTME: Tests for EngineAdapter.load_scenario() (#361).
+# ABOUTME: Verifies the adapter swaps in scenario-driven state and exposes positions.
+
+"""Adapter-level tests for the YAML scenario loader integration.
+
+The engine-only loader is tested in dnd-engine/tests. These tests cover
+the client-2d wrapper that uses the loader: it must replace any existing
+party/state on the adapter and surface positions for the GameWindow
+handler to apply on the visual layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Resolve the starter scenario shipped under dnd-engine/tests so the
+# adapter test stays in lockstep with the engine-side fixtures.
+SCENARIO_DIR = (
+    Path(__file__).parent.parent.parent
+    / "dnd-engine"
+    / "tests"
+    / "scenarios"
+    / "yaml"
+)
+
+
+def test_load_scenario_replaces_party_and_state() -> None:
+    """A fresh adapter loading a scenario YAML gets a fully wired state."""
+    from client_2d.integration.engine_adapter import EngineAdapter
+
+    adapter = EngineAdapter()
+    result = adapter.load_scenario(SCENARIO_DIR / "ranged_attack_basic.yaml")
+
+    # The adapter must now have the scenario's party and game state.
+    assert adapter.party is not None
+    assert len(adapter.party.characters) == 1
+    assert adapter.party.characters[0].name == "Archy"
+    assert adapter.game_state is not None
+    assert adapter.in_combat is True
+
+    # The return payload must carry the positions the GameWindow needs
+    # to wire up the visual entities.
+    assert result["name"] == "ranged_attack_basic"
+    assert result["seed"] == 42
+    assert result["party_positions"]["pc_archy"] == (3, 5)
+    assert result["enemy_positions"]["goblin_0"] == (10, 5)
+
+
+def test_load_scenario_overwrites_previous_state() -> None:
+    """Loading a second scenario must wipe the first one's party."""
+    from client_2d.integration.engine_adapter import EngineAdapter
+
+    adapter = EngineAdapter()
+    adapter.load_scenario(SCENARIO_DIR / "ranged_attack_basic.yaml")
+    first_state_id = id(adapter.game_state)
+
+    adapter.load_scenario(SCENARIO_DIR / "ranged_out_of_range.yaml")
+
+    # New GameState (object identity changes), and the equipped weapon
+    # reflects the dagger from the second scenario.
+    assert id(adapter.game_state) != first_state_id
+    from dnd_engine.systems.inventory import EquipmentSlot
+
+    archy = adapter.party.characters[0]
+    assert archy.inventory.get_equipped_item(EquipmentSlot.WEAPON) == "dagger"

--- a/client-2d/tests/test_mcp_bridge_dev_commands.py
+++ b/client-2d/tests/test_mcp_bridge_dev_commands.py
@@ -17,6 +17,7 @@ DEV_COMMAND_NAMES = (
     "SET_POSITION",
     "CLEAR_ENEMIES",
     "SET_SEED",
+    "LOAD_SCENARIO",
 )
 
 

--- a/dnd-engine/dnd_engine/rules/loader.py
+++ b/dnd-engine/dnd_engine/rules/loader.py
@@ -17,12 +17,19 @@ class DataLoader:
     from the data directory and converting them into usable game objects.
     """
 
-    def __init__(self, data_path: Path | None = None):
+    def __init__(
+        self,
+        data_path: Path | None = None,
+        dice_roller: DiceRoller | None = None,
+    ):
         """
         Initialize the data loader.
 
         Args:
             data_path: Path to the data directory (defaults to dnd_engine/data)
+            dice_roller: DiceRoller to use for content rolls such as monster
+                HP. Defaults to a fresh DiceRoller. Pass a seeded instance to
+                make content generation deterministic (e.g. scenario load).
         """
         if data_path is None:
             # Default to the data directory in the package
@@ -30,7 +37,7 @@ class DataLoader:
         else:
             self.data_path = Path(data_path)
 
-        self.dice_roller = DiceRoller()
+        self.dice_roller = dice_roller if dice_roller is not None else DiceRoller()
 
     def load_monsters(self) -> dict[str, Any]:
         """

--- a/dnd-engine/dnd_engine/scenarios/__init__.py
+++ b/dnd-engine/dnd_engine/scenarios/__init__.py
@@ -1,0 +1,26 @@
+# ABOUTME: Scenario package — YAML-driven test setups for reproducible playtests.
+# ABOUTME: Exposes the ScenarioLoader entry point and supporting types.
+
+"""Public API for the scenario loader (issue #361).
+
+Usage::
+
+    from dnd_engine.scenarios import ScenarioLoader
+
+    loaded = ScenarioLoader().load("path/to/scenario.yaml")
+    loaded.game_state          # ready-to-play GameState
+    loaded.party_positions     # {entity_id: (x, y)} for visual placement
+    loaded.enemy_positions     # {entity_id: (x, y)} for visual placement
+"""
+
+from dnd_engine.scenarios.loader import (
+    LoadedScenario,
+    ScenarioLoader,
+    ScenarioValidationError,
+)
+
+__all__ = [
+    "LoadedScenario",
+    "ScenarioLoader",
+    "ScenarioValidationError",
+]

--- a/dnd-engine/dnd_engine/scenarios/loader.py
+++ b/dnd-engine/dnd_engine/scenarios/loader.py
@@ -1,0 +1,222 @@
+# ABOUTME: YAML scenario loader — builds a deterministic GameState from a fixture file.
+# ABOUTME: Pure-engine; client-2d wraps this in EngineAdapter for visual placement.
+
+"""ScenarioLoader for reproducible playtests (issue #361).
+
+A scenario file captures a map + party + enemies + seed so that a known
+game state is one ``load(path)`` call away. The loader is engine-only:
+positions are returned as data on :class:`LoadedScenario` and applied to
+the visual entity layer by the client adapter.
+
+YAML schema (v1) is documented at
+``dnd-engine/tests/scenarios/yaml/_schema.md``. The validator surfaces
+:class:`ScenarioValidationError` with the offending key/path on every
+failure so a human can fix the file without spelunking through tracebacks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REQUIRED_TOP_LEVEL_KEYS: tuple[str, ...] = (
+    "name",
+    "seed",
+    "map",
+    "party",
+    "enemies",
+)
+
+REQUIRED_MAP_KEYS: tuple[str, ...] = ("dungeon", "campaign")
+
+REQUIRED_PARTY_MEMBER_KEYS: tuple[str, ...] = (
+    "class",
+    "race",
+    "weapons",
+    "position",
+)
+
+REQUIRED_ENEMY_KEYS: tuple[str, ...] = ("monster_id", "position")
+
+
+class ScenarioValidationError(Exception):
+    """Raised when a scenario YAML is missing keys, has wrong types, or
+    references an unknown class/race/monster.
+
+    The message always includes enough context (key path, offending value,
+    file path when relevant) for the human to fix the YAML without
+    additional debugging.
+    """
+
+
+@dataclass
+class LoadedScenario:
+    """Result of loading a scenario YAML.
+
+    ``game_state`` is ready to play. Positions are returned alongside so
+    the client (or test harness) can wire the visual layer; the pure
+    engine has no creature coordinates of its own.
+    """
+
+    name: str
+    seed: int
+    game_state: Any  # forward-typed to avoid importing GameState at module load
+    party_positions: dict[str, tuple[int, int]] = field(default_factory=dict)
+    enemy_positions: dict[str, tuple[int, int]] = field(default_factory=dict)
+    script: list[dict[str, Any]] = field(default_factory=list)
+    assertions: list[dict[str, Any]] = field(default_factory=list)
+    map_config: dict[str, Any] = field(default_factory=dict)
+
+
+class ScenarioLoader:
+    """Loads a YAML scenario file and constructs a fully wired ``GameState``.
+
+    Construction defers all engine imports so importing the loader module
+    doesn't drag in the whole engine when a caller only needs to validate
+    schemas.
+    """
+
+    def load(self, path: str | Path) -> LoadedScenario:
+        """Parse ``path``, validate it, and build the resulting state.
+
+        Args:
+            path: Path to a YAML scenario file.
+
+        Returns:
+            :class:`LoadedScenario` carrying the engine state and the
+            positions to apply on the visual layer.
+
+        Raises:
+            ScenarioValidationError: For any schema, parse, or content
+                error. The message identifies the offending key, value,
+                and (when relevant) the file path.
+        """
+        scenario_path = Path(path)
+        data = self._parse_yaml(scenario_path)
+        self._validate(data)
+
+        # GameState construction lands in Chunk 2; for now the loader is
+        # validation-only. Returning a partial LoadedScenario lets the
+        # schema tests run in isolation without needing the engine wired.
+        return LoadedScenario(
+            name=str(data["name"]),
+            seed=int(data["seed"]),
+            game_state=None,
+            map_config=dict(data["map"]),
+            script=list(data.get("script") or []),
+            assertions=list(data.get("assertions") or []),
+        )
+
+    @staticmethod
+    def _parse_yaml(path: Path) -> dict[str, Any]:
+        if not path.exists():
+            raise ScenarioValidationError(
+                f"Scenario file not found: {path}"
+            )
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError as exc:
+            raise ScenarioValidationError(
+                f"Malformed YAML in {path}: {exc}"
+            ) from exc
+
+        if not isinstance(data, dict):
+            raise ScenarioValidationError(
+                f"Scenario root in {path} must be a mapping, got "
+                f"{type(data).__name__}"
+            )
+        return data
+
+    @classmethod
+    def _validate(cls, data: dict[str, Any]) -> None:
+        missing = [k for k in REQUIRED_TOP_LEVEL_KEYS if k not in data]
+        if missing:
+            raise ScenarioValidationError(
+                f"Scenario missing required key(s): {', '.join(missing)}"
+            )
+
+        if not isinstance(data["seed"], int) or isinstance(data["seed"], bool):
+            raise ScenarioValidationError(
+                f"`seed` must be an int, got {type(data['seed']).__name__}"
+            )
+
+        cls._validate_map(data["map"])
+        cls._validate_party(data["party"])
+        cls._validate_enemies(data["enemies"])
+
+    @staticmethod
+    def _validate_map(map_block: Any) -> None:
+        if not isinstance(map_block, dict):
+            raise ScenarioValidationError(
+                f"`map` must be a mapping, got {type(map_block).__name__}"
+            )
+        missing = [k for k in REQUIRED_MAP_KEYS if k not in map_block]
+        if missing:
+            raise ScenarioValidationError(
+                f"`map` missing required key(s): {', '.join(missing)}"
+            )
+        if "tiles" in map_block:
+            raise ScenarioValidationError(
+                "Inline `map.tiles` is not yet implemented; use "
+                "`map.dungeon` + `map.campaign` to reference an existing "
+                "dungeon."
+            )
+
+    @classmethod
+    def _validate_party(cls, party: Any) -> None:
+        if not isinstance(party, list):
+            raise ScenarioValidationError(
+                f"`party` must be a list, got {type(party).__name__}"
+            )
+        for i, member in enumerate(party):
+            if not isinstance(member, dict):
+                raise ScenarioValidationError(
+                    f"party[{i}] must be a mapping, got "
+                    f"{type(member).__name__}"
+                )
+            missing = [k for k in REQUIRED_PARTY_MEMBER_KEYS if k not in member]
+            if missing:
+                raise ScenarioValidationError(
+                    f"party[{i}] missing required key(s): {', '.join(missing)}"
+                )
+            if not isinstance(member["weapons"], list) or not member["weapons"]:
+                raise ScenarioValidationError(
+                    f"party[{i}].weapons must be a non-empty list of "
+                    f"weapon IDs"
+                )
+            cls._validate_position(member["position"], f"party[{i}].position")
+
+    @classmethod
+    def _validate_enemies(cls, enemies: Any) -> None:
+        if not isinstance(enemies, list):
+            raise ScenarioValidationError(
+                f"`enemies` must be a list, got {type(enemies).__name__}"
+            )
+        for i, enemy in enumerate(enemies):
+            if not isinstance(enemy, dict):
+                raise ScenarioValidationError(
+                    f"enemies[{i}] must be a mapping, got "
+                    f"{type(enemy).__name__}"
+                )
+            missing = [k for k in REQUIRED_ENEMY_KEYS if k not in enemy]
+            if missing:
+                raise ScenarioValidationError(
+                    f"enemies[{i}] missing required key(s): "
+                    f"{', '.join(missing)}"
+                )
+            cls._validate_position(enemy["position"], f"enemies[{i}].position")
+
+    @staticmethod
+    def _validate_position(value: Any, label: str) -> None:
+        if (
+            not isinstance(value, list)
+            or len(value) != 2
+            or not all(isinstance(c, int) and not isinstance(c, bool) for c in value)
+        ):
+            raise ScenarioValidationError(
+                f"{label} must be a list of two ints [x, y]; got {value!r}"
+            )

--- a/dnd-engine/dnd_engine/scenarios/loader.py
+++ b/dnd-engine/dnd_engine/scenarios/loader.py
@@ -112,16 +112,13 @@ class ScenarioLoader:
         campaign = str(map_cfg["campaign"])
         start_room = map_cfg.get("start_room")
 
+        # Share one seeded DiceRoller across the factories that roll for
+        # content (monster HP) and characters (HP / abilities) so the
+        # schema's determinism promise covers the whole load.
         dice_roller = DiceRoller(seed=seed)
-        data_loader = DataLoader()
-        # DataLoader rolls monster HP via its own roller (see
-        # ``create_monster``); swap in the seeded one so enemy stats
-        # honour the scenario seed alongside party rolls.
-        data_loader.dice_roller = dice_roller
+        data_loader = DataLoader(dice_roller=dice_roller)
 
         # Build party first — GameState requires it at construction.
-        # Share the seeded dice_roller so character HP / ability rolls
-        # honour the scenario seed (the schema promises determinism).
         factory = CharacterFactory(dice_roller=dice_roller)
         characters: list[Any] = []
         party_positions: dict[str, tuple[int, int]] = {}

--- a/dnd-engine/dnd_engine/scenarios/loader.py
+++ b/dnd-engine/dnd_engine/scenarios/loader.py
@@ -98,16 +98,97 @@ class ScenarioLoader:
         data = self._parse_yaml(scenario_path)
         self._validate(data)
 
-        # GameState construction lands in Chunk 2; for now the loader is
-        # validation-only. Returning a partial LoadedScenario lets the
-        # schema tests run in isolation without needing the engine wired.
+        from dnd_engine.core.character_factory import CharacterFactory
+        from dnd_engine.core.dice import DiceRoller
+        from dnd_engine.core.game_state import GameState
+        from dnd_engine.core.party import Party
+        from dnd_engine.rules.loader import DataLoader
+        from dnd_engine.systems.inventory import EquipmentSlot
+        from dnd_engine.utils.events import EventBus
+
+        seed = int(data["seed"])
+        map_cfg = data["map"]
+        dungeon = str(map_cfg["dungeon"])
+        campaign = str(map_cfg["campaign"])
+        start_room = map_cfg.get("start_room")
+
+        data_loader = DataLoader()
+        dice_roller = DiceRoller(seed=seed)
+
+        # Build party first — GameState requires it at construction.
+        factory = CharacterFactory()
+        characters: list[Any] = []
+        party_positions: dict[str, tuple[int, int]] = {}
+        for i, member in enumerate(data["party"]):
+            try:
+                character = factory.create_character(
+                    class_name=str(member["class"]),
+                    race_name=str(member["race"]),
+                    data_loader=data_loader,
+                    level=int(member.get("level", 1)),
+                    name=member.get("name"),
+                )
+            except ValueError as exc:
+                # CharacterFactory raises ValueError for unknown class/race;
+                # surface as ScenarioValidationError so callers don't have
+                # to special-case engine exception types.
+                raise ScenarioValidationError(
+                    f"party[{i}]: {exc}"
+                ) from exc
+
+            for j, weapon_id in enumerate(member["weapons"]):
+                character.inventory.add_item(weapon_id, category="weapons")
+                if j == 0:
+                    character.inventory.equip_item(weapon_id, EquipmentSlot.WEAPON)
+
+            characters.append(character)
+            entity_id = f"pc_{character.name.lower().replace(' ', '_')}"
+            x, y = member["position"]
+            party_positions[entity_id] = (int(x), int(y))
+
+        party = Party(characters)
+
+        event_bus = EventBus()
+        game_state = GameState(
+            party=party,
+            dungeon_name=dungeon,
+            event_bus=event_bus,
+            data_loader=data_loader,
+            dice_roller=dice_roller,
+            campaign_id=campaign,
+        )
+        if start_room:
+            game_state.current_room_id = str(start_room)
+
+        # Push scenario enemies. Mirrors the path used by
+        # EngineAdapter.spawn_monster so behaviour stays consistent
+        # whether enemies arrive via spawn tool or via scenario load.
+        enemy_positions: dict[str, tuple[int, int]] = {}
+        for i, enemy in enumerate(data["enemies"]):
+            monster_id = str(enemy["monster_id"])
+            try:
+                creature = data_loader.create_monster(monster_id)
+            except KeyError as exc:
+                raise ScenarioValidationError(
+                    f"enemies[{i}]: unknown monster_id '{monster_id}'"
+                ) from exc
+            game_state.active_enemies.append(creature)
+            entity_id = f"{monster_id}_{i}"
+            x, y = enemy["position"]
+            enemy_positions[entity_id] = (int(x), int(y))
+
+        if game_state.active_enemies:
+            game_state._start_combat()
+
         return LoadedScenario(
             name=str(data["name"]),
-            seed=int(data["seed"]),
-            game_state=None,
-            map_config=dict(data["map"]),
+            seed=seed,
+            game_state=game_state,
+            party_positions=party_positions,
+            enemy_positions=enemy_positions,
             script=list(data.get("script") or []),
             assertions=list(data.get("assertions") or []),
+            map_config=dict(map_cfg),
         )
 
     @staticmethod

--- a/dnd-engine/dnd_engine/scenarios/loader.py
+++ b/dnd-engine/dnd_engine/scenarios/loader.py
@@ -112,11 +112,17 @@ class ScenarioLoader:
         campaign = str(map_cfg["campaign"])
         start_room = map_cfg.get("start_room")
 
-        data_loader = DataLoader()
         dice_roller = DiceRoller(seed=seed)
+        data_loader = DataLoader()
+        # DataLoader rolls monster HP via its own roller (see
+        # ``create_monster``); swap in the seeded one so enemy stats
+        # honour the scenario seed alongside party rolls.
+        data_loader.dice_roller = dice_roller
 
         # Build party first — GameState requires it at construction.
-        factory = CharacterFactory()
+        # Share the seeded dice_roller so character HP / ability rolls
+        # honour the scenario seed (the schema promises determinism).
+        factory = CharacterFactory(dice_roller=dice_roller)
         characters: list[Any] = []
         party_positions: dict[str, tuple[int, int]] = {}
         for i, member in enumerate(data["party"]):

--- a/dnd-engine/pyproject.toml
+++ b/dnd-engine/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "openai>=1.0.0",
     "pydantic>=2.5.0",
     "python-dotenv>=1.0.0",
+    "pyyaml>=6.0.3",
 ]
 
 [project.optional-dependencies]

--- a/dnd-engine/tests/scenarios/yaml/_schema.md
+++ b/dnd-engine/tests/scenarios/yaml/_schema.md
@@ -1,0 +1,91 @@
+# Scenario YAML Schema (v1)
+
+Scenarios capture a complete game setup — map, party, enemies, seed — so a
+single `load_scenario(path)` call reproduces an exact playtest state.
+Lives under `dnd-engine/tests/scenarios/yaml/`. Engine consumer:
+`dnd_engine.scenarios.ScenarioLoader`.
+
+## Top-level keys
+
+| Key | Required | Type | Description |
+| --- | --- | --- | --- |
+| `name` | yes | str | Human-readable scenario name. |
+| `seed` | yes | int | RNG seed; drives all dice rolls deterministically. |
+| `map` | yes | mapping | See **map** below. |
+| `party` | yes | list | One or more party members (see **party member**). |
+| `enemies` | yes | list | Zero or more enemies (see **enemy**); empty list still required. |
+| `script` | no | list | MCP actions to run after load. Parsed but not yet executed (Phase 4 / #363). |
+| `assertions` | no | list | Expected state checks. Parsed but not yet executed (Phase 4 / #363). |
+
+## `map`
+
+| Key | Required | Type | Description |
+| --- | --- | --- | --- |
+| `dungeon` | yes | str | Dungeon file name (without `.json`). |
+| `campaign` | yes | str | Campaign ID containing the dungeon. |
+| `start_room` | no | str | Override start room ID. Falls back to the dungeon's default. |
+| `tiles` | — | — | **Inline tiles are not yet implemented**; the loader rejects this key with a clear message. |
+
+## `party` member
+
+| Key | Required | Type | Description |
+| --- | --- | --- | --- |
+| `class` | yes | str | Class ID (`fighter`, `rogue`, `wizard`). |
+| `race` | yes | str | Race ID (`human`, `mountain_dwarf`, `high_elf`, `halfling`). |
+| `weapons` | yes | list[str] | Ordered weapon item IDs. First is equipped to the WEAPON slot; the rest go in the pack. Must be non-empty. |
+| `position` | yes | [int, int] | `[x, y]` tile coordinates for visual placement. |
+| `name` | no | str | Character name. `CharacterFactory` generates one if omitted. |
+| `level` | no | int | Starting level. Default `1`. |
+
+## `enemy`
+
+| Key | Required | Type | Description |
+| --- | --- | --- | --- |
+| `monster_id` | yes | str | SRD monster ID (e.g. `goblin`, `giant_rat`). Must exist in `dnd_engine/data/srd/monsters.json`. |
+| `position` | yes | [int, int] | `[x, y]` tile coordinates. |
+
+## Entity ID convention
+
+Entity IDs match Phase 1's spawn tools so MCP scripts and assertions stay
+portable across the two paths:
+
+- Party member → `pc_<name_lowercased_with_spaces_as_underscores>`
+- Enemy → `<monster_id>_<index_in_enemies_list>` (zero-indexed)
+
+For example, a party member named `Archy` becomes `pc_archy`; the second
+goblin in the enemies list becomes `goblin_1`.
+
+## Validation guarantees
+
+Every error from `ScenarioLoader.load(path)` is a
+`ScenarioValidationError` whose message includes:
+
+- The offending top-level key, list index, or nested path (e.g.
+  `party[0].position`).
+- The bad value when the failure is type-related.
+- The file path when the YAML itself is malformed or missing.
+
+Unknown class/race/`monster_id` values surface as
+`ScenarioValidationError` (the underlying `ValueError`/`KeyError` from
+`CharacterFactory` / `DataLoader` is wrapped) so callers don't need to
+special-case engine exception types.
+
+## Example
+
+```yaml
+name: ranged_attack_basic
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [shortbow]
+    position: [3, 5]
+    name: Archy
+enemies:
+  - monster_id: goblin
+    position: [10, 5]
+```

--- a/dnd-engine/tests/scenarios/yaml/ranged_attack_basic.yaml
+++ b/dnd-engine/tests/scenarios/yaml/ranged_attack_basic.yaml
@@ -1,0 +1,25 @@
+# Scenario: ranged_attack_basic
+#
+# Exercises the happy path for ranged combat: a high-elf fighter armed
+# with a shortbow facing a goblin at 35 ft (7 tiles), well within
+# shortbow short-range (80 ft). The attack should resolve with a normal
+# d20 roll and apply damage on hit.
+#
+# Use with `load_scenario("...ranged_attack_basic.yaml")` then attack
+# `goblin_0` to verify ranged-attack rules end-to-end.
+
+name: ranged_attack_basic
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [shortbow]
+    position: [3, 5]
+    name: Archy
+enemies:
+  - monster_id: goblin
+    position: [10, 5]

--- a/dnd-engine/tests/scenarios/yaml/ranged_out_of_range.yaml
+++ b/dnd-engine/tests/scenarios/yaml/ranged_out_of_range.yaml
@@ -1,0 +1,27 @@
+# Scenario: ranged_out_of_range
+#
+# Verifies the range-rejection path. A fighter throws a dagger
+# (thrown range 20/60 ft) at a goblin 17 tiles away (85 ft) — past the
+# weapon's long range. The attack must be rejected with a clear
+# out-of-range error, not silently resolve.
+#
+# A dagger is used instead of the shortbow because the laboratory's
+# 25x18 tile layout can't hold a position past the shortbow's 320 ft
+# long range. The dagger's tighter envelope keeps the out-of-range case
+# expressible on the existing map.
+
+name: ranged_out_of_range
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [dagger]
+    position: [3, 5]
+    name: Archy
+enemies:
+  - monster_id: goblin
+    position: [20, 5]

--- a/dnd-engine/tests/test_scenario_loader.py
+++ b/dnd-engine/tests/test_scenario_loader.py
@@ -1,0 +1,159 @@
+# ABOUTME: Happy-path tests for the YAML scenario loader.
+# ABOUTME: Asserts the loader builds GameState with the expected party, enemies, and seed.
+
+"""Loader happy-path tests for issue #361.
+
+The schema/validation failure paths live in
+``test_scenario_schema_validation.py``. Tests here cover successful
+loads: party construction, enemy spawning, combat activation, and seed
+reproducibility.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.scenarios import LoadedScenario, ScenarioLoader, ScenarioValidationError
+
+# Reusable scenario body. Two members keeps tests honest about indexing
+# while staying small enough that the YAML is easy to read inline.
+SCENARIO_YAML = """
+name: loader_smoke
+seed: 7
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [shortbow]
+    position: [3, 5]
+    name: Archy
+  - class: wizard
+    race: human
+    weapons: [dagger]
+    position: [4, 5]
+    name: Merlin
+enemies:
+  - monster_id: goblin
+    position: [10, 5]
+  - monster_id: giant_rat
+    position: [11, 5]
+"""
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "scenario.yaml"
+    path.write_text(body.lstrip())
+    return path
+
+
+def test_load_returns_loaded_scenario_with_game_state(tmp_path: Path) -> None:
+    path = _write(tmp_path, SCENARIO_YAML)
+
+    result = ScenarioLoader().load(path)
+
+    assert isinstance(result, LoadedScenario)
+    assert result.name == "loader_smoke"
+    assert result.seed == 7
+    assert result.game_state is not None
+
+
+def test_load_builds_party_with_classes_and_equipped_weapons(tmp_path: Path) -> None:
+    from dnd_engine.systems.inventory import EquipmentSlot
+
+    path = _write(tmp_path, SCENARIO_YAML)
+    result = ScenarioLoader().load(path)
+
+    party = result.game_state.party
+    assert len(party.characters) == 2
+
+    archy = party.characters[0]
+    assert archy.name == "Archy"
+    assert archy.character_class.value.lower() == "fighter"
+    assert archy.inventory.get_equipped_item(EquipmentSlot.WEAPON) == "shortbow"
+
+    merlin = party.characters[1]
+    assert merlin.character_class.value.lower() == "wizard"
+    assert merlin.inventory.get_equipped_item(EquipmentSlot.WEAPON) == "dagger"
+
+
+def test_load_spawns_enemies_and_starts_combat(tmp_path: Path) -> None:
+    path = _write(tmp_path, SCENARIO_YAML)
+    result = ScenarioLoader().load(path)
+
+    enemy_names = [e.name.lower() for e in result.game_state.active_enemies]
+    assert any("goblin" in n for n in enemy_names)
+    assert any("rat" in n for n in enemy_names)
+    assert result.game_state.in_combat is True
+
+
+def test_load_returns_positions_for_party_and_enemies(tmp_path: Path) -> None:
+    path = _write(tmp_path, SCENARIO_YAML)
+    result = ScenarioLoader().load(path)
+
+    # Positions key by entity_id matching Phase 1's spawn convention:
+    # pc_<name_snake> for party, <monster_id>_<index> for enemies.
+    assert result.party_positions["pc_archy"] == (3, 5)
+    assert result.party_positions["pc_merlin"] == (4, 5)
+    assert result.enemy_positions["goblin_0"] == (10, 5)
+    assert result.enemy_positions["giant_rat_1"] == (11, 5)
+
+
+def test_same_seed_yields_identical_dice_sequence(tmp_path: Path) -> None:
+    path = _write(tmp_path, SCENARIO_YAML)
+    first = ScenarioLoader().load(path)
+    second = ScenarioLoader().load(path)
+
+    first_rolls = [first.game_state.dice_roller.roll("1d20").total for _ in range(5)]
+    second_rolls = [second.game_state.dice_roller.roll("1d20").total for _ in range(5)]
+    assert first_rolls == second_rolls
+
+
+def test_unknown_monster_id_raises_validation_error(tmp_path: Path) -> None:
+    bad = SCENARIO_YAML.replace("monster_id: goblin", "monster_id: dragon_overlord")
+    path = _write(tmp_path, bad)
+
+    with pytest.raises(ScenarioValidationError) as exc_info:
+        ScenarioLoader().load(path)
+
+    assert "dragon_overlord" in str(exc_info.value)
+
+
+def test_unknown_class_raises_validation_error(tmp_path: Path) -> None:
+    bad = SCENARIO_YAML.replace("class: fighter", "class: ranger")
+    path = _write(tmp_path, bad)
+
+    with pytest.raises(ScenarioValidationError) as exc_info:
+        ScenarioLoader().load(path)
+
+    assert "ranger" in str(exc_info.value)
+
+
+def test_unknown_race_raises_validation_error(tmp_path: Path) -> None:
+    bad = SCENARIO_YAML.replace("race: high_elf", "race: tabaxi")
+    path = _write(tmp_path, bad)
+
+    with pytest.raises(ScenarioValidationError) as exc_info:
+        ScenarioLoader().load(path)
+
+    assert "tabaxi" in str(exc_info.value)
+
+
+def test_passthrough_script_and_assertions(tmp_path: Path) -> None:
+    body = SCENARIO_YAML.rstrip() + (
+        "\nscript:\n"
+        "  - {action: move, direction: north}\n"
+        "assertions:\n"
+        "  - {kind: entity_hp, entity: goblin_0, op: lt, value: 7}\n"
+    )
+    path = _write(tmp_path, body)
+
+    result = ScenarioLoader().load(path)
+    assert result.script == [{"action": "move", "direction": "north"}]
+    assert result.assertions == [
+        {"kind": "entity_hp", "entity": "goblin_0", "op": "lt", "value": 7}
+    ]

--- a/dnd-engine/tests/test_scenario_schema_validation.py
+++ b/dnd-engine/tests/test_scenario_schema_validation.py
@@ -1,0 +1,117 @@
+# ABOUTME: Schema validation tests for the YAML scenario loader.
+# ABOUTME: Covers required-field, wrong-type, and malformed-YAML failure paths.
+
+"""Validation-side tests for ScenarioLoader.
+
+The happy paths live in ``test_scenario_loader.py``. Tests here all expect
+``ScenarioValidationError`` with actionable messages — every error must
+mention the offending key (or path) so a human can fix the YAML.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.scenarios import ScenarioLoader, ScenarioValidationError
+
+
+def _minimal_valid_yaml() -> str:
+    """Return a minimal valid scenario YAML body.
+
+    Used as a base that individual tests mutate (drop a key, break a type)
+    so each test exercises exactly one validation failure mode.
+    """
+    return (
+        "name: minimal\n"
+        "seed: 1\n"
+        "map:\n"
+        "  dungeon: laboratory\n"
+        "  campaign: poisoned_laboratory\n"
+        "party:\n"
+        "  - class: fighter\n"
+        "    race: high_elf\n"
+        "    weapons: [shortbow]\n"
+        "    position: [3, 5]\n"
+        "enemies:\n"
+        "  - monster_id: goblin\n"
+        "    position: [10, 5]\n"
+    )
+
+
+def _write_yaml(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "scenario.yaml"
+    path.write_text(body)
+    return path
+
+
+@pytest.mark.parametrize(
+    "missing_key",
+    ["name", "seed", "map", "party", "enemies"],
+)
+def test_missing_required_top_level_key_raises(tmp_path: Path, missing_key: str) -> None:
+    body = _minimal_valid_yaml()
+    # Drop the line(s) for this key. Using a simple line filter is fine
+    # because the minimal YAML keeps each top-level key on its own line.
+    lines = body.splitlines()
+    kept: list[str] = []
+    skip_indent = False
+    for line in lines:
+        if line.startswith(f"{missing_key}:"):
+            skip_indent = True
+            continue
+        if skip_indent and (line.startswith(" ") or line.startswith("-")):
+            continue
+        skip_indent = False
+        kept.append(line)
+    path = _write_yaml(tmp_path, "\n".join(kept) + "\n")
+
+    with pytest.raises(ScenarioValidationError) as exc_info:
+        ScenarioLoader().load(path)
+
+    assert missing_key in str(exc_info.value)
+
+
+def test_party_must_be_a_list(tmp_path: Path) -> None:
+    body = _minimal_valid_yaml().replace(
+        "party:\n  - class: fighter\n    race: high_elf\n"
+        "    weapons: [shortbow]\n    position: [3, 5]\n",
+        "party: not-a-list\n",
+    )
+    path = _write_yaml(tmp_path, body)
+
+    with pytest.raises(ScenarioValidationError) as exc_info:
+        ScenarioLoader().load(path)
+
+    assert "party" in str(exc_info.value)
+    assert "list" in str(exc_info.value).lower()
+
+
+def test_position_must_be_two_ints(tmp_path: Path) -> None:
+    body = _minimal_valid_yaml().replace("position: [3, 5]", "position: [3]")
+    path = _write_yaml(tmp_path, body)
+
+    with pytest.raises(ScenarioValidationError) as exc_info:
+        ScenarioLoader().load(path)
+
+    assert "position" in str(exc_info.value)
+
+
+def test_malformed_yaml_raises_with_path(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, "name: minimal\n  not-indented-properly\n: [1, 2\n")
+
+    with pytest.raises(ScenarioValidationError) as exc_info:
+        ScenarioLoader().load(path)
+
+    # Error message should mention the file so the human can find it.
+    assert str(path) in str(exc_info.value) or path.name in str(exc_info.value)
+
+
+def test_missing_file_raises_validation_error(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.yaml"
+
+    with pytest.raises(ScenarioValidationError) as exc_info:
+        ScenarioLoader().load(missing)
+
+    assert "nope.yaml" in str(exc_info.value)

--- a/dnd-engine/tests/test_starter_scenarios.py
+++ b/dnd-engine/tests/test_starter_scenarios.py
@@ -72,3 +72,26 @@ def test_every_starter_scenario_loads(scenario_file: str) -> None:
     # in the per-scenario tests above.
     result = ScenarioLoader().load(SCENARIO_DIR / scenario_file)
     assert result.game_state is not None
+
+
+def test_load_is_deterministic_across_reloads() -> None:
+    # The schema documents `seed` as driving "all dice rolls
+    # deterministically", which includes character creation HP / ability
+    # rolls. Two loads of the same YAML must produce identical character
+    # max_hp and ability scores.
+    first = ScenarioLoader().load(SCENARIO_DIR / "ranged_attack_basic.yaml")
+    second = ScenarioLoader().load(SCENARIO_DIR / "ranged_attack_basic.yaml")
+
+    first_pc = first.game_state.party.characters[0]
+    second_pc = second.game_state.party.characters[0]
+
+    assert first_pc.max_hp == second_pc.max_hp, (
+        f"max_hp drifted across reloads: {first_pc.max_hp} vs {second_pc.max_hp}"
+    )
+    assert first_pc.abilities.strength == second_pc.abilities.strength
+    assert first_pc.abilities.dexterity == second_pc.abilities.dexterity
+    assert first_pc.abilities.constitution == second_pc.abilities.constitution
+
+    first_enemy = first.game_state.active_enemies[0]
+    second_enemy = second.game_state.active_enemies[0]
+    assert first_enemy.max_hp == second_enemy.max_hp

--- a/dnd-engine/tests/test_starter_scenarios.py
+++ b/dnd-engine/tests/test_starter_scenarios.py
@@ -1,0 +1,74 @@
+# ABOUTME: Smoke tests for the checked-in starter scenario YAML files.
+# ABOUTME: Asserts each one loads with the documented party/enemy composition.
+
+"""Loader tests against the shipped scenario fixtures (issue #361).
+
+These tests catch the easy regressions: a starter scenario referencing
+a renamed weapon, a removed monster, or a class/race that no longer
+exists. They also confirm the schema reference in ``_schema.md`` stays
+honest about what a valid scenario looks like.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.scenarios import ScenarioLoader
+from dnd_engine.systems.inventory import EquipmentSlot
+
+SCENARIO_DIR = Path(__file__).parent / "scenarios" / "yaml"
+
+
+def test_ranged_attack_basic_loads_with_expected_setup() -> None:
+    result = ScenarioLoader().load(SCENARIO_DIR / "ranged_attack_basic.yaml")
+
+    assert result.name == "ranged_attack_basic"
+    assert result.seed == 42
+
+    party = result.game_state.party
+    assert len(party.characters) == 1
+    archy = party.characters[0]
+    assert archy.name == "Archy"
+    assert archy.character_class.value.lower() == "fighter"
+    assert archy.inventory.get_equipped_item(EquipmentSlot.WEAPON) == "shortbow"
+    assert result.party_positions["pc_archy"] == (3, 5)
+
+    assert len(result.game_state.active_enemies) == 1
+    assert result.enemy_positions["goblin_0"] == (10, 5)
+    assert result.game_state.in_combat is True
+
+
+def test_ranged_out_of_range_loads_with_dagger_thrown_setup() -> None:
+    result = ScenarioLoader().load(SCENARIO_DIR / "ranged_out_of_range.yaml")
+
+    assert result.name == "ranged_out_of_range"
+
+    archy = result.game_state.party.characters[0]
+    assert archy.inventory.get_equipped_item(EquipmentSlot.WEAPON) == "dagger"
+    assert result.party_positions["pc_archy"] == (3, 5)
+
+    # 17 tiles between positions = 85 ft, past the dagger's 60 ft long
+    # throw range. The scenario's whole point is exercising the
+    # range-rejection path; if the positions ever drift inside long
+    # range this assertion catches it.
+    archy_x = result.party_positions["pc_archy"][0]
+    goblin_x = result.enemy_positions["goblin_0"][0]
+    tile_distance = abs(goblin_x - archy_x)
+    feet = tile_distance * 5
+    assert feet > 60, (
+        f"Goblin must be past dagger long range (60 ft); got {feet} ft"
+    )
+
+
+@pytest.mark.parametrize(
+    "scenario_file",
+    sorted(p.name for p in SCENARIO_DIR.glob("*.yaml")),
+)
+def test_every_starter_scenario_loads(scenario_file: str) -> None:
+    # Cheap belt-and-suspenders: any new YAML dropped in the directory
+    # at least parses and builds a GameState. Detailed assertions live
+    # in the per-scenario tests above.
+    result = ScenarioLoader().load(SCENARIO_DIR / scenario_file)
+    assert result.game_state is not None

--- a/uv.lock
+++ b/uv.lock
@@ -548,6 +548,7 @@ dependencies = [
     { name = "openai" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
@@ -569,6 +570,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary
- Reproducible playtest scenarios authored as YAML and loaded into a live `GameState` via `load_scenario(path)`.
- Wired end-to-end: engine loader → adapter wrapper → dev-gated MCP tool → GameWindow handler (visual entity rebuild) → proxy forwarding.
- Two starter fixtures (`ranged_attack_basic.yaml`, `ranged_out_of_range.yaml`) exercise in-range and out-of-range ranged combat.

## Changes
- **dnd-engine/dnd_engine/scenarios/loader.py** (new): `ScenarioLoader` parses + validates YAML, builds a fresh `GameState` with the declared party + enemies, starts combat. Returns positions for the visual layer.
- **dnd-engine/dnd_engine/scenarios/__init__.py** (new): package surface.
- **dnd-engine/tests/scenarios/yaml/_schema.md** (new): schema reference (top-level keys, party/enemy shapes, seed semantics).
- **dnd-engine/tests/scenarios/yaml/{ranged_attack_basic,ranged_out_of_range}.yaml** (new): starter fixtures.
- **dnd-engine/tests/test_scenario_loader.py, test_scenario_schema_validation.py, test_starter_scenarios.py** (new): 14 loader + schema tests, including a determinism regression.
- **dnd-engine/dnd_engine/rules/loader.py**: `DataLoader.__init__` now accepts an optional seeded `dice_roller`. Default behavior unchanged.
- **dnd-engine/pyproject.toml, uv.lock**: PyYAML added.
- **client-2d/src/client_2d/integration/engine_adapter.py**: `EngineAdapter.load_scenario()` wraps the engine loader and swaps in the new `GameState` / `Party` / `EventBus`.
- **client-2d/src/client_2d/embedded_mcp_server.py**: `load_scenario` MCP tool registered (dev-gated).
- **client-2d/src/client_2d/game.py**: `_mcp_load_scenario` handler — reloads room layout, clears the visual entity layer, places party + scenario enemies at their YAML positions, boots into combat.
- **client-2d/src/client_2d/mcp_proxy.py**: proxy forwarder so the tool reaches the live game over SSE.
- **client-2d/tests/test_engine_adapter_scenario.py** (new): adapter tests for the wrapper.

## Determinism Fix
During manual MCP verification, two reloads of the same scenario produced different character/monster HP — the seed wasn't reaching `CharacterFactory` or `DataLoader.create_monster`. Now a single seeded `DiceRoller` is threaded through both via constructor injection. The schema documents `seed` as driving "all dice rolls deterministically", and `test_load_is_deterministic_across_reloads` enforces it.

## Testing
- [x] 14 scenario/loader unit + integration tests pass
- [x] Full engine suite: 2112 passed, 1 skipped
- [x] Ruff lint clean
- [x] Manual MCP verification: load + attack (in range), reload + identical outcome (determinism), out-of-range rejection
- [x] Dev gating: `load_scenario` only registered when `--dev` / `DND_DEBUG=1`

## Related Issues
Fixes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)