### PR TITLE
Add hook: nudge /code-review after gh pr create

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(gh pr create*)",
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"A pull request was just created via `gh pr create`. Before continuing other work or marking the task complete, invoke the /code-review skill against this PR — review the diff, post findings as inline PR comments where useful, and report a brief summary back. (The PR URL is in the Bash tool output above.)\"}}'"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `PostToolUse` hook in `.claude/settings.json` that fires whenever a Bash call invokes `gh pr create`. The hook injects a system-reminder into the next Claude turn telling it to invoke the `/code-review` skill against the just-opened PR.

- **Non-blocking** — PR creation completes normally
- **Pre-filtered** — uses the `if: "Bash(gh pr create*)"` field so the hook only spawns on matching commands (no overhead on other Bash calls)
- **Safety net** — `/submit` already reviews; this catches paths that bypass `/submit` and call `gh pr create` directly

## Activation note

The Claude Code settings watcher only watches files that existed at session start. After merging, anyone whose current session predates the file will need to run `/hooks` once (or restart) to pick it up. New sessions get it automatically.

## Test plan

- [x] `jq -e '.hooks.PostToolUse[].hooks[].command' .claude/settings.json` — valid JSON, command extracted
- [x] `jq -e '.hooks.PostToolUse[].hooks[].if' .claude/settings.json` — `if` filter present
- [x] Pipe-test of the hook command emits valid `hookSpecificOutput.additionalContext` JSON
- [ ] End-to-end: next `gh pr create` triggers the reminder (will be observable once the watcher reloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)