### PR TITLE
Add reset_game dev MCP primitive (#373)

### DIFF
--- a/client-2d/src/client_2d/embedded_mcp_server.py
+++ b/client-2d/src/client_2d/embedded_mcp_server.py
@@ -305,6 +305,25 @@ class EmbeddedMCPServer:
             )
             return bridge.submit_command(request, timeout=15.0)
 
+        @mcp.tool()
+        def reset_game() -> str:
+            """Wipe party + enemies + combat state for a clean test slate.
+
+            Drops every PC and active enemy from the engine and visual
+            layers, ends combat, and resets the combat FSM. The dungeon
+            and current room are left intact so callers compose with
+            ``load_scenario`` (swap maps) and ``spawn_character`` /
+            ``spawn_monster`` (rebuild entities) afterward.
+
+            Useful between sequential scenarios in an auto-play harness.
+
+            Returns:
+                Status string with the number of party members and
+                enemies cleared, followed by the post-reset game state.
+            """
+            request = CommandRequest(command_type=CommandType.RESET_GAME)
+            return bridge.submit_command(request, timeout=5.0)
+
     def start(self) -> None:
         """Start HTTP server in background thread."""
         self._shutdown_event.clear()

--- a/client-2d/src/client_2d/entities/entity_manager.py
+++ b/client-2d/src/client_2d/entities/entity_manager.py
@@ -286,10 +286,12 @@ class EntityManager:
         return positions
 
     def collapse_party(self) -> None:
-        """Remove party member entities after combat ends.
+        """Remove all party member entities from the manager.
 
