### PR TITLE
Add #382: Wizard UI step for A/B/C starting equipment choice

### DIFF
--- a/client-terminal/terminal_client/ui/character_wizard.py
+++ b/client-terminal/terminal_client/ui/character_wizard.py
@@ -798,6 +798,7 @@ class CharacterCreationWizard:
             self.race = template["race"]
             self.character_class = template["class"]
             self.abilities = template["abilities"].copy()
+            self.equipment_option_index = template.get("equipment_choice", 0)
 
             # Apply racial bonuses
             self.abilities = self.factory.apply_racial_bonuses(

--- a/client-terminal/terminal_client/ui/character_wizard.py
+++ b/client-terminal/terminal_client/ui/character_wizard.py
@@ -77,6 +77,7 @@ class CharacterCreationWizard:
         self.skill_proficiencies: list[str] = []
         self.expertise_skills: list[str] = []
         self.selected_spells: list[str] = []
+        self.equipment_option_index: int = 0
         self.level: int = 1
 
     def _load_templates(self) -> dict[str, Any]:
@@ -173,6 +174,7 @@ class CharacterCreationWizard:
             ("Class", self._custom_step_class),
             ("Abilities", self._custom_step_abilities),
             ("Skills", self._custom_step_skills),
+            ("Equipment", self._custom_step_equipment),
             ("Name", self._custom_step_name),
         ]
 
@@ -410,6 +412,73 @@ class CharacterCreationWizard:
             return self._get_navigation_choice()
         except (EOFError, KeyboardInterrupt):
             return "cancel"
