### PR TITLE
Fix #365: game_attack reports roll, hit/miss, damage, target HP

### DIFF
--- a/client-2d/src/client_2d/integration/engine_adapter.py
+++ b/client-2d/src/client_2d/integration/engine_adapter.py
@@ -669,6 +669,7 @@ class EngineAdapter:
                 "target_killed": not target.is_alive,
                 "attacker_name": attacker.name,
                 "attack_roll": result.attack_result.attack_roll if result.attack_result else 0,
+                "attack_bonus": result.attack_result.attack_bonus if result.attack_result else 0,
                 "target_ac": result.attack_result.target_ac if result.attack_result else 0,
             }
         except Exception as e:

--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -569,12 +569,16 @@ class GameSession:
         elif check.get("party_wiped"):
             self._add_combat_log("Defeat! Your party has fallen...")
 
-    def execute_attack(self) -> None:
+    def execute_attack(self) -> dict[str, Any] | None:
         """Execute an attack on the currently-selected enemy.
 
         Reads ``self.selected_enemy`` (the engine's enemy index) and
         delegates to the engine adapter. Called by both GameWindow's
         input handler and the MCP attack path.
+
+        Returns the engine adapter's attack-result dict on success so callers
+        (notably the MCP attack handler) can render hit/miss/damage details.
+        Returns ``None`` if the engine rejected the attack outright.
         """
         result = self.engine.execute_attack(target_index=self.selected_enemy)
 
@@ -604,10 +608,13 @@ class GameSession:
             elif not turn_result.get("is_player_turn"):
                 self.processing_enemy_turn = True
                 self.enemy_turn_timer = ENEMY_TURN_DELAY
-        else:
-            self._add_combat_log(
-                f"Attack failed: {result.get('error', 'Unknown error')}"
-            )
+
+            return result
+
+        self._add_combat_log(
+            f"Attack failed: {result.get('error', 'Unknown error')}"
+        )
+        return None
 
     def pass_turn(self) -> None:
         """Pass the current turn."""
@@ -1038,7 +1045,7 @@ class GameSession:
         pre_attack_combatant = current["name"] if current else None
 
         self.selected_enemy = target_entity.enemy_index
-        self.execute_attack()
+        attack_result = self.execute_attack()
 
         post_attack_combatant = self.engine.get_current_combatant()
         post_name = post_attack_combatant["name"] if post_attack_combatant else None
@@ -1049,12 +1056,76 @@ class GameSession:
                 f"Use game_wait() to pass."
             )
 
+        report = self._format_attack_report(
+            attack_result,
+            target_entity,
+            weapon_name=weapon_name,
+            in_long_range=in_long_range,
+        )
+
         # Drain enemy turns synchronously so the MCP caller sees the
         # post-enemy-action state.
         while self.processing_enemy_turn:
             self._process_enemy_turn()
 
-        return self.get_state()
+        state = self.get_state()
+        return f"{report}\n\n{state}" if report else state
+
+    def _format_attack_report(
+        self,
+        result: dict[str, Any] | None,
+        target_entity: Any,
+        *,
+        weapon_name: str,
+        in_long_range: bool,
+    ) -> str:
+        """Format a hit/miss/damage block for a player's attack.
+
+        Returns an empty string if no result is available — preserves the
+        existing state-only response in that case.
+        """
+        if not result:
+            return ""
+
+        attacker = result.get("attacker_name", "Attacker")
+        target_name = result.get("target_name", "target")
+        attack_roll = result.get("attack_roll", 0)
+        attack_bonus = result.get("attack_bonus", 0)
+        target_ac = result.get("target_ac", 0)
+        total = attack_roll + attack_bonus
+        bonus_text = f"+{attack_bonus}" if attack_bonus >= 0 else str(attack_bonus)
+
+        if result.get("critical"):
+            outcome = "CRITICAL HIT"
+        elif result.get("hit"):
+            outcome = "HIT"
+        else:
+            outcome = "MISS"
+
+        suffix = ""
+        if in_long_range:
+            suffix = " (long range - disadvantage)"
+
+        lines = [
+            f"{attacker} attacks {target_name} with {weapon_name}: "
+            f"roll {attack_roll}{bonus_text} = {total} vs AC {target_ac} -> "
+            f"{outcome}{suffix}"
+        ]
+
+        if result.get("hit"):
+            lines[0] += f" for {result.get('damage', 0)} damage"
+
+        if result.get("target_killed"):
+            lines.append(f"{target_name} is defeated!")
+        else:
+            # Cached hp/max_hp on the entity is updated by sync_from_engine
+            # inside execute_attack, so this reflects post-attack HP.
+            hp = getattr(target_entity, "hp", None)
+            max_hp = getattr(target_entity, "max_hp", None)
+            if hp is not None and max_hp:
+                lines.append(f"{target_name}: {hp}/{max_hp} HP")
+
+        return "\n".join(lines)
 
     def wait(self) -> str:
         """Pass the current turn."""

