### PR TITLE
Chore: PostToolUse hook nudges /code-review instead of auto-firing

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
           {
             "type": "command",
             "if": "Bash(gh pr create*)",
-            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"A pull request was just created via `gh pr create`. Before continuing other work or marking the task complete, invoke the /code-review skill against this PR — review the diff, post findings as inline PR comments where useful, and report a brief summary back. (The PR URL is in the Bash tool output above.)\"}}'"
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"A pull request was just created via `gh pr create`. Offer the user a deep multi-agent review by asking via AskUserQuestion whether to run /code-review on this PR (it spawns several finder agents and can take a few minutes). Do NOT run it without their consent — default to skipping if they decline. Then continue with whatever was next regardless of their answer. The PR URL is in the Bash tool output above.\"}}'"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Switches the post-`gh pr create` hook from a directive ("invoke /code-review now") to a nudge ("ask the user whether to run /code-review").
- Defaults to skipping if the user declines; the deep multi-agent review stays available on demand.

## Why
Running `/code-review` (5 finder agents, verify+sweep) on every PR is the right depth for PRs worth pressure-testing but too expensive for routine ones. Making the hook ask preserves the option without paying the cost by default.

## Changes
- **.claude/settings.json**: updated `additionalContext` text inside the existing PostToolUse hook entry. No new hook, no schema change.

## Testing
- [x] `jq . .claude/settings.json` parses (JSON valid)
- [ ] Manually verify on next `gh pr create` — assistant should surface an AskUserQuestion instead of auto-firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)