### PR TITLE
Coverage script: filter SRD-splitter stubs from the audit queue

### DIFF
--- a/dnd-engine/tests/srd/README.md
+++ b/dnd-engine/tests/srd/README.md
@@ -50,6 +50,13 @@ The script also warns about **stale markers** — tests pointing at SRD
 files that no longer exist (e.g. after a `scripts/split_srd.py` rerun
 that renamed a section).
 
+It also separates **likely SRD-splitter stubs** from the audit queue
+— files whose YAML frontmatter `source_lines` range is 5 lines or
+fewer are chapter intros and framing text with no auditable rule.
+They're surfaced in their own section of the report but excluded from
+the suggested queue and the progress denominator so they don't pad
+the work to be done.
+
 ## Adding a new conformance file
 
 1. Identify the SRD doc you're auditing (e.g.

--- a/scripts/srd_audit_coverage.py
+++ b/scripts/srd_audit_coverage.py
@@ -16,6 +16,15 @@ Catalog chapters (spells, monsters, magic items, animals) are excluded
 from this report because they're audited by JSON data parity against
 `dnd-engine/dnd_engine/data/srd/`, not by behavioral conformance tests.
 
+Files whose YAML frontmatter `source_lines` range is `STUB_LINE_THRESHOLD`
+lines or fewer are surfaced separately as "likely SRD-splitter stubs"
+and excluded from the suggested queue and progress denominator. These
+are chapter intros and framing text that the PDF splitter pulls into
+their own files but which contain no auditable rule. Spot-checking the
+SRD tree found these range up to 5 lines reliably; rules definitions
+of 6+ lines (e.g. critical-hits, immunity) are real rules even if
+terse.
+
 Run:
     uv run python scripts/srd_audit_coverage.py
 """
@@ -35,7 +44,15 @@ CATALOG_CHAPTERS = {"spells", "monsters", "magic-items", "animals"}
 # Index and readme files are scaffolding, not rules.
 SKIP_NAMES = {"_index.md", "README.md"}
 
+# Files with this many source lines or fewer are treated as SRD-splitter
+# stubs (chapter intros, single-paragraph framing) and held out of the
+# audit queue. Verified against the full prose tree: range <= 5 catches
+# only true stubs; the shortest real rules (e.g., critical-hits.md at 8
+# lines) sit comfortably above this threshold.
+STUB_LINE_THRESHOLD = 5
+
 MARKER_PATTERN = re.compile(r'pytest\.mark\.srd\(\s*"([^"]+)"')
+SOURCE_LINES_PATTERN = re.compile(r"^source_lines:\s*(\d+)\s*-\s*(\d+)\s*$", re.MULTILINE)
 
 
 def audited_paths() -> dict[str, list[Path]]:
@@ -50,27 +67,56 @@ def audited_paths() -> dict[str, list[Path]]:
     return out
 
 
-def rule_files_by_chapter() -> dict[str, list[str]]:
-    """Return chapter -> sorted list of SRD-relative paths."""
-    out: dict[str, list[str]] = {}
+def source_lines_range(path: Path) -> int | None:
+    """Return the `source_lines: N-M` span size from frontmatter, or None.
+
+    The SRD splitter writes a `source_lines: <start>-<end>` field in the
+    YAML frontmatter recording which lines of `SRD_CC_v5.2.1.txt` the
+    file was sliced from. The size of that range is a robust proxy for
+    how much rule content the file actually carries.
+    """
+    text = path.read_text()
+    match = SOURCE_LINES_PATTERN.search(text)
+    if not match:
+        return None
+    start, end = int(match.group(1)), int(match.group(2))
+    return end - start + 1
+
+
+def is_stub(path: Path) -> bool:
+    """True if the file is a likely SRD-splitter stub (chapter intro / framing)."""
+    rng = source_lines_range(path)
+    return rng is not None and rng <= STUB_LINE_THRESHOLD
+
+
+def classify_rule_files() -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Walk docs/srd/ and partition into substantive vs stub files by chapter.
+
+    Returns (substantive_by_chapter, stubs_by_chapter).
+    """
+    substantive: dict[str, list[str]] = {}
+    stubs: dict[str, list[str]] = {}
     for md in sorted(SRD_DOCS.rglob("*.md")):
         if md.name in SKIP_NAMES:
             continue
         rel = md.relative_to(SRD_DOCS).as_posix()
         chapter = rel.split("/", 1)[0]
-        out.setdefault(chapter, []).append(rel)
-    return out
+        target = stubs if is_stub(md) else substantive
+        target.setdefault(chapter, []).append(rel)
+    return substantive, stubs
 
 
 def main() -> None:
     audited = audited_paths()
-    by_chapter = rule_files_by_chapter()
+    substantive, stubs = classify_rule_files()
 
     print("SRD conformance audit coverage")
     print("=" * 60)
 
     # Stale-marker check: tests pointing at SRD files that don't exist.
-    all_rule_paths = {p for paths in by_chapter.values() for p in paths}
+    all_rule_paths = {p for paths in substantive.values() for p in paths} | {
+        p for paths in stubs.values() for p in paths
+    }
     stale = sorted(set(audited) - all_rule_paths)
     if stale:
         print()
@@ -96,41 +142,59 @@ def main() -> None:
     print("Prose chapters (conformance audit targets):")
     prose_total = 0
     prose_done = 0
-    for chapter in sorted(by_chapter):
+    for chapter in sorted(substantive):
         if chapter in CATALOG_CHAPTERS:
             continue
-        files = by_chapter[chapter]
+        files = substantive[chapter]
         done_in_chapter = [f for f in files if f in audited]
         prose_total += len(files)
         prose_done += len(done_in_chapter)
         bar = "#" * len(done_in_chapter) + "-" * (len(files) - len(done_in_chapter))
         print(f"  {chapter:25s}  {len(done_in_chapter):3d} / {len(files):3d}  [{bar}]")
 
