### PR TITLE
Fix #411: Honor monster reach in melee attack resolution (SRD)

### DIFF
--- a/dnd-engine/dnd_engine/scenarios/script_executor.py
+++ b/dnd-engine/dnd_engine/scenarios/script_executor.py
@@ -348,6 +348,7 @@ class ScriptExecutor:
                 f"out of reach: {distance} ft > reach {reach_ft} ft "
                 f"({monster_action_name})"
             )
+            self.ctx.last_attack = None
             return
 
         attack_bonus = action_data.get("attack_bonus")

--- a/dnd-engine/dnd_engine/scenarios/script_executor.py
+++ b/dnd-engine/dnd_engine/scenarios/script_executor.py
@@ -124,6 +124,32 @@ def _attack_range_for(weapon_data: dict[str, Any] | None) -> tuple[int, int]:
     return (5, 5)
 
 
+def _attack_reach_for(monster_action: dict[str, Any] | None) -> int:
+    """Parse a monster action's ``reach`` string into feet.
+
+    monsters.json encodes reach per attack action as ``"5 ft."`` or
+    ``"10 ft."``. Per SRD § Playing the Game › Melee Attacks, a creature
+    has a 5-foot reach by default; creatures with greater reach declare
+    it on the action. This helper returns the integer feet so the
+    executor can gate attack resolution on distance.
+
+    Missing or unparseable values fall back to the SRD default (5 ft) so
+    a malformed catalog row degrades to vanilla melee rather than
+    silently widening reach.
+    """
+    if not monster_action:
+        return 5
+    raw = monster_action.get("reach")
+    if not raw:
+        return 5
+    # "10 ft." → "10"; tolerate stray whitespace too.
+    head = str(raw).strip().split()[0]
+    try:
+        return int(head)
+    except ValueError:
+        return 5
+
+
 def _is_ranged_attack(weapon_data: dict[str, Any] | None) -> bool:
     """Return True when an attack with this weapon is a ranged attack roll.
 
@@ -180,6 +206,18 @@ class ScriptExecutor:
             if target is None:
                 raise ScriptExecutionError("attack action missing 'target'")
             self._action_attack(str(target))
+        elif a_type == "monster_attack":
+            attacker = action.get("attacker")
+            target = action.get("target")
+            monster_action_name = action.get("monster_action")
+            if attacker is None or target is None or monster_action_name is None:
+                raise ScriptExecutionError(
+                    "monster_attack action requires 'attacker', 'target', "
+                    "and 'monster_action'"
+                )
+            self._action_monster_attack(
+                str(attacker), str(target), str(monster_action_name)
+            )
         else:
             raise ScriptExecutionError(
                 f"unknown script action: {a_type!r}"
@@ -253,6 +291,90 @@ class ScriptExecutor:
             tracker.next_turn()
         self.ctx.turn_count += 1
 
+    def _action_monster_attack(
+        self,
+        attacker_id: str,
+        target_id: str,
+        monster_action_name: str,
+    ) -> None:
+        """Resolve a monster's melee attack, gated on the action's reach.
+
+        Mirrors ``_action_attack`` for the inverse direction (enemy →
+        party member). Reads the monster's action definition from
+        ``monsters.json`` via the engine's own data loader, parses the
+        action's ``reach`` field (SRD § Melee Attacks › Reach), and
+        rejects the attack if the target sits beyond it. A bearded
+        devil's Glaive (10 ft.) can hit a target two tiles away; a
+        goblin's Scimitar (5 ft.) cannot.
+        """
+        if attacker_id not in self.ctx.enemy_entity_ids:
+            raise ScriptExecutionError(
+                f"monster_attack: unknown attacker '{attacker_id}'"
+            )
+        if target_id not in self.ctx.party_entity_ids:
+            raise ScriptExecutionError(
+                f"monster_attack: unknown target '{target_id}'"
+            )
+
+        attacker = self.ctx.resolve_entity(attacker_id)
+        target = self.ctx.resolve_entity(target_id)
+        if attacker is None or target is None:
+            raise ScriptExecutionError(
+                f"monster_attack: could not resolve "
+                f"{attacker_id!r} or {target_id!r}"
+            )
+
+        attacker_pos = self.ctx.position_of(attacker_id)
+        target_pos = self.ctx.position_of(target_id)
+        if attacker_pos is None or target_pos is None:
+            raise ScriptExecutionError(
+                f"monster_attack: missing position for "
+                f"{attacker_id!r} or {target_id!r}"
+            )
+
+        action_data = self._monster_action_data(attacker_id, monster_action_name)
+        if action_data is None:
+            raise ScriptExecutionError(
+                f"monster_attack: no action {monster_action_name!r} on "
+                f"monster {attacker_id!r}"
+            )
+
+        reach_ft = _attack_reach_for(action_data)
+        distance = distance_in_feet(
+            attacker_pos[0], attacker_pos[1], target_pos[0], target_pos[1]
+        )
+        if distance > reach_ft:
+            self.ctx.last_attack_error = (
+                f"out of reach: {distance} ft > reach {reach_ft} ft "
+                f"({monster_action_name})"
+            )
+            return
+
+        attack_bonus = action_data.get("attack_bonus")
+        damage_dice = action_data.get("damage")
+        if attack_bonus is None or damage_dice is None:
+            raise ScriptExecutionError(
+                f"monster_attack: action {monster_action_name!r} on "
+                f"{attacker_id!r} is missing attack_bonus/damage"
+            )
+
+        result = self.ctx.game_state.combat_engine.resolve_attack(
+            attacker=attacker,
+            defender=target,
+            attack_bonus=int(attack_bonus),
+            damage_dice=str(damage_dice),
+            apply_damage=True,
+            event_bus=getattr(self.ctx.game_state, "event_bus", None),
+            action=action_data,
+            game_state=self.ctx.game_state,
+        )
+        self.ctx.last_attack = result
+
+        tracker = self.ctx.game_state.initiative_tracker
+        if tracker is not None:
+            tracker.next_turn()
+        self.ctx.turn_count += 1
+
     # --- helpers ----------------------------------------------------------
 
     def _current_player_attacker(self) -> tuple[Any, str]:
@@ -317,3 +439,29 @@ class ScriptExecutor:
             return None
         items = data_loader.load_items(campaign_id)
         return items.get("weapons", {}).get(weapon_id)
+
+    def _monster_action_data(
+        self, enemy_entity_id: str, action_name: str
+    ) -> dict[str, Any] | None:
+        """Look up a named action on the given enemy's monster catalog row.
+
+        The entity_id encodes the monster id as ``{monster_id}_{index}``
+        (see ``ScenarioLoader``). Splits on the trailing index, loads
+        ``monsters.json`` through the engine's data loader, and returns
+        the first action whose ``name`` matches. Returns ``None`` when
+        the catalog row, action, or loader is unavailable so callers can
+        surface a precise script-level error.
+        """
+        # entity_id is "{monster_id}_{i}"; rstrip the index segment.
+        monster_id = enemy_entity_id.rsplit("_", 1)[0]
+        data_loader = getattr(self.ctx.game_state, "data_loader", None)
+        if data_loader is None:
+            return None
+        monsters = data_loader.load_monsters()
+        mdata = monsters.get(monster_id)
+        if not mdata:
+            return None
+        for act in mdata.get("actions") or []:
+            if act.get("name") == action_name:
+                return act
+        return None

--- a/dnd-engine/tests/srd/playing_the_game/test_melee_attacks.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_melee_attacks.py
@@ -21,7 +21,12 @@ import pytest
 from dnd_engine.core.combat import CombatEngine
 from dnd_engine.core.creature import Abilities, Creature
 from dnd_engine.core.dice import DiceRoller
-from dnd_engine.scenarios.script_executor import _attack_range_for
+from dnd_engine.scenarios.loader import ScenarioLoader
+from dnd_engine.scenarios.script_executor import (
+    ScriptExecutor,
+    _attack_range_for,
+    _attack_reach_for,
+)
 
 pytestmark = pytest.mark.srd(
     "playing-the-game/melee-attacks.md",
@@ -149,7 +154,7 @@ class TestReach_GreaterThanFiveFeet:
             "in monsters.json (e.g., bearded_devil: Glaive 10 ft.)."
         )
 
-    def test_extended_reach_data_is_consumed_by_attack_resolution(self):
+    def test_extended_reach_data_is_consumed_by_attack_resolution(self, tmp_path: Path):
         """A 10-ft reach action lands at 10 ft; a 5-ft action is rejected.
 
         Verifies the SRD's "noted in their descriptions" clause is honored
