### PR TITLE
Fix #416: Double sneak attack dice on critical hits

### DIFF
--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -170,7 +170,7 @@ class CombatEngine:
                     sneak_attack_dice = attacker.get_sneak_attack_dice()
                     if sneak_attack_dice:
                         sneak_attack_damage = self._calculate_damage(
-                            sneak_attack_dice, critical_hit=False
+                            sneak_attack_dice, critical_hit=critical_hit
                         )
 
                         # Emit sneak attack event

--- a/dnd-engine/tests/srd/playing_the_game/test_critical_hits.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_critical_hits.py
@@ -17,6 +17,7 @@ import inspect
 
 import pytest
 
+from dnd_engine.core.character import Character, CharacterClass
 from dnd_engine.core.combat import CombatEngine
 from dnd_engine.core.creature import Abilities, Creature
 from dnd_engine.core.dice import DiceRoller
@@ -139,36 +140,83 @@ class TestCriticalHit_ExtraDamageDiceAlsoDoubled:
     > Rogue's Sneak Attack feature, you also roll those dice twice.
     """
 
-    def test_sneak_attack_dice_doubled_on_critical_hit(self):
-        pytest.skip(
-            "GAP: sneak attack dice are NOT doubled on a critical hit. "
-            "dnd-engine/dnd_engine/core/combat.py:173 calls "
-            "`self._calculate_damage(sneak_attack_dice, critical_hit=False)` "
-            "with a hardcoded False inside the `if hit:` branch of "
-            "`resolve_attack`. SRD example explicitly calls out Sneak "
-            "Attack as a class of 'other damage dice' that must double "
-            "on a crit; the current implementation rolls them once "
-            "regardless of the attack's crit status. Tracked by issue "
-            "#416."
+    def test_sneak_attack_dice_doubled_on_critical_hit(self, monkeypatch):
+        """A nat-20 Sneak Attack rolls the sneak dice doubled.
+
+        Builds a level-3 Rogue (sneak attack 2d6), spies on
+        `_calculate_damage` to capture the dice notation and crit flag
+        used for each call, then loops attacks with advantage until a
+        critical hit lands with a sneak-attack proc. Asserts the spy
+        recorded the sneak-attack dice being passed with
+        `critical_hit=True`.
+        """
+        engine = _make_engine()
+
+        rogue_abilities = Abilities(
+            strength=10, dexterity=16, constitution=14, intelligence=12, wisdom=13, charisma=8
         )
+        rogue = Character(
+            name="Sneaky",
+            character_class=CharacterClass.ROGUE,
+            level=3,
+            abilities=rogue_abilities,
+            max_hp=20,
+            ac=14,
+        )
+        target_abilities = Abilities(
+            strength=8, dexterity=14, constitution=10, intelligence=10, wisdom=8, charisma=8
+        )
+        target = Creature(name="Dummy", max_hp=200, ac=10, abilities=target_abilities)
+
+        damage_calls: list[tuple[str, bool]] = []
+        original = engine._calculate_damage
+
+        def spy(damage_dice: str, critical_hit: bool) -> int:
+            damage_calls.append((damage_dice, critical_hit))
+            return original(damage_dice, critical_hit)
+
+        monkeypatch.setattr(engine, "_calculate_damage", spy)
+
+        for _ in range(500):
+            damage_calls.clear()
+            result = engine.resolve_attack(
+                attacker=rogue,
+                defender=target,
+                attack_bonus=5,
+                damage_dice="1d8+3",
+                advantage=True,
+            )
+            if result.critical_hit and result.sneak_attack_damage > 0:
+                sneak_calls = [c for c in damage_calls if c[0] == result.sneak_attack_dice]
+                assert sneak_calls, (
+                    "Spy did not observe sneak attack dice flowing through "
+                    "_calculate_damage — instrumentation broken."
+                )
+                assert all(c[1] is True for c in sneak_calls), (
+                    f"Sneak attack dice {result.sneak_attack_dice} were rolled "
+                    f"with critical_hit=False on a crit. Calls: {sneak_calls}"
+                )
+                return
+
+        pytest.fail("Did not observe a critical hit with sneak attack in 500 attempts.")
 
     def test_resolve_attack_sneak_attack_passes_critical_flag(self):
         """Source-level contract: the call site MUST consult `critical_hit`.
 
         Inspects `CombatEngine.resolve_attack` source to assert the
         sneak-attack damage calculation does not pass a hardcoded
-        `critical_hit=False`. When the gap is fixed, this assertion
-        flips from skip-companion to a real guard.
+        `critical_hit=False`. Regression guard against the original
+        #416 bug pattern.
         """
         src = inspect.getsource(CombatEngine.resolve_attack)
         assert "sneak_attack_dice" in src, (
             "resolve_attack must compute sneak attack dice — otherwise "
             "the SRD 'other damage dice' rule cannot be honored."
         )
-        pytest.skip(
-            "GAP companion (issue #416): when the hardcoded "
-            "`critical_hit=False` in combat.py:173 is replaced with the "
-            "live `critical_hit` flag, drop this skip and add a strict "
-            "negative assertion: `assert 'critical_hit=False' not in "
-            "<sneak-attack call site>`."
+        sneak_idx = src.index("sneak_attack_damage = self._calculate_damage(")
+        call_site = src[sneak_idx : sneak_idx + 200]
+        assert "critical_hit=False" not in call_site, (
+            "Sneak attack damage must not be calculated with a hardcoded "
+            "`critical_hit=False`; it must consult the live crit flag so "
+            "the SRD 'other damage dice' rule fires on a nat 20."
         )


### PR DESCRIPTION
## Summary
- Rogue's Sneak Attack dice now roll **2dN** on a critical hit, per SRD § Playing the Game › Critical Hits.
- One-line engine fix in `CombatEngine.resolve_attack` swaps a hardcoded `critical_hit=False` for the live crit flag.
- Two previously-skipped SRD audit tests are flipped to real assertions; one becomes a strict source-level regression guard.

## Changes
- **`dnd-engine/dnd_engine/core/combat.py:173`**: pass live `critical_hit` flag to `_calculate_damage` for sneak-attack dice (was hardcoded `False`).
- **`dnd-engine/tests/srd/playing_the_game/test_critical_hits.py`**:
  - `test_sneak_attack_dice_doubled_on_critical_hit` — spies on `_calculate_damage` via `monkeypatch` to assert the sneak dice are passed with `critical_hit=True` on a nat-20 hit. Loops a seeded Rogue (advantage, level-3 sneak `2d6`) until a crit-with-sneak lands.
  - `test_resolve_attack_sneak_attack_passes_critical_flag` — now a strict negative source guard: the sneak-attack call site must not contain the literal `critical_hit=False`.

## SRD reference
> If the attack involves other damage dice, such as from the Rogue's Sneak Attack feature, you also roll those dice twice.
>
> — `docs/srd/playing-the-game/critical-hits.md` (SRD_CC_v5.2.1, lines 2220–2227)

## Testing
- [x] Audit suite: `tests/srd/playing_the_game/test_critical_hits.py` — 6 passed (was 4 passed, 2 skipped)
- [x] Regression sweep: `tests/test_combat.py`, `tests/test_rogue_integration.py`, full `tests/srd/` — 89 passed, 19 known skips, 0 failures
- [x] Ruff lint + format clean on changed files

## Impact
Per the issue write-up, a level-1 Rogue with a Shortsword (1d6+3) + 1d6 sneak attack went from ~13.5 avg crit damage to ~17 avg crit damage — closes a ~26% damage shortfall on the Rogue's signature payoff turn.

## Related Issues
Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)