+
+    def _custom_step_equipment(self) -> str:
+        """Custom path: pick a starting equipment option (A/B/C) for the class.
+
+        Classes that only declare the legacy `starting_equipment` field (no
+        `starting_equipment_options`) skip the prompt and keep the default
+        index of 0, since the engine ignores `option_index` in that case.
+        """
+        class_data = self.classes_data[self.character_class]
+        options = class_data.get("starting_equipment_options")
+        if not options:
+            return "next"
+
+        choices = []
+        for index, option in enumerate(options):
+            summary = self._format_option_summary(option)
+            choices.append(questionary.Choice(title=summary, value=index))
+        choices.append(questionary.Choice(title="← Back", value="back"))
+
+        try:
+            selected = questionary.select(
+                "Choose your starting equipment loadout:",
+                choices=choices,
+                use_arrow_keys=True,
+            ).ask()
+
+            if selected is None:
+                return "cancel"
+            if selected == "back":
+                return "back"
+
+            self.equipment_option_index = selected
+            option = options[selected]
+            print_status_message(f"✓ Equipment: {option['name']}", "success")
+
+            return self._get_navigation_choice()
+        except (EOFError, KeyboardInterrupt):
+            return "cancel"
+
+    def _format_option_summary(self, option: dict[str, Any]) -> str:
+        """Build a one-line label for an equipment option, truncated for display."""
+        item_names: list[str] = []
+        for item_id in option.get("items", []):
+            display = self._lookup_item_display_name(item_id)
+            item_names.append(display)
+        items_str = ", ".join(item_names) if item_names else "(no items)"
+        gold = option.get("gold", 0)
+        label = f"{option['name']} — {items_str} ({gold} gp)"
+        if len(label) > 100:
+            label = label[:97] + "..."
+        return label
+
+    def _lookup_item_display_name(self, item_id: str) -> str:
+        """Resolve an item id to its display name across all categories."""
+        for category in (
+            "weapons",
+            "armor",
+            "consumables",
+            "tools",
+            "ammunition",
+            "equipment",
+            "packs",
+        ):
+            entry = self.items_data.get(category, {}).get(item_id)
+            if entry:
+                return entry.get("name", item_id.replace("_", " ").title())
+        return item_id.replace("_", " ").title()
 
     def _select_skills_questionary(
         self, class_data: dict[str, Any], skills_data: dict[str, Any]

--- a/client-terminal/terminal_client/ui/character_wizard.py
+++ b/client-terminal/terminal_client/ui/character_wizard.py
@@ -945,6 +945,14 @@ class CharacterCreationWizard:
         if self.character_class == "rogue" and len(self.skill_proficiencies) >= 2:
             self.expertise_skills = rng.sample(self.skill_proficiencies, 2)
 
+        # Random starting equipment option (A/B/C). Classes that only declare
+        # the legacy `starting_equipment` field keep the default index of 0.
+        equipment_options = class_data.get("starting_equipment_options")
+        if equipment_options:
+            self.equipment_option_index = rng.randrange(len(equipment_options))
+        else:
+            self.equipment_option_index = 0
+
     def _show_random_preview(self) -> None:
         """Show preview of randomly generated character."""
         console.print(f"[bold]Race:[/bold] {self.races_data[self.race]['name']}")

--- a/client-terminal/terminal_client/ui/character_wizard.py
+++ b/client-terminal/terminal_client/ui/character_wizard.py
@@ -1080,10 +1080,11 @@ class CharacterCreationWizard:
         con_modifier = abilities_obj.con_mod
         hp = self.factory.calculate_hp(class_data, con_modifier)
 
-        # Get AC from starting equipment
-        starting_equipment = class_data.get("starting_equipment", [])
+        # AC depends on whatever armor the resolved starting loadout grants.
+        # Resolve from the chosen option (or the legacy starting_equipment).
+        resolved_loadout = self._resolved_loadout_items(class_data)
         armor_id = None
-        for item_id in starting_equipment:
+        for item_id in resolved_loadout:
             if item_id in self.items_data.get("armor", {}):
                 armor_id = item_id
                 break
@@ -1110,27 +1111,73 @@ class CharacterCreationWizard:
             console.print()
 
         # Equipment preview
-        if starting_equipment:
+        self._render_equipment_summary(class_data)
+
+    def _resolved_loadout_items(self, class_data: dict[str, Any]) -> list[str]:
+        """Return the flat list of item ids for the currently selected loadout.
+
+        Honors `equipment_option_index` when the class declares
+        `starting_equipment_options`; otherwise falls back to the legacy
+        `starting_equipment` list.
+        """
+        options = class_data.get("starting_equipment_options")
+        if options:
+            index = self.equipment_option_index
+            if 0 <= index < len(options):
+                return list(options[index].get("items", []))
+        return list(class_data.get("starting_equipment", []))
+
+    def _render_equipment_summary(self, class_data: dict[str, Any]) -> None:
+        """Print the Starting Equipment section of the summary screen."""
+        options = class_data.get("starting_equipment_options")
+        if options and 0 <= self.equipment_option_index < len(options):
+            option = options[self.equipment_option_index]
             console.print("[bold]Starting Equipment:[/bold]")
-            weapon_id = None
-            for item_id in starting_equipment:
-                if item_id in self.items_data.get("weapons", {}):
-                    weapon_id = item_id
-                    weapon_data = self.items_data["weapons"][weapon_id]
-                    console.print(f"  Weapon: {weapon_data['name']}")
-                    break
+            console.print(f"  Loadout: {option['name']}")
 
-            if armor_data:
+            packs = self.items_data.get("packs", {})
+            for item_id in option.get("items", []):
+                display = self._lookup_item_display_name(item_id)
+                console.print(f"  • {display}")
+                if item_id in packs:
+                    contents = packs[item_id].get("contents", {})
+                    if contents:
+                        preview = ", ".join(
+                            f"{qty}× {self._lookup_item_display_name(cid)}"
+                            for cid, qty in list(contents.items())[:3]
+                        )
+                        more = len(contents) - 3
+                        suffix = f", +{more} more" if more > 0 else ""
+                        console.print(f"      [dim]contains: {preview}{suffix}[/dim]")
+
+            gold = option.get("gold", 0)
+            console.print(f"  Gold: {gold} gp")
+            return
+
+        # Legacy fallback: classes without options keep the previous summary.
+        starting_equipment = class_data.get("starting_equipment", [])
+        if not starting_equipment:
+            return
+        console.print("[bold]Starting Equipment:[/bold]")
+        for item_id in starting_equipment:
+            if item_id in self.items_data.get("weapons", {}):
+                weapon_data = self.items_data["weapons"][item_id]
+                console.print(f"  Weapon: {weapon_data['name']}")
+                break
+
+        for item_id in starting_equipment:
+            if item_id in self.items_data.get("armor", {}):
+                armor_data = self.items_data["armor"][item_id]
                 console.print(f"  Armor: {armor_data['name']}")
+                break
 
-            # Count consumables
-            consumable_count = sum(
-                1
-                for item_id in starting_equipment
-                if item_id in self.items_data.get("consumables", {})
-            )
-            if consumable_count > 0:
-                console.print(f"  + {consumable_count} consumable items")
+        consumable_count = sum(
+            1
+            for item_id in starting_equipment
+            if item_id in self.items_data.get("consumables", {})
+        )
+        if consumable_count > 0:
+            console.print(f"  + {consumable_count} consumable items")
 
     def _create_character(self) -> Character:
         """

--- a/client-terminal/terminal_client/ui/character_wizard.py
+++ b/client-terminal/terminal_client/ui/character_wizard.py
@@ -1201,6 +1201,7 @@ class CharacterCreationWizard:
                 abilities=self.abilities,  # Already has racial bonuses
                 skill_proficiencies=self.skill_proficiencies,
                 expertise_skills=self.expertise_skills,
+                option_index=self.equipment_option_index,
             )
 
             # If we have pre-selected spells (from template), use those

--- a/client-terminal/tests/test_character_wizard.py
+++ b/client-terminal/tests/test_character_wizard.py
@@ -590,3 +590,67 @@ class TestCustomStepEquipment:
         assert result == "next"
         assert wizard.equipment_option_index == 0
         mock_select_module.assert_not_called()
+
+
+class TestRandomPathEquipment:
+    """Random path should pick an equipment option via the seeded RNG."""
+
+    def test_random_picks_equipment_option_in_range(self):
+        dice_roller = DiceRoller(seed=42)
+        wizard = CharacterCreationWizard(
+            character_factory=CharacterFactory(dice_roller=dice_roller),
+            data_loader=DataLoader(),
+            dice_roller=dice_roller,
+        )
+
+        wizard._generate_random_character()
+
+        class_data = wizard.classes_data[wizard.character_class]
+        options = class_data.get("starting_equipment_options", [])
+        if options:
+            assert 0 <= wizard.equipment_option_index < len(options)
+        else:
+            assert wizard.equipment_option_index == 0
+
+    def test_random_equipment_choice_varies_across_seeds(self):
+        """Across many seeds, random picks should hit more than just index 0.
+
+        Locks in that we are actually rolling for the option rather than
+        leaving it at the default of 0.
+        """
+        seen_indices: set[int] = set()
+        for seed in range(50):
+            dice_roller = DiceRoller(seed=seed)
+            wizard = CharacterCreationWizard(
+                character_factory=CharacterFactory(dice_roller=dice_roller),
+                data_loader=DataLoader(),
+                dice_roller=dice_roller,
+            )
+            wizard._generate_random_character()
+            class_data = wizard.classes_data[wizard.character_class]
+            if class_data.get("starting_equipment_options"):
+                seen_indices.add(wizard.equipment_option_index)
+        # All current SRD classes have exactly 3 options
+        assert len(seen_indices) > 1, (
+            f"Expected random rolls to hit multiple option indices, got {seen_indices}"
+        )
+
+    def test_random_equipment_choice_is_deterministic_with_seed(self):
+        d1 = DiceRoller(seed=100)
+        w1 = CharacterCreationWizard(
+            character_factory=CharacterFactory(dice_roller=d1),
+            data_loader=DataLoader(),
+            dice_roller=d1,
+        )
+        d2 = DiceRoller(seed=100)
+        w2 = CharacterCreationWizard(
+            character_factory=CharacterFactory(dice_roller=d2),
+            data_loader=DataLoader(),
+            dice_roller=d2,
+        )
+
+        w1._generate_random_character()
+        w2._generate_random_character()
+
+        assert w1.character_class == w2.character_class
+        assert w1.equipment_option_index == w2.equipment_option_index

--- a/client-terminal/tests/test_character_wizard.py
+++ b/client-terminal/tests/test_character_wizard.py
@@ -719,3 +719,70 @@ class TestTemplateEquipmentChoice:
         wizard.equipment_option_index = 99  # poison value to prove a write happened
         self._drive_template(wizard, "legacy_fighter")
         assert wizard.equipment_option_index == 0
+
+
+class TestSummaryDisplaysChosenEquipment:
+    """The summary screen should reflect the chosen equipment option."""
+
+    @pytest.fixture
+    def wizard(self):
+        return CharacterCreationWizard(
+            character_factory=CharacterFactory(),
+            data_loader=DataLoader(),
+            dice_roller=DiceRoller(seed=42),
+        )
+
+    def _capture_summary(self, wizard) -> str:
+        """Run _show_character_summary and return the joined console output."""
+        captured: list[str] = []
+
+        def fake_print(*args, **kwargs):
+            captured.append(" ".join(str(a) for a in args))
+
+        with patch(
+            "terminal_client.ui.character_wizard.console.print", side_effect=fake_print
+        ):
+            wizard._show_character_summary()
+
+        return "\n".join(captured)
+
+    def _set_state(self, wizard, character_class, option_index):
+        wizard.name = "Tester"
+        wizard.race = "human"
+        wizard.character_class = character_class
+        wizard.abilities = {
+            "strength": 15,
+            "dexterity": 12,
+            "constitution": 14,
+            "intelligence": 8,
+            "wisdom": 13,
+            "charisma": 10,
+        }
+        wizard.skill_proficiencies = []
+        wizard.expertise_skills = []
+        wizard.equipment_option_index = option_index
+
+    def test_summary_shows_fighter_skirmisher_loadout(self, wizard):
+        """Fighter option 1 (Skirmisher): longbow + studded leather + 11 gp."""
+        self._set_state(wizard, "fighter", 1)
+        output = self._capture_summary(wizard)
+        assert "Skirmisher" in output
+        assert "Longbow" in output
+        assert "Studded Leather" in output
+        assert "11" in output  # gold
+
+    def test_summary_shows_standard_loadout(self, wizard):
+        """Fighter option 0 (Standard Loadout): chain mail + longsword."""
+        self._set_state(wizard, "fighter", 0)
+        output = self._capture_summary(wizard)
+        assert "Standard Loadout" in output
+        assert "Chain Mail" in output
+        assert "Longsword" in output
+        assert "10" in output  # gold
+
+    def test_summary_shows_gold_only_loadout(self, wizard):
+        """Fighter option 2 (Mercenary): 155 gp, no items."""
+        self._set_state(wizard, "fighter", 2)
+        output = self._capture_summary(wizard)
+        assert "Mercenary" in output
+        assert "155" in output

--- a/client-terminal/tests/test_character_wizard.py
+++ b/client-terminal/tests/test_character_wizard.py
@@ -786,3 +786,51 @@ class TestSummaryDisplaysChosenEquipment:
         output = self._capture_summary(wizard)
         assert "Mercenary" in output
         assert "155" in output
+
+
+class TestCreateCharacterWiresOptionIndex:
+    """`_create_character` must pass equipment_option_index to the factory."""
+
+    @pytest.fixture
+    def wizard(self):
+        dice_roller = DiceRoller(seed=42)
+        return CharacterCreationWizard(
+            character_factory=CharacterFactory(dice_roller=dice_roller),
+            data_loader=DataLoader(),
+            dice_roller=dice_roller,
+        )
+
+    def _set_fighter_state(self, wizard, option_index):
+        wizard.name = "Test"
+        wizard.race = "human"
+        wizard.character_class = "fighter"
+        wizard.abilities = {
+            "strength": 16,
+            "dexterity": 14,
+            "constitution": 15,
+            "intelligence": 10,
+            "wisdom": 12,
+            "charisma": 8,
+        }
+        wizard.skill_proficiencies = ["athletics", "intimidation"]
+        wizard.expertise_skills = []
+        wizard.selected_spells = []
+        wizard.equipment_option_index = option_index
+
+    def test_option_zero_grants_standard_loadout(self, wizard):
+        self._set_fighter_state(wizard, 0)
+        with patch("terminal_client.ui.character_wizard.console.status"):
+            with patch("terminal_client.ui.character_wizard.print_status_message"):
+                character = wizard._create_character()
+        assert character.inventory.has_item("chain_mail")
+        assert character.inventory.has_item("longsword")
+        assert not character.inventory.has_item("longbow")
+
+    def test_option_one_grants_skirmisher_loadout(self, wizard):
+        self._set_fighter_state(wizard, 1)
+        with patch("terminal_client.ui.character_wizard.console.status"):
+            with patch("terminal_client.ui.character_wizard.print_status_message"):
+                character = wizard._create_character()
+        assert character.inventory.has_item("longbow")
+        assert character.inventory.has_item("studded_leather")
+        assert not character.inventory.has_item("chain_mail")

--- a/client-terminal/tests/test_character_wizard.py
+++ b/client-terminal/tests/test_character_wizard.py
@@ -502,3 +502,91 @@ class TestCharacterCreationWizard:
 
         assert character is not None
         assert character.name == "Test Character"
+
+
+class TestCustomStepEquipment:
+    """Unit tests for the custom-path Equipment step (issue #382)."""
+
+    @pytest.fixture
+    def wizard(self):
+        dice_roller = DiceRoller(seed=42)
+        factory = CharacterFactory(dice_roller=dice_roller)
+        return CharacterCreationWizard(
+            character_factory=factory, data_loader=DataLoader(), dice_roller=dice_roller
+        )
+
+    def test_wizard_initializes_equipment_option_index_to_zero(self, wizard):
+        """Default equipment_option_index should be 0 (Standard Loadout)."""
+        assert wizard.equipment_option_index == 0
+
+    def test_custom_step_equipment_records_selection(self, wizard):
+        """Selecting option 1 stores its index on the wizard and continues."""
+        wizard.character_class = "fighter"
+
+        mock_select = MagicMock()
+        mock_select.ask.return_value = 1
+
+        mock_nav = MagicMock()
+        mock_nav.ask.return_value = "next"
+
+        with patch(
+            "terminal_client.ui.character_wizard.questionary.select",
+            side_effect=[mock_select, mock_nav],
+        ):
+            with patch("terminal_client.ui.character_wizard.print_status_message"):
+                with patch("terminal_client.ui.character_wizard.console.print"):
+                    result = wizard._custom_step_equipment()
+
+        assert wizard.equipment_option_index == 1
+        assert result == "next"
+
+    def test_custom_step_equipment_back_navigation(self, wizard):
+        """Back sentinel returns 'back' without setting an option."""
+        wizard.character_class = "fighter"
+        wizard.equipment_option_index = 0
+
+        mock_select = MagicMock()
+        mock_select.ask.return_value = "back"
+
+        with patch(
+            "terminal_client.ui.character_wizard.questionary.select", return_value=mock_select
+        ):
+            with patch("terminal_client.ui.character_wizard.console.print"):
+                result = wizard._custom_step_equipment()
+
+        assert result == "back"
+        assert wizard.equipment_option_index == 0
+
+    def test_custom_step_equipment_cancel(self, wizard):
+        """questionary returning None (Ctrl-C) cancels the step."""
+        wizard.character_class = "fighter"
+
+        mock_select = MagicMock()
+        mock_select.ask.return_value = None
+
+        with patch(
+            "terminal_client.ui.character_wizard.questionary.select", return_value=mock_select
+        ):
+            with patch("terminal_client.ui.character_wizard.console.print"):
+                result = wizard._custom_step_equipment()
+
+        assert result == "cancel"
+
+    def test_custom_step_equipment_no_options_skipped(self, wizard):
+        """Classes without starting_equipment_options skip the step silently."""
+        # Mutate the in-memory class data to simulate the legacy fallback
+        wizard.character_class = "fighter"
+        wizard.classes_data["fighter"] = {
+            k: v
+            for k, v in wizard.classes_data["fighter"].items()
+            if k != "starting_equipment_options"
+        }
+
+        with patch(
+            "terminal_client.ui.character_wizard.questionary.select"
+        ) as mock_select_module:
+            result = wizard._custom_step_equipment()
+
+        assert result == "next"
+        assert wizard.equipment_option_index == 0
+        mock_select_module.assert_not_called()

--- a/client-terminal/tests/test_character_wizard.py
+++ b/client-terminal/tests/test_character_wizard.py
@@ -654,3 +654,68 @@ class TestRandomPathEquipment:
 
         assert w1.character_class == w2.character_class
         assert w1.equipment_option_index == w2.equipment_option_index
+
+
+class TestTemplateEquipmentChoice:
+    """Template path should honor the per-template equipment_choice field."""
+
+    @pytest.fixture
+    def wizard(self):
+        dice_roller = DiceRoller(seed=42)
+        return CharacterCreationWizard(
+            character_factory=CharacterFactory(dice_roller=dice_roller),
+            data_loader=DataLoader(),
+            dice_roller=dice_roller,
+        )
+
+    def _drive_template(self, wizard, template_id):
+        mock_text = MagicMock()
+        mock_text.ask.return_value = "Test"
+
+        with patch("terminal_client.ui.character_wizard.questionary.text", return_value=mock_text):
+            with patch("terminal_client.ui.character_wizard.console.print"):
+                with patch("terminal_client.ui.character_wizard.print_status_message"):
+                    with patch.object(wizard, "_finalize_character", return_value=None):
+                        wizard._create_from_template(template_id)
+
+    def test_template_honors_equipment_choice(self, wizard):
+        """A template declaring equipment_choice: 2 should set the index."""
+        wizard.templates_data["custom_fighter"] = {
+            "name": "Custom Fighter",
+            "description": "Test fighter with chosen loadout",
+            "race": "human",
+            "class": "fighter",
+            "abilities": {
+                "strength": 15,
+                "dexterity": 12,
+                "constitution": 14,
+                "intelligence": 8,
+                "wisdom": 13,
+                "charisma": 10,
+            },
+            "skill_choices": ["athletics", "intimidation"],
+            "equipment_choice": 2,
+        }
+        self._drive_template(wizard, "custom_fighter")
+        assert wizard.equipment_option_index == 2
+
+    def test_template_defaults_equipment_choice_zero(self, wizard):
+        """A template without equipment_choice keeps the default of 0."""
+        wizard.templates_data["legacy_fighter"] = {
+            "name": "Legacy Fighter",
+            "description": "Pre-#382 template (no equipment_choice)",
+            "race": "human",
+            "class": "fighter",
+            "abilities": {
+                "strength": 15,
+                "dexterity": 12,
+                "constitution": 14,
+                "intelligence": 8,
+                "wisdom": 13,
+                "charisma": 10,
+            },
+            "skill_choices": ["athletics", "intimidation"],
+        }
+        wizard.equipment_option_index = 99  # poison value to prove a write happened
+        self._drive_template(wizard, "legacy_fighter")
+        assert wizard.equipment_option_index == 0

--- a/client-terminal/tests/test_character_wizard_e2e.py
+++ b/client-terminal/tests/test_character_wizard_e2e.py
@@ -1,0 +1,120 @@
+# ABOUTME: End-to-end tests for the character creation wizard, driving run()
+# ABOUTME: through real data with only the questionary input layer mocked.
+
+from collections import deque
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dnd_engine.core.character_factory import CharacterFactory
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.rules.loader import DataLoader
+from terminal_client.ui.character_wizard import CharacterCreationWizard, CreationPath
+
+
+class _QuestionaryDriver:
+    """Helper that hands back queued answers to each questionary.* call.
+
+    Each entry in ``answers`` is the next value any ``.ask()`` will return,
+    regardless of which questionary helper raised it. This mirrors the
+    deterministic order of prompts the wizard issues, so the test reads as
+    a script of user keystrokes.
+    """
+
+    def __init__(self, answers):
+        self._queue: deque = deque(answers)
+
+    def __call__(self, *args, **kwargs):
+        mock = MagicMock()
+        if not self._queue:
+            raise AssertionError("Ran out of queued questionary answers")
+        mock.ask.return_value = self._queue.popleft()
+        return mock
+
+    @property
+    def remaining(self):
+        return list(self._queue)
+
+
+@pytest.fixture
+def wizard():
+    dice_roller = DiceRoller(seed=42)
+    return CharacterCreationWizard(
+        character_factory=CharacterFactory(dice_roller=dice_roller),
+        data_loader=DataLoader(),
+        dice_roller=dice_roller,
+    )
+
+
+def _run_wizard_with_inputs(
+    wizard, select_answers, text_answers, confirm_answers, checkbox_answers
+):
+    """Drive ``wizard.run()`` with queued answers per questionary helper.
+
+    Returns the resulting Character (or None).
+    """
+    select_driver = _QuestionaryDriver(select_answers)
+    text_driver = _QuestionaryDriver(text_answers)
+    confirm_driver = _QuestionaryDriver(confirm_answers)
+    checkbox_driver = _QuestionaryDriver(checkbox_answers)
+
+    with patch("terminal_client.ui.character_wizard.questionary.select", side_effect=select_driver):
+        with patch("terminal_client.ui.character_wizard.questionary.text", side_effect=text_driver):
+            with patch(
+                "terminal_client.ui.character_wizard.questionary.confirm",
+                side_effect=confirm_driver,
+            ):
+                with patch(
+                    "terminal_client.ui.character_wizard.questionary.checkbox",
+                    side_effect=checkbox_driver,
+                ):
+                    return wizard.run()
+
+
+def test_full_custom_path_with_equipment_choice(wizard):
+    """End-to-end: a player walks through the entire custom wizard and
+    chooses the Skirmisher (option 1) fighter loadout.
+
+    Verifies acceptance criterion #6 from issue #382 — the equipment
+    choice survives every wizard step and ends up in the final Character.
+    """
+    # questionary.select sequence — in the exact order the wizard issues them:
+    select_answers = [
+        CreationPath.CUSTOM,  # _step_choose_path
+        "human",  # _custom_step_race: race select
+        "next",  # nav after race
+        "fighter",  # _custom_step_class: class select
+        "next",  # nav after class
+        # _custom_step_abilities: no swap, so confirm() returns False; just one nav select
+        "next",  # nav after abilities
+        "next",  # nav after skills
+        1,  # _custom_step_equipment: pick Skirmisher (index 1)
+        "next",  # nav after equipment
+        "next",  # nav after name
+        "confirm",  # _finalize_character
+    ]
+    text_answers = ["TestHero"]  # _custom_step_name
+    confirm_answers = [False]  # "Would you like to swap any abilities?" -> No
+    checkbox_answers = [["athletics", "intimidation"]]  # _custom_step_skills
+
+    character = _run_wizard_with_inputs(
+        wizard,
+        select_answers=select_answers,
+        text_answers=text_answers,
+        confirm_answers=confirm_answers,
+        checkbox_answers=checkbox_answers,
+    )
+
+    assert character is not None
+    assert character.name == "TestHero"
+    assert character.race == "human"
+    # Skirmisher (option 1) loadout for fighter:
+    assert character.inventory.has_item("longbow")
+    assert character.inventory.has_item("studded_leather")
+    assert character.inventory.has_item("arrows")
+    assert character.inventory.has_item("quiver")
+    # And NOT the standard loadout's chain mail / longsword
+    assert not character.inventory.has_item("chain_mail")
+    assert not character.inventory.has_item("longsword")
+    # Skirmisher gold
+    assert character.inventory.gold == 11

--- a/client-terminal/tests/test_character_wizard_integration.py
+++ b/client-terminal/tests/test_character_wizard_integration.py
@@ -352,3 +352,80 @@ class TestCharacterCreationFlow:
         assert character.spellcasting_ability == "int"
         # Either known_spells from wizard state or initialized by factory
         assert len(character.known_spells) > 0
+
+
+class TestEquipmentOptionFlow:
+    """Verify wizard equipment_option_index actually reaches the inventory."""
+
+    @pytest.fixture
+    def wizard(self):
+        dice_roller = DiceRoller(seed=42)
+        return CharacterCreationWizard(
+            character_factory=CharacterFactory(dice_roller=dice_roller),
+            data_loader=DataLoader(),
+            dice_roller=dice_roller,
+        )
+
+    def _baseline_fighter(self, wizard, option_index):
+        wizard.name = "Test Fighter"
+        wizard.race = "human"
+        wizard.character_class = "fighter"
+        wizard.abilities = {
+            "strength": 16,
+            "dexterity": 14,
+            "constitution": 15,
+            "intelligence": 10,
+            "wisdom": 12,
+            "charisma": 8,
+        }
+        wizard.skill_proficiencies = ["athletics", "intimidation"]
+        wizard.expertise_skills = []
+        wizard.selected_spells = []
+        wizard.equipment_option_index = option_index
+
+    def test_fighter_option_zero_grants_standard_loadout(self, wizard):
+        self._baseline_fighter(wizard, 0)
+        character = wizard._create_character()
+
+        assert character.inventory.has_item("longsword")
+        assert character.inventory.has_item("chain_mail")
+        # Standard Loadout gold: 10 gp
+        assert character.inventory.gold == 10
+
+    def test_fighter_option_one_grants_skirmisher_loadout(self, wizard):
+        self._baseline_fighter(wizard, 1)
+        character = wizard._create_character()
+
+        assert character.inventory.has_item("studded_leather")
+        assert character.inventory.has_item("longbow")
+        assert character.inventory.has_item("arrows")
+        assert character.inventory.has_item("quiver")
+        # Skirmisher gold: 11 gp
+        assert character.inventory.gold == 11
+        # Should NOT have the standard loadout's armor
+        assert not character.inventory.has_item("chain_mail")
+
+    def test_rogue_freelancer_option_two_grants_gold_only(self, wizard):
+        wizard.name = "Test Rogue"
+        wizard.race = "halfling"
+        wizard.character_class = "rogue"
+        wizard.abilities = {
+            "strength": 8,
+            "dexterity": 16,
+            "constitution": 12,
+            "intelligence": 13,
+            "wisdom": 10,
+            "charisma": 14,
+        }
+        wizard.skill_proficiencies = ["stealth", "sleight_of_hand", "deception", "perception"]
+        wizard.expertise_skills = ["stealth", "sleight_of_hand"]
+        wizard.selected_spells = []
+        wizard.equipment_option_index = 2  # Freelancer: 100 gp, no items
+
+        character = wizard._create_character()
+
+        # Freelancer is a gold-only loadout
+        assert character.inventory.gold == 100
+        assert not character.inventory.has_item("rapier")
+        assert not character.inventory.has_item("shortbow")
+        assert not character.inventory.has_item("leather_armor")

--- a/dnd-engine/dnd_engine/data/srd/character_templates.json
+++ b/dnd-engine/dnd_engine/data/srd/character_templates.json
@@ -13,7 +13,8 @@
       "charisma": 10
     },
     "skill_choices": ["athletics", "intimidation"],
-    "equipment_preference": "melee"
+    "equipment_preference": "melee",
+    "equipment_choice": 0
   },
   "sneaky_rogue": {
     "name": "Sneaky Rogue",
@@ -30,7 +31,8 @@
     },
     "skill_choices": ["stealth", "sleight_of_hand", "deception", "perception"],
     "expertise_choices": ["stealth", "sleight_of_hand"],
