### PR TITLE
Add #363: Pytest harness for scenario-driven auto-play regression tests

### DIFF
--- a/dnd-engine/dnd_engine/scenarios/__init__.py
+++ b/dnd-engine/dnd_engine/scenarios/__init__.py
@@ -13,14 +13,28 @@ Usage::
     loaded.enemy_positions     # {entity_id: (x, y)} for visual placement
 """
 
+from dnd_engine.scenarios.assertions import (
+    ScenarioAssertionError,
+    run_assertion,
+)
 from dnd_engine.scenarios.loader import (
     LoadedScenario,
     ScenarioLoader,
     ScenarioValidationError,
 )
+from dnd_engine.scenarios.script_executor import (
+    ScriptContext,
+    ScriptExecutionError,
+    ScriptExecutor,
+)
 
 __all__ = [
     "LoadedScenario",
+    "ScenarioAssertionError",
     "ScenarioLoader",
     "ScenarioValidationError",
+    "ScriptContext",
+    "ScriptExecutionError",
+    "ScriptExecutor",
+    "run_assertion",
 ]

--- a/dnd-engine/dnd_engine/scenarios/assertions.py
+++ b/dnd-engine/dnd_engine/scenarios/assertions.py
@@ -1,0 +1,164 @@
+# ABOUTME: Assertion vocabulary for YAML scenarios — readable failures, no magic.
+# ABOUTME: Each runner takes a ScriptContext + spec and raises ScenarioAssertionError on mismatch.
+
+"""Assertion runners for YAML scenario tests (issue #363).
+
+The supported assertion types are the floor that #363 specifies:
+``entity_hp``, ``entity_present``, ``entity_absent``, ``combat_active``,
+``turn_count``, ``last_attack_hit``, ``last_attack_damage_in_range``.
+
+Every failure raises :class:`ScenarioAssertionError` with a message that
+includes the assertion type, the entity/value at issue, and the
+expected operator + bound. Acceptance criterion 2 of the issue is that
+corrupting an assertion produces a clear, useful failure — the messages
+here are designed to be greppable and self-explanatory.
+"""
+
+from __future__ import annotations
+
+import operator
+from collections.abc import Callable
+from typing import Any
+
+from dnd_engine.scenarios.script_executor import ScriptContext
+
+
+class ScenarioAssertionError(AssertionError):
+    """Raised when a scenario assertion fails.
+
+    Subclasses ``AssertionError`` so pytest reports it like any other
+    failed expectation, but the distinct type lets harness code
+    distinguish assertion failures from engine errors.
+    """
+
+
+_OPS: dict[str, Callable[[Any, Any], bool]] = {
+    "==": operator.eq,
+    "!=": operator.ne,
+    "<": operator.lt,
+    "<=": operator.le,
+    ">": operator.gt,
+    ">=": operator.ge,
+}
+
+
+def _apply_op(op: str, lhs: Any, rhs: Any, *, assertion: str) -> bool:
+    if op not in _OPS:
+        raise ScenarioAssertionError(
+            f"{assertion}: unknown operator '{op}'. "
+            f"Valid: {', '.join(sorted(_OPS))}"
+        )
+    return _OPS[op](lhs, rhs)
+
+
+def entity_hp(ctx: ScriptContext, spec: dict[str, Any]) -> None:
+    entity_id = spec["entity_id"]
+    op = spec["op"]
+    value = spec["value"]
+    creature = ctx.resolve_entity(entity_id)
+    if creature is None:
+        raise ScenarioAssertionError(
+            f"entity_hp: unknown entity '{entity_id}'"
+        )
+    actual = getattr(creature, "current_hp", None)
+    if not _apply_op(op, actual, value, assertion="entity_hp"):
+        raise ScenarioAssertionError(
+            f"entity_hp({entity_id}): expected {op} {value}, got {actual}"
+        )
+
+
+def entity_present(ctx: ScriptContext, spec: dict[str, Any]) -> None:
+    entity_id = spec["entity_id"]
+    creature = ctx.resolve_entity(entity_id)
+    if creature is None or not getattr(creature, "is_alive", False):
+        raise ScenarioAssertionError(
+            f"entity_present: '{entity_id}' is not present "
+            f"(creature={'missing' if creature is None else 'dead'})"
+        )
+
+
+def entity_absent(ctx: ScriptContext, spec: dict[str, Any]) -> None:
+    entity_id = spec["entity_id"]
+    creature = ctx.resolve_entity(entity_id)
+    if creature is not None and getattr(creature, "is_alive", False):
+        raise ScenarioAssertionError(
+            f"entity_absent: '{entity_id}' is still alive"
+        )
+
+
+def combat_active(ctx: ScriptContext, spec: dict[str, Any]) -> None:
+    expected = bool(spec["value"])
+    actual = bool(getattr(ctx.game_state, "in_combat", False))
+    if actual != expected:
+        raise ScenarioAssertionError(
+            f"combat_active: expected {expected}, got {actual}"
+        )
+
+
+def turn_count(ctx: ScriptContext, spec: dict[str, Any]) -> None:
+    op = spec["op"]
+    value = spec["value"]
+    actual = ctx.turn_count
+    if not _apply_op(op, actual, value, assertion="turn_count"):
+        raise ScenarioAssertionError(
+            f"turn_count: expected {op} {value}, got {actual}"
+        )
+
+
+def last_attack_hit(ctx: ScriptContext, spec: dict[str, Any]) -> None:
+    expected = bool(spec["value"])
+    if ctx.last_attack is None:
+        raise ScenarioAssertionError(
+            "last_attack_hit: no attack has been made in this scenario"
+        )
+    actual = bool(getattr(ctx.last_attack, "hit", False))
+    if actual != expected:
+        raise ScenarioAssertionError(
+            f"last_attack_hit: expected {expected}, got {actual}"
+        )
+
+
+def last_attack_damage_in_range(ctx: ScriptContext, spec: dict[str, Any]) -> None:
+    lo = int(spec["min"])
+    hi = int(spec["max"])
+    if ctx.last_attack is None:
+        raise ScenarioAssertionError(
+            "last_attack_damage_in_range: no attack has been made in this scenario"
+        )
+    actual = int(getattr(ctx.last_attack, "damage", 0))
+    if not (lo <= actual <= hi):
+        raise ScenarioAssertionError(
+            f"last_attack_damage_in_range: expected {lo}..{hi}, got {actual}"
+        )
+
+
+_ASSERTIONS: dict[str, Callable[[ScriptContext, dict[str, Any]], None]] = {
+    "entity_hp": entity_hp,
+    "entity_present": entity_present,
+    "entity_absent": entity_absent,
+    "combat_active": combat_active,
+    "turn_count": turn_count,
+    "last_attack_hit": last_attack_hit,
+    "last_attack_damage_in_range": last_attack_damage_in_range,
+}
+
+
+def run_assertion(ctx: ScriptContext, spec: dict[str, Any]) -> None:
+    """Dispatch a single assertion spec to its runner.
+
+    The ``type`` key selects the runner; everything else is the runner's
+    spec. An unknown type is itself an assertion failure with a clear
+    error message rather than a silent no-op.
+    """
+    a_type = spec.get("type")
+    if a_type is None:
+        raise ScenarioAssertionError(
+            f"assertion missing 'type' key: {spec!r}"
+        )
+    runner = _ASSERTIONS.get(a_type)
+    if runner is None:
+        raise ScenarioAssertionError(
+            f"unknown assertion type '{a_type}'. "
+            f"Valid: {', '.join(sorted(_ASSERTIONS))}"
+        )
+    runner(ctx, spec)

--- a/dnd-engine/dnd_engine/scenarios/loader.py
+++ b/dnd-engine/dnd_engine/scenarios/loader.py
@@ -70,6 +70,30 @@ class LoadedScenario:
     assertions: list[dict[str, Any]] = field(default_factory=list)
     map_config: dict[str, Any] = field(default_factory=dict)
 
+    def run(self) -> Any:
+        """Execute the YAML's ``script`` then check its ``assertions``.
+
+        Convenience for the pytest auto-play harness (issue #363): one
+        call drives the scenario from loaded state through every action
+        and every assertion. Returns the populated ``ScriptContext`` so
+        callers can inspect anything beyond what the assertions checked.
+
+        Raises:
+            ScriptExecutionError: If the script references an unknown
+                entity, action, or state.
+            ScenarioAssertionError: If any declared assertion fails.
+        """
+        # Imports are local to avoid circulars: the assertion + executor
+        # modules already import ``LoadedScenario`` for typing.
+        from dnd_engine.scenarios.assertions import run_assertion
+        from dnd_engine.scenarios.script_executor import ScriptExecutor
+
+        executor = ScriptExecutor(self)
+        ctx = executor.run(self.script)
+        for spec in self.assertions:
+            run_assertion(ctx, spec)
+        return ctx
+
 
 class ScenarioLoader:
     """Loads a YAML scenario file and constructs a fully wired ``GameState``.

--- a/dnd-engine/dnd_engine/scenarios/script_executor.py
+++ b/dnd-engine/dnd_engine/scenarios/script_executor.py
@@ -12,12 +12,29 @@ side-effects (last attack result, last rejection reason, turn count) on
 The vocabulary is intentionally narrow: ``attack`` and ``wait``. Those
 two cover every scenario the issue lists. Adding more is the next
 ticket's job.
+
+Range checking lives here because the pure engine doesn't validate
+weapon ranges — that's a client-layer concern (``client-2d`` does the
+same check in ``session.get_attack_range``). Duplicating ten lines of
+parsing here keeps the engine layer free of any cross-package import.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from dnd_engine.core.distance import distance_in_feet
+
+if TYPE_CHECKING:
+    from dnd_engine.scenarios.loader import LoadedScenario
+
+
+class ScriptExecutionError(RuntimeError):
+    """Raised when a script action references an unknown entity, an
+    unknown action type, or runs in a state where it cannot proceed
+    (e.g. trying to attack while it's not a player's turn).
+    """
 
 
 @dataclass
@@ -63,3 +80,191 @@ class ScriptContext:
             if i < len(enemies):
                 return enemies[i]
         return None
+
+    def position_of(self, entity_id: str) -> tuple[int, int] | None:
+        if entity_id in self.party_positions:
+            return self.party_positions[entity_id]
+        if entity_id in self.enemy_positions:
+            return self.enemy_positions[entity_id]
+        return None
+
+
+def _parse_weapon_range(range_str: str | None) -> tuple[int, int]:
+    """Parse a weapon ``range`` string from items.json into (normal, max) feet.
+
+    items.json stores ranges as ``"80/320"`` (ranged) or ``"20/60"``
+    (thrown). A single value means normal == max. A missing value falls
+    back to melee reach (5 ft for both bounds).
+    """
+    if not range_str:
+        return (5, 5)
+    parts = str(range_str).split("/")
+    if len(parts) == 2:
+        return (int(parts[0]), int(parts[1]))
+    return (int(parts[0]), int(parts[0]))
+
+
+def _attack_range_for(weapon_data: dict[str, Any] | None) -> tuple[int, int]:
+    """Compute the effective attack range for the equipped weapon.
+
+    Ranged weapons always honor their range tuple. A melee weapon with
+    the ``thrown`` property keeps its range tuple too. Anything else is
+    melee reach (5 ft).
+    """
+    if not weapon_data:
+        return (5, 5)
+    range_str = weapon_data.get("range")
+    properties = weapon_data.get("properties", []) or []
+    category = weapon_data.get("category", "melee")
+    if category == "ranged":
+        return _parse_weapon_range(range_str)
+    if "thrown" in properties and range_str:
+        return _parse_weapon_range(range_str)
+    return (5, 5)
+
+
+class ScriptExecutor:
+    """Runs a script of action dicts against a ``LoadedScenario``.
+
+    Construction primes a :class:`ScriptContext` with the scenario's
+    positions and entity-id ordering. ``run(script)`` then drives the
+    actions in sequence and returns the final context for assertion
+    runners.
+    """
+
+    def __init__(self, loaded: LoadedScenario) -> None:
+        self.loaded = loaded
+        self.ctx = ScriptContext(
+            game_state=loaded.game_state,
+            party_positions=dict(loaded.party_positions),
+            enemy_positions=dict(loaded.enemy_positions),
+            party_entity_ids=list(loaded.party_positions.keys()),
+            enemy_entity_ids=list(loaded.enemy_positions.keys()),
+        )
+
+    def run(self, script: list[dict[str, Any]]) -> ScriptContext:
+        for i, action in enumerate(script):
+            try:
+                self._run_action(action)
+            except ScriptExecutionError:
+                raise
+            except Exception as exc:
+                raise ScriptExecutionError(
+                    f"script[{i}] ({action!r}) failed: {exc}"
+                ) from exc
+        return self.ctx
+
+    def _run_action(self, action: dict[str, Any]) -> None:
+        a_type = action.get("action")
+        if a_type == "wait":
+            self._action_wait()
+        elif a_type == "attack":
+            target = action.get("target")
+            if target is None:
+                raise ScriptExecutionError("attack action missing 'target'")
+            self._action_attack(str(target))
+        else:
+            raise ScriptExecutionError(
+                f"unknown script action: {a_type!r}"
+            )
+
+    # --- actions ----------------------------------------------------------
+
+    def _action_wait(self) -> None:
+        tracker = self.ctx.game_state.initiative_tracker
+        if tracker is None:
+            raise ScriptExecutionError(
+                "wait: combat is not active (no initiative tracker)"
+            )
+        tracker.next_turn()
+        self.ctx.turn_count += 1
+
+    def _action_attack(self, target_id: str) -> None:
+        target = self.ctx.resolve_entity(target_id)
+        if target is None or target_id not in self.ctx.enemy_entity_ids:
+            raise ScriptExecutionError(
+                f"attack: unknown target '{target_id}'"
+            )
+
+        attacker, attacker_id = self._current_player_attacker()
+        attacker_pos = self.ctx.position_of(attacker_id)
+        target_pos = self.ctx.position_of(target_id)
+        if attacker_pos is None or target_pos is None:
+            raise ScriptExecutionError(
+                f"attack: missing position for "
+                f"{attacker_id!r} or {target_id!r}"
+            )
+
+        distance = distance_in_feet(
+            attacker_pos[0], attacker_pos[1], target_pos[0], target_pos[1]
+        )
+
+        # Look up the equipped weapon's range data via the engine's own
+        # data loader so the executor stays inside the engine layer.
+        weapon_data = self._equipped_weapon_data(attacker)
+        normal_range, max_range = _attack_range_for(weapon_data)
+
+        if distance > max_range:
+            self.ctx.last_attack_error = (
+                f"out of range: {distance} ft > max {max_range} ft "
+                f"({weapon_data.get('name') if weapon_data else 'unarmed'})"
+            )
+            return
+
+        self.ctx.last_attack_disadvantage = distance > normal_range
+
+        result = self.ctx.game_state.execute_player_attack(attacker, target)
+        # ``execute_player_attack`` returns ``PlayerAttackResult``; the
+        # nested ``AttackResult`` carries the fields the assertion
+        # vocabulary actually inspects (hit, damage, attack_roll).
+        self.ctx.last_attack = getattr(result, "attack_result", result)
+
+        tracker = self.ctx.game_state.initiative_tracker
+        if tracker is not None:
+            tracker.next_turn()
+        self.ctx.turn_count += 1
+
+    # --- helpers ----------------------------------------------------------
+
+    def _current_player_attacker(self) -> tuple[Any, str]:
+        tracker = self.ctx.game_state.initiative_tracker
+        if tracker is None:
+            raise ScriptExecutionError(
+                "attack: combat is not active (no initiative tracker)"
+            )
+        current = tracker.get_current_combatant()
+        if current is None:
+            raise ScriptExecutionError("attack: no current combatant")
+        creature = current.creature
+        party = getattr(self.ctx.game_state, "party", None)
+        chars = list(getattr(party, "characters", []) or [])
+        for i, character in enumerate(chars):
+            if character is creature:
+                if i < len(self.ctx.party_entity_ids):
+                    return character, self.ctx.party_entity_ids[i]
+                raise ScriptExecutionError(
+                    "attack: party_entity_ids out of sync with party"
+                )
+        raise ScriptExecutionError(
+            f"attack: current combatant {creature.name!r} is not a "
+            f"party member (enemy turn?)"
+        )
+
+    def _equipped_weapon_data(self, attacker: Any) -> dict[str, Any] | None:
+        # Lazy-import to avoid pulling EquipmentSlot at module load — the
+        # inventory subsystem is heavyweight and the executor is imported
+        # by every scenario fixture.
+        from dnd_engine.systems.inventory import EquipmentSlot
+
+        inventory = getattr(attacker, "inventory", None)
+        if inventory is None:
+            return None
+        weapon_id = inventory.get_equipped_item(EquipmentSlot.WEAPON)
+        if not weapon_id:
+            return None
+        data_loader = getattr(self.ctx.game_state, "data_loader", None)
+        campaign_id = getattr(self.ctx.game_state, "campaign_id", None)
+        if data_loader is None or campaign_id is None:
+            return None
+        items = data_loader.load_items(campaign_id)
+        return items.get("weapons", {}).get(weapon_id)

--- a/dnd-engine/dnd_engine/scenarios/script_executor.py
+++ b/dnd-engine/dnd_engine/scenarios/script_executor.py
@@ -1,0 +1,65 @@
+# ABOUTME: Executes a scenario script (list of action dicts) against a LoadedScenario.
+# ABOUTME: Records each action's effect on a ScriptContext for assertion runners to inspect.
+
+"""Script execution for YAML scenarios (issue #363).
+
+A scenario YAML may carry a ``script:`` block — a sequence of action
+dicts that drive the game forward from the loaded state. The executor
+applies them in order against the underlying ``GameState`` and records
+side-effects (last attack result, last rejection reason, turn count) on
+:class:`ScriptContext` so assertion runners can inspect what happened.
+
+The vocabulary is intentionally narrow: ``attack`` and ``wait``. Those
+two cover every scenario the issue lists. Adding more is the next
+ticket's job.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ScriptContext:
+    """State carried through script execution and read by assertion runners.
+
+    ``game_state`` is the engine state from the loader. The position
+    dicts mirror what ``LoadedScenario`` returns and are required for
+    distance/range calculations on attacks. ``party_entity_ids`` and
+    ``enemy_entity_ids`` preserve the entity-id ↔ list-index mapping so
+    a YAML can address creatures by stable id (e.g. ``goblin_0``)
+    rather than positional index.
+    """
+
+    game_state: Any
+    party_positions: dict[str, tuple[int, int]] = field(default_factory=dict)
+    enemy_positions: dict[str, tuple[int, int]] = field(default_factory=dict)
+    party_entity_ids: list[str] = field(default_factory=list)
+    enemy_entity_ids: list[str] = field(default_factory=list)
+
+    last_attack: Any | None = None
+    last_attack_error: str | None = None
+    last_attack_disadvantage: bool = False
+    turn_count: int = 0
+
+    def resolve_entity(self, entity_id: str) -> Any | None:
+        """Return the creature with the given entity_id, or None.
+
+        The lookup walks the engine state (party + active_enemies). Dead
+        enemies remain in ``active_enemies`` with ``is_alive=False``, so
+        callers asking about a defeated entity still get the creature
+        back and can inspect its state.
+        """
+        if entity_id in self.party_entity_ids:
+            i = self.party_entity_ids.index(entity_id)
+            party = getattr(self.game_state, "party", None)
+            chars = getattr(party, "characters", None) if party else None
+            if chars is not None and i < len(chars):
+                return chars[i]
+        if entity_id in self.enemy_entity_ids:
+            i = self.enemy_entity_ids.index(entity_id)
+            enemies = getattr(self.game_state, "active_enemies", None) or []
+            if i < len(enemies):
+                return enemies[i]
+        return None

--- a/dnd-engine/tests/conftest.py
+++ b/dnd-engine/tests/conftest.py
@@ -1,0 +1,87 @@
+# ABOUTME: Pytest plumbing for scenario-driven auto-play tests (issue #363).
+# ABOUTME: Exposes `scenario_session` + auto-discovers YAMLs under tests/scenarios/yaml/auto/.
+
+"""Auto-play harness conftest.
+
+Provides two pieces of pytest plumbing:
+
+1. The ``scenario_session`` fixture — loads a YAML scenario (chosen by
+   the parametrized ``scenario_path``) into a ``LoadedScenario`` ready
+   for ``.run()``.
+2. The ``scenario`` marker — when a test takes ``scenario_path`` or
+   ``scenario_session`` as a parameter, it gets parametrized across
+   every YAML under ``tests/scenarios/yaml/auto/``. Pass explicit
+   paths via ``@pytest.mark.scenario("path/to/x.yaml")`` to pin a test
+   to a specific file (or files).
+
+Adding a new auto-play scenario is therefore a no-code task: drop a
+YAML into the ``auto/`` directory and the parametrized test picks it
+up on the next pytest run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.scenarios import LoadedScenario, ScenarioLoader
+
+AUTO_SCENARIO_DIR = Path(__file__).parent / "scenarios" / "yaml" / "auto"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the ``scenario`` marker so ``pytest --strict-markers`` is happy."""
+    config.addinivalue_line(
+        "markers",
+        "scenario(*paths): parametrize a test across YAML scenarios. "
+        "With no args, auto-discovers all YAMLs in tests/scenarios/yaml/auto/.",
+    )
+
+
+def _discover_auto_scenarios() -> list[Path]:
+    if not AUTO_SCENARIO_DIR.exists():
+        return []
+    return sorted(AUTO_SCENARIO_DIR.glob("*.yaml"))
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """Parametrize ``scenario_path`` from the ``scenario`` marker.
+
+    A test triggers parametrization if it takes ``scenario_path`` (or
+    pulls it in transitively via ``scenario_session``). Explicit paths
+    in the marker take precedence; otherwise the ``auto/`` directory is
+    walked.
+    """
+    if "scenario_path" not in metafunc.fixturenames:
+        return
+
+    marker = metafunc.definition.get_closest_marker("scenario")
+    if marker is not None and marker.args:
+        paths = [Path(p) for p in marker.args]
+    else:
+        paths = _discover_auto_scenarios()
+
+    if not paths:
+        # Skip rather than crash so an empty auto/ directory doesn't
+        # break a developer's first run.
+        metafunc.parametrize("scenario_path", [], ids=[])
+        return
+
+    metafunc.parametrize(
+        "scenario_path",
+        paths,
+        ids=[p.stem for p in paths],
+    )
+
+
+@pytest.fixture
+def scenario_session(scenario_path: Path) -> LoadedScenario:
+    """Load the parametrized scenario YAML into a ``LoadedScenario``.
+
+    The returned object exposes ``.run()`` to execute the scenario's
+    script and assertions in one call, and ``.game_state`` /
+    ``.party_positions`` / ``.enemy_positions`` for tests that want to
+    inspect or drive the engine manually.
+    """
+    return ScenarioLoader().load(scenario_path)

--- a/dnd-engine/tests/scenarios/yaml/auto/melee_basic_hit.yaml
+++ b/dnd-engine/tests/scenarios/yaml/auto/melee_basic_hit.yaml
@@ -1,0 +1,35 @@
+# Auto-play scenario: melee swing at an adjacent goblin hits + kills it.
+#
+# Shortsword vs goblin at 5 ft (1 tile). Seed=7 → d20 rolls 19 with
+# +5 attack bonus, hits for 7 damage; goblin starts at 3 HP and goes
+# to 0. Asserts the basic melee mechanics end-to-end.
+
+name: melee_basic_hit
+seed: 7
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: human
+    weapons: [shortsword]
+    position: [3, 5]
+    name: Brick
+enemies:
+  - monster_id: goblin
+    position: [4, 5]
+script:
+  - action: attack
+    target: goblin_0
+assertions:
+  - type: last_attack_hit
+    value: true
+  - type: last_attack_damage_in_range
+    min: 1
+    max: 20
+  - type: turn_count
+    op: '=='
+    value: 1
+  - type: entity_absent
+    entity_id: goblin_0

--- a/dnd-engine/tests/scenarios/yaml/auto/ranged_long_range.yaml
+++ b/dnd-engine/tests/scenarios/yaml/auto/ranged_long_range.yaml
@@ -1,0 +1,36 @@
+# Auto-play scenario: thrown dagger at long range still resolves.
+#
+# Dagger thrown range is 20/60 — at 25 ft (5 tiles) the attack sits in
+# long range (above normal, below max). The harness raises its
+# `last_attack_disadvantage` flag for the long-range case; the engine
+# itself does not yet honor disadvantage on long shots (separate
+# ticket), so we don't assert the roll was disadvantaged — only that
+# the attack resolved.
+
+name: ranged_long_range
+seed: 7
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [dagger]
+    position: [3, 5]
+    name: Archy
+enemies:
+  - monster_id: goblin
+    position: [8, 5]
+script:
+  - action: attack
+    target: goblin_0
+assertions:
+  - type: last_attack_hit
+    value: true
+  - type: last_attack_damage_in_range
+    min: 1
+    max: 20
+  - type: turn_count
+    op: '=='
+    value: 1

--- a/dnd-engine/tests/scenarios/yaml/auto/ranged_out_of_range_rejected.yaml
+++ b/dnd-engine/tests/scenarios/yaml/auto/ranged_out_of_range_rejected.yaml
@@ -1,0 +1,36 @@
+# Auto-play scenario: attacking past max range is rejected outright.
+#
+# Dagger thrown range is 20/60. At 85 ft (17 tiles) the target is past
+# the dagger's max range and the harness rejects the attack without
+# invoking the engine — the goblin takes no damage and the player's
+# turn is not consumed. This guards the rejection path so a future
+# regression can't silently turn an illegal attack into a missed one.
+
+name: ranged_out_of_range_rejected
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [dagger]
+    position: [3, 5]
+    name: Archy
+enemies:
+  - monster_id: goblin
+    position: [20, 5]
+script:
+  - action: attack
+    target: goblin_0
+assertions:
+  - type: turn_count
+    op: '=='
+    value: 0
+  - type: entity_present
+    entity_id: goblin_0
+  - type: entity_hp
+    entity_id: goblin_0
+    op: '=='
+    value: 7

--- a/dnd-engine/tests/scenarios/yaml/auto/ranged_short_hit.yaml
+++ b/dnd-engine/tests/scenarios/yaml/auto/ranged_short_hit.yaml
@@ -1,0 +1,36 @@
+# Auto-play scenario: ranged attack at short range hits and applies damage.
+#
+# A high-elf fighter with shortbow + arrows attacks a goblin at 35 ft
+# (7 tiles), well inside shortbow's normal range (80 ft). With seed=7
+# the d20 rolls a 19 → hit, 7 damage, goblin (3 HP) drops. Asserts the
+# happy path end-to-end: hit, damage, turn advanced, target absent.
+
+name: ranged_short_hit
+seed: 7
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [shortbow, arrows]
+    position: [3, 5]
+    name: Archy
+enemies:
+  - monster_id: goblin
+    position: [10, 5]
+script:
+  - action: attack
+    target: goblin_0
+assertions:
+  - type: last_attack_hit
+    value: true
+  - type: last_attack_damage_in_range
+    min: 1
+    max: 20
+  - type: turn_count
+    op: '=='
+    value: 1
+  - type: entity_absent
+    entity_id: goblin_0

--- a/dnd-engine/tests/scenarios/yaml/auto/wait_advances_turn.yaml
+++ b/dnd-engine/tests/scenarios/yaml/auto/wait_advances_turn.yaml
@@ -1,0 +1,30 @@
+# Auto-play scenario: wait passes the turn cleanly.
+#
+# Fighter is far enough from the goblin that no attack is in play; the
+# script just `wait`s. After execution, turn_count must be 1 and combat
+# must remain active. Guards the turn-pass plumbing so a regression that
+# stalls the initiative tracker surfaces immediately.
+
+name: wait_advances_turn
+seed: 1
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: human
+    weapons: [shortsword]
+    position: [3, 5]
+    name: Brick
+enemies:
+  - monster_id: goblin
+    position: [15, 15]
+script:
+  - action: wait
+assertions:
+  - type: turn_count
+    op: '=='
+    value: 1
+  - type: combat_active
+    value: true

--- a/dnd-engine/tests/test_auto_play.py
+++ b/dnd-engine/tests/test_auto_play.py
@@ -1,0 +1,65 @@
+# ABOUTME: Parametrized auto-discovery test — every YAML in scenarios/yaml/auto/ runs as a test.
+# ABOUTME: Adding a scenario YAML grows the suite without touching Python code.
+
+"""Auto-play regression suite (issue #363).
+
+This module is intentionally tiny: the real work lives in the YAMLs
+under ``tests/scenarios/yaml/auto/``. The conftest's
+``pytest_generate_tests`` walks that directory and parametrizes the
+test below across every file, so dropping a new YAML in is sufficient
+to grow the suite — no Python changes required (acceptance criterion
+3).
+
+The deliberate-corruption test at the bottom guards acceptance
+criterion 2: a wrong assertion must produce a clear, useful failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.scenarios import ScenarioLoader
+from dnd_engine.scenarios.assertions import ScenarioAssertionError
+
+
+@pytest.mark.scenario
+def test_scenario_runs_and_assertions_pass(scenario_session) -> None:
+    """Drive every YAML in ``auto/`` through its script and assertions.
+
+    A failure here means either the engine regressed against the
+    scenario's expected outcome, or the scenario itself drifted from
+    reality. The parametrization id is the YAML filename stem, so
+    ``pytest -k ranged_long_range`` selects a single scenario.
+    """
+    scenario_session.run()
+
+
+def test_corrupted_assertion_produces_clear_failure(tmp_path: Path) -> None:
+    """Acceptance criterion: corrupting an assertion fails informatively.
+
+    Take a known-good auto-play scenario, mutate its damage range to
+    impossible bounds, and verify the resulting error names the
+    assertion type and the offending values. Catches regressions that
+    would swap a precise assertion failure for a generic crash.
+    """
+    src = (
+        Path(__file__).parent / "scenarios" / "yaml" / "auto" / "ranged_short_hit.yaml"
+    )
+    body = src.read_text()
+    # Replace the in-range damage bound with one no real shortbow can hit.
+    corrupted = body.replace(
+        "    min: 1\n    max: 20",
+        "    min: 9000\n    max: 9001",
+    )
+    bad_path = tmp_path / "corrupted.yaml"
+    bad_path.write_text(corrupted)
+
+    loaded = ScenarioLoader().load(bad_path)
+
+    with pytest.raises(ScenarioAssertionError) as exc:
+        loaded.run()
+    msg = str(exc.value)
+    assert "last_attack_damage_in_range" in msg
+    assert "9000" in msg

--- a/dnd-engine/tests/test_loaded_scenario_run.py
+++ b/dnd-engine/tests/test_loaded_scenario_run.py
@@ -1,0 +1,113 @@
+# ABOUTME: Tests for LoadedScenario.run() — the script+assertion convenience entry point.
+# ABOUTME: Verifies end-to-end YAML → script → assertions flow in a single call.
+
+"""Tests for ``LoadedScenario.run()`` (issue #363).
+
+The convenience method ties the loader, executor, and assertion runner
+together so a test or fixture can drive a YAML scenario to completion
+in one call. These tests exercise both the happy path (script runs,
+assertions pass) and the failure path (a deliberately wrong assertion
+produces a clear, named error).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.scenarios import ScenarioLoader
+from dnd_engine.scenarios.assertions import ScenarioAssertionError
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "scenario.yaml"
+    p.write_text(body.lstrip())
+    return p
+
+
+# Short-range happy-path scenario: shortbow attack on a goblin 35 ft
+# away. The seed pins the goblin's max_hp via the data loader and the
+# attack roll via the engine's DiceRoller, so the post-script HP is
+# deterministic across runs.
+HAPPY_YAML = """
+name: lr_happy
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [shortbow]
+    position: [3, 5]
+    name: Archy
+enemies:
+  - monster_id: goblin
+    position: [10, 5]
+script:
+  - action: attack
+    target: goblin_0
+assertions:
+  - type: turn_count
+    op: '=='
+    value: 1
+  - type: entity_present
+    entity_id: goblin_0
+"""
+
+
+def test_run_executes_script_and_assertions(tmp_path: Path) -> None:
+    path = _write(tmp_path, HAPPY_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    ctx = loaded.run()
+
+    assert ctx.turn_count == 1
+    assert ctx.last_attack is not None
+
+
+def test_run_returns_context_with_no_script_or_assertions(tmp_path: Path) -> None:
+    # A scenario with no `script` and no `assertions` should still
+    # return a usable context (empty effect).
+    body = """
+name: lr_empty
+seed: 1
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: human
+    weapons: [shortsword]
+    position: [3, 5]
+    name: Quiet
+enemies: []
+"""
+    path = _write(tmp_path, body)
+    loaded = ScenarioLoader().load(path)
+
+    ctx = loaded.run()
+
+    assert ctx.turn_count == 0
+    assert ctx.last_attack is None
+
+
+def test_run_surfaces_assertion_failure_with_clear_message(tmp_path: Path) -> None:
+    # Swap the damage range for an impossible bound so the assertion
+    # must fail. The error message has to name the assertion type and
+    # the offending value.
+    bad_yaml = HAPPY_YAML + """  - type: last_attack_damage_in_range
+    min: 9000
+    max: 9001
+"""
+    path = _write(tmp_path, bad_yaml)
+    loaded = ScenarioLoader().load(path)
+
+    with pytest.raises(ScenarioAssertionError) as exc:
+        loaded.run()
+    msg = str(exc.value)
+    assert "last_attack_damage_in_range" in msg
+    assert "9000" in msg

--- a/dnd-engine/tests/test_scenario_assertions.py
+++ b/dnd-engine/tests/test_scenario_assertions.py
@@ -1,0 +1,270 @@
+# ABOUTME: Unit tests for the scenario assertion vocabulary (issue #363).
+# ABOUTME: Each assertion type gets a passing and a failing path with clear-message checks.
+
+"""Unit tests for ``dnd_engine.scenarios.assertions``.
+
+The assertion module is the vocabulary the YAML ``assertions:`` block
+declares. Each runner takes a ``ScriptContext`` and a spec dict, returns
+``None`` on success, and raises ``ScenarioAssertionError`` with a
+human-readable message on failure. These tests pin both the success
+shape and the message shape — corrupting an assertion in a real scenario
+must surface a useful error (acceptance criterion 2 on #363).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from dnd_engine.scenarios.assertions import (
+    ScenarioAssertionError,
+    run_assertion,
+)
+from dnd_engine.scenarios.script_executor import ScriptContext
+
+
+@dataclass
+class _StubCreature:
+    """Minimal stand-in for a Creature/Character used by assertion tests.
+
+    Assertions only read ``current_hp``, ``is_alive``, and ``name`` —
+    nothing else from the engine is needed to exercise them in
+    isolation.
+    """
+
+    name: str
+    current_hp: int = 10
+    max_hp: int = 10
+    is_alive: bool = True
+
+
+@dataclass
+class _StubParty:
+    characters: list[_StubCreature] = field(default_factory=list)
+
+
+@dataclass
+class _StubGameState:
+    party: _StubParty = field(default_factory=_StubParty)
+    active_enemies: list[_StubCreature] = field(default_factory=list)
+    in_combat: bool = False
+
+
+def _ctx(
+    party: list[_StubCreature] | None = None,
+    enemies: list[_StubCreature] | None = None,
+    in_combat: bool = False,
+    last_attack: Any | None = None,
+    last_attack_error: str | None = None,
+    turn_count: int = 0,
+) -> ScriptContext:
+    """Build a ScriptContext with stubbed game state for assertion tests."""
+    party = party or []
+    enemies = enemies or []
+    game_state = _StubGameState(
+        party=_StubParty(characters=party),
+        active_enemies=enemies,
+        in_combat=in_combat,
+    )
+    party_ids = [f"pc_{c.name.lower().replace(' ', '_')}" for c in party]
+    enemy_ids = [f"{e.name.lower()}_{i}" for i, e in enumerate(enemies)]
+    return ScriptContext(
+        game_state=game_state,
+        party_positions=dict.fromkeys(party_ids, (0, 0)),
+        enemy_positions=dict.fromkeys(enemy_ids, (0, 0)),
+        party_entity_ids=party_ids,
+        enemy_entity_ids=enemy_ids,
+        last_attack=last_attack,
+        last_attack_error=last_attack_error,
+        turn_count=turn_count,
+    )
+
+
+# --- entity_hp ---------------------------------------------------------------
+
+
+def test_entity_hp_passes_when_op_matches() -> None:
+    ctx = _ctx(enemies=[_StubCreature(name="goblin", current_hp=4)])
+    run_assertion(ctx, {"type": "entity_hp", "entity_id": "goblin_0", "op": "<=", "value": 5})
+
+
+def test_entity_hp_fails_with_clear_message() -> None:
+    ctx = _ctx(enemies=[_StubCreature(name="goblin", current_hp=7)])
+    with pytest.raises(ScenarioAssertionError) as exc:
+        run_assertion(
+            ctx,
+            {"type": "entity_hp", "entity_id": "goblin_0", "op": "<=", "value": 5},
+        )
+    msg = str(exc.value)
+    assert "entity_hp" in msg
+    assert "goblin_0" in msg
+    assert "7" in msg
+    assert "<= 5" in msg
+
+
+def test_entity_hp_unknown_entity_raises_useful_error() -> None:
+    ctx = _ctx()
+    with pytest.raises(ScenarioAssertionError) as exc:
+        run_assertion(ctx, {"type": "entity_hp", "entity_id": "ghost_0", "op": "==", "value": 0})
+    assert "ghost_0" in str(exc.value)
+    assert "unknown entity" in str(exc.value).lower()
+
+
+def test_entity_hp_supports_all_operators() -> None:
+    goblin = _StubCreature(name="goblin", current_hp=5)
+    ctx = _ctx(enemies=[goblin])
+    for op, value in [("==", 5), ("!=", 4), ("<", 6), (">", 4), ("<=", 5), (">=", 5)]:
+        run_assertion(ctx, {"type": "entity_hp", "entity_id": "goblin_0", "op": op, "value": value})
+
+
+# --- entity_present / entity_absent -----------------------------------------
+
+
+def test_entity_present_passes_for_living_enemy() -> None:
+    ctx = _ctx(enemies=[_StubCreature(name="goblin", is_alive=True)])
+    run_assertion(ctx, {"type": "entity_present", "entity_id": "goblin_0"})
+
+
+def test_entity_present_fails_for_dead_enemy() -> None:
+    ctx = _ctx(enemies=[_StubCreature(name="goblin", is_alive=False, current_hp=0)])
+    with pytest.raises(ScenarioAssertionError) as exc:
+        run_assertion(ctx, {"type": "entity_present", "entity_id": "goblin_0"})
+    assert "goblin_0" in str(exc.value)
+
+
+def test_entity_absent_passes_for_dead_enemy() -> None:
+    ctx = _ctx(enemies=[_StubCreature(name="goblin", is_alive=False, current_hp=0)])
+    run_assertion(ctx, {"type": "entity_absent", "entity_id": "goblin_0"})
+
+
+def test_entity_absent_passes_when_entity_does_not_exist() -> None:
+    ctx = _ctx()
+    run_assertion(ctx, {"type": "entity_absent", "entity_id": "ghost_0"})
+
+
+def test_entity_absent_fails_for_living_enemy() -> None:
+    ctx = _ctx(enemies=[_StubCreature(name="goblin", is_alive=True)])
+    with pytest.raises(ScenarioAssertionError):
+        run_assertion(ctx, {"type": "entity_absent", "entity_id": "goblin_0"})
+
+
+# --- combat_active ----------------------------------------------------------
+
+
+def test_combat_active_passes_when_in_combat() -> None:
+    ctx = _ctx(in_combat=True)
+    run_assertion(ctx, {"type": "combat_active", "value": True})
+
+
+def test_combat_active_fails_when_in_combat_but_expected_out() -> None:
+    ctx = _ctx(in_combat=True)
+    with pytest.raises(ScenarioAssertionError):
+        run_assertion(ctx, {"type": "combat_active", "value": False})
+
+
+def test_combat_active_passes_when_out_of_combat() -> None:
+    ctx = _ctx(in_combat=False)
+    run_assertion(ctx, {"type": "combat_active", "value": False})
+
+
+# --- turn_count -------------------------------------------------------------
+
+
+def test_turn_count_passes_when_op_matches() -> None:
+    ctx = _ctx(turn_count=3)
+    run_assertion(ctx, {"type": "turn_count", "op": "==", "value": 3})
+    run_assertion(ctx, {"type": "turn_count", "op": ">=", "value": 2})
+
+
+def test_turn_count_fails_with_value_in_message() -> None:
+    ctx = _ctx(turn_count=3)
+    with pytest.raises(ScenarioAssertionError) as exc:
+        run_assertion(ctx, {"type": "turn_count", "op": "==", "value": 5})
+    msg = str(exc.value)
+    assert "turn_count" in msg
+    assert "3" in msg
+    assert "== 5" in msg
+
+
+# --- last_attack_hit --------------------------------------------------------
+
+
+@dataclass
+class _StubAttackResult:
+    hit: bool
+    damage: int
+
+
+def test_last_attack_hit_passes_when_match() -> None:
+    ctx = _ctx(last_attack=_StubAttackResult(hit=True, damage=4))
+    run_assertion(ctx, {"type": "last_attack_hit", "value": True})
+
+
+def test_last_attack_hit_fails_when_no_attack_made() -> None:
+    ctx = _ctx()
+    with pytest.raises(ScenarioAssertionError) as exc:
+        run_assertion(ctx, {"type": "last_attack_hit", "value": True})
+    assert "no attack" in str(exc.value).lower()
+
+
+def test_last_attack_hit_fails_when_mismatch() -> None:
+    ctx = _ctx(last_attack=_StubAttackResult(hit=False, damage=0))
+    with pytest.raises(ScenarioAssertionError) as exc:
+        run_assertion(ctx, {"type": "last_attack_hit", "value": True})
+    assert "last_attack_hit" in str(exc.value)
+
+
+# --- last_attack_damage_in_range -------------------------------------------
+
+
+def test_last_attack_damage_in_range_passes_at_bounds() -> None:
+    for damage in (3, 5, 7):
+        ctx = _ctx(last_attack=_StubAttackResult(hit=True, damage=damage))
+        run_assertion(
+            ctx,
+            {"type": "last_attack_damage_in_range", "min": 3, "max": 7},
+        )
+
+
+def test_last_attack_damage_in_range_fails_below_min() -> None:
+    ctx = _ctx(last_attack=_StubAttackResult(hit=True, damage=2))
+    with pytest.raises(ScenarioAssertionError) as exc:
+        run_assertion(
+            ctx,
+            {"type": "last_attack_damage_in_range", "min": 3, "max": 7},
+        )
+    msg = str(exc.value)
+    assert "2" in msg
+    assert "3" in msg
+
+
+def test_last_attack_damage_in_range_fails_above_max() -> None:
+    ctx = _ctx(last_attack=_StubAttackResult(hit=True, damage=10))
+    with pytest.raises(ScenarioAssertionError):
+        run_assertion(
+            ctx,
+            {"type": "last_attack_damage_in_range", "min": 3, "max": 7},
+        )
+
+
+def test_last_attack_damage_in_range_fails_when_no_attack_made() -> None:
+    ctx = _ctx()
+    with pytest.raises(ScenarioAssertionError) as exc:
+        run_assertion(
+            ctx,
+            {"type": "last_attack_damage_in_range", "min": 1, "max": 5},
+        )
+    assert "no attack" in str(exc.value).lower()
+
+
+# --- unknown assertion type -------------------------------------------------
+
+
+def test_unknown_assertion_type_raises_clear_error() -> None:
+    ctx = _ctx()
+    with pytest.raises(ScenarioAssertionError) as exc:
+        run_assertion(ctx, {"type": "nope"})
+    assert "nope" in str(exc.value)
+    assert "unknown" in str(exc.value).lower()

--- a/dnd-engine/tests/test_script_executor.py
+++ b/dnd-engine/tests/test_script_executor.py
@@ -1,0 +1,284 @@
+# ABOUTME: Tests for the YAML scenario script executor (issue #363).
+# ABOUTME: Covers wait/attack actions, range rejection, and disadvantage flagging.
+
+"""Unit + integration tests for ``dnd_engine.scenarios.script_executor``.
+
+The executor takes a ``LoadedScenario`` (produced by ``ScenarioLoader``)
+and runs its ``script`` field — a list of action dicts — against the
+underlying ``GameState``, recording effects on a ``ScriptContext``.
+These tests verify the action vocabulary (``wait``, ``attack``), the
+disadvantage flag at long range, and the out-of-range rejection path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.scenarios import ScenarioLoader
+from dnd_engine.scenarios.script_executor import (
+    ScriptContext,
+    ScriptExecutionError,
+    ScriptExecutor,
+)
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "scenario.yaml"
+    p.write_text(body.lstrip())
+    return p
+
+
+# Inline scenario body for short-range attack tests. High-elf fighter
+# with shortbow vs a goblin 7 tiles (35 ft) away — comfortably in
+# normal range (80 ft). Seed pinned so attack rolls are reproducible.
+SHORT_RANGE_YAML = """
+name: exec_short_range
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [shortbow]
+    position: [3, 5]
+    name: Archy
+enemies:
+  - monster_id: goblin
+    position: [10, 5]
+"""
+
+# Long-range body: dagger thrown beyond normal range (20 ft) but
+# within max (60 ft). Dagger normal 20 ft → 4 tiles. Distance 5 tiles
+# = 25 ft sits in long range and must flip the disadvantage flag on.
+LONG_RANGE_YAML = """
+name: exec_long_range
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [dagger]
+    position: [3, 5]
+    name: Archy
+enemies:
+  - monster_id: goblin
+    position: [8, 5]
+"""
+
+# Out-of-range body: dagger past long range. Distance 17 tiles
+# = 85 ft, beyond dagger long range of 60 ft. Attack must be
+# rejected without invoking the engine.
+OUT_OF_RANGE_YAML = """
+name: exec_out_of_range
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [dagger]
+    position: [3, 5]
+    name: Archy
+enemies:
+  - monster_id: goblin
+    position: [20, 5]
+"""
+
+# Adjacent enemy for melee: distance 1 tile = 5 ft, well within
+# longsword's melee reach.
+MELEE_ADJACENT_YAML = """
+name: exec_melee
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [longsword]
+    position: [3, 5]
+    name: Archy
+enemies:
+  - monster_id: goblin
+    position: [4, 5]
+"""
+
+
+# --- scaffold ---------------------------------------------------------------
+
+
+def test_empty_script_is_noop(tmp_path: Path) -> None:
+    path = _write(tmp_path, SHORT_RANGE_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    ctx = ScriptExecutor(loaded).run([])
+
+    assert isinstance(ctx, ScriptContext)
+    assert ctx.turn_count == 0
+    assert ctx.last_attack is None
+    assert ctx.last_attack_error is None
+    assert ctx.game_state is loaded.game_state
+
+
+def test_executor_seeds_context_with_entity_ids(tmp_path: Path) -> None:
+    path = _write(tmp_path, SHORT_RANGE_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    ctx = ScriptExecutor(loaded).run([])
+
+    assert ctx.party_entity_ids == ["pc_archy"]
+    assert ctx.enemy_entity_ids == ["goblin_0"]
+    assert ctx.party_positions["pc_archy"] == (3, 5)
+    assert ctx.enemy_positions["goblin_0"] == (10, 5)
+
+
+# --- wait action ------------------------------------------------------------
+
+
+def test_wait_advances_turn_count(tmp_path: Path) -> None:
+    path = _write(tmp_path, SHORT_RANGE_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    ctx = ScriptExecutor(loaded).run([{"action": "wait"}])
+
+    assert ctx.turn_count == 1
+
+
+def test_wait_calls_initiative_next_turn(tmp_path: Path) -> None:
+    path = _write(tmp_path, SHORT_RANGE_YAML)
+    loaded = ScenarioLoader().load(path)
+    tracker = loaded.game_state.initiative_tracker
+    assert tracker is not None
+    starting_total = tracker.total_turns_taken
+
+    ScriptExecutor(loaded).run([{"action": "wait"}])
+
+    assert tracker.total_turns_taken == starting_total + 1
+
+
+# --- attack: in-range hit/miss path ----------------------------------------
+
+
+def test_attack_in_range_stores_attack_result(tmp_path: Path) -> None:
+    path = _write(tmp_path, SHORT_RANGE_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    ctx = ScriptExecutor(loaded).run(
+        [{"action": "attack", "target": "goblin_0"}]
+    )
+
+    assert ctx.last_attack is not None
+    assert ctx.last_attack_error is None
+    # Every AttackResult has these fields — pinning their presence guards
+    # the contract the assertions rely on without baking in a particular
+    # roll outcome.
+    assert hasattr(ctx.last_attack, "hit")
+    assert hasattr(ctx.last_attack, "damage")
+    assert hasattr(ctx.last_attack, "attack_roll")
+
+
+def test_attack_in_range_advances_turn(tmp_path: Path) -> None:
+    path = _write(tmp_path, SHORT_RANGE_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    ctx = ScriptExecutor(loaded).run(
+        [{"action": "attack", "target": "goblin_0"}]
+    )
+
+    assert ctx.turn_count == 1
+
+
+def test_melee_attack_in_range_resolves(tmp_path: Path) -> None:
+    path = _write(tmp_path, MELEE_ADJACENT_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    ctx = ScriptExecutor(loaded).run(
+        [{"action": "attack", "target": "goblin_0"}]
+    )
+
+    assert ctx.last_attack is not None
+    assert ctx.last_attack_error is None
+
+
+# --- attack: out-of-range rejection ----------------------------------------
+
+
+def test_attack_out_of_range_rejects_without_resolving(tmp_path: Path) -> None:
+    path = _write(tmp_path, OUT_OF_RANGE_YAML)
+    loaded = ScenarioLoader().load(path)
+    goblin = loaded.game_state.active_enemies[0]
+    starting_hp = goblin.current_hp
+
+    ctx = ScriptExecutor(loaded).run(
+        [{"action": "attack", "target": "goblin_0"}]
+    )
+
+    assert ctx.last_attack is None
+    assert ctx.last_attack_error is not None
+    assert "range" in ctx.last_attack_error.lower()
+    # Rejection must not consume the attacker's turn, otherwise scenarios
+    # can't deterministically distinguish "out of range" from "missed
+    # and turn passed".
+    assert ctx.turn_count == 0
+    assert goblin.current_hp == starting_hp
+
+
+# --- attack: long-range disadvantage flag ----------------------------------
+
+
+def test_attack_in_long_range_sets_disadvantage_flag(tmp_path: Path) -> None:
+    path = _write(tmp_path, LONG_RANGE_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    ctx = ScriptExecutor(loaded).run(
+        [{"action": "attack", "target": "goblin_0"}]
+    )
+
+    assert ctx.last_attack is not None
+    assert ctx.last_attack_disadvantage is True
+
+
+def test_attack_in_normal_range_leaves_disadvantage_off(tmp_path: Path) -> None:
+    path = _write(tmp_path, SHORT_RANGE_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    ctx = ScriptExecutor(loaded).run(
+        [{"action": "attack", "target": "goblin_0"}]
+    )
+
+    assert ctx.last_attack_disadvantage is False
+
+
+# --- error handling --------------------------------------------------------
+
+
+def test_unknown_target_raises_clear_error(tmp_path: Path) -> None:
+    path = _write(tmp_path, SHORT_RANGE_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    with pytest.raises(ScriptExecutionError) as exc:
+        ScriptExecutor(loaded).run(
+            [{"action": "attack", "target": "ghost_0"}]
+        )
+    assert "ghost_0" in str(exc.value)
+
+
+def test_unknown_action_raises_clear_error(tmp_path: Path) -> None:
+    path = _write(tmp_path, SHORT_RANGE_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    with pytest.raises(ScriptExecutionError) as exc:
+        ScriptExecutor(loaded).run([{"action": "teleport"}])
+    msg = str(exc.value).lower()
+    assert "teleport" in msg
+    assert "unknown" in msg


### PR DESCRIPTION
## Summary
- Closes the `feature/in-game-testing-tools` arc: YAML scenarios become executable regression tests via a parametrized pytest harness.
- Drop a YAML into `dnd-engine/tests/scenarios/yaml/auto/` and it becomes a test on the next run — no Python changes required.
- Engine-only harness: no client-2d coupling, runs whether the 2D client is installed or not.

## Changes
- **`dnd-engine/dnd_engine/scenarios/assertions.py`** *(new)*: Seven assertion runners — `entity_hp`, `entity_present`, `entity_absent`, `combat_active`, `turn_count`, `last_attack_hit`, `last_attack_damage_in_range`. Failures raise `ScenarioAssertionError` with self-explanatory messages.
- **`dnd-engine/dnd_engine/scenarios/script_executor.py`** *(new)*: `ScriptExecutor` + `ScriptContext`. Action vocabulary is `attack` and `wait`. Range parsing duplicated locally (10 lines) instead of importing from `client-2d` to keep the engine layer free of backwards cross-package dependencies.
- **`dnd-engine/dnd_engine/scenarios/loader.py`**: Added `LoadedScenario.run()` — one call drives script + assertions and returns the populated `ScriptContext`.
- **`dnd-engine/dnd_engine/scenarios/__init__.py`**: Public surface for the new types.
- **`dnd-engine/tests/conftest.py`** *(new)*: `scenario_session` fixture + `pytest.mark.scenario` discovery — explicit paths via marker args, otherwise walks `auto/`.
- **`dnd-engine/tests/scenarios/yaml/auto/*.yaml`** *(new, 5 files)*: Ranged-short-hit, ranged-long-range, ranged-out-of-range-rejected, melee-basic-hit, wait-advances-turn.
- **`dnd-engine/tests/test_*.py`** *(new, 4 files)*: 43 new tests — assertion vocabulary (22), script executor (12), `LoadedScenario.run()` (3), parametrized auto-play discovery + corruption check (6).

## Acceptance criteria (issue #363)
- [x] `uv run pytest dnd-engine/tests/test_auto_play.py` green (6 tests).
- [x] Deliberately corrupting an assertion produces a clear, useful failure — verified by `test_corrupted_assertion_produces_clear_failure`.
- [x] Adding a YAML to `auto/` auto-discovers via parametrization — verified by the structure of `pytest_generate_tests`.

## Out of scope (filed in plan for follow-up)
- Engine-side disadvantage on long-range ranged attacks (currently the harness flags it; the engine doesn't honor it).
- Refactoring the `get_attack_range` duplication in `client-2d` (`session.py` + `game.py`).
- A `move` script action.

## Test plan
- [x] `uv run pytest dnd-engine/tests/test_auto_play.py` — 6 passed.
- [x] `uv run pytest dnd-engine/tests/test_scenario_assertions.py dnd-engine/tests/test_script_executor.py dnd-engine/tests/test_loaded_scenario_run.py` — 37 passed.
- [x] Full engine suite: `uv run pytest dnd-engine/` — 2155 passed, 1 skipped (pre-existing).
- [x] Ruff lint clean across all new files.
- [ ] Reviewer to spot-check the YAMLs and confirm the assertions match expected scenario outcomes.

## Related Issues
Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)