### PR TITLE
Refactor #316: Remove Rich dependency from dnd-engine via DI

### DIFF
--- a/client-terminal/terminal_client/ui/rich_ui.py
+++ b/client-terminal/terminal_client/ui/rich_ui.py
@@ -1,7 +1,8 @@
 # ABOUTME: Rich UI utilities for enhanced terminal display
 # ABOUTME: Provides reusable rich components for formatting game output
 
-from typing import Any
+import sys
+from typing import Any, TextIO
 
 from rich import box
 from rich.align import Align
@@ -10,10 +11,33 @@ from rich.panel import Panel
 from rich.style import Style
 from rich.table import Table
 
-from dnd_engine.utils.logging_config import MAX_CONSOLE_WIDTH, init_logging
+from dnd_engine.utils.logging_config import MAX_CONSOLE_WIDTH, TeeFile, init_logging
 
 # Global console instance - initialized via init_console()
 console = Console(width=MAX_CONSOLE_WIDTH)
+
+
+def _rich_console_factory(log_file: TextIO | None) -> Console:
+    """
+    Build the terminal client's Rich console.
+
+    Injected into ``LoggingConfig`` so the engine never has to import
+    Rich. When debug mode is on, the engine hands us the open log file
+    and we wrap it in a ``TeeFile`` so console output is mirrored to
+    disk.
+
+    Args:
+        log_file: Live log file handle when debug mode is on, else None.
+    """
+    if log_file is not None:
+        tee_file = TeeFile(log_file, sys.stdout)
+        return Console(
+            file=tee_file,
+            force_terminal=True,
+            legacy_windows=False,
+            width=MAX_CONSOLE_WIDTH,
+        )
+    return Console(width=MAX_CONSOLE_WIDTH)
 
 
 def init_console(debug_mode: bool = False) -> None:
@@ -28,10 +52,7 @@ def init_console(debug_mode: bool = False) -> None:
     """
     global console
 
-    # Initialize logging config
-    logging_config = init_logging(debug_mode)
-
-    # Create console (will be dual-output if debug enabled)
+    logging_config = init_logging(debug_mode, console_factory=_rich_console_factory)
     console = logging_config.create_console()
 
 

--- a/dnd-engine/dnd_engine/utils/logging_config.py
+++ b/dnd-engine/dnd_engine/utils/logging_config.py
@@ -1,5 +1,6 @@
 # ABOUTME: Debug logging configuration for dual console/file output
-# ABOUTME: Manages log file rotation, timestamps, and Rich console integration
+# ABOUTME: Manages log file rotation, timestamps, and a UI-toolkit-agnostic
+# ABOUTME: console factory hook so clients can plug in their own renderer.
 
 import logging
 from collections.abc import Callable
@@ -21,8 +22,8 @@ class TeeFile:
     """
     File-like object that writes to both stdout and a log file.
 