-        Called when combat ends to remove the spread party members.
-        The player returns to single-unit representation.
+        Called when combat ends (the spread formation collapses back to
+        a single-unit player representation) and by the reset_game
+        teardown primitive (#373) which wipes the party between
+        scenarios. Monsters and items are left untouched.
         """
         for entity_id in list(self._party_members.keys()):
             self._entities.pop(entity_id, None)

--- a/client-2d/src/client_2d/integration/engine_adapter.py
+++ b/client-2d/src/client_2d/integration/engine_adapter.py
@@ -902,6 +902,36 @@ class EngineAdapter:
         self._game_state.initiative_tracker = None
         return {"success": True, "cleared": cleared}
 
+    def reset_game(self) -> dict[str, Any]:
+        """Wipe party + enemies + combat state to a clean engine slate.
+
+        Test-harness teardown primitive (#373). Goes one step beyond
+        ``clear_enemies`` by also emptying the party so the next
+        ``load_scenario`` or ``spawn_character`` composes against a known
+        zero state. The dungeon / map is left intact — callers swap maps
+        via ``load_scenario`` when they need to.
+
+        Returns:
+            ``{"success": True, "cleared_party": <int>,
+            "cleared_enemies": <int>}``.
+
+        Raises:
+            ValueError: If initialize_game() has not been called.
+        """
+        if self._game_state is None:
+            raise ValueError("Must call initialize_game() first")
+        cleared_party = len(self._party.characters)
+        cleared_enemies = len(self._game_state.active_enemies)
+        self._party.characters = []
+        self._game_state.active_enemies = []
+        self._game_state.in_combat = False
+        self._game_state.initiative_tracker = None
+        return {
+            "success": True,
+            "cleared_party": cleared_party,
+            "cleared_enemies": cleared_enemies,
+        }
+
     def set_seed(self, seed: int) -> dict[str, Any]:
         """Reseed the live DiceRoller in place.
 

--- a/client-2d/src/client_2d/integration/engine_adapter.py
+++ b/client-2d/src/client_2d/integration/engine_adapter.py
@@ -911,6 +911,11 @@ class EngineAdapter:
         zero state. The dungeon / map is left intact — callers swap maps
         via ``load_scenario`` when they need to.
 
+        Mutates engine objects (``Party.characters``, ``GameState.active_enemies``,
+        ``in_combat``, ``initiative_tracker``) directly. This is the
+        established dev-mutation pattern for the adapter's test-harness
+        surface — see ``clear_enemies`` and ``set_seed`` for siblings.
+
         Returns:
             ``{"success": True, "cleared_party": <int>,
             "cleared_enemies": <int>}``.

--- a/client-2d/src/client_2d/mcp_bridge.py
+++ b/client-2d/src/client_2d/mcp_bridge.py
@@ -38,6 +38,7 @@ class CommandType(Enum):
     CLEAR_ENEMIES = auto()
     SET_SEED = auto()
     LOAD_SCENARIO = auto()
+    RESET_GAME = auto()
 
 
 @dataclass

--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -673,6 +673,8 @@ class GameSession:
                 result = self.set_seed(request.args.get("seed", 0))
             elif request.command_type == CommandType.LOAD_SCENARIO:
                 result = self.load_scenario(request.args.get("path", ""))
+            elif request.command_type == CommandType.RESET_GAME:
+                result = self.reset_game()
             else:
                 result = f"Unknown command: {request.command_type}"
             request.response_future.set_result(result)

--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -184,9 +184,7 @@ class GameSession:
             print(f"  Combat started! Enemies: {', '.join(start_info['enemies'])}")
             self.current_mode = GameMode.COMBAT
             self._spread_party_for_combat()
-            self._add_combat_log(
-                f"Combat begins! {len(start_info['enemies'])} enemies!"
-            )
+            self._add_combat_log(f"Combat begins! {len(start_info['enemies'])} enemies!")
             current = self.engine.get_current_combatant()
             if current:
                 self._add_combat_log(f"{current['name']}'s turn first!")
@@ -342,9 +340,7 @@ class GameSession:
         dungeon_name = game_state.dungeon_name
         campaign_id = game_state.campaign_id
 
-        room_data = self.layout_loader.get_room_data(
-            dungeon_name, room_id, campaign_id
-        )
+        room_data = self.layout_loader.get_room_data(dungeon_name, room_id, campaign_id)
         exits = {}
         if room_data:
             raw_exits = room_data.get("exits", {})
@@ -431,8 +427,7 @@ class GameSession:
         new_y = self.player_y + dy
 
         if self.room_layout and (
-            0 <= new_x < self.room_layout.width
-            and 0 <= new_y < self.room_layout.height
+            0 <= new_x < self.room_layout.width and 0 <= new_y < self.room_layout.height
         ):
             if not self.room_layout.is_blocking(new_x, new_y):
                 self.player_x = new_x
@@ -458,9 +453,7 @@ class GameSession:
                 enemies = [e.name for e in game_state.active_enemies]
                 self.current_mode = GameMode.COMBAT
                 self._spread_party_for_combat()
-                self._add_combat_log(
-                    f"Combat! {len(enemies)} enemies: {', '.join(enemies)}"
-                )
+                self._add_combat_log(f"Combat! {len(enemies)} enemies: {', '.join(enemies)}")
                 current = self.engine.get_current_combatant()
                 if current:
                     if current["is_player"]:
@@ -489,9 +482,7 @@ class GameSession:
                     if result.get("target_killed"):
                         self._add_combat_log(f"{result['target_name']} is down!")
                 else:
-                    self._add_combat_log(
-                        f"{result['enemy_name']} misses {result['target_name']}!"
-                    )
+                    self._add_combat_log(f"{result['enemy_name']} misses {result['target_name']}!")
             else:
                 self._add_combat_log(f"{result['enemy_name']} takes no action.")
 
@@ -519,17 +510,14 @@ class GameSession:
             return
 
         if result.already_stabilized:
-            self._add_combat_log(
-                f"{result.character_name} is stabilized (no death save needed)"
-            )
+            self._add_combat_log(f"{result.character_name} is stabilized (no death save needed)")
         elif result.natural_20:
             self._add_combat_log(
                 f"{result.character_name} rolls NAT 20! Regains consciousness with 1 HP!"
             )
         elif result.natural_1:
             self._add_combat_log(
-                f"{result.character_name} rolls NAT 1! Two failures! "
-                f"({result.failures}/3)"
+                f"{result.character_name} rolls NAT 1! Two failures! ({result.failures}/3)"
             )
         elif result.success:
             self._add_combat_log(
@@ -611,9 +599,7 @@ class GameSession:
 
             return result
 
-        self._add_combat_log(
-            f"Attack failed: {result.get('error', 'Unknown error')}"
-        )
+        self._add_combat_log(f"Attack failed: {result.get('error', 'Unknown error')}")
         return None
 
     def pass_turn(self) -> None:
@@ -655,9 +641,7 @@ class GameSession:
             elif request.command_type == CommandType.MOVE:
                 result = self.move(request.args.get("direction", ""))
             elif request.command_type == CommandType.ATTACK:
-                target = request.args.get(
-                    "target", request.args.get("target_index", 0)
-                )
+                target = request.args.get("target", request.args.get("target_index", 0))
                 result = self.attack(target)
             elif request.command_type == CommandType.WAIT:
                 result = self.wait()
@@ -699,11 +683,7 @@ class GameSession:
 
     def get_state(self) -> str:
         """Generate the ASCII state string used by MCP and headless reporting."""
-        if (
-            self._state_renderer is None
-            or self.room_layout is None
-            or self.fog is None
-        ):
+        if self._state_renderer is None or self.room_layout is None or self.fog is None:
             # Lazy-init the state renderer so headless mode and tests can
             # call get_state() before initialize_mcp_server() is invoked.
             if self.room_layout is not None and self._state_renderer is None:
@@ -711,11 +691,7 @@ class GameSession:
                     width=self.room_layout.width,
                     height=self.room_layout.height,
                 )
-            if (
-                self._state_renderer is None
-                or self.room_layout is None
-                or self.fog is None
-            ):
+            if self._state_renderer is None or self.room_layout is None or self.fog is None:
                 return "Game not initialized"
 
         entities = self._build_state_entities()
@@ -769,11 +745,7 @@ class GameSession:
 
             display_id = entity.sub_type or entity.entity_id
             unique_suffix = entity.entity_id.split("_")[-1]
-            unique_id = (
-                f"{display_id}_{unique_suffix}"
-                if entity.sub_type
-                else entity.entity_id
-            )
+            unique_id = f"{display_id}_{unique_suffix}" if entity.sub_type else entity.entity_id
 
             entities.append(
                 StateEntity(
@@ -812,18 +784,12 @@ class GameSession:
                         weapon_name = "Unarmed"
                         range_text = "5 ft (melee)"
                         if hasattr(creature, "inventory"):
-                            weapon_id = creature.inventory.get_equipped_item(
-                                EquipmentSlot.WEAPON
-                            )
+                            weapon_id = creature.inventory.get_equipped_item(EquipmentSlot.WEAPON)
                             if weapon_id and self.engine.game_state:
-                                items_data = (
-                                    self.engine.game_state.data_loader.load_items(
-                                        self.engine.game_state.campaign_id
-                                    )
+                                items_data = self.engine.game_state.data_loader.load_items(
+                                    self.engine.game_state.campaign_id
                                 )
-                                weapon_data = items_data.get("weapons", {}).get(
-                                    weapon_id, {}
-                                )
+                                weapon_data = items_data.get("weapons", {}).get(weapon_id, {})
                                 weapon_name = weapon_data.get(
                                     "name", weapon_id.replace("_", " ").title()
                                 )
@@ -834,13 +800,15 @@ class GameSession:
                                     range_text = "5 ft (melee)"
                         lines.append(f"Equipped: {weapon_name} (range: {range_text})")
 
-        lines.extend([
-            "",
-            "Map:",
-            state_dict["map"],
-            "",
-            "Legend:",
-        ])
+        lines.extend(
+            [
+                "",
+                "Map:",
+                state_dict["map"],
+                "",
+                "Legend:",
+            ]
+        )
 
         for symbol, entity in state_dict["legend"].items():
             lines.append(f"  {symbol} = {entity}")
@@ -871,9 +839,7 @@ class GameSession:
         if self.engine.in_combat:
             turn_state = self.engine.get_current_turn_state()
             if turn_state:
-                lines.append(
-                    f"  Movement: {turn_state.movement_remaining} ft remaining"
-                )
+                lines.append(f"  Movement: {turn_state.movement_remaining} ft remaining")
             lines.append("  - game_move(direction) - Move north/south/east/west")
             lines.append("  - game_attack(target) - Attack enemy in weapon range")
             lines.append("  - game_wait() - Pass turn")
@@ -906,10 +872,7 @@ class GameSession:
         if turn_state.movement_remaining < 5:
             current = self.engine.get_current_combatant()
             speed = current["creature"].speed if current else 30
-            return (
-                f"No movement remaining (0/{speed} ft). "
-                f"Use game_attack() or game_wait()."
-            )
+            return f"No movement remaining (0/{speed} ft). Use game_attack() or game_wait()."
 
         dx, dy = {
             "north": (0, -1),
@@ -921,8 +884,7 @@ class GameSession:
         new_y = self.player_y + dy
 
         if not self.room_layout or not (
-            0 <= new_x < self.room_layout.width
-            and 0 <= new_y < self.room_layout.height
+            0 <= new_x < self.room_layout.width and 0 <= new_y < self.room_layout.height
         ):
             return "Path blocked! Cannot move outside room."
 
@@ -930,10 +892,7 @@ class GameSession:
             return "Path blocked! Wall in the way."
 
         entity_at_dest = self.entity_manager.get_at_position(new_x, new_y)
-        if (
-            entity_at_dest is not None
-            and entity_at_dest in self.entity_manager.get_monsters()
-        ):
+        if entity_at_dest is not None and entity_at_dest in self.entity_manager.get_monsters():
             if entity_at_dest._creature_ref:
                 name = entity_at_dest._creature_ref.name
             else:
@@ -945,15 +904,10 @@ class GameSession:
         turn_state.consume_movement(5)
         self._update_lighting()
 
-        self.entity_manager.update_current_turn_position(
-            self.engine, new_x, new_y
-        )
+        self.entity_manager.update_current_turn_position(self.engine, new_x, new_y)
 
         remaining = turn_state.movement_remaining
-        return (
-            f"Moved {direction}. Movement remaining: {remaining} ft.\n"
-            + self.get_state()
-        )
+        return f"Moved {direction}. Movement remaining: {remaining} ft.\n" + self.get_state()
 
     def attack(self, target: int | str) -> str:
         """Attack a target enemy by index or entity ID."""
@@ -983,14 +937,10 @@ class GameSession:
             )
             if target_entity is None:
                 valid_ids = [
-                    f"{m.sub_type}_{m.entity_id.split('_')[-1]}"
-                    if m.sub_type
-                    else m.entity_id
+                    f"{m.sub_type}_{m.entity_id.split('_')[-1]}" if m.sub_type else m.entity_id
                     for m in monsters
                 ]
-                return (
-                    f"Unknown target: {target}. Valid targets: {', '.join(valid_ids)}"
-                )
+                return f"Unknown target: {target}. Valid targets: {', '.join(valid_ids)}"
 
         from dnd_engine.core.distance import distance_in_feet
         from dnd_engine.systems.inventory import EquipmentSlot
@@ -1017,18 +967,14 @@ class GameSession:
                         self.engine.game_state.campaign_id
                     )
                     weapon_data = items_data.get("weapons", {}).get(weapon_id, {})
-                    weapon_name = weapon_data.get(
-                        "name", weapon_id.replace("_", " ").title()
-                    )
+                    weapon_name = weapon_data.get("name", weapon_id.replace("_", " ").title())
 
         normal_range, max_range = get_attack_range(weapon_data)
 
         if distance_ft > max_range:
             turn_state = self.engine.get_current_turn_state()
             movement_info = (
-                f" Movement remaining: {turn_state.movement_remaining} ft."
-                if turn_state
-                else ""
+                f" Movement remaining: {turn_state.movement_remaining} ft." if turn_state else ""
             )
             return (
                 f"Out of range! ({distance_ft} ft away, "
@@ -1169,8 +1115,7 @@ class GameSession:
                 self._spread_party_for_combat()
 
         return (
-            f"Spawned {result['name']} at ({x},{y}) as {result['entity_id']}. "
-            + self.get_state()
+            f"Spawned {result['name']} at ({x},{y}) as {result['entity_id']}. " + self.get_state()
         )
 
     def spawn_character(
@@ -1216,10 +1161,7 @@ class GameSession:
             return f"Entity '{entity_id}' not found on the map."
         target.grid_x = x
         target.grid_y = y
-        return (
-            f"Moved {entity_id} to {tuple(result['position'])}. "
-            + self.get_state()
-        )
+        return f"Moved {entity_id} to {tuple(result['position'])}. " + self.get_state()
 
     def clear_enemies(self) -> str:
         """Wipe enemies from engine and visual layer."""
@@ -1231,6 +1173,39 @@ class GameSession:
         if self.current_mode == GameMode.COMBAT:
             self.current_mode = GameMode.EXPLORATION
         return f"Cleared {result['cleared']} enemies. " + self.get_state()
+
+    def reset_game(self) -> str:
+        """Wipe party + enemies + combat state for clean scenario reuse.
+
+        Test-harness teardown primitive (#373). Goes one step beyond
+        ``clear_enemies`` by also dropping party-member entities so the
+        next ``load_scenario`` or ``spawn_character`` composes against a
+        known zero state. The room layout / fog / lighting stay intact.
+        """
+        result = self.engine.reset_game()
+
+        # Drop monsters via the existing dead-removal path.
+        for monster in self.entity_manager.get_monsters():
+            monster.is_alive = False
+        self.entity_manager.remove_dead_entities()
+
+        # remove_dead_entities intentionally preserves party members for
+        # resurrection flows; reset_game wipes them explicitly.
+        for party_member in list(self.entity_manager.get_party_members()):
+            self.entity_manager._entities.pop(party_member.entity_id, None)
+            self.entity_manager._party_members.pop(party_member.entity_id, None)
+
+        if self.current_mode == GameMode.COMBAT:
+            self.current_mode = GameMode.EXPLORATION
+        self.processing_enemy_turn = False
+        self.enemy_turn_timer = 0.0
+        self.party_spread = False
+        self.party_positions = []
+
+        return (
+            f"Reset game ({result['cleared_party']} party, "
+            f"{result['cleared_enemies']} enemies cleared). " + self.get_state()
+        )
 
     def set_seed(self, seed: int) -> str:
         """Reseed the engine dice roller."""
@@ -1270,9 +1245,7 @@ class GameSession:
                 sub_type=character.character_class.value.lower(),
                 party_index=game_state.party.characters.index(character),
                 character_class=character.character_class.value.lower(),
-                texture=self.character_textures.get(
-                    character.character_class.value.lower()
-                ),
+                texture=self.character_textures.get(character.character_class.value.lower()),
             )
             entity.creature = character
             self.entity_manager._add_entity(entity)
@@ -1303,8 +1276,7 @@ class GameSession:
         # dim view because _load_room_layout lit the fog around the room
         # spawn point, not the scenario's PC positions. #372.
         scenario_party_positions = [
-            (e.grid_x, e.grid_y)
-            for e in self.entity_manager.get_party_members()
+            (e.grid_x, e.grid_y) for e in self.entity_manager.get_party_members()
         ]
         if scenario_party_positions:
             self.player_x, self.player_y = scenario_party_positions[0]
@@ -1317,7 +1289,4 @@ class GameSession:
         else:
             self.current_mode = GameMode.EXPLORATION
 
-        return (
-            f"Loaded scenario '{result['name']}' (seed={result['seed']}). "
-            + self.get_state()
-        )
+        return f"Loaded scenario '{result['name']}' (seed={result['seed']}). " + self.get_state()

--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -1192,10 +1192,8 @@ class GameSession:
         self.entity_manager.remove_dead_entities()
 
         # remove_dead_entities intentionally preserves party members for
-        # resurrection flows; reset_game wipes them explicitly.
-        for party_member in list(self.entity_manager.get_party_members()):
-            self.entity_manager._entities.pop(party_member.entity_id, None)
-            self.entity_manager._party_members.pop(party_member.entity_id, None)
+        # resurrection flows; collapse_party drops them unconditionally.
+        self.entity_manager.collapse_party()
 
         if self.current_mode == GameMode.COMBAT:
             self.current_mode = GameMode.EXPLORATION

--- a/client-2d/tests/test_dev_mode_mcp.py
+++ b/client-2d/tests/test_dev_mode_mcp.py
@@ -21,6 +21,7 @@ DEV_TOOL_NAMES = {
     "clear_enemies",
     "set_seed",
     "load_scenario",
+    "reset_game",
 }
 
 PLAY_TOOL_NAMES = {"game_state", "game_move", "game_attack", "game_wait"}

--- a/client-2d/tests/test_engine_adapter_spawn.py
+++ b/client-2d/tests/test_engine_adapter_spawn.py
@@ -1,5 +1,5 @@
-# ABOUTME: Tests for EngineAdapter dev-mode spawn/setup methods (#360).
-# ABOUTME: Covers set_seed, spawn_monster, spawn_character, set_position, clear_enemies.
+# ABOUTME: Tests for EngineAdapter dev-mode spawn/setup methods (#360, #373).
+# ABOUTME: Covers set_seed, spawn_monster, spawn_character, set_position, clear_enemies, reset_game.
 
 """Tests for the engine adapter's dev-mode spawn primitives.
 
@@ -278,3 +278,44 @@ class TestClearEnemies:
 
         with pytest.raises(ValueError, match="initialize_game"):
             EngineAdapter().clear_enemies()
+
+
+class TestResetGame:
+    """EngineAdapter.reset_game wipes party + enemies + combat state (#373)."""
+
+    def test_clears_party_enemies_and_combat(self, initialized_adapter) -> None:
+        """Reset returns a fully empty engine state and ends combat."""
+        adapter = initialized_adapter
+        adapter.spawn_character(
+            "fighter", "human", ["longsword"], 5, 5, name="Extra",
+        )
+        adapter.spawn_monster("goblin", 12, 7)
+        adapter.spawn_monster("goblin", 14, 7)
+        assert len(adapter.party.characters) == 2
+        assert len(adapter.game_state.active_enemies) == 2
+        assert adapter.in_combat
+
+        result = adapter.reset_game()
+
+        assert result == {"success": True, "cleared_party": 2, "cleared_enemies": 2}
+        assert adapter.party.characters == []
+        assert adapter.game_state.active_enemies == []
+        assert not adapter.in_combat
+        assert adapter.game_state.initiative_tracker is None
+
+    def test_noop_when_already_empty(self, initialized_adapter) -> None:
+        """Calling reset after another reset returns zero counts."""
+        adapter = initialized_adapter
+        adapter.reset_game()
+
+        result = adapter.reset_game()
+
+        assert result == {"success": True, "cleared_party": 0, "cleared_enemies": 0}
+        assert adapter.party.characters == []
+        assert not adapter.in_combat
+
+    def test_raises_when_not_initialized(self) -> None:
+        from client_2d.integration.engine_adapter import EngineAdapter
+
+        with pytest.raises(ValueError, match="initialize_game"):
+            EngineAdapter().reset_game()

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -321,3 +321,38 @@ class TestSessionResetGame:
         assert len(session.engine.game_state.active_enemies) == 1
         assert len(session.entity_manager.get_party_members()) == 1
         assert len(session.entity_manager.get_monsters()) == 1
+
+
+class TestSessionResetGameMCPDispatch:
+    """Tests for the MCP bridge dispatch path of reset_game (#373).
+
+    Exercises the same path the HTTP MCP server uses: queue a
+    CommandRequest with CommandType.RESET_GAME and let _process_mcp_commands
+    drain it. The session must invoke its reset_game() and resolve the
+    response future with the returned status string.
+    """
+
+    def test_process_mcp_command_routes_reset_game(self, session) -> None:
+        """Submitting RESET_GAME via the bridge wipes engine + entity state."""
+        from client_2d.mcp_bridge import CommandRequest, CommandType, MCPBridge
+
+        bridge = MCPBridge()
+        bridge.set_session(session)
+        session._mcp_bridge = bridge
+
+        request = CommandRequest(command_type=CommandType.RESET_GAME)
+        bridge._command_queue.put(request)
+
+        session._process_mcp_commands()
+
+        # Future resolved with the session's status string.
+        result = request.response_future.result(timeout=0.1)
+        assert isinstance(result, str)
+        assert "party" in result.lower()
+        assert "enemies" in result.lower()
+
+        # And the state was actually wiped.
+        assert session.engine.party.characters == []
+        assert session.engine.game_state.active_enemies == []
+        assert session.entity_manager.get_party_members() == []
+        assert session.entity_manager.get_monsters() == []

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -17,13 +17,7 @@ import pytest
 # Path to the starter scenarios shipped with the engine. The session
 # accepts any filesystem path; we use the ranged-attack basic scenario
 # as a deterministic fixture.
-SCENARIO_DIR = (
-    Path(__file__).parent.parent.parent
-    / "dnd-engine"
-    / "tests"
-    / "scenarios"
-    / "yaml"
-)
+SCENARIO_DIR = Path(__file__).parent.parent.parent / "dnd-engine" / "tests" / "scenarios" / "yaml"
 
 
 @pytest.fixture
@@ -71,9 +65,7 @@ class TestSessionLoadScenario:
         assert session.engine.party is not None
         assert session.engine.party.characters[0].name == "Archy"
         assert len(session.engine.game_state.active_enemies) == 1
-        assert session.engine.game_state.active_enemies[0].name.lower().startswith(
-            "goblin"
-        )
+        assert session.engine.game_state.active_enemies[0].name.lower().startswith("goblin")
 
     def test_load_scenario_populates_entity_manager(self, session) -> None:
         """The entity manager mirrors the scenario's party and enemies."""
@@ -116,16 +108,12 @@ class TestSessionSpawn:
     def test_spawn_character_adds_party_member(self, session) -> None:
         """spawn_character extends the party via the engine adapter."""
         before = len(session.engine.party.characters)
-        session.spawn_character(
-            "fighter", "human", ["longsword"], 4, 5, name="Probe"
-        )
+        session.spawn_character("fighter", "human", ["longsword"], 4, 5, name="Probe")
         after = len(session.engine.party.characters)
         assert after == before + 1
         assert session.engine.party.characters[-1].name == "Probe"
 
-    def test_spawn_monster_from_exploration_keeps_party_positions(
-        self, session
-    ) -> None:
+    def test_spawn_monster_from_exploration_keeps_party_positions(self, session) -> None:
         """Re-entering combat via spawn_monster must not stomp PartyMemberEntity positions.
 
         Regression for #371: when current_mode was EXPLORATION, spawn_monster
@@ -137,8 +125,7 @@ class TestSessionSpawn:
         session.clear_enemies()
         assert session.engine.in_combat is False
         before = {
-            e.entity_id: (e.grid_x, e.grid_y)
-            for e in session.entity_manager.get_party_members()
+            e.entity_id: (e.grid_x, e.grid_y) for e in session.entity_manager.get_party_members()
         }
         assert before, "fixture should have at least one party member"
 
@@ -146,8 +133,7 @@ class TestSessionSpawn:
 
         # Same ids, same positions — no spread.
         after = {
-            e.entity_id: (e.grid_x, e.grid_y)
-            for e in session.entity_manager.get_party_members()
+            e.entity_id: (e.grid_x, e.grid_y) for e in session.entity_manager.get_party_members()
         }
         assert after == before
 
@@ -181,31 +167,26 @@ class TestSessionSpawn:
         # Visible-entities entry from render_state.
         assert f"goblin_0 at [{gx}, {gy}]" in state
 
-    def test_spawn_monster_in_combat_preserves_party_positions(
-        self, session
-    ) -> None:
+    def test_spawn_monster_in_combat_preserves_party_positions(self, session) -> None:
         """Spawning a second enemy while already in combat must not respread.
 
         Pins the existing in-combat path: party positions stay put, second
         monster gets entity_id <monster_id>_1 at the requested tile.
         """
         before = {
-            e.entity_id: (e.grid_x, e.grid_y)
-            for e in session.entity_manager.get_party_members()
+            e.entity_id: (e.grid_x, e.grid_y) for e in session.entity_manager.get_party_members()
         }
         assert session.engine.in_combat is True
 
         session.spawn_monster("goblin", 8, 6)
 
         after = {
-            e.entity_id: (e.grid_x, e.grid_y)
-            for e in session.entity_manager.get_party_members()
+            e.entity_id: (e.grid_x, e.grid_y) for e in session.entity_manager.get_party_members()
         }
         assert after == before
 
         monsters = {
-            e.entity_id: (e.grid_x, e.grid_y)
-            for e in session.entity_manager.get_monsters()
+            e.entity_id: (e.grid_x, e.grid_y) for e in session.entity_manager.get_monsters()
         }
         # Scenario fixture starts with goblin_0; second spawn is goblin_1.
         assert "goblin_1" in monsters
@@ -257,3 +238,86 @@ class TestMCPServerWiring:
         s.initialize_mcp_server(start_http=False)
         assert s._mcp_bridge is not None
         assert s._mcp_server is not None
+
+
+class TestSessionResetGame:
+    """Tests for the session-layer reset_game primitive (#373).
+
+    reset_game must wipe both the engine layer (party + active_enemies +
+    combat) AND the visual entity manager (party members + monsters), so
+    a subsequent load_scenario or spawn_character composes against a
+    clean slate. The room layout / fog / lighting stay intact - callers
+    swap maps via load_scenario when they need a different room.
+    """
+
+    def test_reset_game_clears_engine_party_and_enemies(self, session) -> None:
+        """Engine state must be empty of party + enemies after reset."""
+        # Fixture loaded a scenario with at least one PC and one goblin.
+        assert len(session.engine.party.characters) >= 1
+        assert len(session.engine.game_state.active_enemies) >= 1
+
+        session.reset_game()
+
+        assert session.engine.party.characters == []
+        assert session.engine.game_state.active_enemies == []
+
+    def test_reset_game_clears_entity_manager_party_and_monsters(self, session) -> None:
+        """Visual entities for party + monsters must be dropped."""
+        assert session.entity_manager.get_party_members(), "fixture should populate party members"
+        assert session.entity_manager.get_monsters(), "fixture should populate monsters"
+
+        session.reset_game()
+
+        assert session.entity_manager.get_party_members() == []
+        assert session.entity_manager.get_monsters() == []
+
+    def test_reset_game_exits_combat_mode(self, session) -> None:
+        """Combat flag + mode flip out of combat after reset."""
+        from client_2d.core.constants import GameMode
+
+        assert session.engine.in_combat is True
+        session.current_mode = GameMode.COMBAT
+        session.processing_enemy_turn = True
+
+        session.reset_game()
+
+        assert session.engine.in_combat is False
+        assert session.current_mode == GameMode.EXPLORATION
+        assert session.processing_enemy_turn is False
+
+    def test_reset_game_preserves_room_layout(self, session) -> None:
+        """Room layout / tiles stay intact - reset wipes entities, not the map."""
+        room_layout_before = session.room_layout
+        room_tiles_before = session.room_tiles
+
+        session.reset_game()
+
+        assert session.room_layout is room_layout_before
+        assert session.room_tiles is room_tiles_before
+
+    def test_reset_game_returns_status_string(self, session) -> None:
+        """Returns a string suitable for surfacing through MCP."""
+        result = session.reset_game()
+        assert isinstance(result, str)
+        # Mentions both counts so the caller can verify what was cleared.
+        assert "party" in result.lower()
+        assert "enemies" in result.lower()
+
+    def test_reset_game_idempotent(self, session) -> None:
+        """Calling reset twice in a row must not raise."""
+        session.reset_game()
+        # Second call against the already-empty state should be a no-op.
+        session.reset_game()
+        assert session.engine.party.characters == []
+        assert session.engine.game_state.active_enemies == []
+
+    def test_reset_game_then_load_scenario_composes(self, session) -> None:
+        """After reset, load_scenario rebuilds party + enemies cleanly."""
+        session.reset_game()
+        session.load_scenario(SCENARIO_DIR / "ranged_attack_basic.yaml")
+
+        # Scenario has 1 party member + 1 goblin; no leftover duplicates.
+        assert len(session.engine.party.characters) == 1
+        assert len(session.engine.game_state.active_enemies) == 1
+        assert len(session.entity_manager.get_party_members()) == 1
+        assert len(session.entity_manager.get_monsters()) == 1

--- a/client-2d/tests/test_mcp_bridge_dev_commands.py
+++ b/client-2d/tests/test_mcp_bridge_dev_commands.py
@@ -18,6 +18,7 @@ DEV_COMMAND_NAMES = (
     "CLEAR_ENEMIES",
     "SET_SEED",
     "LOAD_SCENARIO",
+    "RESET_GAME",
 )
 
 


### PR DESCRIPTION
## Summary

Adds a `reset_game()` dev-mode MCP primitive that wipes party + active enemies + combat state in one call, unblocking back-to-back scenario testing for the #363 auto-play harness. Composes with `load_scenario` (swap maps) and `spawn_character` / `spawn_monster` (rebuild entities) without leaking state between runs.

The dungeon / current room is intentionally left intact — callers swap maps via `load_scenario` when they need a different room.

## Implementation

Four TDD cycles across the four architectural layers (matching the existing `clear_enemies` / `set_seed` / `load_scenario` shape):

1. **EngineAdapter.reset_game()** — clears `party.characters`, `active_enemies`, ends combat, drops the initiative tracker. Returns `{success, cleared_party, cleared_enemies}`.
2. **GameSession.reset_game()** — wraps the engine call with visual teardown: drops monster + party-member entities, exits combat mode, resets the combat FSM (`processing_enemy_turn`, `enemy_turn_timer`, `party_spread`).
3. **MCP bridge** — `CommandType.RESET_GAME` enum variant + dispatch case in `GameSession._process_mcp_commands`.
4. **Dev-mode MCP tool** — `reset_game` registered alongside the other `--dev` spawn / setup tools on `EmbeddedMCPServer`; gated by `dev_mode=True` so it never leaks into normal play.

Closes #373.

## Test plan

- [x] All 401 client-2d tests passing locally (`uv run pytest`)
- [x] All 25 engine adapter spawn tests passing (cycle 1 layer)
- [x] All 22 game session tests passing (cycle 2 + 3 layers)
- [x] All 5 dev-mode MCP gating tests passing (cycle 4 layer)
- [x] Ruff lint + format clean
- [ ] Manual: run `uv run dnd-2d --headless --dev --mcp`, call `reset_game()` via MCP between two `load_scenario` calls, verify state doesn't leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)