### PR TITLE
Refactor #391: Remove stale duplicate dnd_engine/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,5 @@ Thumbs.db
 logs/
 
 # Generated dungeons (runtime artifacts, not source content)
-dnd_engine/data/content/dungeons/generated_*.json
+dnd-engine/dnd_engine/data/content/dungeons/generated_*.json
 saves/


### PR DESCRIPTION
## Summary

Cleans up a pre-monorepo leftover: the top-level `dnd_engine/` directory
that was supposed to be deleted in #309 (commit 7a1f812) but persisted
locally as untracked pycache artifacts. The canonical engine package
lives at `dnd-engine/dnd_engine/`.

## Changes

- **`.gitignore`**: relocates the stale path
  (`dnd_engine/data/content/dungeons/generated_*.json`) to the canonical
  location (`dnd-engine/dnd_engine/data/content/dungeons/generated_*.json`).
  Preserves the original intent — runtime-generated dungeon files stay ignored.

No source code changes — only `.gitignore`. The working-tree directory
removal is a local cleanup (zero tracked files were inside).

## Why now

Discovered during sprint planning while auditing engine ↔ client decoupling.
With two `dnd_engine` directories on disk (one canonical, one orphaned),
there's confusion risk: depending on `sys.path` ordering, edits might appear
to "not take effect" because Python could bind to the stale copy. Removing
the artifact eliminates the ambiguity before tackling the keystone MCP
refactor (#326) later in this sprint.

## Audit evidence

- `git ls-files dnd_engine/` → empty (nothing tracked since #309)
- Top-level `/dnd_engine/` had no `__init__.py` → never a valid Python package
- No `pyproject.toml`, script, or doc referenced the old path
- `import dnd_engine` resolves to `dnd-engine/dnd_engine/__init__.py` ✓ (verified post-change)

## Testing

- [x] `import dnd_engine` resolves to canonical path
- [x] `git ls-files dnd_engine/` confirms zero tracked files
- [x] `uv run pytest` in `dnd-engine`, `client-terminal`, `client-2d` — all green (manual)
- [x] `uv run dnd-game` launches — manual

## Related

- Fixes #391
- Follow-up to #309 (monorepo split cleanup)
- Sets up sprint to tackle #326 (MCP → real engine) with a clean engine surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)