### PR TITLE
Add #351: Apply disadvantage to long-range ranged attacks

### DIFF
--- a/client-2d/src/client_2d/game.py
+++ b/client-2d/src/client_2d/game.py
@@ -299,8 +299,8 @@ class GameWindow(arcade.Window):
     def _handle_combat_end(self) -> None:
         self.session._handle_combat_end()
 
-    def _execute_attack(self) -> None:
-        self.session.execute_attack()
+    def _execute_attack(self, *, disadvantage: bool = False) -> None:
+        self.session.execute_attack(disadvantage=disadvantage)
 
     def _pass_turn(self) -> None:
         self.session.pass_turn()
@@ -1282,7 +1282,7 @@ class GameWindow(arcade.Window):
             )
             return
 
-        # Log long range (disadvantage in future)
+        # Long-range attacks roll with disadvantage per D&D 5E.
         in_long_range = distance_ft > normal_range
         if in_long_range:
             self._add_combat_log(
@@ -1292,7 +1292,7 @@ class GameWindow(arcade.Window):
         # Set selected enemy and execute attack
         self.selected_enemy = target.enemy_index
         self.selected_target = target
-        self._execute_attack()
+        self._execute_attack(disadvantage=in_long_range)
 
     def _cycle_target(self, reverse: bool = False) -> None:
         """Cycle through targets sorted by distance (nearest first)."""

--- a/client-2d/src/client_2d/integration/engine_adapter.py
+++ b/client-2d/src/client_2d/integration/engine_adapter.py
@@ -627,12 +627,16 @@ class EngineAdapter:
         self,
         target_index: int,
         attacker: Character | None = None,
+        *,
+        disadvantage: bool = False,
     ) -> dict[str, Any]:
-        """Execute a melee attack against an enemy.
+        """Execute an attack against an enemy.
 
         Args:
             target_index: Index into active_enemies list.
             attacker: Character making the attack. Uses current turn character if not provided.
+            disadvantage: Roll the attack with disadvantage (e.g. ranged attack
+                at long range). Forwarded to the engine's d20 roll.
 
         Returns:
             Dict with attack result info (hit, damage, target_killed, etc.)
@@ -658,7 +662,9 @@ class EngineAdapter:
 
         # Execute attack through game state
         try:
-            result = self._game_state.execute_player_attack(attacker, target)
+            result = self._game_state.execute_player_attack(
+                attacker, target, disadvantage=disadvantage
+            )
 
             return {
                 "success": True,
@@ -671,6 +677,9 @@ class EngineAdapter:
                 "attack_roll": result.attack_result.attack_roll if result.attack_result else 0,
                 "attack_bonus": result.attack_result.attack_bonus if result.attack_result else 0,
                 "target_ac": result.attack_result.target_ac if result.attack_result else 0,
+                "disadvantage": (
+                    result.attack_result.disadvantage if result.attack_result else False
+                ),
             }
         except Exception as e:
             return {"success": False, "error": str(e)}

--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -557,18 +557,24 @@ class GameSession:
         elif check.get("party_wiped"):
             self._add_combat_log("Defeat! Your party has fallen...")
 
-    def execute_attack(self) -> dict[str, Any] | None:
+    def execute_attack(self, *, disadvantage: bool = False) -> dict[str, Any] | None:
         """Execute an attack on the currently-selected enemy.
 
         Reads ``self.selected_enemy`` (the engine's enemy index) and
         delegates to the engine adapter. Called by both GameWindow's
         input handler and the MCP attack path.
 
+        Args:
+            disadvantage: Roll with disadvantage (e.g. ranged attack at long
+                range). Forwarded to the engine adapter.
+
         Returns the engine adapter's attack-result dict on success so callers
         (notably the MCP attack handler) can render hit/miss/damage details.
         Returns ``None`` if the engine rejected the attack outright.
         """
-        result = self.engine.execute_attack(target_index=self.selected_enemy)
+        result = self.engine.execute_attack(
+            target_index=self.selected_enemy, disadvantage=disadvantage
+        )
 
         if result["success"]:
             if result["hit"]:
@@ -993,7 +999,7 @@ class GameSession:
         pre_attack_combatant = current["name"] if current else None
 
         self.selected_enemy = target_entity.enemy_index
-        attack_result = self.execute_attack()
+        attack_result = self.execute_attack(disadvantage=in_long_range)
 
         post_attack_combatant = self.engine.get_current_combatant()
         post_name = post_attack_combatant["name"] if post_attack_combatant else None

