### PR TITLE
Add #381: SRD A/B/C starting equipment options (data + engine)

### DIFF
--- a/dnd-engine/dnd_engine/core/character_factory.py
+++ b/dnd-engine/dnd_engine/core/character_factory.py
@@ -252,8 +252,7 @@ class CharacterFactory:
         if options:
             if option_index < 0 or option_index >= len(options):
                 raise ValueError(
-                    f"option_index {option_index} out of range for "
-                    f"{len(options)} options"
+                    f"option_index {option_index} out of range for {len(options)} options"
                 )
             raw_items: list[str] = list(options[option_index].get("items", []))
         else:
@@ -687,9 +686,6 @@ class CharacterFactory:
         self.initialize_spellcasting(character, class_data, spells_data)
 
         # Apply starting equipment
-        self.apply_starting_equipment(
-            character, class_data, items_data, option_index=option_index
-        )
+        self.apply_starting_equipment(character, class_data, items_data, option_index=option_index)
 
         return character
-

--- a/dnd-engine/dnd_engine/core/character_factory.py
+++ b/dnd-engine/dnd_engine/core/character_factory.py
@@ -522,6 +522,7 @@ class CharacterFactory:
         abilities: dict[str, int] | None = None,
         skill_proficiencies: list[str] | None = None,
         expertise_skills: list[str] | None = None,
+        option_index: int = 0,
     ) -> Character:
         """
         Create a character with all proficiencies and equipment - no UI dependencies.
@@ -539,6 +540,9 @@ class CharacterFactory:
             abilities: Pre-rolled abilities dict (rolls new if not provided)
             skill_proficiencies: Skill proficiencies (auto-selects if not provided)
             expertise_skills: Expertise skills (auto-selects for rogues if not provided)
+            option_index: Which starting_equipment_options entry to grant
+                (default 0). Ignored when the class only declares the legacy
+                starting_equipment field.
 
         Returns:
             Fully initialized Character with all proficiencies, equipment, and resources
@@ -613,10 +617,12 @@ class CharacterFactory:
         con_modifier = self.calculate_ability_modifier(abilities["constitution"])
         hp = self.calculate_hp(class_data, con_modifier, level=1)
 
-        # Calculate AC based on starting armor
-        starting_equipment = class_data.get("starting_equipment", [])
+        # Calculate AC based on the armor in the selected starting option
+        resolved_starting = self._resolve_starting_items(
+            class_data, items_data, option_index=option_index
+        )
         armor_id = None
-        for item_id in starting_equipment:
+        for item_id, _qty in resolved_starting:
             if item_id in items_data.get("armor", {}):
                 armor_id = item_id
                 break
@@ -681,7 +687,9 @@ class CharacterFactory:
         self.initialize_spellcasting(character, class_data, spells_data)
 
         # Apply starting equipment
-        self.apply_starting_equipment(character, class_data, items_data)
+        self.apply_starting_equipment(
+            character, class_data, items_data, option_index=option_index
+        )
 
         return character
 

--- a/dnd-engine/dnd_engine/core/character_factory.py
+++ b/dnd-engine/dnd_engine/core/character_factory.py
@@ -271,28 +271,41 @@ class CharacterFactory:
 
     @staticmethod
     def apply_starting_equipment(
-        character: Character, class_data: dict[str, Any], items_data: dict[str, Any]
+        character: Character,
+        class_data: dict[str, Any],
+        items_data: dict[str, Any],
+        option_index: int = 0,
     ) -> None:
         """
         Add starting equipment to character inventory and equip.
 
-        Automatically includes appropriate ammunition for ranged weapons
-        that have the "ammunition" property.
+        When the class defines `starting_equipment_options`, the option at
+        `option_index` is selected (default 0) and its `items` are granted, along
+        with the option's `gold`. Otherwise the legacy `starting_equipment` /
+        `starting_gold` fields are used and `option_index` is ignored.
+
+        Pack item ids in the selected loadout are expanded into their contents
+        via `_resolve_starting_items`. Ammunition for ranged weapons is added
+        automatically.
 
         Args:
             character: Character object
-            class_data: Class definition with starting_equipment
+            class_data: Class definition (with starting_equipment_options or
+                legacy starting_equipment)
             items_data: Full items.json data