-    "equipment_preference": "finesse"
+    "equipment_preference": "finesse",
+    "equipment_choice": 0
   },
   "wise_wizard": {
     "name": "Wise Wizard",
@@ -50,7 +52,8 @@
       "cantrips": ["fire_bolt", "mage_hand", "light"],
       "level_1": ["mage_armor", "shield", "magic_missile", "detect_magic", "identify", "burning_hands"]
     },
-    "equipment_preference": "arcane_focus"
+    "equipment_preference": "arcane_focus",
+    "equipment_choice": 0
   },
   "arcane_wizard": {
     "name": "Arcane Wizard",
@@ -70,7 +73,8 @@
       "cantrips": ["fire_bolt", "mage_hand", "light"],
       "level_1": ["mage_armor", "magic_missile", "shield", "detect_magic", "burning_hands", "sleep"]
     },
-    "equipment_preference": "arcane_focus"
+    "equipment_preference": "arcane_focus",
+    "equipment_choice": 0
   },
   "versatile_fighter": {
     "name": "Versatile Fighter",
@@ -86,7 +90,8 @@
       "charisma": 8
     },
     "skill_choices": ["acrobatics", "perception"],
-    "equipment_preference": "ranged"
+    "equipment_preference": "ranged",
+    "equipment_choice": 0
   },
   "cunning_rogue": {
     "name": "Cunning Rogue",
@@ -103,6 +108,7 @@
     },
     "skill_choices": ["investigation", "perception", "stealth", "sleight_of_hand"],
     "expertise_choices": ["investigation", "stealth"],