--- a/client-2d/tests/test_ranged_attack_integration.py
+++ b/client-2d/tests/test_ranged_attack_integration.py
@@ -3,6 +3,8 @@
 
 """Integration tests for ranged attack support via MCP commands."""
 
+from pathlib import Path
+
 import pytest
 from client_2d.game import get_attack_range
 
@@ -200,3 +202,162 @@ class TestRangedAttackDistanceCheck:
         target_distance_ft = distance_in_feet(0, 0, 2, 0)
 
         assert target_distance_ft > max_range  # Out of melee range
+
+
+class TestEngineAdapterDisadvantage:
+    """EngineAdapter.execute_attack must forward the disadvantage flag to
+    GameState.execute_player_attack and expose the resulting flag on the
+    returned dict so the session/UI can show the modifier.
+    """
+
+    SCENARIO_DIR = (
+        Path(__file__).parent.parent.parent
+        / "dnd-engine"
+        / "tests"
+        / "scenarios"
+        / "yaml"
+    )
+
+    @pytest.fixture
+    def adapter_in_combat(self):
+        from client_2d.integration.engine_adapter import EngineAdapter
+
+        adapter = EngineAdapter()
+        adapter.load_scenario(self.SCENARIO_DIR / "ranged_attack_basic.yaml")
+        assert adapter.in_combat
+        return adapter
+
+    def _player_target_index(self, adapter):
+        """Return the active_enemies index of the goblin while it's alive."""
+        enemies = adapter.game_state.active_enemies
+        for idx, enemy in enumerate(enemies):
+            if enemy.is_alive:
+                return idx
+        pytest.skip("No live enemy to attack")
+
+    def test_execute_attack_forwards_disadvantage_kwarg(
+        self, adapter_in_combat, monkeypatch
+    ):
+        """The disadvantage kwarg must reach game_state.execute_player_attack.
+
+        We patch the engine method to capture call kwargs without depending
+        on ammo, dice seeds, or hit/miss outcomes.
+        """
+        captured: dict = {}
+        real_method = adapter_in_combat.game_state.execute_player_attack
+
+        def spy(attacker, target, *, disadvantage=False):
+            captured["disadvantage"] = disadvantage
+            return real_method(attacker, target, disadvantage=disadvantage)
+
+        monkeypatch.setattr(
+            adapter_in_combat.game_state, "execute_player_attack", spy
+        )
+
+        target_index = self._player_target_index(adapter_in_combat)
+        adapter_in_combat.execute_attack(target_index=target_index, disadvantage=True)
+
+        assert captured["disadvantage"] is True
+
+    def test_execute_attack_default_passes_false(self, adapter_in_combat, monkeypatch):
+        """Default call must pass disadvantage=False to the engine."""
+        captured: dict = {}
+        real_method = adapter_in_combat.game_state.execute_player_attack
+
+        def spy(attacker, target, *, disadvantage=False):
+            captured["disadvantage"] = disadvantage
+            return real_method(attacker, target, disadvantage=disadvantage)
+
+        monkeypatch.setattr(
+            adapter_in_combat.game_state, "execute_player_attack", spy
+        )
+
+        target_index = self._player_target_index(adapter_in_combat)
+        adapter_in_combat.execute_attack(target_index=target_index)
+
+        assert captured["disadvantage"] is False
+
+    def test_execute_attack_result_includes_disadvantage_field(
+        self, adapter_in_combat
+    ):
+        """The returned dict must surface the disadvantage flag for the UI."""
+        target_index = self._player_target_index(adapter_in_combat)
+
+        result = adapter_in_combat.execute_attack(target_index=target_index)
+
+        assert "disadvantage" in result
+
+
+class TestSessionLongRangeDisadvantage:
+    """When session.attack() fires at a target in long range, the attack roll
+    must use disadvantage. The session detects long range via
+    distance_in_feet() vs the weapon's normal/max range; this test confirms
+    the flag actually reaches the engine, not just the combat log.
+    """
+
+    SCENARIO_DIR = (
+        Path(__file__).parent.parent.parent
+        / "dnd-engine"
+        / "tests"
+        / "scenarios"
+        / "yaml"
+    )
+
+    @pytest.fixture
+    def session_in_combat(self):
+        """Spin up a GameSession around the ranged_attack_basic scenario.
+
+        Uses the session-level loader (not the adapter) so visual entities
+        are populated alongside the engine state.
+        """
+        from client_2d.session import GameSession
+
+        session = GameSession(enable_mcp=False, dev_mode=False)
+        session.load_scenario(str(self.SCENARIO_DIR / "ranged_attack_basic.yaml"))
+        assert session.engine.in_combat
+        return session
+
+    def _attach_attack_spy(self, session, monkeypatch):
+        """Patch the engine adapter's execute_attack to record disadvantage."""
+        captured: dict = {}
+        real_method = session.engine.execute_attack
+
+        def spy(target_index, *, disadvantage=False, **kwargs):
+            captured["disadvantage"] = disadvantage
+            return real_method(target_index, disadvantage=disadvantage, **kwargs)
+
+        monkeypatch.setattr(session.engine, "execute_attack", spy)
+        return captured
+
+    def test_session_attack_at_long_range_passes_disadvantage(
+        self, session_in_combat, monkeypatch
+    ):
+        """When the target sits past normal range, session.attack must call
+        through with disadvantage=True so the engine rolls accordingly.
+        """
+        captured = self._attach_attack_spy(session_in_combat, monkeypatch)
+
+        # Shortbow is 80/320 ft → > 16 tiles puts the target in long range.
+        # Move the goblin visual entity (and engine creature) to (25, 5),
+        # 22 tiles = 110 ft from Archy at (3, 5).
+        monsters = session_in_combat.entity_manager.get_monsters()
+        assert monsters, "Scenario should have at least one monster"
+        target = monsters[0]
+        target.grid_x = 25
+        target.grid_y = 5
+
+        session_in_combat.attack(0)
+
+        assert captured["disadvantage"] is True
+
+    def test_session_attack_at_normal_range_passes_no_disadvantage(
+        self, session_in_combat, monkeypatch
+    ):
+        """Inside normal range, no disadvantage should be applied."""
+        captured = self._attach_attack_spy(session_in_combat, monkeypatch)
+
+        # Default scenario position is (10, 5) — 35 ft from (3, 5), well
+        # inside the 80 ft shortbow normal range.
+        session_in_combat.attack(0)
+
+        assert captured["disadvantage"] is False

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -2179,7 +2179,13 @@ class GameState:
         result.resources_consumed = resources_consumed
         return result
 