+            option_index: Index into starting_equipment_options (default 0)
 
         Side Effects:
             - Adds items to character.inventory
             - Equips weapon and armor automatically
             - Adds ammunition for ranged weapons
         """
-        starting_equipment = class_data.get("starting_equipment", [])
+        resolved = CharacterFactory._resolve_starting_items(
+            class_data, items_data, option_index=option_index
+        )
         weapons_needing_ammo: list[str] = []
 
-        for item_id in starting_equipment:
+        for item_id, base_quantity in resolved:
             # Determine category
             category = None
             if item_id in items_data.get("weapons", {}):
@@ -305,11 +318,13 @@ class CharacterFactory:
                 category = "tools"
             elif item_id in items_data.get("ammunition", {}):
                 category = "ammunition"
+            elif item_id in items_data.get("equipment", {}):
+                category = "equipment"
 
             if category:
-                # Get default quantity for ammunition items
-                quantity = 1
-                if category == "ammunition":
+                # Ammunition has a standard "quantity per stack" default
+                quantity = base_quantity
+                if category == "ammunition" and base_quantity == 1:
                     ammo_data = items_data.get("ammunition", {}).get(item_id, {})
                     quantity = ammo_data.get("quantity", 20)
 
@@ -332,8 +347,13 @@ class CharacterFactory:
         # Auto-add ammunition for weapons that require it
         CharacterFactory._add_starting_ammunition(character, weapons_needing_ammo, items_data)
 
-        # Add starting gold
-        starting_gold = class_data.get("starting_gold", 0)
+        # Add starting gold: prefer per-option gold when options are defined,
+        # otherwise fall back to the legacy class-level field.
+        options = class_data.get("starting_equipment_options")
+        if options:
+            starting_gold = options[option_index].get("gold", 0)
+        else:
+            starting_gold = class_data.get("starting_gold", 0)
         if starting_gold > 0:
             character.inventory.add_gold(starting_gold)
 

--- a/dnd-engine/dnd_engine/core/character_factory.py
+++ b/dnd-engine/dnd_engine/core/character_factory.py
@@ -221,6 +221,55 @@ class CharacterFactory:
             return base_ac
 
     @staticmethod
+    def _resolve_starting_items(
+        class_data: dict[str, Any],
+        items_data: dict[str, Any],
+        option_index: int = 0,
+    ) -> list[tuple[str, int]]:
+        """
+        Resolve a class's starting items into a flat list of (item_id, quantity) tuples.
+
+        When `starting_equipment_options` is present, the option at `option_index` is
+        selected and its `items` list is resolved. When only the legacy
+        `starting_equipment` field is present, that flat list is used and
+        `option_index` is ignored.
+
+        Items whose id matches a pack in `items_data["packs"]` are expanded into the
+        pack's `contents` map; the pack id itself is not included in the output.
+        Non-pack items appear with quantity 1 unless an option provides explicit
+        per-item quantities in the future.
+
+        Args:
+            class_data: Class definition (may include starting_equipment_options
+                or legacy starting_equipment)
+            items_data: Full items.json data
+            option_index: Index into starting_equipment_options (default 0)
+
+        Returns:
+            List of (item_id, quantity) tuples after pack expansion.
+        """
+        options = class_data.get("starting_equipment_options")
+        if options:
+            if option_index < 0 or option_index >= len(options):
+                raise ValueError(
+                    f"option_index {option_index} out of range for "
+                    f"{len(options)} options"
+                )
+            raw_items: list[str] = list(options[option_index].get("items", []))
+        else:
+            raw_items = list(class_data.get("starting_equipment", []))
+
+        packs = items_data.get("packs", {})
+        resolved: list[tuple[str, int]] = []
+        for item_id in raw_items:
+            if item_id in packs:
+                for contained_id, qty in packs[item_id].get("contents", {}).items():
+                    resolved.append((contained_id, qty))
+            else:
+                resolved.append((item_id, 1))
+        return resolved
+
+    @staticmethod
     def apply_starting_equipment(
         character: Character, class_data: dict[str, Any], items_data: dict[str, Any]
     ) -> None:

--- a/dnd-engine/dnd_engine/core/character_factory.py
+++ b/dnd-engine/dnd_engine/core/character_factory.py
@@ -321,7 +321,10 @@ class CharacterFactory:
                 category = "equipment"
 
             if category:
-                # Ammunition has a standard "quantity per stack" default
+                # Ammunition entries from a flat starting list (quantity 1) get the
+                # default stack size from the item definition. Packs that include
+                # ammunition are expected to specify explicit quantities and bypass
+                # this override.
                 quantity = base_quantity
                 if category == "ammunition" and base_quantity == 1:
                     ammo_data = items_data.get("ammunition", {}).get(item_id, {})

--- a/dnd-engine/dnd_engine/data/srd/classes.json
+++ b/dnd-engine/dnd_engine/data/srd/classes.json
@@ -14,6 +14,26 @@
     },
     "starting_equipment": ["longsword", "chain_mail", "potion_of_healing", "potion_of_healing", "potion_of_healing", "potion_of_healing", "potion_of_healing"],
     "starting_gold": 10,
+    "starting_equipment_options": [
+      {
+        "name": "Standard Loadout",
+        "description": "Longsword, chain mail, and five potions of healing.",
+        "items": ["longsword", "chain_mail", "potion_of_healing", "potion_of_healing", "potion_of_healing", "potion_of_healing", "potion_of_healing"],
+        "gold": 10
+      },
+      {
+        "name": "Skirmisher",
+        "description": "Studded leather, longbow with arrows and quiver, and a Dungeoneer's Pack.",
+        "items": ["studded_leather", "longbow", "arrows", "quiver", "dungeoneers_pack"],
+        "gold": 11
+      },
+      {
+        "name": "Mercenary",
+        "description": "Buy your own gear with 155 GP.",
+        "items": [],
+        "gold": 155
+      }
+    ],
     "features_by_level": {
       "1": [
         {
@@ -65,6 +85,26 @@
     },
     "starting_equipment": ["rapier", "shortbow", "leather_armor", "thieves_tools", "potion_of_healing", "potion_of_healing"],
     "starting_gold": 15,
+    "starting_equipment_options": [
+      {
+        "name": "Standard Loadout",
+        "description": "Rapier, shortbow, leather armor, thieves' tools, and two potions of healing.",
+        "items": ["rapier", "shortbow", "leather_armor", "thieves_tools", "potion_of_healing", "potion_of_healing"],
+        "gold": 15
+      },
+      {
+        "name": "Cutthroat",
+        "description": "Shortsword, shortbow with arrows and quiver, leather armor, thieves' tools, and a Burglar's Pack.",
+        "items": ["shortsword", "shortbow", "arrows", "quiver", "leather_armor", "thieves_tools", "burglars_pack"],
+        "gold": 0
+      },
+      {
+        "name": "Freelancer",
+        "description": "Buy your own gear with 100 GP.",
+        "items": [],
+        "gold": 100
+      }
+    ],
     "features_by_level": {
       "1": [
         {
@@ -110,6 +150,26 @@
     },
     "starting_equipment": ["quarterstaff", "dagger", "potion_of_healing"],
     "starting_gold": 5,
+    "starting_equipment_options": [
+      {
+        "name": "Standard Loadout",
+        "description": "Quarterstaff, dagger, and a potion of healing.",
+        "items": ["quarterstaff", "dagger", "potion_of_healing"],
+        "gold": 5
+      },
+      {
+        "name": "Scholar",
+        "description": "Quarterstaff, component pouch, spellbook, and a Scholar's Pack.",
+        "items": ["quarterstaff", "component_pouch", "spellbook", "scholars_pack"],
+        "gold": 0
+      },
+      {
+        "name": "Independent Practitioner",
+        "description": "Buy your own gear with 50 GP.",
+        "items": [],
+        "gold": 50
+      }
+    ],
     "spellcasting": {
       "ability": "int",
       "cantrips_known": {

--- a/dnd-engine/dnd_engine/data/srd/items.json
+++ b/dnd-engine/dnd_engine/data/srd/items.json
@@ -1255,5 +1255,75 @@
       "value": 0.01,
       "weight": 1
     }
+  },
+  "packs": {
+    "dungeoneers_pack": {
+      "name": "Dungeoneer's Pack",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "pack",
+      "description": "Includes a backpack, a crowbar, a hammer, 10 pitons, 10 torches, a tinderbox, 10 days of rations, a waterskin, and 50 feet of hempen rope.",
+      "value": 12,
+      "contents": {
+        "backpack": 1,
+        "crowbar": 1,
+        "hammer": 1,
+        "piton": 10,
+        "torch": 10,
+        "tinderbox": 1,
+        "rations": 10,
+        "waterskin": 1,
+        "rope_hempen": 1
+      }
+    },
+    "explorers_pack": {
+      "name": "Explorer's Pack",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "pack",
+      "description": "Includes a backpack, a bedroll, a mess kit, a tinderbox, 10 torches, 10 days of rations, a waterskin, and 50 feet of hempen rope.",
+      "value": 10,
+      "contents": {
+        "backpack": 1,
+        "bedroll": 1,
+        "mess_kit": 1,
+        "tinderbox": 1,
+        "torch": 10,
+        "rations": 10,
+        "waterskin": 1,
+        "rope_hempen": 1
+      }
+    },
+    "burglars_pack": {
+      "name": "Burglar's Pack",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "pack",
+      "description": "Includes a backpack, a bag of 1,000 ball bearings, 10 feet of string, a bell, 5 candles, a crowbar, a hammer, 10 pitons, a hooded lantern, 2 flasks of oil, 5 days of rations, a tinderbox, a waterskin, and 50 feet of hempen rope.",
+      "value": 16,
+      "contents": {
+        "backpack": 1,
+        "ball_bearings": 1,
+        "piton": 10,
+        "torch": 5,
+        "tinderbox": 1,
+        "candle": 5,
+        "rations": 5,
+        "waterskin": 1,
+        "rope_hempen": 1
+      }
+    },
+    "scholars_pack": {
+      "name": "Scholar's Pack",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "pack",
+      "description": "Includes a backpack, a book of lore, a bottle of ink, an ink pen, 10 sheets of parchment, a little bag of sand, and a small knife.",
+      "value": 40,
+      "contents": {
+        "backpack": 1,
+        "book": 1,
+        "ink": 1,
+        "ink_pen": 1,
+        "parchment": 10,
+        "sack": 1
+      }
+    }
   }
 }

--- a/dnd-engine/dnd_engine/data/srd/items.json
+++ b/dnd-engine/dnd_engine/data/srd/items.json
@@ -164,6 +164,63 @@
       "properties": ["finesse"],
       "value": 25
     },
+    "greatsword": {
+      "name": "Greatsword",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "weapon",
+      "weapon_type": "martial",
+      "category": "melee",
+      "damage": "2d6",
+      "damage_type": "slashing",
+      "properties": ["heavy", "two-handed"],
+      "value": 50
+    },
+    "scimitar": {
+      "name": "Scimitar",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "weapon",
+      "weapon_type": "martial",
+      "category": "melee",
+      "damage": "1d6",
+      "damage_type": "slashing",
+      "properties": ["finesse", "light"],
+      "value": 25
+    },
+    "javelin": {
+      "name": "Javelin",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "weapon",
+      "weapon_type": "simple",
+      "category": "melee",
+      "damage": "1d6",
+      "damage_type": "piercing",
+      "properties": ["thrown"],
+      "range": "30/120",
+      "value": 0.5
+    },
+    "light_hammer": {
+      "name": "Light Hammer",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "weapon",
+      "weapon_type": "simple",
+      "category": "melee",
+      "damage": "1d4",
+      "damage_type": "bludgeoning",
+      "properties": ["light", "thrown"],
+      "range": "20/60",
+      "value": 2
+    },
+    "flail": {
+      "name": "Flail",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "weapon",
+      "weapon_type": "martial",
+      "category": "melee",
+      "damage": "1d8",
+      "damage_type": "bludgeoning",
+      "properties": [],
+      "value": 10
+    },
     "longsword_plus_1": {
       "name": "Longsword +1",
       "source": "The Unquiet Dead (Adventures Await Studios, OGL)",
@@ -1214,6 +1271,14 @@
       "description": "Objects viewed through a spyglass are magnified to twice their size.",
       "value": 1000,
       "weight": 1
+    },
+    "spellbook": {
+      "name": "Spellbook",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "equipment",
+      "description": "Essential for wizards, a spellbook is a leather-bound tome with 100 blank vellum pages suitable for recording spells.",
+      "value": 50,
+      "weight": 3
     },
     "tent": {
       "name": "Tent, Two-Person",

--- a/dnd-engine/tests/test_starting_equipment_options.py
+++ b/dnd-engine/tests/test_starting_equipment_options.py
@@ -291,8 +291,12 @@ class TestCreateCharacterWithOptionIndex:
             level=1,
             name="Default Fighter",
             abilities={
-                "strength": 15, "dexterity": 12, "constitution": 14,
-                "intelligence": 10, "wisdom": 10, "charisma": 10,
+                "strength": 15,
+                "dexterity": 12,
+                "constitution": 14,
+                "intelligence": 10,
+                "wisdom": 10,
+                "charisma": 10,
             },
         )
 
@@ -312,8 +316,12 @@ class TestCreateCharacterWithOptionIndex:
             level=1,
             name="Mercenary",
             abilities={
-                "strength": 15, "dexterity": 14, "constitution": 14,
-                "intelligence": 10, "wisdom": 10, "charisma": 10,
+                "strength": 15,
+                "dexterity": 14,
+                "constitution": 14,
+                "intelligence": 10,
+                "wisdom": 10,
+                "charisma": 10,
             },
             option_index=2,
         )

--- a/dnd-engine/tests/test_starting_equipment_options.py
+++ b/dnd-engine/tests/test_starting_equipment_options.py
@@ -1,0 +1,324 @@
+# ABOUTME: Tests for SRD A/B/C starting equipment options, pack expansion, and legacy fallback
+# ABOUTME: Covers _resolve_starting_items helper, apply_starting_equipment option_index, and create_character threading
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.character_factory import CharacterFactory
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.systems.inventory import EquipmentSlot
+
+
+class TestPacksData:
+    """Verify the new packs category exists in items.json with expected entries."""
+
+    def test_packs_category_present(self):
+        items = DataLoader().load_items()
+        assert "packs" in items
+
+    def test_expected_packs_defined(self):
+        packs = DataLoader().load_items()["packs"]
+        for pack_id in ("dungeoneers_pack", "explorers_pack", "burglars_pack", "scholars_pack"):
+            assert pack_id in packs, f"missing pack: {pack_id}"
+
+    def test_dungeoneers_pack_contents(self):
+        pack = DataLoader().load_items()["packs"]["dungeoneers_pack"]
+        assert "contents" in pack
+        contents = pack["contents"]
+        assert contents.get("rations") == 10
+        assert contents.get("torch") == 10
+        assert contents.get("piton") == 10
+        assert contents.get("backpack") == 1
+        assert contents.get("rope_hempen") == 1
+        assert contents.get("waterskin") == 1
+        assert contents.get("tinderbox") == 1
+        assert contents.get("crowbar") == 1
+        assert contents.get("hammer") == 1
+
+    def test_scholars_pack_contents(self):
+        pack = DataLoader().load_items()["packs"]["scholars_pack"]
+        contents = pack["contents"]
+        assert contents.get("book") == 1
+        assert contents.get("parchment") == 10
+        assert contents.get("ink") == 1
+
+
+class TestResolveStartingItems:
+    """Verify _resolve_starting_items resolves options, expands packs, and falls back to legacy."""
+
+    def test_legacy_class_data_returns_flat_list(self):
+        """Class data with only legacy `starting_equipment` is honored as a single option."""
+        items = DataLoader().load_items()
+        class_data = {"starting_equipment": ["longsword", "chain_mail"]}
+
+        resolved = CharacterFactory._resolve_starting_items(class_data, items, option_index=0)
+
+        # Each item is a (item_id, quantity) tuple
+        assert ("longsword", 1) in resolved
+        assert ("chain_mail", 1) in resolved
+        assert len(resolved) == 2
+
+    def test_options_field_selects_by_index(self):
+        items = DataLoader().load_items()
+        class_data = {
+            "starting_equipment_options": [
+                {"name": "A", "items": ["longsword"], "gold": 1},
+                {"name": "B", "items": ["shortsword"], "gold": 2},
+            ]
+        }
+
+        resolved_a = CharacterFactory._resolve_starting_items(class_data, items, option_index=0)
+        resolved_b = CharacterFactory._resolve_starting_items(class_data, items, option_index=1)
+
+        assert ("longsword", 1) in resolved_a
+        assert ("shortsword", 1) not in resolved_a
+        assert ("shortsword", 1) in resolved_b
+        assert ("longsword", 1) not in resolved_b
+
+    def test_pack_item_expands_to_contents(self):
+        items = DataLoader().load_items()
+        class_data = {
+            "starting_equipment_options": [
+                {"name": "A", "items": ["dungeoneers_pack"], "gold": 0},
+            ]
+        }
+
+        resolved = CharacterFactory._resolve_starting_items(class_data, items, option_index=0)
+
+        resolved_dict = dict(resolved)
+        # Pack itself should not be in resolved items — only its contents
+        assert "dungeoneers_pack" not in resolved_dict
+        assert resolved_dict.get("rations") == 10
+        assert resolved_dict.get("torch") == 10
+        assert resolved_dict.get("backpack") == 1
+
+    def test_options_with_empty_items_returns_empty_list(self):
+        """Gold-only option (e.g. SRD Option C) resolves to no items."""
+        items = DataLoader().load_items()
+        class_data = {
+            "starting_equipment_options": [
+                {"name": "Gold Only", "items": [], "gold": 155},
+            ]
+        }
+
+        resolved = CharacterFactory._resolve_starting_items(class_data, items, option_index=0)
+        assert resolved == []
+
+
+class TestMissingWeaponsAndSpellbook:
+    """Verify new SRD weapons + spellbook are loadable."""
+
+    def test_greatsword_loaded(self):
+        weapons = DataLoader().load_items()["weapons"]
+        assert "greatsword" in weapons
+        assert weapons["greatsword"]["damage"] == "2d6"
+        assert weapons["greatsword"]["damage_type"] == "slashing"
+        assert "heavy" in weapons["greatsword"]["properties"]
+        assert "two-handed" in weapons["greatsword"]["properties"]
+
+    def test_scimitar_loaded(self):
+        weapons = DataLoader().load_items()["weapons"]
+        assert "scimitar" in weapons
+        assert weapons["scimitar"]["damage"] == "1d6"
+        assert "finesse" in weapons["scimitar"]["properties"]
+        assert "light" in weapons["scimitar"]["properties"]
+
+    def test_javelin_loaded(self):
+        weapons = DataLoader().load_items()["weapons"]
+        assert "javelin" in weapons
+        assert "thrown" in weapons["javelin"]["properties"]
+        assert weapons["javelin"]["range"] == "30/120"
+
+    def test_light_hammer_loaded(self):
+        weapons = DataLoader().load_items()["weapons"]
+        assert "light_hammer" in weapons
+        assert weapons["light_hammer"]["damage"] == "1d4"
+        assert "thrown" in weapons["light_hammer"]["properties"]
+
+    def test_flail_loaded(self):
+        weapons = DataLoader().load_items()["weapons"]
+        assert "flail" in weapons
+        assert weapons["flail"]["damage"] == "1d8"
+        assert weapons["flail"]["damage_type"] == "bludgeoning"
+
+    def test_spellbook_loaded(self):
+        equipment = DataLoader().load_items()["equipment"]
+        assert "spellbook" in equipment
+
+
+def _new_blank_character(klass: CharacterClass = CharacterClass.FIGHTER) -> Character:
+    return Character(
+        name="Test",
+        character_class=klass,
+        level=1,
+        abilities=Abilities(10, 10, 10, 10, 10, 10),
+        max_hp=10,
+        ac=10,
+    )
+
+
+class TestApplyStartingEquipmentWithOptions:
+    """Verify apply_starting_equipment honors option_index and gold."""
+
+    def test_default_option_index_zero_preserves_legacy_loadout(self):
+        """Fighter Option 0 must equal current loadout for test-compat."""
+        loader = DataLoader()
+        items = loader.load_items()
+        classes = loader.load_classes()
+        character = _new_blank_character()
+
+        CharacterFactory.apply_starting_equipment(character, classes["fighter"], items)
+
+        assert character.inventory.has_item("longsword")
+        assert character.inventory.has_item("chain_mail")
+        assert character.inventory.get_item_quantity("potion_of_healing") == 5
+        assert character.inventory.gold == 10
+
+    def test_option_index_one_grants_alternate_loadout_and_gold(self):
+        """A synthetic class with two options grants the chosen option's items + gold."""
+        items = DataLoader().load_items()
+        class_data = {
+            "starting_equipment_options": [
+                {"name": "A", "items": ["longsword"], "gold": 5},
+                {"name": "B", "items": ["shortsword"], "gold": 99},
+            ],
+        }
+        character = _new_blank_character()
+
+        CharacterFactory.apply_starting_equipment(character, class_data, items, option_index=1)
+
+        assert character.inventory.has_item("shortsword")
+        assert not character.inventory.has_item("longsword")
+        assert character.inventory.gold == 99
+
+    def test_legacy_class_data_ignores_option_index(self):
+        """Classes without options field still work; option_index is ignored."""
+        items = DataLoader().load_items()
+        class_data = {
+            "starting_equipment": ["longsword"],
+            "starting_gold": 7,
+        }
+        character = _new_blank_character()
+
+        CharacterFactory.apply_starting_equipment(character, class_data, items, option_index=5)
+
+        assert character.inventory.has_item("longsword")
+        assert character.inventory.gold == 7
+
+    def test_pack_item_in_option_expands_into_inventory(self):
+        items = DataLoader().load_items()
+        class_data = {
+            "starting_equipment_options": [
+                {"name": "Packer", "items": ["dungeoneers_pack"], "gold": 0},
+            ],
+        }
+        character = _new_blank_character()
+
+        CharacterFactory.apply_starting_equipment(character, class_data, items, option_index=0)
+
+        # Pack should NOT exist as an item; its contents should
+        assert not character.inventory.has_item("dungeoneers_pack")
+        assert character.inventory.has_item("backpack")
+        assert character.inventory.get_item_quantity("rations") == 10
+        assert character.inventory.get_item_quantity("torch") == 10
+
+
+class TestClassOptionsPopulated:
+    """Verify the three classes have three options each and Option 0 matches legacy loadout."""
+
+    def test_fighter_has_three_options(self):
+        classes = DataLoader().load_classes()
+        opts = classes["fighter"].get("starting_equipment_options")
+        assert opts is not None and len(opts) == 3
+
+    def test_rogue_has_three_options(self):
+        classes = DataLoader().load_classes()
+        opts = classes["rogue"].get("starting_equipment_options")
+        assert opts is not None and len(opts) == 3
+
+    def test_wizard_has_three_options(self):
+        classes = DataLoader().load_classes()
+        opts = classes["wizard"].get("starting_equipment_options")
+        assert opts is not None and len(opts) == 3
+
+    def test_fighter_option_zero_matches_legacy(self):
+        classes = DataLoader().load_classes()
+        opt0 = classes["fighter"]["starting_equipment_options"][0]
+        # Must produce: longsword, chain_mail, 5 potions, 10 gp
+        assert "longsword" in opt0["items"]
+        assert "chain_mail" in opt0["items"]
+        assert opt0["items"].count("potion_of_healing") == 5
+        assert opt0["gold"] == 10
+
+    def test_rogue_option_zero_matches_legacy(self):
+        classes = DataLoader().load_classes()
+        opt0 = classes["rogue"]["starting_equipment_options"][0]
+        assert "rapier" in opt0["items"]
+        assert "shortbow" in opt0["items"]
+        assert "leather_armor" in opt0["items"]
+        assert "thieves_tools" in opt0["items"]
+        assert opt0["items"].count("potion_of_healing") == 2
+        assert opt0["gold"] == 15
+
+    def test_wizard_option_zero_matches_legacy(self):
+        classes = DataLoader().load_classes()
+        opt0 = classes["wizard"]["starting_equipment_options"][0]
+        assert "quarterstaff" in opt0["items"]
+        assert "dagger" in opt0["items"]
+        assert opt0["items"].count("potion_of_healing") == 1
+        assert opt0["gold"] == 5
+
+    def test_each_class_third_option_is_gold_only(self):
+        classes = DataLoader().load_classes()
+        for class_id in ("fighter", "rogue", "wizard"):
+            opt2 = classes[class_id]["starting_equipment_options"][2]
+            assert opt2["items"] == [], f"{class_id} option 2 should be gold-only"
+            assert opt2["gold"] > 0, f"{class_id} option 2 should grant gold"
+
+
+class TestCreateCharacterWithOptionIndex:
+    """Verify create_character threads option_index through to inventory and AC."""
+
+    def test_create_character_default_option_index(self):
+        """Default (no option_index passed) creates the legacy Fighter."""
+        loader = DataLoader()
+        factory = CharacterFactory(dice_roller=DiceRoller(seed=42))
+
+        character = factory.create_character(
+            class_name="fighter",
+            race_name="human",
+            data_loader=loader,
+            level=1,
+            name="Default Fighter",
+            abilities={
+                "strength": 15, "dexterity": 12, "constitution": 14,
+                "intelligence": 10, "wisdom": 10, "charisma": 10,
+            },
+        )
+
+        assert character.inventory.has_item("longsword")
+        assert character.inventory.has_item("chain_mail")
+        assert character.inventory.gold == 10
+
+    def test_create_character_option_index_two_is_gold_only_fighter(self):
+        """Fighter option 2 (gold-only) creates a character with 155 gp and no armor."""
+        loader = DataLoader()
+        factory = CharacterFactory(dice_roller=DiceRoller(seed=42))
+
+        character = factory.create_character(
+            class_name="fighter",
+            race_name="human",
+            data_loader=loader,
+            level=1,
+            name="Mercenary",
+            abilities={
+                "strength": 15, "dexterity": 14, "constitution": 14,
+                "intelligence": 10, "wisdom": 10, "charisma": 10,
+            },
+            option_index=2,
+        )
+
+        assert character.inventory.get_equipped_item(EquipmentSlot.ARMOR) is None
+        assert character.inventory.gold == 155
+        # AC = 10 + dex_mod (no armor); dex 14 → +2 → AC 12
+        assert character.ac == 12