-    "equipment_preference": "finesse"
+    "equipment_preference": "finesse",
+    "equipment_choice": 0
   }
 }


### PR DESCRIPTION
## Summary

Surfaces the engine's SRD A/B/C starting equipment options (shipped in #383) through the character creation wizard. Adds a new **Equipment** step to the custom path, picks an option randomly in the random path, and honors a new `equipment_choice` field on character templates. The summary screen now shows the chosen loadout (name, every item, gold).

Closes #382.

## Changes

- **`client-terminal/terminal_client/ui/character_wizard.py`**
  - New `equipment_option_index` field on `CharacterCreationWizard`
  - New `_custom_step_equipment` step inserted between Skills and Name in `_run_custom_path`
  - `_generate_random_character` rolls a random option via the seeded RNG
  - `_create_from_template` reads `template.get("equipment_choice", 0)`
  - `_create_character` forwards `option_index=self.equipment_option_index` to `CharacterFactory.create_character`
  - `_show_character_summary` rendered through new `_render_equipment_summary` helper: loadout name, every item (with pack contents preview), gold; AC now follows the selected option's armor
  - New helpers: `_format_option_summary`, `_lookup_item_display_name`, `_resolved_loadout_items`

- **`dnd-engine/dnd_engine/data/srd/character_templates.json`**
  - `equipment_choice: 0` added to all six templates (preserves current behavior; per-template tuning can come later)

