### PR TITLE
Fix #385 + #386: PR #383 follow-ups (test + docs)

### DIFF
--- a/dnd-engine/dnd_engine/systems/inventory.py
+++ b/dnd-engine/dnd_engine/systems/inventory.py
@@ -25,7 +25,7 @@ class InventoryItem:
     """
 
     item_id: str
-    category: str  # "weapons", "armor", "consumables"
+    category: str  # "weapons", "armor", "consumables", "tools", "ammunition", "equipment"
     quantity: int = 1
     quest_item: bool = False  # Quest items don't transfer between campaigns
 
@@ -76,7 +76,8 @@ class Inventory:
 
         Args:
             item_id: ID of the item from items.json
-            category: Item category ("weapons", "armor", "consumables")
+            category: Item category — one of "weapons", "armor", "consumables",
+                "tools", "ammunition", or "equipment"
             quantity: Number to add (default 1)
             quest_item: Whether this item is campaign-specific (won't transfer)
 

--- a/dnd-engine/tests/test_starting_equipment_options.py
+++ b/dnd-engine/tests/test_starting_equipment_options.py
@@ -1,6 +1,8 @@
 # ABOUTME: Tests for SRD A/B/C starting equipment options, pack expansion, and legacy fallback
 # ABOUTME: Covers _resolve_starting_items helper, apply_starting_equipment option_index, and create_character threading
 
+import pytest
+
 from dnd_engine.core.character import Character, CharacterClass
 from dnd_engine.core.character_factory import CharacterFactory
 from dnd_engine.core.creature import Abilities
@@ -110,6 +112,29 @@ class TestResolveStartingItems:
         assert ("shortsword", 1) not in resolved_a
         assert ("shortsword", 1) in resolved_b
         assert ("longsword", 1) not in resolved_b
+
+    def test_option_index_above_range_raises(self):
+        """option_index >= len(options) must raise ValueError."""
+        items = DataLoader().load_items()
+        class_data = {
+            "starting_equipment_options": [
+                {"name": "A", "items": ["longsword"], "gold": 0},
+                {"name": "B", "items": ["shortsword"], "gold": 0},
+            ]
+        }
+        with pytest.raises(ValueError, match="out of range"):
+            CharacterFactory._resolve_starting_items(class_data, items, option_index=99)
+
+    def test_option_index_negative_raises(self):
+        """Negative option_index must raise ValueError instead of silently wrapping."""
+        items = DataLoader().load_items()
+        class_data = {
+            "starting_equipment_options": [
+                {"name": "A", "items": ["longsword"], "gold": 0},
+            ]
+        }
+        with pytest.raises(ValueError, match="out of range"):
+            CharacterFactory._resolve_starting_items(class_data, items, option_index=-1)
 
     def test_pack_item_expands_to_contents(self):
         items = DataLoader().load_items()


### PR DESCRIPTION
## Summary
Bundled two small PR #383 follow-ups:
- **#385** — Add tests covering `ValueError` for out-of-range `option_index` in `_resolve_starting_items`
- **#386** — Update `inventory.py` category docstrings to enumerate all six supported categories

## Changes
- **dnd-engine/tests/test_starting_equipment_options.py** (#385):
  - `test_option_index_above_range_raises` — asserts `ValueError("out of range")` for `option_index=99`
  - `test_option_index_negative_raises` — asserts `ValueError` for `option_index=-1` (no silent wraparound)
  - Adds `import pytest`
- **dnd-engine/dnd_engine/systems/inventory.py** (#386):
  - `InventoryItem.category` inline comment updated to list all six categories
  - `Inventory.add_item` docstring `category` arg description expanded to match

## Notes
- #385 tests are characterization tests — the `ValueError` path already existed at `character_factory.py:253-256`. These lock down the behavior to prevent silent regression.
- #386 dispatch is data-driven (`items_data.get(category)`), so this is informative-only — no behavior change.

## Testing
- [x] Full engine suite: 2188 passed, 1 skipped (was 2186 — the +2 are the new ValueError tests)
- [x] Ruff lint + format clean

## Related Issues
Fixes #385
Fixes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)