### PR TITLE
Fix #390: Declare dnd-engine as runtime dependency in client-2d

### DIFF
--- a/client-2d/pyproject.toml
+++ b/client-2d/pyproject.toml
@@ -13,8 +13,8 @@ authors = [
 ]
 
 dependencies = [
+    "dnd-engine",
     "fastmcp>=2.14.2",
-    # Phase 1: Standalone systems (fog, lighting, input, assets) - no engine dependency
     "numpy>=1.24.0",
 ]
 
@@ -22,10 +22,6 @@ dependencies = [
 graphics = [
     # Required for actual rendering (not needed for unit tests)
     "arcade>=2.6.0",
-]
-engine = [
-    # Required for Phase 2+ integration with dnd-engine
-    # "dnd-engine",  # Uncomment when ready for integration
 ]
 mcp = [
     # Required for MCP server (Claude-driven playtesting)

--- a/uv.lock
+++ b/uv.lock
@@ -506,6 +506,7 @@ name = "dnd-2d-client"
 version = "0.1.0"
 source = { editable = "client-2d" }
 dependencies = [
+    { name = "dnd-engine" },
     { name = "fastmcp" },
     { name = "numpy" },
 ]
@@ -528,6 +529,7 @@ mcp = [
 [package.metadata]
 requires-dist = [
     { name = "arcade", marker = "extra == 'graphics'", specifier = ">=2.6.0" },
+    { name = "dnd-engine", editable = "dnd-engine" },
     { name = "fastmcp", specifier = ">=2.14.2" },
     { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
@@ -537,7 +539,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
-provides-extras = ["graphics", "engine", "mcp", "dev"]
+provides-extras = ["graphics", "mcp", "dev"]
 
 [[package]]
 name = "dnd-engine"


### PR DESCRIPTION
## Summary
- `client-2d` imports `dnd_engine.*` across core gameplay code paths (`entity.py`, `session.py`, `game.py`, `integration/engine_bridge.py`, `integration/engine_adapter.py`), but the manifest only listed `dnd-engine` in a commented-out optional `engine` extra.
- This worked in development because the `uv` workspace installs all monorepo packages into the same environment, but a standalone install of `dnd-2d-client` would have raised `ModuleNotFoundError` at import time.

## Changes
- **client-2d/pyproject.toml**: Added `dnd-engine` to the main `dependencies` list; removed the now-empty `engine` optional-dependencies extra.
- **uv.lock**: Regenerated to reflect the declared dependency on the workspace `dnd-engine` package.

## Testing
- [x] `uv sync` resolves cleanly (no new packages added — already installed via workspace)
- [x] `from dnd_engine.core import dice` imports successfully from client-2d
- [x] All 401 tests in `client-2d/tests/` collect without error
- [ ] Manual verification (deferred to reviewer)

## Acceptance Criteria
- [x] `dnd-engine` declared as a runtime dependency in `client-2d/pyproject.toml`
- [x] `engine` optional-dependencies extra removed
- [x] `uv sync` still resolves cleanly
- [x] Existing tests still collect

## Related Issues
Fixes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)