--- a/client-2d/tests/test_attack_result_output.py
+++ b/client-2d/tests/test_attack_result_output.py
@@ -1,0 +1,252 @@
+# ABOUTME: Tests for game_attack MCP result text (issue #365).
+# ABOUTME: Verifies attack roll, hit/miss, damage, and target HP are reported.
+
+"""Tests for the attack-result block prepended to game_attack responses."""
+
+from unittest.mock import MagicMock, PropertyMock
+
+
+def _make_session():
+    """Build a session-shaped mock that GameSession.attack can drive."""
+    from client_2d.session import GameSession
+
+    session = MagicMock()
+    type(session).width = PropertyMock(return_value=1280)
+    type(session).height = PropertyMock(return_value=900)
+    session.player_x = 5
+    session.player_y = 5
+    session.selected_enemy = 0
+    session.processing_enemy_turn = False
+    session.combat_log = []
+    session.current_mode = MagicMock()
+    session.party_spread = False
+    session.party_positions = []
+    session._state_renderer = None
+    # Bind real methods so the attack-result block actually renders.
+    session._format_attack_report = GameSession._format_attack_report.__get__(session)
+    session.execute_attack = GameSession.execute_attack.__get__(session)
+    session.get_state = lambda: "<state>"
+    return session
+
+
+def _wire_player_with_longsword(session):
+    """Configure session.engine for an adjacent melee combatant."""
+    session.engine = MagicMock()
+    session.engine.in_combat = True
+    session.engine.is_player_turn.return_value = True
+    session.engine.get_current_turn_state.return_value = MagicMock(movement_remaining=30)
+
+    creature = MagicMock()
+    creature.inventory.get_equipped_item.return_value = "longsword"
+    archy = {
+        "is_player": True,
+        "creature": creature,
+        "name": "Archy",
+    }
+    next_turn = {
+        "is_player": True,
+        "creature": creature,
+        "name": "Bran",
+    }
+    # First call (pre-attack) returns Archy; subsequent calls return the next
+    # combatant so the session's "attack didn't execute" check is bypassed.
+    session.engine.get_current_combatant.side_effect = [archy] + [next_turn] * 20
+    session.engine.game_state.data_loader.load_items.return_value = {
+        "weapons": {
+            "longsword": {
+                "name": "Longsword",
+                "category": "melee",
+                "damage": "1d8",
+                "properties": ["versatile"],
+            }
+        }
+    }
+    session.engine.advance_turn.return_value = {"combat_ended": True}
+    session.engine.get_party_data.return_value = []
+
+
+def _wire_adjacent_target(session, hp=7, max_hp=7):
+    monster = MagicMock()
+    monster.grid_x = 5
+    monster.grid_y = 6  # adjacent (5 ft)
+    monster.enemy_index = 0
+    monster.entity_id = "monster_0"
+    monster.sub_type = "giant_rat"
+    monster.hp = hp
+    monster.max_hp = max_hp
+    monster._creature_ref = MagicMock(current_hp=hp, max_hp=max_hp, name="Giant Rat 1")
+    session.entity_manager = MagicMock()
+    session.entity_manager.get_monsters.return_value = [monster]
+    session.entity_manager.get_current_turn_position.return_value = (5, 5)
+    return monster
+
+
+class TestAttackResultText:
+    """game_attack must surface attack roll, hit/miss, damage, target HP."""
+
+    def test_hit_reports_roll_and_damage(self):
+        from client_2d.session import GameSession
+
+        session = _make_session()
+        _wire_player_with_longsword(session)
+        target = _wire_adjacent_target(session, hp=7, max_hp=7)
+
+        # After the attack the target's cached HP drops to 3.
+        def _post_attack_sync(*_args, **_kwargs):
+            target.hp = 3
+            target._creature_ref.current_hp = 3
+
+        session.entity_manager.sync_from_engine.side_effect = _post_attack_sync
+
+        session.engine.execute_attack.return_value = {
+            "success": True,
+            "hit": True,
+            "critical": False,
+            "damage": 4,
+            "attack_roll": 14,
+            "attack_bonus": 5,
+            "target_ac": 12,
+            "target_name": "Giant Rat 1",
+            "attacker_name": "Archy",
+            "target_killed": False,
+        }
+
+        result = GameSession.attack(session, 0)
+
+        assert "Archy" in result
+        assert "Giant Rat 1" in result
+        assert "14" in result  # natural roll
+        assert "+5" in result or "+ 5" in result  # bonus
+        assert "19" in result  # total
+        assert "AC 12" in result
+        assert "HIT" in result
+        assert "4 damage" in result
+        assert "3/7 HP" in result
+
+    def test_miss_reports_roll_no_damage(self):
+        from client_2d.session import GameSession
+
+        session = _make_session()
+        _wire_player_with_longsword(session)
+        _wire_adjacent_target(session, hp=7, max_hp=7)
+
+        session.engine.execute_attack.return_value = {
+            "success": True,
+            "hit": False,
+            "critical": False,
+            "damage": 0,
+            "attack_roll": 5,
+            "attack_bonus": 5,
+            "target_ac": 12,
+            "target_name": "Giant Rat 1",
+            "attacker_name": "Archy",
+            "target_killed": False,
+        }
+
+        result = GameSession.attack(session, 0)
+
+        assert "MISS" in result
+        assert "5" in result
+        assert "AC 12" in result
+        # On a miss the target HP is unchanged.
+        assert "7/7 HP" in result
+        assert "damage" not in result.split("Map:")[0].lower() or "0 damage" not in result
+
+    def test_critical_hit_is_called_out(self):
+        from client_2d.session import GameSession
+
+        session = _make_session()
+        _wire_player_with_longsword(session)
+        target = _wire_adjacent_target(session, hp=7, max_hp=7)
+
+        def _post_attack_sync(*_args, **_kwargs):
+            target.hp = 0
+            target._creature_ref.current_hp = 0
+
+        session.entity_manager.sync_from_engine.side_effect = _post_attack_sync
+
+        session.engine.execute_attack.return_value = {
+            "success": True,
+            "hit": True,
+            "critical": True,
+            "damage": 12,
+            "attack_roll": 20,
+            "attack_bonus": 5,
+            "target_ac": 12,
+            "target_name": "Giant Rat 1",
+            "attacker_name": "Archy",
+            "target_killed": True,
+        }
+
+        result = GameSession.attack(session, 0)
+
+        assert "CRITICAL" in result
+        assert "12 damage" in result
+        assert "defeated" in result.lower() or "down" in result.lower()
+
+    def test_long_range_disadvantage_called_out(self):
+        from client_2d.session import GameSession
+
+        session = _make_session()
+        # Shortbow: normal 80, max 320. Position target 25 squares (125 ft) away.
+        session.engine = MagicMock()
+        session.engine.in_combat = True
+        session.engine.is_player_turn.return_value = True
+        session.engine.get_current_turn_state.return_value = MagicMock(movement_remaining=30)
+
+        creature = MagicMock()
+        creature.inventory.get_equipped_item.return_value = "shortbow"
+        archy = {
+            "is_player": True,
+            "creature": creature,
+            "name": "Archy",
+        }
+        next_turn = {
+            "is_player": True,
+            "creature": creature,
+            "name": "Bran",
+        }
+        session.engine.get_current_combatant.side_effect = [archy] + [next_turn] * 20
+        session.engine.game_state.data_loader.load_items.return_value = {
+            "weapons": {
+                "shortbow": {
+                    "name": "Shortbow",
+                    "category": "ranged",
+                    "damage": "1d6",
+                    "range": "80/320",
+                }
+            }
+        }
+        session.engine.advance_turn.return_value = {"combat_ended": True}
+        session.engine.get_party_data.return_value = []
+
+        monster = MagicMock()
+        monster.grid_x = 30
+        monster.grid_y = 5  # 25 squares = 125 ft (long range for shortbow)
+        monster.enemy_index = 0
+        monster.entity_id = "monster_0"
+        monster.sub_type = "giant_rat"
+        monster.hp = 5
+        monster.max_hp = 7
+        monster._creature_ref = MagicMock(current_hp=5, max_hp=7, name="Giant Rat 1")
+        session.entity_manager = MagicMock()
+        session.entity_manager.get_monsters.return_value = [monster]
+        session.entity_manager.get_current_turn_position.return_value = (5, 5)
+
+        session.engine.execute_attack.return_value = {
+            "success": True,
+            "hit": True,
+            "critical": False,
+            "damage": 2,
+            "attack_roll": 11,
+            "attack_bonus": 5,
+            "target_ac": 12,
+            "target_name": "Giant Rat 1",
+            "attacker_name": "Archy",
+            "target_killed": False,
+        }
+
+        result = GameSession.attack(session, 0)
+
+        assert "long range" in result.lower()
+        assert "disadvantage" in result.lower()