@@ -158,14 +163,6 @@ class TestReach_GreaterThanFiveFeet:
         it. Mirrors the player-weapon range pattern (#400) so scenario
         scripts can express monster melee that depends on reach.
         """
-        import tempfile
-
-        from dnd_engine.scenarios.loader import ScenarioLoader
-        from dnd_engine.scenarios.script_executor import (
-            ScriptExecutor,
-            _attack_reach_for,
-        )
-
         monsters = json.loads(MONSTERS_JSON.read_text())
 
         glaive = next(
@@ -219,49 +216,47 @@ enemies:
     position: [5, 5]
 """
 
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            bd_path = tmp_path / "bd.yaml"
-            bd_path.write_text(bearded_devil_yaml.lstrip())
-            gb_path = tmp_path / "gb.yaml"
-            gb_path.write_text(goblin_yaml.lstrip())
+        bd_path = tmp_path / "bd.yaml"
+        bd_path.write_text(bearded_devil_yaml.lstrip())
+        gb_path = tmp_path / "gb.yaml"
+        gb_path.write_text(goblin_yaml.lstrip())
 
-            # Advance to the monster's turn, then have it attack the PC.
-            bd_loaded = ScenarioLoader().load(bd_path)
-            bd_executor = ScriptExecutor(bd_loaded)
-            bd_ctx = bd_executor.run([
-                {"action": "wait"},  # let fighter pass
-                {
-                    "action": "monster_attack",
-                    "attacker": "bearded_devil_0",
-                    "target": "pc_brick",
-                    "monster_action": "Glaive",
-                },
-            ])
-            # Glaive (10 ft) at 10 ft must resolve, not reject.
-            assert bd_ctx.last_attack is not None, (
-                f"bearded devil glaive (10 ft reach) should hit at 10 ft, "
-                f"got error: {bd_ctx.last_attack_error}"
-            )
+        # Advance to the monster's turn, then have it attack the PC.
+        bd_loaded = ScenarioLoader().load(bd_path)
+        bd_executor = ScriptExecutor(bd_loaded)
+        bd_ctx = bd_executor.run([
+            {"action": "wait"},  # let fighter pass
+            {
+                "action": "monster_attack",
+                "attacker": "bearded_devil_0",
+                "target": "pc_brick",
+                "monster_action": "Glaive",
+            },
+        ])
+        # Glaive (10 ft) at 10 ft must resolve, not reject.
+        assert bd_ctx.last_attack is not None, (
+            f"bearded devil glaive (10 ft reach) should hit at 10 ft, "
+            f"got error: {bd_ctx.last_attack_error}"
+        )
 
-            gb_loaded = ScenarioLoader().load(gb_path)
-            gb_executor = ScriptExecutor(gb_loaded)
-            gb_ctx = gb_executor.run([
-                {"action": "wait"},
-                {
-                    "action": "monster_attack",
-                    "attacker": "goblin_0",
-                    "target": "pc_brick",
-                    "monster_action": "Scimitar",
-                },
-            ])
-            # Scimitar (5 ft) at 10 ft must be rejected.
-            assert gb_ctx.last_attack is None
-            assert gb_ctx.last_attack_error is not None
-            assert "reach" in gb_ctx.last_attack_error.lower(), (
-                f"expected out-of-reach rejection, got: "
-                f"{gb_ctx.last_attack_error}"
-            )
+        gb_loaded = ScenarioLoader().load(gb_path)
+        gb_executor = ScriptExecutor(gb_loaded)
+        gb_ctx = gb_executor.run([
+            {"action": "wait"},
+            {
+                "action": "monster_attack",
+                "attacker": "goblin_0",
+                "target": "pc_brick",
+                "monster_action": "Scimitar",
+            },
+        ])
+        # Scimitar (5 ft) at 10 ft must be rejected.
+        assert gb_ctx.last_attack is None
+        assert gb_ctx.last_attack_error is not None
+        assert "reach" in gb_ctx.last_attack_error.lower(), (
+            f"expected out-of-reach rejection, got: "
+            f"{gb_ctx.last_attack_error}"
+        )
 
 
 class TestOpportunityAttacks_Triggering:

--- a/dnd-engine/tests/srd/playing_the_game/test_melee_attacks.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_melee_attacks.py
@@ -150,18 +150,118 @@ class TestReach_GreaterThanFiveFeet:
         )
 
     def test_extended_reach_data_is_consumed_by_attack_resolution(self):