-    def execute_player_attack(self, attacker: Character, target: Creature) -> "PlayerAttackResult":
+    def execute_player_attack(
+        self,
+        attacker: Character,
+        target: Creature,
+        *,
+        disadvantage: bool = False,
+    ) -> "PlayerAttackResult":
         """
         Execute a player's attack with their equipped weapon.
 
@@ -2193,6 +2199,9 @@ class GameState:
         Args:
             attacker: Character making the attack
             target: Target creature
+            disadvantage: Roll the attack with disadvantage (e.g. ranged attack
+                at long range, target obscured). Forwarded to the combat
+                engine's d20 roll.
 
         Returns:
             PlayerAttackResult with all information needed for UI display.
@@ -2250,6 +2259,7 @@ class GameState:
             defender=target,
             attack_bonus=attack_bonus,
             damage_dice=damage_dice,
+            disadvantage=disadvantage,
             apply_damage=True,
             game_state=self,
         )

--- a/dnd-engine/tests/test_execute_player_attack.py
+++ b/dnd-engine/tests/test_execute_player_attack.py
@@ -274,3 +274,66 @@ class TestConcentrationBreak(TestExecutePlayerAttack):
             assert result.concentration_broken is None or isinstance(
                 result.concentration_broken, dict
             )
+
+
+class TestDisadvantage(TestExecutePlayerAttack):
+    """Test that the disadvantage flag is forwarded to the underlying attack roll."""
+
+    def test_disadvantage_flag_propagates_to_attack_result(
+        self, game_state, fighter, goblin
+    ):
+        """When called with disadvantage=True, the AttackResult records it."""
+        result = game_state.execute_player_attack(fighter, goblin, disadvantage=True)
+
+        assert result.success is True
+        assert result.attack_result is not None
+        assert result.attack_result.disadvantage is True
+
+    def test_default_attack_has_no_disadvantage(self, game_state, fighter, goblin):
+        """Default attack (no kwarg) records disadvantage=False."""
+        result = game_state.execute_player_attack(fighter, goblin)
+
+        assert result.success is True
+        assert result.attack_result is not None
+        assert result.attack_result.disadvantage is False
+
+    def test_disadvantage_lowers_attack_roll(
+        self, fighter, goblin, event_bus, data_loader
+    ):
+        """A disadvantaged roll is the lower of two d20s; over many trials it
+        should produce a lower average attack roll than a normal attack with
+        the same seed sequence.
+        """
+        normal_rolls: list[int] = []
+        disadv_rolls: list[int] = []
+
+        for seed in range(50):
+            for bucket, disadvantage in ((normal_rolls, False), (disadv_rolls, True)):
+                dice_roller = DiceRoller(seed=seed)
+                party = Party([fighter])
+                gs = GameState(
+                    party=party,
+                    dungeon_name="test_dungeon",
+                    event_bus=event_bus,
+                    data_loader=data_loader,
+                    dice_roller=dice_roller,
+                )
+                # Use a fresh goblin per trial so HP changes don't matter.
+                target = Creature(
+                    name="Goblin",
+                    max_hp=999,
+                    ac=99,  # Guarantees miss so target stays alive
+                    abilities=Abilities(8, 14, 10, 10, 8, 8),
+                )
+                gs.active_enemies = [target]
+                result = gs.execute_player_attack(
+                    fighter, target, disadvantage=disadvantage
+                )
+                bucket.append(result.attack_result.attack_roll)
+
+        normal_avg = sum(normal_rolls) / len(normal_rolls)
+        disadv_avg = sum(disadv_rolls) / len(disadv_rolls)
+        assert disadv_avg < normal_avg, (
+            f"Expected disadvantage to lower avg roll, "
+            f"got normal={normal_avg:.2f} vs disadv={disadv_avg:.2f}"
+        )


### PR DESCRIPTION
## Summary

When a ranged attack fired from the 2D client landed past the equipped weapon's normal range, the session and windowed-mode attack paths *detected* long range and logged "(long range - disadvantage)" — but the disadvantage flag never reached the engine's d20 roll. Per D&D 5E, that roll should be made with disadvantage.

This PR plumbs the existing detection through the call chain so the engine actually rolls at disadvantage.

## Changes

- **`dnd-engine/dnd_engine/core/game_state.py`** — `execute_player_attack` accepts `disadvantage: bool = False` and forwards it to `combat_engine.resolve_attack`.
- **`client-2d/src/client_2d/integration/engine_adapter.py`** — `execute_attack` accepts `disadvantage` and surfaces the resolved flag on its return dict so the UI/MCP layer can render it.
- **`client-2d/src/client_2d/session.py`** — `execute_attack` accepts `disadvantage`; `session.attack` passes `disadvantage=in_long_range` (the existing detection).
- **`client-2d/src/client_2d/game.py`** — `_execute_attack` and `_attack_entity` (windowed mode) pass `disadvantage=in_long_range` down through the same delegator.

## Call chain

```
GameWindow._attack_entity (game.py)
  → GameWindow._execute_attack (game.py)
    → GameSession.execute_attack (session.py)
      → EngineAdapter.execute_attack (engine_adapter.py)
        → GameState.execute_player_attack (game_state.py)
          → CombatEngine.resolve_attack (combat.py, already accepted disadvantage)
```

## Testing

- [x] Engine: 3 new tests in `test_execute_player_attack.py` (kwarg propagation, default-False, statistical check that disadvantaged rolls average lower)
- [x] Adapter: 3 new tests in `test_ranged_attack_integration.py` (forwards kwarg to engine, default-False, return dict surfaces flag)
- [x] Session end-to-end: 2 new tests confirming `session.attack()` against a target at long range produces `disadvantage=True` at the engine boundary, and against a target at normal range produces `disadvantage=False`
- [x] Full client-2d suite: 406/406 passing
- [x] Full engine suite: 2191 passing, 1 pre-existing skip

## Acceptance criteria for #351

- [x] Detect if equipped weapon is ranged — pre-existing
- [x] Allow attacking non-adjacent enemies within weapon range — pre-existing
- [ ] Show range indicator or valid targets — **deliberately out of scope** (visual UI polish; can split out)
- [x] Ammunition tracking (if applicable) — pre-existing in engine
- [x] **Disadvantage at long range per D&D 5E rules** — this PR

## TDD note

Step 6 in the plan — the one-line windowed `_attack_entity` change in `game.py` — is exercised indirectly via the session-layer tests. A direct arcade-driven test is impractical for what amounts to a delegator.

## Related

- Fixes #351
- Part of epic #348 (2D Client Combat Feature Parity)
- Side-finding filed as #394 (`EngineAdapter.execute_attack` masks `PlayerAttackResult.success=False` as success) — discovered while testing, not addressed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)