### PR TITLE
Fix #372: load_scenario re-anchors lighting on scenario party

### DIFF
--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -1227,6 +1227,20 @@ class GameSession:
             entity.creature = creature
             self.entity_manager._add_entity(entity)
 
+        # Re-anchor fog/lighting on the scenario party positions. Without
+        # this the renderer filters every scenario entity out of bright/
+        # dim view because _load_room_layout lit the fog around the room
+        # spawn point, not the scenario's PC positions. #372.
+        scenario_party_positions = [
+            (e.grid_x, e.grid_y)
+            for e in self.entity_manager.get_party_members()
+        ]
+        if scenario_party_positions:
+            self.player_x, self.player_y = scenario_party_positions[0]
+            self.party_positions = scenario_party_positions
+            self.party_spread = True
+            self._update_lighting()
+
         if game_state.in_combat:
             self.current_mode = GameMode.COMBAT
         else:

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -85,6 +85,20 @@ class TestSessionLoadScenario:
         assert (monsters[0].grid_x, monsters[0].grid_y) == (10, 5)
         assert (party[0].grid_x, party[0].grid_y) == (3, 5)
 
+    def test_load_scenario_enemies_appear_in_state_output(self, session) -> None:
+        """Regression for #372: scenario enemies must render in
+        ``game_state`` after ``load_scenario``. Before the fix the fog
+        was lit around the room spawn point, not the scenario party
+        positions, so the renderer's BRIGHT/DIM filter hid every
+        scenario enemy.
+
+        Goblin at [10, 5] is 7 tiles from Archy at [3, 5] — inside the
+        torch dim range (bright=4 + dim=4 = 8) so natural lighting is
+        sufficient once the lighting is anchored on the party.
+        """
+        state = session.get_state()
+        assert "goblin_0" in state
+
 
 class TestSessionSpawn:
     def test_spawn_monster_adds_to_engine_and_entity_manager(self, session) -> None:


### PR DESCRIPTION
## Summary
- `GameSession.load_scenario` relied on the lighting calculated inside `_load_room_layout`, which uses `player_x/player_y` set from the room's spawn point. Scenario party members are then placed at YAML coordinates that may be far from that spawn point, so the `StateRenderer`'s BRIGHT/DIM visibility filter hid every scenario entity — engine had the goblin in `active_enemies` but the ASCII map, legend, and visible-entities list never mentioned it.
- Mirror `_spread_party_for_combat`: after rebuilding the entity manager from scenario positions, point `player_x/player_y` at the first PC, set `party_spread=True` with `party_positions=[scenario PCs]`, and call `_update_lighting()` so torch radius is calculated against where the PCs actually are.
- No engine-side changes; engine state was already correct. No fog-of-war bypass / dev hack — fix uses the normal torch lighting path the renderer already trusts.

## Changes
- **client-2d/src/client_2d/session.py** — `load_scenario`: collect party positions from `entity_manager.get_party_members()`, re-anchor `player_x/y`, set `party_spread`/`party_positions`, call `_update_lighting()`. Empty-party fallback leaves the room-spawn lighting from `_load_room_layout` in place.
- **client-2d/tests/test_game_session.py** — `TestSessionLoadScenario.test_load_scenario_enemies_appear_in_state_output`: regression asserting `goblin_0` appears in `get_state()` output after the ranged-attack-basic scenario loads.

## Testing
- [x] `uv run pytest client-2d/tests/test_game_session.py` — 14 passed (including the new regression and the three #371 regressions)
- [x] `uv run pytest client-2d/tests/` — 385 passed, 1 skipped
- [x] `uv run ruff check` on changed files — clean
- [x] End-to-end MCP playtest mirroring the bug repro: `load_scenario("ranged_attack_basic.yaml")` → `game_state()` shows `#..@....,,A,` on row 5, legend `A = monster:goblin_0`, "Visible Entities: A monster:goblin_0 at [10, 5] (7 squares east)"

## Related Issues
Fixes #372.

Builds on #374 (#371 fix). Related-but-separate: #365 (`game_attack` text gap), #363 (regression-harness blocker now unblocked), #373 (clean-state primitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)