-        pytest.skip(
-            "GAP: monster `reach` data in monsters.json is not read by "
-            'any attack-resolution code path. Grep for `"reach"` '
-            "across dnd-engine/dnd_engine/ outside of monsters.json "
-            "returns only script_executor._attack_range_for, which "
-            "operates on items.json (player weapons), not monster "
-            "actions. A bearded devil's Glaive (10 ft. reach) and a "
-            "goblin's Scimitar (5 ft. reach) behave identically. "
-            "Combat is room-scoped with no per-creature positions on "
-            "the engine side, so reach is effectively a flavor field. "
-            "Tracked by issue #411."
+        """A 10-ft reach action lands at 10 ft; a 5-ft action is rejected.
+
+        Verifies the SRD's "noted in their descriptions" clause is honored
+        end-to-end: `script_executor._attack_reach_for` parses the action's
+        `reach` string, and the `monster_attack` action gates resolution on
+        it. Mirrors the player-weapon range pattern (#400) so scenario
+        scripts can express monster melee that depends on reach.
+        """
+        import tempfile
+
+        from dnd_engine.scenarios.loader import ScenarioLoader
+        from dnd_engine.scenarios.script_executor import (
+            ScriptExecutor,
+            _attack_reach_for,
         )
+
+        monsters = json.loads(MONSTERS_JSON.read_text())
+
+        glaive = next(
+            a for a in monsters["bearded_devil"]["actions"]
+            if a.get("name") == "Glaive"
+        )
+        scimitar = next(
+            a for a in monsters["goblin"]["actions"]
+            if a.get("name") == "Scimitar"
+        )
+
+        # Helper consumes the field — that alone closes the GAP.
+        assert _attack_reach_for(glaive) == 10
+        assert _attack_reach_for(scimitar) == 5
+
+        # And it gates attack resolution: a 10-ft reach action lands at
+        # 10 ft, but a 5-ft action at the same distance is out of reach.
+        # Fixture: PC at (3, 5), monster at (5, 5) — 2 tiles = 10 ft.
+        bearded_devil_yaml = """
+name: srd_reach_extended
+seed: 7
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: human
+    weapons: [longsword]
+    position: [3, 5]
+    name: Brick
+enemies:
+  - monster_id: bearded_devil
+    position: [5, 5]
+"""
+        goblin_yaml = """
+name: srd_reach_default
+seed: 7
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: human
+    weapons: [longsword]
+    position: [3, 5]
+    name: Brick
+enemies:
+  - monster_id: goblin
+    position: [5, 5]
+"""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            bd_path = tmp_path / "bd.yaml"
+            bd_path.write_text(bearded_devil_yaml.lstrip())
+            gb_path = tmp_path / "gb.yaml"
+            gb_path.write_text(goblin_yaml.lstrip())
+
+            # Advance to the monster's turn, then have it attack the PC.
+            bd_loaded = ScenarioLoader().load(bd_path)
+            bd_executor = ScriptExecutor(bd_loaded)
+            bd_ctx = bd_executor.run([
+                {"action": "wait"},  # let fighter pass
+                {
+                    "action": "monster_attack",
+                    "attacker": "bearded_devil_0",
+                    "target": "pc_brick",
+                    "monster_action": "Glaive",
+                },
+            ])
+            # Glaive (10 ft) at 10 ft must resolve, not reject.
+            assert bd_ctx.last_attack is not None, (
+                f"bearded devil glaive (10 ft reach) should hit at 10 ft, "
+                f"got error: {bd_ctx.last_attack_error}"
+            )
+
+            gb_loaded = ScenarioLoader().load(gb_path)
+            gb_executor = ScriptExecutor(gb_loaded)
+            gb_ctx = gb_executor.run([
+                {"action": "wait"},
+                {
+                    "action": "monster_attack",
+                    "attacker": "goblin_0",
+                    "target": "pc_brick",
+                    "monster_action": "Scimitar",
+                },
+            ])
+            # Scimitar (5 ft) at 10 ft must be rejected.
+            assert gb_ctx.last_attack is None
+            assert gb_ctx.last_attack_error is not None
+            assert "reach" in gb_ctx.last_attack_error.lower(), (
+                f"expected out-of-reach rejection, got: "
+                f"{gb_ctx.last_attack_error}"
+            )
 
 
 class TestOpportunityAttacks_Triggering:

--- a/dnd-engine/tests/test_script_executor.py
+++ b/dnd-engine/tests/test_script_executor.py
@@ -406,3 +406,179 @@ def test_unknown_action_raises_clear_error(tmp_path: Path) -> None:
     msg = str(exc.value).lower()
     assert "teleport" in msg
     assert "unknown" in msg
+
+
+# --- monster reach parsing (#411) ------------------------------------------
+
+
+def test_attack_reach_for_parses_five_foot_default() -> None:
+    """A `5 ft.` reach string maps to 5."""
+    from dnd_engine.scenarios.script_executor import _attack_reach_for
+
+    assert _attack_reach_for({"reach": "5 ft."}) == 5
+
+
+def test_attack_reach_for_parses_ten_foot_extended() -> None:
+    """A `10 ft.` reach (bearded devil glaive) maps to 10."""
+    from dnd_engine.scenarios.script_executor import _attack_reach_for
+
+    assert _attack_reach_for({"reach": "10 ft."}) == 10
+
+
+def test_attack_reach_for_defaults_when_missing() -> None:
+    """Missing or empty reach falls back to the SRD default (5 ft).
+
+    Guards against silent reach-widening when a catalog row omits the
+    field — e.g., a homebrew monster JSON.
+    """
+    from dnd_engine.scenarios.script_executor import _attack_reach_for
+
+    assert _attack_reach_for({}) == 5
+    assert _attack_reach_for({"reach": None}) == 5
+    assert _attack_reach_for({"reach": ""}) == 5
+    assert _attack_reach_for(None) == 5
+
+
+def test_attack_reach_for_defaults_when_unparseable() -> None:
+    """A non-numeric reach value falls back to 5 ft.
+
+    Defensive: rather than crash on a malformed string, the helper
+    degrades to vanilla melee. Loud data errors are catalog-validator
+    territory, not attack-resolution territory.
+    """
+    from dnd_engine.scenarios.script_executor import _attack_reach_for
+
+    assert _attack_reach_for({"reach": "abc"}) == 5
+
+
+# --- monster_attack action (#411) ------------------------------------------
+
+# Fighter at (3, 5), bearded devil at (5, 5) — 2 tiles = 10 ft. The
+# devil's Glaive has reach 10 ft, so it can hit at this range.
+MONSTER_EXTENDED_REACH_YAML = """
+name: exec_monster_extended_reach
+seed: 7
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: human
+    weapons: [longsword]
+    position: [3, 5]
+    name: Brick
+enemies:
+  - monster_id: bearded_devil
+    position: [5, 5]
+"""
+
+# Same layout but the attacker is a goblin (Scimitar, reach 5 ft).
+# At 10 ft away the attack must be rejected.
+MONSTER_DEFAULT_REACH_YAML = """
+name: exec_monster_default_reach
+seed: 7
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: human
+    weapons: [longsword]
+    position: [3, 5]
+    name: Brick
+enemies:
+  - monster_id: goblin
+    position: [5, 5]
+"""
+
+
+def test_monster_attack_extended_reach_lands(tmp_path: Path) -> None:
+    """Bearded devil's Glaive (10 ft) resolves at 10 ft."""
+    path = _write(tmp_path, MONSTER_EXTENDED_REACH_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    ctx = ScriptExecutor(loaded).run([
+        {"action": "wait"},
+        {
+            "action": "monster_attack",
+            "attacker": "bearded_devil_0",
+            "target": "pc_brick",
+            "monster_action": "Glaive",
+        },
+    ])
+
+    assert ctx.last_attack is not None
+    assert ctx.last_attack_error is None
+    assert hasattr(ctx.last_attack, "hit")
+
+
+def test_monster_attack_default_reach_rejected_at_ten_feet(tmp_path: Path) -> None:
+    """Goblin Scimitar (5 ft) is rejected at 10 ft and HP is preserved."""
+    path = _write(tmp_path, MONSTER_DEFAULT_REACH_YAML)
+    loaded = ScenarioLoader().load(path)
+    fighter = loaded.game_state.party.characters[0]
+    starting_hp = fighter.current_hp
+
+    ctx = ScriptExecutor(loaded).run([
+        {"action": "wait"},
+        {
+            "action": "monster_attack",
+            "attacker": "goblin_0",
+            "target": "pc_brick",
+            "monster_action": "Scimitar",
+        },
+    ])
+
+    assert ctx.last_attack is None
+    assert ctx.last_attack_error is not None
+    assert "reach" in ctx.last_attack_error.lower()
+    assert fighter.current_hp == starting_hp
+
+
+def test_monster_attack_missing_attacker_raises(tmp_path: Path) -> None:
+    """Unknown attacker entity_id surfaces a clear ScriptExecutionError."""
+    path = _write(tmp_path, MONSTER_EXTENDED_REACH_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    with pytest.raises(ScriptExecutionError) as exc:
+        ScriptExecutor(loaded).run([
+            {
+                "action": "monster_attack",
+                "attacker": "ghost_0",
+                "target": "pc_brick",
+                "monster_action": "Glaive",
+            },
+        ])
+    assert "ghost_0" in str(exc.value)
+
+
+def test_monster_attack_unknown_action_raises(tmp_path: Path) -> None:
+    """Referencing an action the monster doesn't have raises an error."""
+    path = _write(tmp_path, MONSTER_EXTENDED_REACH_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    with pytest.raises(ScriptExecutionError) as exc:
+        ScriptExecutor(loaded).run([
+            {
+                "action": "monster_attack",
+                "attacker": "bearded_devil_0",
+                "target": "pc_brick",
+                "monster_action": "DoesNotExist",
+            },
+        ])
+    assert "DoesNotExist" in str(exc.value)
+
+
+def test_monster_attack_missing_required_field_raises(tmp_path: Path) -> None:
+    """The action dispatcher rejects a monster_attack missing required keys."""
+    path = _write(tmp_path, MONSTER_EXTENDED_REACH_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    with pytest.raises(ScriptExecutionError) as exc:
+        ScriptExecutor(loaded).run([
+            {"action": "monster_attack", "attacker": "bearded_devil_0"},
+        ])
+    msg = str(exc.value).lower()
+    assert "monster_attack" in msg or "target" in msg or "monster_action" in msg


### PR DESCRIPTION
## Summary

Fix #411 — monsters' per-action `reach` field in `monsters.json` ("5 ft." / "10 ft.") was previously flavor text. A bearded devil's Glaive (10 ft.) behaved identically to a goblin's Scimitar (5 ft.) in attack resolution.

Per SRD § Playing the Game › Melee Attacks: *"A creature has a 5-foot reach... Certain creatures have melee attacks with a reach greater than 5 feet, as noted in their descriptions."*

Combat is room-scoped on the engine side, so per-creature positions only exist in the scenario `script_executor` — the fix lives where the data lives, mirroring the player-weapon range pattern introduced in #400.

- New `_attack_reach_for(monster_action)` parses the reach string into feet, defaulting to 5 ft when missing/unparseable.
- New `monster_attack` script action drives a monster's attack against a party member, gated on the action's reach.
- New `_monster_action_data` helper looks up the named action via the engine's existing data loader (no duplicated JSON loading).

## Gating test flipped from skip → live

`tests/srd/playing_the_game/test_melee_attacks.py::TestReach_GreaterThanFiveFeet::test_extended_reach_data_is_consumed_by_attack_resolution`

Now asserts:
- Bearded devil Glaive (10 ft.) lands at 10 ft (2 tiles).
- Goblin Scimitar (5 ft.) is rejected with an "out of reach" error at 10 ft.
- `_attack_reach_for` consumes the field directly (`Glaive → 10`, `Scimitar → 5`).

## New unit/integration tests

`tests/test_script_executor.py` (9 new):
- `_attack_reach_for` parses 5/10 ft, defaults on missing/empty/None, defaults on unparseable
- `monster_attack` resolves at extended reach (bearded devil)
- `monster_attack` rejects beyond default reach (goblin) without consuming target HP
- `monster_attack` raises `ScriptExecutionError` on unknown attacker / unknown action / missing required field

## Out of scope

- Disengage, opportunity attacks on tactical movement, Reaction economy — those are #412/#413/#414.
- Engine-level (non-scripted) enemy turn handling is unchanged; the engine still has no per-creature positions outside the scenarios layer.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_melee_attacks.py -v` — 6 passed, 5 unrelated skips (#412/#413/#414).
- [x] `cd dnd-engine && uv run pytest tests/test_script_executor.py -v` — 25 passed (16 pre-existing + 9 new).
- [x] `cd dnd-engine && uv run pytest tests/srd/ --no-cov` — 62 passed, 15 unrelated skips.
- [x] `cd dnd-engine && uv run pytest -k "scenario_runs_and_assertions_pass" --no-cov` — 5 auto-play scenarios still green.

Fix #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)