### PR DESCRIPTION
## Summary

Adds the data-layer schema and engine-layer support for the SRD's multi-option starting equipment per class. The character wizard UI for choosing among options is tracked separately in #382.

This is the first half of the work split from #288.

## Changes

- **`dnd-engine/dnd_engine/data/srd/items.json`**
  - New `packs` category with Dungeoneer's, Explorer's, Burglar's, and Scholar's packs. Each pack has a `contents` map of item_id → quantity for expansion on grant.
  - 5 new SRD weapons: greatsword, scimitar, javelin, light hammer, flail.
  - New equipment entry: spellbook.

- **`dnd-engine/dnd_engine/data/srd/classes.json`**
  - `starting_equipment_options` array added to Fighter, Rogue, Wizard with three options each (Standard / SRD-flavored alternative / Gold-only). **Option 0 is byte-identical to the existing legacy loadout** so every existing test passes without edits.

- **`dnd-engine/dnd_engine/core/character_factory.py`**
  - New static helper `_resolve_starting_items(class_data, items_data, option_index=0)` that returns a flat list of `(item_id, quantity)` tuples with pack expansion and legacy-fallback.
  - `apply_starting_equipment` gains an `option_index: int = 0` parameter and reads gold from the selected option (or the legacy `starting_gold` field).
  - `create_character` gains `option_index: int = 0` and the AC armor-detection block now consults the resolved option's items rather than the raw legacy list (fixes a latent bug for non-default options).
  - Adds dispatch for the `equipment` category so spellbook + future spellcasting foci can be granted via starting equipment.

- **`dnd-engine/tests/test_starting_equipment_options.py`** (new, 27 tests)
  - Pack data presence and contents
  - `_resolve_starting_items` selection, pack expansion, legacy fallback, empty-items case
  - New weapons + spellbook loadable
  - `apply_starting_equipment` honors option_index and per-option gold
  - Each class has 3 options with Option 0 matching legacy and Option 2 being gold-only
  - `create_character` end-to-end with non-default option (AC correctly reflects new armor)

## Backward compatibility

- Legacy `starting_equipment` + `starting_gold` fields are retained on the three classes as a safety net. They will be removed in a follow-up once the wizard UI (#382) is migrating callers to options explicitly.
- All 113 pre-existing character / inventory / vault / ammunition tests pass unchanged.

## Test plan

- [x] `uv run pytest` — engine: 2184 passed (+27 new)
- [x] `uv run pytest` — terminal client: 401 passed
- [x] `uv run pytest` — 2d client: 400 passed
- [x] Ruff check + ruff format — clean
- [x] Python code review (skill) — no critical/high issues

## Related issues

- Parent: #288
- Companion: #382 (wizard UI step — depends on this)
- Fixes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)