### PR DESCRIPTION
## Summary
- `game_attack` MCP tool now prepends an attack-result block to its response so callers can see the attack roll, hit/miss/critical, damage, and the target's post-attack HP — closing the diagnostic gap reported in #365.
- Long-range shots (e.g. shortbow beyond 80 ft) are explicitly flagged with `(long range - disadvantage)`.
- Engine adapter `execute_attack` now also returns `attack_bonus`, so the total attack (roll + bonus) can be shown.

## Sample output
```
Archy attacks Giant Rat with Shortbow: roll 18+6 = 24 vs AC 12 -> HIT for 5 damage
Giant Rat: 2/7 HP

Turn: 1
Party HP: 38/38 ...
```

Miss case:
```
Archy attacks Giant Rat with Shortbow: roll 5+6 = 11 vs AC 12 -> MISS
Giant Rat: 7/7 HP
```

## Test plan
- [x] New unit tests `tests/test_attack_result_output.py` cover hit / miss / critical / long-range disadvantage cases.
- [x] Full `client-2d` test suite (`uv run pytest tests/`) — 390 passed.
- [x] Full `dnd-engine` test suite — 2112 passed.
- [x] End-to-end manual playtest via the repro in #365 (set_seed 42, spawn rogue/halfling with shortbow, spawn giant_rat, attack) — output now includes roll, hit/miss, damage, and target HP.

Closes #365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)