- **Tests**
  - 14 unit tests (`test_character_wizard.py`): custom step navigation, no-options skip, random pick range + variance + determinism, template field, summary content for all three fighter loadouts, factory wiring for option 0 vs option 1
  - 3 integration tests (`test_character_wizard_integration.py`): real `DataLoader` + `CharacterFactory` verifying inventory/gold for fighter option 0, fighter option 1 (Skirmisher), rogue option 2 (Freelancer gold-only)
  - 1 e2e test (`test_character_wizard_e2e.py`): drives `wizard.run()` end-to-end through every custom-path step with mocked questionary input layer only

## Testing

- [x] `uv run pytest` — 55 wizard tests pass (was 41, added 14)
- [x] `uv run pytest` (engine) — 76 character-creation tests still pass
- [x] `ruff check` — clean
- [x] Legacy fallback (classes without `starting_equipment_options`) preserved end-to-end
- [ ] Manual: `uv run dnd-game` → new game → Custom path → confirm Equipment step appears and selected loadout shows on summary

## TDD Trail

Each commit pairs a failing test with its implementation:

```
35db8f3 Test #382: E2E test for full custom-path wizard with equipment choice
4cb2fce Test #382: Integration tests for wizard equipment choice flow
eff2996 Add  #382: Wire equipment_option_index into CharacterFactory call
17ccbea Add  #382: Character summary shows chosen equipment loadout
101078f Add  #382: equipment_choice field on all SRD character templates
463041a Add  #382: Template path honors equipment_choice field
8c1e44d Add  #382: Random path picks a starting equipment option
c7b0456 Add  #382: Custom-path Equipment step in character wizard
```

## Related

- Closes #382
- Builds on #383 (engine layer for A/B/C options)
- Parent epic: #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)