### PR TITLE
Fix #394: Propagate PlayerAttackResult.success from EngineAdapter

### DIFF
--- a/client-2d/src/client_2d/integration/engine_adapter.py
+++ b/client-2d/src/client_2d/integration/engine_adapter.py
@@ -667,7 +667,8 @@ class EngineAdapter:
             )
 
             return {
-                "success": True,
+                "success": result.success,
+                "error": result.error if not result.success else None,
                 "hit": result.attack_result.hit if result.attack_result else False,
                 "damage": result.attack_result.damage if result.attack_result else 0,
                 "critical": result.attack_result.critical_hit if result.attack_result else False,

--- a/client-2d/tests/test_engine_adapter_attack_success.py
+++ b/client-2d/tests/test_engine_adapter_attack_success.py
@@ -14,13 +14,7 @@ from pathlib import Path
 
 import pytest
 
-SCENARIO_DIR = (
-    Path(__file__).parent.parent.parent
-    / "dnd-engine"
-    / "tests"
-    / "scenarios"
-    / "yaml"
-)
+SCENARIO_DIR = Path(__file__).parent.parent.parent / "dnd-engine" / "tests" / "scenarios" / "yaml"
 
 
 @pytest.fixture
@@ -128,9 +122,7 @@ class TestEngineAdapterSuccessPassthrough:
         def _stub(*_args, **_kwargs):
             return fake_result
 
-        monkeypatch.setattr(
-            adapter_no_ammo.game_state, "execute_player_attack", _stub
-        )
+        monkeypatch.setattr(adapter_no_ammo.game_state, "execute_player_attack", _stub)
 
         result = adapter_no_ammo.execute_attack(target_index=target_index)
 

--- a/client-2d/tests/test_engine_adapter_attack_success.py
+++ b/client-2d/tests/test_engine_adapter_attack_success.py
@@ -1,0 +1,140 @@
+# ABOUTME: Adapter-level tests for EngineAdapter.execute_attack success/error
+# ABOUTME: propagation from the underlying PlayerAttackResult (issue #394).
+
+"""Regression tests for issue #394.
+
+The adapter must mirror ``PlayerAttackResult.success`` and forward
+``PlayerAttackResult.error`` to the caller. Prior to this fix the adapter
+hard-coded ``success=True`` whenever the engine call did not raise, which
+silently swallowed legitimate failures such as the no-ammunition short-circuit
+in ``GameState.execute_player_attack`` (``game_state.py`` ammo check).
+"""
+
+from pathlib import Path
+
+import pytest
+
+SCENARIO_DIR = (
+    Path(__file__).parent.parent.parent
+    / "dnd-engine"
+    / "tests"
+    / "scenarios"
+    / "yaml"
+)
+
+
+@pytest.fixture
+def adapter_no_ammo():
+    """Adapter loaded into a scenario whose fighter has a shortbow but no arrows.
+
+    ``ranged_attack_basic.yaml`` arms its high-elf fighter with a shortbow
+    and never grants ammunition, so the engine short-circuits the attack on
+    the ammo check and returns ``PlayerAttackResult(success=False, ...)``.
+    """
+    from client_2d.integration.engine_adapter import EngineAdapter
+
+    adapter = EngineAdapter()
+    adapter.load_scenario(SCENARIO_DIR / "ranged_attack_basic.yaml")
+    assert adapter.in_combat
+    return adapter
+
+
+def _live_enemy_index(adapter):
+    for idx, enemy in enumerate(adapter.game_state.active_enemies):
+        if enemy.is_alive:
+            return idx
+    pytest.skip("No live enemy to attack")
+
+
+class TestEngineAdapterSuccessPassthrough:
+    """The adapter must mirror PlayerAttackResult.success/error."""
+
+    def test_no_ammo_attack_returns_success_false(self, adapter_no_ammo):
+        """No-ammo failure must surface as success=False, not True."""
+        target_index = _live_enemy_index(adapter_no_ammo)
+
+        result = adapter_no_ammo.execute_attack(target_index=target_index)
+
+        assert result["success"] is False
+
+    def test_no_ammo_attack_returns_engine_error_message(self, adapter_no_ammo):
+        """The engine's error string must be forwarded verbatim."""
+        target_index = _live_enemy_index(adapter_no_ammo)
+
+        result = adapter_no_ammo.execute_attack(target_index=target_index)
+
+        assert result["error"] == "No ammunition available for this weapon"
+
+    def test_no_ammo_attack_preserves_metadata_keys(self, adapter_no_ammo):
+        """Failure dict must still expose the keys callers index into.
+
+        Existing callers (session, MCP attack report) read hit/damage/etc.
+        unconditionally. A regression that omits keys would surface as
+        KeyError rather than a graceful failure path.
+        """
+        target_index = _live_enemy_index(adapter_no_ammo)
+
+        result = adapter_no_ammo.execute_attack(target_index=target_index)
+
+        for key in (
+            "hit",
+            "damage",
+            "critical",
+            "target_name",
+            "target_killed",
+            "attacker_name",
+            "attack_roll",
+            "attack_bonus",
+            "target_ac",
+            "disadvantage",
+        ):
+            assert key in result, f"missing key: {key}"
+
+    def test_successful_attack_returns_success_true_and_no_error(
+        self, adapter_no_ammo, monkeypatch
+    ):
+        """Sanity: when the engine reports success=True, the adapter mirrors it.
+
+        We monkeypatch ``execute_player_attack`` so the test does not depend
+        on either dice outcomes or scenario-specific ammo state.
+        """
+        from dnd_engine.core.combat import AttackResult
+        from dnd_engine.core.game_state import PlayerAttackResult
+
+        attacker = adapter_no_ammo.party.characters[0]
+        target_index = _live_enemy_index(adapter_no_ammo)
+        target = adapter_no_ammo.game_state.active_enemies[target_index]
+
+        fake_attack = AttackResult(
+            attacker_name=attacker.name,
+            defender_name=target.name,
+            attack_roll=15,
+            attack_bonus=4,
+            target_ac=13,
+            hit=True,
+            critical_hit=False,
+            damage=6,
+            advantage=False,
+            disadvantage=False,
+        )
+        fake_result = PlayerAttackResult(
+            success=True,
+            attack_result=fake_attack,
+            attacker_name=attacker.name,
+            target_name=target.name,
+            weapon_name="shortbow",
+        )
+
+        def _stub(*_args, **_kwargs):
+            return fake_result
+
+        monkeypatch.setattr(
+            adapter_no_ammo.game_state, "execute_player_attack", _stub
+        )
+
+        result = adapter_no_ammo.execute_attack(target_index=target_index)
+
+        assert result["success"] is True
+        assert result["error"] is None
+        assert result["hit"] is True
+        assert result["damage"] == 6

--- a/client-2d/tests/test_ranged_attack_integration.py
+++ b/client-2d/tests/test_ranged_attack_integration.py
@@ -361,3 +361,60 @@ class TestSessionLongRangeDisadvantage:
         session_in_combat.attack(0)
 
         assert captured["disadvantage"] is False
+
+
+class TestSessionNoAmmoAttack:
+    """Regression coverage for issue #394.
+
+    When the engine short-circuits an attack because the equipped weapon has
+    no ammunition, the session must not advance the turn and must log the
+    real engine error (not a fabricated miss).
+    """
+
+    SCENARIO_DIR = (
+        Path(__file__).parent.parent.parent
+        / "dnd-engine"
+        / "tests"
+        / "scenarios"
+        / "yaml"
+    )
+
+    @pytest.fixture
+    def session_no_ammo(self):
+        from client_2d.session import GameSession
+
+        session = GameSession(enable_mcp=False, dev_mode=False)
+        session.load_scenario(str(self.SCENARIO_DIR / "ranged_attack_basic.yaml"))
+        assert session.engine.in_combat
+        # Aim at the live goblin; index matches the engine's active_enemies.
+        for idx, enemy in enumerate(session.engine.game_state.active_enemies):
+            if enemy.is_alive:
+                session.selected_enemy = idx
+                break
+        else:
+            pytest.skip("Scenario has no live enemy")
+        return session
+
+    def test_no_ammo_attack_does_not_advance_turn(self, session_no_ammo):
+        pre = session_no_ammo.engine.get_current_combatant()
+        pre_name = pre["name"] if pre else None
+
+        session_no_ammo.execute_attack()
+
+        post = session_no_ammo.engine.get_current_combatant()
+        post_name = post["name"] if post else None
+        assert pre_name == post_name, (
+            "Turn should not advance when the attack failed for lack of ammo"
+        )
+
+    def test_no_ammo_attack_logs_engine_error_to_combat_log(self, session_no_ammo):
+        session_no_ammo.execute_attack()
+
+        assert any(
+            "No ammunition" in entry for entry in session_no_ammo.combat_log
+        ), f"Expected ammo error in combat log, got: {session_no_ammo.combat_log}"
+
+    def test_no_ammo_attack_returns_none(self, session_no_ammo):
+        result = session_no_ammo.execute_attack()
+
+        assert result is None

--- a/client-2d/tests/test_ranged_attack_integration.py
+++ b/client-2d/tests/test_ranged_attack_integration.py
@@ -410,9 +410,9 @@ class TestSessionNoAmmoAttack:
     def test_no_ammo_attack_logs_engine_error_to_combat_log(self, session_no_ammo):
         session_no_ammo.execute_attack()
 
-        assert any(
-            "No ammunition" in entry for entry in session_no_ammo.combat_log
-        ), f"Expected ammo error in combat log, got: {session_no_ammo.combat_log}"
+        assert any("No ammunition" in entry for entry in session_no_ammo.combat_log), (
+            f"Expected ammo error in combat log, got: {session_no_ammo.combat_log}"
+        )
 
     def test_no_ammo_attack_returns_none(self, session_no_ammo):
         result = session_no_ammo.execute_attack()


### PR DESCRIPTION
## Summary
- `EngineAdapter.execute_attack` no longer masks engine-side failures as `success=True`
- Adapter now mirrors `PlayerAttackResult.success` and forwards `error` to callers
- Session callers (combat log, MCP) stop burning the player's turn on no-ammo attacks

## Why
`PlayerAttackResult.success=False` is the engine's signal that an attack didn't physically happen (no ammunition, etc.). The adapter was discarding that signal and returning a synthetic miss with `attack_roll=0` and `success=True`. Downstream, the session logged the no-op as a regular miss and advanced the turn — so a player without arrows would silently lose their action and see a fake miss in the combat log.

Discovered while writing tests for #351 (long-range disadvantage) using `ranged_attack_basic.yaml`, which arms its fighter with a shortbow but no arrows.

## Changes
- **`client-2d/src/client_2d/integration/engine_adapter.py`**: `execute_attack` now returns `success=result.success` and `error=result.error if not result.success else None`. All other metadata keys preserved.
- **`client-2d/tests/test_engine_adapter_attack_success.py`** (new): 4 adapter tests covering success=False mirroring, error propagation, metadata key preservation, and success=True sanity (monkeypatched).
- **`client-2d/tests/test_ranged_attack_integration.py`**: appended `TestSessionNoAmmoAttack` (3 tests) — confirms session does not advance turn, logs the engine error to combat log, and returns `None` on ammo-less attacks.

## Testing
- [x] New adapter tests: 4/4 pass (verified RED→GREEN)
- [x] New session regression tests: 3/3 pass
- [x] Full client-2d suite: 416/416 pass
- [x] Full dnd-engine suite: 2191/2191 pass
- [ ] Manual gameplay check — not required (pure data-flow fix, fully test-covered)

## Out of Scope
- The MCP `attack()` response message at `session.py:1007-1011` still reads "cannot reach the target" for any session failure (now including ammo failures). The real reason lands in `combat_log` but not in the MCP response text. Will file as a follow-up if it bites in playtesting.
- Pre-existing ruff format drift in `engine_adapter.py` and the rest of `test_ranged_attack_integration.py` is tracked under #396 and left alone.

## Related
Fixes #394
Discovered during #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)