+    stub_total = sum(
+        len(paths) for chapter, paths in stubs.items() if chapter not in CATALOG_CHAPTERS
+    )
+
     print()
-    print(f"Prose progress: {prose_done} / {prose_total} files audited")
+    print(
+        f"Prose progress: {prose_done} / {prose_total} files audited (+ {stub_total} stubs held out)"
+    )
+
+    print()
+    print(f"Likely SRD-splitter stubs (source_lines range <= {STUB_LINE_THRESHOLD}):")
+    if not stub_total:
+        print("  (none)")
+    else:
+        for chapter in sorted(stubs):
+            if chapter in CATALOG_CHAPTERS:
+                continue
+            for path in stubs[chapter]:
+                print(f"  {path}")
 
     print()
     print("Catalog chapters (audited via JSON data parity, not this tool):")
-    for chapter in sorted(by_chapter):
+    for chapter in sorted(substantive):
         if chapter not in CATALOG_CHAPTERS:
             continue
-        files = by_chapter[chapter]
+        files = substantive[chapter]
         print(f"  {chapter:25s}  {len(files):4d} entries")
 
     print()
     print("Suggested queue (next unaudited prose files):")
     shown = 0
-    for chapter in sorted(by_chapter):
+    for chapter in sorted(substantive):
         if chapter in CATALOG_CHAPTERS:
             continue
-        for path in by_chapter[chapter]:
+        for path in substantive[chapter]:
             if path not in audited:
                 print(f"  {path}")
                 shown += 1
                 if shown >= 20:
-                    print(f"  ... (and {prose_total - prose_done - 20} more)")
+                    remaining = prose_total - prose_done - shown
+                    if remaining > 0:
+                        print(f"  ... (and {remaining} more)")
                     return
-                continue
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`scripts/srd_audit_coverage.py`'s suggested queue surfaced SRD-splitter stub files (chapter-intro snippets with no auditable rule) at the top of the list. Future audit sessions would re-skip these manually, or — worse — produce empty "audit" passes that pad the coverage report without adding verification.

This PR teaches the script to recognize stubs by their `source_lines` range and segregate them.

**Stacked on #402.** Base is `feature/srd-conformance-audit-pilot`. Once #402 lands on `main`, GitHub auto-retargets this to `main`.

## Behavior change

Before:
```
Suggested queue (next unaudited prose files):
  character-creation/character-creation.md       ← stub (2 lines of content)
  character-creation/choose-a-character-sheet.md
  ...
```

After:
```
Prose progress: 1 / 118 files audited (+ 3 stubs held out)

Likely SRD-splitter stubs (source_lines range <= 5):
  character-creation/character-creation.md
  playing-the-game/combat.md
  playing-the-game/damage-and-healing.md

Suggested queue (next unaudited prose files):
  character-creation/choose-a-character-sheet.md
  character-creation/create-your-character.md
  ...
```

Stubs are now visible (you can still find them if you want to investigate) but not in the suggested queue and not counted against progress.

## How the heuristic works

The SRD splitter writes a YAML frontmatter `source_lines: <start>-<end>` field recording which lines of `SRD_CC_v5.2.1.txt` the file was sliced from. The range size is a robust proxy for how much content the file actually carries.

- Range ≤ 5: classified as stub.
- Range ≥ 6: treated as substantive (default; safe fallback if the field is missing or malformed).

## Threshold validation

Walked the full prose tree (121 files in the affected chapters) and inspected every file with a `source_lines` range of 10 or fewer (11 files):

| Range | File | Verdict | Caught? |
|---|---|---|---|
| 2 | character-creation/character-creation.md | stub (just "Creation") | ✓ |
| 5 | playing-the-game/combat.md | stub (chapter intro) | ✓ |
| 5 | playing-the-game/damage-and-healing.md | stub (chapter intro) | ✓ |
| 6 | playing-the-game/hiding.md | **real** (Hide action definition) | correctly skipped |
| 7 | classes/classes.md | stub (column bleed) | missed — acceptable false negative |
| 7 | equipment/brewing-potions-of-healing.md | **real** (specific rule) | correctly skipped |
| 7 | playing-the-game/immunity.md | **real** (definition) | correctly skipped |
| 8 | playing-the-game/critical-hits.md | **real** (specific rule) | correctly skipped |
| 9 | playing-the-game/damage-types.md | **real** (definition) | correctly skipped |
| 10 | character-origins/acolyte.md | **real** (background) | correctly skipped |
| 10 | playing-the-game/advantage-disadvantage.md | **real** (definition) | correctly skipped |

Threshold of 5 catches all 3 clear stubs with zero false positives. One known false negative (`classes/classes.md` is column-bleed-only despite 7 lines) — accepted because tightening the threshold would misclassify real rules and the auditor can recognize it manually.

## Test plan

- [x] `uv run python scripts/srd_audit_coverage.py` — output matches the "After" sample above
- [x] `uv run ruff check scripts/srd_audit_coverage.py` and `--format --check` — clean
- [x] Threshold doesn't regress prior pilot output: ranged-attacks still listed as audited, queue still produces a 20-item list, stale-marker warning still functions if a marker breaks

## What's deliberately out of scope

- Auto-detecting column-bleed (heuristic on words-per-source-line ratio) — overfits.
- A manual stub-override file (curated list of paths to exclude). Could be added later if the heuristic missed-positives become annoying; currently we only have one (`classes/classes.md`).
- Re-running `scripts/split_srd.py` to produce cleaner output. The README says "do not edit files in this tree by hand — re-run the splitter instead"; whether the splitter itself can be improved to emit fewer stubs is a separate question for a future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)