-    This allows Rich console output to be simultaneously displayed
-    in the terminal and captured to a log file.
+    Lets a UI client mirror terminal output into a log file by passing
+    a ``TeeFile`` wherever a writable stream is expected.
     """
 
     def __init__(self, file: TextIO, stdout: TextIO):
@@ -49,8 +50,8 @@ class TeeFile:
         # Write to stdout
         self.stdout.write(text)
 
-        # Write to file (will be plain text without ANSI codes
-        # because the console was created with force_terminal=False)
+        # Write to file. Any ANSI / styling decisions are the caller's
+        # responsibility — this class is a plain stream tee.
         self.file.write(text)
 
         return len(text)
@@ -74,7 +75,8 @@ class LoggingConfig:
     - Generate timestamped log files
     - Rotate old log files (keep last 10)
     - Set up Python logging
-    - Create dual-output Rich console
+    - Dispatch console creation to an injected UI factory so the engine
+      itself stays UI-toolkit agnostic
     """
 
     def __init__(

--- a/dnd-engine/dnd_engine/utils/logging_config.py
+++ b/dnd-engine/dnd_engine/utils/logging_config.py
@@ -7,9 +7,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, TextIO
 
-from rich.console import Console
-
-# Maximum console width for readable output
+# Maximum console width for readable output. Kept here for backwards
+# compatibility with UI clients that import it; the engine itself no longer
+# builds consoles.
 MAX_CONSOLE_WIDTH = 100
 
 # A console factory is given the active log-file handle (or None when debug is
@@ -97,7 +97,6 @@ class LoggingConfig:
         self.console_factory = console_factory
         self.log_file_path: Path | None = None
         self.log_file: TextIO | None = None
-        self.tee_console: Console | None = None
         self._event_counter = 0
 
         if debug_enabled:

--- a/dnd-engine/dnd_engine/utils/logging_config.py
+++ b/dnd-engine/dnd_engine/utils/logging_config.py
@@ -2,15 +2,19 @@
 # ABOUTME: Manages log file rotation, timestamps, and Rich console integration
 
 import logging
-import sys
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import TextIO
+from typing import Any, TextIO
 
 from rich.console import Console
 
 # Maximum console width for readable output
 MAX_CONSOLE_WIDTH = 100
+
+# A console factory is given the active log-file handle (or None when debug is
+# off) and returns whatever console object the UI client wants to use.
+ConsoleFactory = Callable[[TextIO | None], Any]
 
 
 class TeeFile:
@@ -73,14 +77,24 @@ class LoggingConfig:
     - Create dual-output Rich console
     """
 
-    def __init__(self, debug_enabled: bool = False):
+    def __init__(
+        self,
+        debug_enabled: bool = False,
+        console_factory: ConsoleFactory | None = None,
+    ):
         """
         Initialize logging configuration.
 
         Args:
             debug_enabled: Whether debug mode is enabled
+            console_factory: Optional callable that builds a UI console. It is
+                invoked by ``create_console()`` and receives the active log
+                file handle when debug mode is on, ``None`` otherwise. Keeps
+                this module free of any UI-toolkit dependency; clients (e.g.
+                the Rich-based terminal UI) inject their own factory.
         """
         self.debug_enabled = debug_enabled
+        self.console_factory = console_factory
         self.log_file_path: Path | None = None
         self.log_file: TextIO | None = None
         self.tee_console: Console | None = None
@@ -150,30 +164,22 @@ class LoggingConfig:
             # Add handler to logger
             logger.addHandler(file_handler)
 
-    def create_console(self) -> Console:
+    def create_console(self) -> Any:
         """
-        Create a Rich console that optionally writes to log file.
+        Build a UI console via the injected factory.
+
+        The active log file is passed to the factory when debug mode is on
+        (so the factory can wrap it for dual stdout/file output), and ``None``
+        otherwise. When no factory was injected the engine has no UI to build,
+        and this returns ``None`` — appropriate for headless callers.
 
         Returns:
-            Rich Console instance
+            Whatever the factory returns, or ``None`` if no factory was given.
         """
-        if self.debug_enabled and self.log_file:
-            # Create TeeFile that writes to both stdout and log file
-            tee_file = TeeFile(self.log_file, sys.stdout)
-
-            # Create console with dual output
-            # force_terminal=False strips ANSI codes from file output
-            self.tee_console = Console(
-                file=tee_file,
-                force_terminal=True,  # Keep colors for terminal
-                legacy_windows=False,
-                width=MAX_CONSOLE_WIDTH,
-            )
-
-            return self.tee_console
-        else:
-            # Normal console without file logging
-            return Console(width=MAX_CONSOLE_WIDTH)
+        if self.console_factory is None:
+            return None
+        log_file = self.log_file if self.debug_enabled else None
+        return self.console_factory(log_file)
 
     def log_event(self, event_type: str, data: dict) -> None:
         """
@@ -302,18 +308,22 @@ class LoggingConfig:
 _logging_config: LoggingConfig | None = None
 
 
-def init_logging(debug_enabled: bool = False) -> LoggingConfig:
+def init_logging(
+    debug_enabled: bool = False,
+    console_factory: ConsoleFactory | None = None,
+) -> LoggingConfig:
     """
     Initialize global logging configuration.
 
     Args:
         debug_enabled: Whether debug mode is enabled
+        console_factory: Optional UI console factory; see ``LoggingConfig``.
 
     Returns:
         LoggingConfig instance
     """
     global _logging_config
-    _logging_config = LoggingConfig(debug_enabled)
+    _logging_config = LoggingConfig(debug_enabled, console_factory=console_factory)
     return _logging_config
 
 

--- a/dnd-engine/tests/test_logging.py
+++ b/dnd-engine/tests/test_logging.py
@@ -23,7 +23,6 @@ class TestLoggingConfig:
         assert config.debug_enabled is False
         assert config.log_file_path is None
         assert config.log_file is None
-        assert config.tee_console is None
 
     def test_init_with_debug(self, tmp_path):
         """Test initialization with debug mode."""
@@ -424,3 +423,34 @@ class TestGlobalLoggingFunctions:
         get_logging_config()
         # Actually, it will return the previously set config, so let's just check it's callable
         assert True  # This test just verifies the function doesn't crash
+
+
+class TestEnginePackageIsUiFree:
+    """Guard the monorepo boundary: engine code must not import UI libs."""
+
+    def test_engine_has_no_rich_imports(self):
+        """
+        Walk every .py file under dnd_engine/ and assert that none of them
+        import from the Rich library. This is the testable form of the
+        ``rg 'from rich' dnd-engine/`` acceptance check on #316.
+        """
+        import ast
+        from pathlib import Path
+
+        import dnd_engine
+
+        engine_root = Path(dnd_engine.__file__).parent
+        offenders: list[str] = []
+
+        for path in engine_root.rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom):
+                    if node.module and node.module.split(".")[0] == "rich":
+                        offenders.append(f"{path}: from {node.module} import ...")
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name.split(".")[0] == "rich":
+                            offenders.append(f"{path}: import {alias.name}")
+
+        assert offenders == [], "Rich imports must not exist in engine: " + "; ".join(offenders)

