### PR TITLE
Fix #384: Burglar's Pack contents drift from SRD

### DIFF
--- a/dnd-engine/dnd_engine/data/srd/items.json
+++ b/dnd-engine/dnd_engine/data/srd/items.json
@@ -1285,7 +1285,7 @@
       "source": "D&D 5E SRD (CC BY 4.0)",
       "type": "equipment",
       "description": "Ten feet of common string.",
-      "value": 0,
+      "value": 0.01,
       "weight": 0
     },
     "tent": {

--- a/dnd-engine/dnd_engine/data/srd/items.json
+++ b/dnd-engine/dnd_engine/data/srd/items.json
@@ -1280,6 +1280,14 @@
       "value": 50,
       "weight": 3
     },
+    "string": {
+      "name": "String (10 feet)",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "equipment",
+      "description": "Ten feet of common string.",
+      "value": 0,
+      "weight": 0
+    },
     "tent": {
       "name": "Tent, Two-Person",
       "source": "D&D 5E SRD (CC BY 4.0)",
@@ -1366,11 +1374,16 @@
       "contents": {
         "backpack": 1,
         "ball_bearings": 1,
-        "piton": 10,
-        "torch": 5,
-        "tinderbox": 1,
+        "string": 1,
+        "bell": 1,
         "candle": 5,
+        "crowbar": 1,
+        "hammer": 1,
+        "piton": 10,
+        "lantern_hooded": 1,
+        "oil_flask": 2,
         "rations": 5,
+        "tinderbox": 1,
         "waterskin": 1,
         "rope_hempen": 1
       }

--- a/dnd-engine/tests/test_starting_equipment_options.py
+++ b/dnd-engine/tests/test_starting_equipment_options.py
@@ -63,18 +63,20 @@ class TestPacksData:
         # Torch is NOT in the SRD Burglar's Pack — was a copy-paste from Dungeoneer's Pack
         assert "torch" not in contents
 
-    def test_burglars_pack_referenced_items_exist(self):
-        """All items referenced by burglars_pack.contents must exist in items.json."""
+    def test_all_pack_referenced_items_exist(self):
+        """All items referenced by any pack.contents must exist in items.json."""
         items = DataLoader().load_items()
-        pack = items["packs"]["burglars_pack"]
         # Flatten all non-pack categories into a single ID set
         all_item_ids: set[str] = set()
         for category, entries in items.items():
             if category == "packs":
                 continue
             all_item_ids.update(entries.keys())
-        for item_id in pack["contents"]:
-            assert item_id in all_item_ids, f"burglars_pack references missing item: {item_id}"
+        for pack_id, pack in items["packs"].items():
+            for item_id in pack["contents"]:
+                assert item_id in all_item_ids, (
+                    f"{pack_id} references missing item: {item_id}"
+                )
 
 
 class TestResolveStartingItems:

--- a/dnd-engine/tests/test_starting_equipment_options.py
+++ b/dnd-engine/tests/test_starting_equipment_options.py
@@ -42,6 +42,40 @@ class TestPacksData:
         assert contents.get("parchment") == 10
         assert contents.get("ink") == 1
 
+    def test_burglars_pack_contents(self):
+        """Burglar's Pack contents must match the SRD description (issue #384)."""
+        pack = DataLoader().load_items()["packs"]["burglars_pack"]
+        contents = pack["contents"]
+        assert contents.get("backpack") == 1
+        assert contents.get("ball_bearings") == 1
+        assert contents.get("string") == 1
+        assert contents.get("bell") == 1
+        assert contents.get("candle") == 5
+        assert contents.get("crowbar") == 1
+        assert contents.get("hammer") == 1
+        assert contents.get("piton") == 10
+        assert contents.get("lantern_hooded") == 1
+        assert contents.get("oil_flask") == 2
+        assert contents.get("rations") == 5
+        assert contents.get("tinderbox") == 1
+        assert contents.get("waterskin") == 1
+        assert contents.get("rope_hempen") == 1
+        # Torch is NOT in the SRD Burglar's Pack — was a copy-paste from Dungeoneer's Pack
+        assert "torch" not in contents
+
+    def test_burglars_pack_referenced_items_exist(self):
+        """All items referenced by burglars_pack.contents must exist in items.json."""
+        items = DataLoader().load_items()
+        pack = items["packs"]["burglars_pack"]
+        # Flatten all non-pack categories into a single ID set
+        all_item_ids: set[str] = set()
+        for category, entries in items.items():
+            if category == "packs":
+                continue
+            all_item_ids.update(entries.keys())
+        for item_id in pack["contents"]:
+            assert item_id in all_item_ids, f"burglars_pack references missing item: {item_id}"
+
 
 class TestResolveStartingItems:
     """Verify _resolve_starting_items resolves options, expands packs, and falls back to legacy."""


### PR DESCRIPTION
## Summary
- Aligns `burglars_pack.contents` to the SRD description it already advertises
- Adds the missing `string` equipment item referenced by the pack
- Removes `torch:5` (copy-paste from Dungeoneer's Pack, not in SRD Burglar's Pack)

## Changes
- **dnd-engine/dnd_engine/data/srd/items.json**:
  - Added `string` (10 ft) to the `equipment` category
  - Updated `burglars_pack.contents` to: `backpack`, `ball_bearings`, `string`, `bell`, `candle×5`, `crowbar`, `hammer`, `piton×10`, `lantern_hooded`, `oil_flask×2`, `rations×5`, `tinderbox`, `waterskin`, `rope_hempen`
- **dnd-engine/tests/test_starting_equipment_options.py**:
  - Added `test_burglars_pack_contents` covering the corrected SRD contents (and asserting `torch` is absent)
  - Added `test_burglars_pack_referenced_items_exist` as an invariant guard against future drift

## Note on item ID
The issue proposed `hooded_lantern`, but the existing item ID is `lantern_hooded`. Used the existing ID rather than creating a duplicate.

## Testing
- [x] New tests fail before the fix, pass after (TDD)
- [x] Full engine suite: 2186 passed, 1 skipped
- [x] Ruff lint + format clean

## Related Issues
Fixes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)