--- a/dnd-engine/tests/test_logging.py
+++ b/dnd-engine/tests/test_logging.py
@@ -89,32 +89,50 @@ class TestLoggingConfig:
         finally:
             os.chdir(original_cwd)
 
-    def test_create_console_without_debug(self):
-        """Test console creation without debug mode."""
-        config = LoggingConfig(debug_enabled=False)
-        console = config.create_console()
+    def test_create_console_invokes_factory_without_debug(self):
+        """Factory is called with None when debug is disabled."""
+        calls = []
 
-        assert console is not None
-        assert config.tee_console is None  # No dual output
+        def factory(log_file):
+            calls.append(log_file)
+            return ("made", log_file)
 
-    def test_create_console_with_debug(self, tmp_path):
-        """Test console creation with debug mode (dual output)."""
+        config = LoggingConfig(debug_enabled=False, console_factory=factory)
+        result = config.create_console()
+
+        assert calls == [None]
+        assert result == ("made", None)
+
+    def test_create_console_invokes_factory_with_debug(self, tmp_path):
+        """Factory is called with the open log file when debug is enabled."""
         import os
 
         original_cwd = os.getcwd()
         os.chdir(tmp_path)
 
         try:
-            config = LoggingConfig(debug_enabled=True)
-            console = config.create_console()
+            calls = []
 
-            assert console is not None
-            assert config.tee_console is not None
+            def factory(log_file):
+                calls.append(log_file)
+                return "sentinel-console"
 
-            # Clean up
+            config = LoggingConfig(debug_enabled=True, console_factory=factory)
+            result = config.create_console()
+
+            assert len(calls) == 1
+            assert calls[0] is config.log_file
+            assert calls[0] is not None
+            assert result == "sentinel-console"
+
             config.close()
         finally:
             os.chdir(original_cwd)
+
+    def test_create_console_returns_none_without_factory(self):
+        """create_console() returns None when no factory was injected."""
+        config = LoggingConfig(debug_enabled=False)
+        assert config.create_console() is None
 
     def test_log_event(self, tmp_path):
         """Test event logging."""


### PR DESCRIPTION
## Summary
- Removes the only remaining Rich import from `dnd-engine` (`logging_config.py:10`), restoring the UI-free monorepo boundary established by #304.
- Adds a `console_factory` callable to `LoggingConfig` / `init_logging` so UI clients inject their own console builder.
- Wires the Rich-backed factory from `client-terminal/terminal_client/ui/rich_ui.py`; debug-mode dual stdout/file output via `TeeFile` is preserved.

## Changes
- **`dnd-engine/dnd_engine/utils/logging_config.py`**: drop `from rich.console import Console`; introduce `ConsoleFactory` type alias; `create_console()` now dispatches to the injected factory (handing it the live log file when debug is on, `None` otherwise); retire the unused `self.tee_console` field; refresh docstrings/ABOUTME after Rich removal. `MAX_CONSOLE_WIDTH` and `TeeFile` stay — they are UI-toolkit-agnostic.
- **`dnd-engine/tests/test_logging.py`**: replace the old `test_create_console_*` tests with three factory-contract tests; add `TestEnginePackageIsUiFree::test_engine_has_no_rich_imports` — walks every `.py` under `dnd_engine/` with `ast` and asserts no `rich` imports (testable form of the issue's `rg` acceptance check).
- **`client-terminal/terminal_client/ui/rich_ui.py`**: define `_rich_console_factory(log_file)`; pass it to `init_logging` inside `init_console`. Behavior unchanged from a user's perspective.

## Testing
- [x] `uv run pytest dnd-engine/tests/` — 2157 passed, 1 skipped
- [x] `uv run pytest client-terminal/tests/` — 401 passed
- [x] `uv run pytest client-2d/tests/` — 400 passed, 1 skipped
- [x] `rg "from rich" dnd-engine/` returns empty (acceptance criterion)
- [x] Python code review (ruff lint/format + manual) — clean after docstring tidy-up

## Acceptance criteria (from #316)
- [x] `rg "from rich" dnd-engine/` returns empty
- [x] All tests pass
- [x] Game launches and logging works normally (covered by existing `test_logging_integration.py` end-to-end tests)

## Related Issues
Fixes #316
Follow-up to #304 (monorepo split)

🤖 Generated with [Claude Code](https://claude.com/claude-code)