### PR TITLE
Fix #418: Enforce 'Only One Base AC' when alternate AC formulas are added

### DIFF
--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -141,9 +141,23 @@ class Creature:
         that callable is invoked with `self` and its return value is the
         base AC. Otherwise `_base_ac` (the stored default) is returned.
 
+        The active formula is invoked on every call, so the result tracks
+        live ability scores (e.g., a Mage-Armor or Unarmored-Defense
+        formula reads the current DEX/CON/WIS modifier each time AC is
+        queried). Callers that need to memoize must do so themselves.
+
         Per SRD "Only One Base AC", at most one alternate formula is in
         effect at a time even when several are registered — the active
         selection is the single source of truth.
+
+        Interplay with `ModifierType.AC_SET_BASE`: `GameState.get_effective_ac`
+        seeds its layered-modifier stack with this value, then applies
+        `AC_SET_BASE` effects (Mage Armor, Barkskin) on top with
+        "first-wins" semantics. If an `AC_SET_BASE` effect is active on
+        the same creature as an alt-formula selection, the effect will
+        overwrite the alt formula's base. Migrating the remaining
+        `AC_SET_BASE` consumers onto this seam (issue #426) collapses
+        the two mechanisms into one and removes that footgun.
 
         Returns:
             The base AC value to use for this creature.

--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -1,6 +1,9 @@
 # ABOUTME: Base Creature class representing any living entity in the game
 # ABOUTME: Handles HP, abilities, conditions, damage, and healing
 
+from __future__ import annotations
+
+from collections.abc import Callable
 from dataclasses import dataclass
 
 
@@ -88,6 +91,16 @@ class Creature:
         # Maps condition name -> metadata dict
         self.active_conditions: dict[str, dict] = {}
 
+        # Alternate base-AC formulas (SRD § Playing the Game › Attack Rolls
+        # › Armor Class › "Only One Base AC"). A creature may register
+        # multiple ways to calculate its base AC (Mage Armor, Barbarian /
+        # Monk Unarmored Defense, Draconic Resilience, etc.) but only the
+        # one named in `active_base_ac_formula` is honored when computing
+        # base AC. `None` means "use `_base_ac`" — the default unarmored
+        # or armor-derived value supplied at construction time.
+        self._alt_base_ac_formulas: dict[str, Callable[[Creature], int]] = {}
+        self.active_base_ac_formula: str | None = None
+
     @property
     def is_alive(self) -> bool:
         """Check if the creature is alive (HP > 0)"""
@@ -103,15 +116,87 @@ class Creature:
         """
         Base armor class (without spell modifiers).
 
-        For effective AC including active effects like Mage Armor or Shield,
-        use GameState.get_effective_ac(creature) instead.
+        Honors the "Only One Base AC" rule (SRD § Playing the Game ›
+        Attack Rolls › Armor Class): if the creature has an alternate
+        base-AC formula selected via `active_base_ac_formula`, that
+        formula's value is returned; otherwise the stored `_base_ac`
+        (the unarmored or armor-derived default) is returned.
+
+        For effective AC including active effects like Mage Armor or
+        Shield, use GameState.get_effective_ac(creature) instead — that
+        path layers AC bonuses on top of this base value.
         """
-        return self._base_ac
+        return self.get_base_ac()
 
     @ac.setter
     def ac(self, value: int) -> None:
         """Set base armor class."""
         self._base_ac = value
+
+    def get_base_ac(self) -> int:
+        """
+        Return the creature's current base AC honoring the active alt formula.
+
+        If `active_base_ac_formula` names a registered alternate formula,
+        that callable is invoked with `self` and its return value is the
+        base AC. Otherwise `_base_ac` (the stored default) is returned.
+
+        Per SRD "Only One Base AC", at most one alternate formula is in
+        effect at a time even when several are registered — the active
+        selection is the single source of truth.
+
+        Returns:
+            The base AC value to use for this creature.
+        """
+        if self.active_base_ac_formula is not None:
+            formula = self._alt_base_ac_formulas.get(self.active_base_ac_formula)
+            if formula is not None:
+                return formula(self)
+        return self._base_ac
+
+    def register_base_ac_formula(self, name: str, formula: Callable[[Creature], int]) -> None:
+        """
+        Register an alternate base-AC formula on this creature.
+
+        Registration alone does NOT change the creature's AC; the formula
+        is dormant until `active_base_ac_formula` names it. This separation
+        enforces the SRD "Only One Base AC" rule even when multiple
+        features (e.g., Mage Armor + Barbarian Unarmored Defense) are
+        present on the same creature.
+
+        Args:
+            name: Stable identifier for the formula (e.g.,
+                "mage_armor", "barbarian_unarmored_defense"). Re-registering
+                the same name overwrites the previous formula.
+            formula: Callable taking the creature and returning its base AC.
+        """
+        self._alt_base_ac_formulas[name] = formula
+
+    def unregister_base_ac_formula(self, name: str) -> None:
+        """
+        Remove a previously registered alternate base-AC formula.
+
+        If the removed formula was the active selection, the selection is
+        cleared so AC reverts to the stored `_base_ac` default.
+
+        Args:
+            name: Identifier passed to `register_base_ac_formula`.
+        """
+        self._alt_base_ac_formulas.pop(name, None)
+        if self.active_base_ac_formula == name:
+            self.active_base_ac_formula = None
+
+    def has_base_ac_formula(self, name: str) -> bool:
+        """
+        Check whether a named alternate base-AC formula is registered.
+
+        Args:
+            name: Identifier to look up.
+
+        Returns:
+            True if the formula is registered (active or not).
+        """
+        return name in self._alt_base_ac_formulas
 
     def take_damage(self, amount: int) -> None:
         """

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -2792,7 +2792,11 @@ class GameState:
         """
         from dnd_engine.systems.time_manager import ModifierType
 
-        base_ac = creature._base_ac
+        # Use get_base_ac() so an active alternate base-AC formula (per
+        # SRD "Only One Base AC") feeds into the layered-modifier stack.
+        # When no alt formula is selected, this is identical to reading
+        # `_base_ac` directly.
+        base_ac = creature.get_base_ac()
 
         # Query active effects for this creature
         effects = self.time_manager.get_effects_for_character(creature.name)

--- a/dnd-engine/tests/srd/playing_the_game/test_attack_rolls.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_attack_rolls.py
@@ -321,18 +321,56 @@ class TestArmorClass_OnlyOneBaseAC:
     """
 
     def test_only_one_base_ac_selection_is_enforced(self):
-        pytest.skip(
-            "LATENT: no engine support for alternate base-AC formulas, "
-            "so the 'choose one' constraint cannot be violated today. "
-            "The unarmored default (character_factory.calculate_ac) is "
-            "the sole base-AC code path; there is no Mage Armor, "
-            "Barbarian Unarmored Defense, Monk Unarmored Defense, or "
-            "Draconic Resilience implementation that could compete. "
-            "When the first alternate base-AC feature lands, this test "
-            "becomes load-bearing: it must assert that activating one "
-            "alt-AC formula deactivates any other on the same creature. "
-            "Tracked by issue #418."
+        """Registering two alt-AC formulas must honor exactly one selection.
+
+        Builds two competing alternate base-AC formulas (the same shape
+        as Barbarian / Monk Unarmored Defense or Draconic Resilience
+        would take) on a single creature, then asserts:
+
+        1. With no selection, the creature's base AC is the default
+           value passed at construction time.
+        2. With formula A selected, AC matches A's output (and not B's).
+        3. Switching the selection to B flips AC to B's output (and
+           not A's). Both formulas remain registered — the SRD "choose
+           one" constraint is enforced by the *selector*, not by
+           unregistering competitors.
+        4. The wrong formula's value never leaks through when the
+           other is selected.
+
+        Tracked by issue #418.
+        """
+        abilities = Abilities(
+            strength=15, dexterity=14, constitution=16, intelligence=10, wisdom=13, charisma=8
         )
+        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=abilities)
+
+        # Two competing base-AC formulas with distinct, stable outputs:
+        #   dex_mod = (14-10)//2 = 2
+        #   con_mod = (16-10)//2 = 3
+        # alt_a => 10 + dex_mod + con_mod = 15  (Barbarian-Unarmored-style)
+        # alt_b => 16 + dex_mod           = 18  (Mage-Armor-style)
+        creature.register_base_ac_formula(
+            "alt_a", lambda c: 10 + c.abilities.dex_mod + c.abilities.con_mod
+        )
+        creature.register_base_ac_formula("alt_b", lambda c: 16 + c.abilities.dex_mod)
+
+        # Default: no alt-AC selected, base AC is the constructor value.
+        assert creature.active_base_ac_formula is None
+        assert creature.ac == 11
+
+        # Select A: AC must reflect A only (15), not B (18).
+        creature.active_base_ac_formula = "alt_a"
+        assert creature.ac == 15
+        assert creature.ac != 18, "Formula B must not leak through when A is selected."
+
+        # Switch to B: AC must reflect B only (18), not A (15).
+        creature.active_base_ac_formula = "alt_b"
+        assert creature.ac == 18
+        assert creature.ac != 15, "Formula A must not leak through when B is selected."
+
+        # Clear selection: fall back to the constructor base AC.
+        creature.active_base_ac_formula = None
+        assert creature.ac == 11
 
     def test_layered_modifiers_are_not_base_ac_alternatives(self):
         """Effective-AC overlays (Shield spell, etc.) are not 'base' AC.

--- a/dnd-engine/tests/test_creature.py
+++ b/dnd-engine/tests/test_creature.py
@@ -419,26 +419,6 @@ class TestAlternateBaseACFormulas:
         # 13 + dex_mod = 13 + ((14-10)//2) = 15
         assert creature.ac == 15
 
-    def test_only_active_selection_is_honored_with_multiple_registered(self):
-        """Multiple registered formulas — only the selected one is honored."""
-        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)
-        creature.register_base_ac_formula(
-            "barbarian_unarmored",
-            lambda c: 10 + c.abilities.dex_mod + c.abilities.con_mod,
-        )
-        creature.register_base_ac_formula("mage_armor", lambda c: 13 + c.abilities.dex_mod)
-
-        # barbarian: 10 + 2 + 3 = 15
-        creature.active_base_ac_formula = "barbarian_unarmored"
-        assert creature.ac == 15
-
-        # mage_armor: 13 + 2 = 15 — choose distinct DEX to force divergence
-        # Instead, swap and verify mage_armor value is what's returned.
-        # Use a tweaked formula with a unique constant offset:
-        creature.register_base_ac_formula("mage_armor", lambda c: 16 + c.abilities.dex_mod)
-        creature.active_base_ac_formula = "mage_armor"
-        assert creature.ac == 18
-
     def test_unknown_active_selection_falls_back_to_stored_base_ac(self):
         """Pointing at an unregistered formula name reverts to `_base_ac`."""
         creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)

--- a/dnd-engine/tests/test_creature.py
+++ b/dnd-engine/tests/test_creature.py
@@ -378,6 +378,145 @@ class TestCreature:
         assert creature.initiative_modifier == self.abilities.dex_mod
 
 
+class TestAlternateBaseACFormulas:
+    """Test the alt-AC registration + selection seam.
+
+    Backs the SRD "Only One Base AC" rule (Playing the Game › Attack
+    Rolls › Armor Class). The integration-level guard lives in the
+    SRD conformance suite (tests/srd/playing_the_game/test_attack_rolls.py
+    ::TestArmorClass_OnlyOneBaseAC); this class unit-tests the
+    registration, selection, and unregistration mechanics in isolation.
+    """
+
+    def setup_method(self):
+        self.abilities = Abilities(
+            strength=10, dexterity=14, constitution=16, intelligence=10, wisdom=12, charisma=8
+        )
+
+    def test_no_formula_registered_returns_stored_base_ac(self):
+        """Default behavior: with no alt formula, `ac` returns `_base_ac`."""
+        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)
+        assert creature.active_base_ac_formula is None
+        assert creature.ac == 11
+        assert creature.get_base_ac() == 11
+
+    def test_register_does_not_change_ac_until_selected(self):
+        """Registering a formula must not silently switch the active base AC."""
+        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)
+        creature.register_base_ac_formula("mage_armor", lambda c: 13 + c.abilities.dex_mod)
+
+        # Still default until explicit selection
+        assert creature.active_base_ac_formula is None
+        assert creature.ac == 11
+        assert creature.has_base_ac_formula("mage_armor")
+
+    def test_selecting_formula_changes_ac(self):
+        """`active_base_ac_formula` flips `ac` to the formula's value."""
+        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)
+        creature.register_base_ac_formula("mage_armor", lambda c: 13 + c.abilities.dex_mod)
+
+        creature.active_base_ac_formula = "mage_armor"
+        # 13 + dex_mod = 13 + ((14-10)//2) = 15
+        assert creature.ac == 15
+
+    def test_only_active_selection_is_honored_with_multiple_registered(self):
+        """Multiple registered formulas — only the selected one is honored."""
+        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)
+        creature.register_base_ac_formula(
+            "barbarian_unarmored",
+            lambda c: 10 + c.abilities.dex_mod + c.abilities.con_mod,
+        )
+        creature.register_base_ac_formula("mage_armor", lambda c: 13 + c.abilities.dex_mod)
+
+        # barbarian: 10 + 2 + 3 = 15
+        creature.active_base_ac_formula = "barbarian_unarmored"
+        assert creature.ac == 15
+
+        # mage_armor: 13 + 2 = 15 — choose distinct DEX to force divergence
+        # Instead, swap and verify mage_armor value is what's returned.
+        # Use a tweaked formula with a unique constant offset:
+        creature.register_base_ac_formula("mage_armor", lambda c: 16 + c.abilities.dex_mod)
+        creature.active_base_ac_formula = "mage_armor"
+        assert creature.ac == 18
+
+    def test_unknown_active_selection_falls_back_to_stored_base_ac(self):
+        """Pointing at an unregistered formula name reverts to `_base_ac`."""
+        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)
+
+        creature.active_base_ac_formula = "no_such_formula"
+        assert creature.ac == 11
+
+    def test_clearing_selection_reverts_to_stored_base_ac(self):
+        """Setting `active_base_ac_formula = None` reverts to `_base_ac`."""
+        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)
+        creature.register_base_ac_formula("mage_armor", lambda c: 13 + c.abilities.dex_mod)
+        creature.active_base_ac_formula = "mage_armor"
+        assert creature.ac == 15
+
+        creature.active_base_ac_formula = None
+        assert creature.ac == 11
+
+    def test_unregister_removes_formula_and_clears_active_selection(self):
+        """Unregistering the active formula resets the selection."""
+        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)
+        creature.register_base_ac_formula("mage_armor", lambda c: 13 + c.abilities.dex_mod)
+        creature.active_base_ac_formula = "mage_armor"
+
+        creature.unregister_base_ac_formula("mage_armor")
+
+        assert not creature.has_base_ac_formula("mage_armor")
+        assert creature.active_base_ac_formula is None
+        assert creature.ac == 11
+
+    def test_unregister_inactive_formula_does_not_clear_selection(self):
+        """Unregistering a non-active formula leaves the active one alone."""
+        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)
+        creature.register_base_ac_formula("mage_armor", lambda c: 13 + c.abilities.dex_mod)
+        creature.register_base_ac_formula(
+            "barbarian_unarmored",
+            lambda c: 10 + c.abilities.dex_mod + c.abilities.con_mod,
+        )
+        creature.active_base_ac_formula = "mage_armor"
+
+        creature.unregister_base_ac_formula("barbarian_unarmored")
+
+        assert creature.active_base_ac_formula == "mage_armor"
+        assert creature.ac == 15  # 13 + 2
+
+    def test_unregister_unknown_formula_is_a_no_op(self):
+        """Unregistering a never-registered name does not raise."""
+        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)
+        # Must not raise.
+        creature.unregister_base_ac_formula("never_registered")
+        assert creature.ac == 11
+
+    def test_re_registering_same_name_overwrites_formula(self):
+        """Re-registering the same name replaces the previous callable."""
+        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)
+        creature.register_base_ac_formula("alt", lambda c: 12)
+        creature.register_base_ac_formula("alt", lambda c: 17)
+
+        creature.active_base_ac_formula = "alt"
+        assert creature.ac == 17
+
+    def test_setter_assigns_base_ac_without_disturbing_alt_machinery(self):
+        """Assigning `creature.ac = N` updates `_base_ac` (the fallback)."""
+        creature = Creature(name="Brawler", max_hp=20, ac=11, abilities=self.abilities)
+        creature.ac = 13
+
+        assert creature._base_ac == 13
+        assert creature.ac == 13
+
+        # Alt formula still wins when selected
+        creature.register_base_ac_formula("alt", lambda c: 18)
+        creature.active_base_ac_formula = "alt"
+        assert creature.ac == 18
+
+        # Clearing reverts to the (updated) stored base
+        creature.active_base_ac_formula = None
+        assert creature.ac == 13
+
+
 class TestCharacter:
     """Test the Character class (player character)"""
 

--- a/dnd-engine/tests/test_spell_effect_modifiers.py
+++ b/dnd-engine/tests/test_spell_effect_modifiers.py
@@ -380,3 +380,75 @@ class TestSpellCastingACModifierIntegration:
         assert effect.effect_data.get("value") == 5
         assert effect.duration_type == "rounds"
         assert effect.remaining_value == 1
+
+
+class TestAlternateBaseACComposesWithLayeredModifiers:
+    """SRD § Playing the Game › Attack Rolls › Armor Class.
+
+    The "Only One Base AC" rule applies to base-AC formulas (Mage Armor,
+    Unarmored Defense, Draconic Resilience, etc.). Layered modifiers
+    (Shield, magic-item AC bonuses, Haste) remain orthogonal and stack
+    on top of the selected base.
+
+    This guards that the registration seam introduced for issue #418
+    composes correctly with `GameState.get_effective_ac` so a future
+    Mage Armor / Unarmored Defense implementation can rely on it.
+    """
+
+    def test_alt_base_ac_formula_stacks_with_shield_bonus(self, game_state_with_wizard, wizard):
+        """Active alt-AC formula feeds the base; Shield's +5 stacks on top."""
+        from dnd_engine.systems.time_manager import ActiveEffect, EffectType, ModifierType
+
+        # Register an alt base-AC formula and select it. wizard DEX is 14
+        # (mod +2), so this yields a base of 13 + 2 = 15.
+        wizard.register_base_ac_formula("test_alt_base", lambda c: 13 + c.abilities.dex_mod)
+        wizard.active_base_ac_formula = "test_alt_base"
+
+        # Base reflects the alt formula (no spell modifiers yet).
+        assert game_state_with_wizard.get_effective_ac(wizard) == 15
+
+        # Shield is a layered AC bonus — it must stack on top of the alt
+        # base, not be treated as a competing base.
+        shield = ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="Shield",
+            duration_type="rounds",
+            duration_value=1,
+            remaining_value=1,
+            target_name=wizard.name,
+            description="+5 AC",
+            concentration=False,
+            effect_data={"modifier_type": ModifierType.AC_BONUS.value, "value": 5},
+        )
+        game_state_with_wizard.time_manager.add_effect(shield)
+
+        # 15 (alt base) + 5 (Shield) = 20.
+        assert game_state_with_wizard.get_effective_ac(wizard) == 20
+
+    def test_clearing_alt_selection_reverts_base_without_dropping_bonuses(
+        self, game_state_with_wizard, wizard
+    ):
+        """Clearing the alt selection drops only the base, not layered bonuses."""
+        from dnd_engine.systems.time_manager import ActiveEffect, EffectType, ModifierType
+
+        wizard.register_base_ac_formula("test_alt_base", lambda c: 13 + c.abilities.dex_mod)
+        wizard.active_base_ac_formula = "test_alt_base"
+
+        shield = ActiveEffect(
+            effect_type=EffectType.SPELL,
+            source="Shield",
+            duration_type="rounds",
+            duration_value=1,
+            remaining_value=1,
+            target_name=wizard.name,
+            description="+5 AC",
+            concentration=False,
+            effect_data={"modifier_type": ModifierType.AC_BONUS.value, "value": 5},
+        )
+        game_state_with_wizard.time_manager.add_effect(shield)
+        assert game_state_with_wizard.get_effective_ac(wizard) == 20  # 15 + 5
+
+        # Drop the alt base — Shield's +5 must still apply on top of the
+        # original `_base_ac` (10), giving 15.
+        wizard.active_base_ac_formula = None
+        assert game_state_with_wizard.get_effective_ac(wizard) == 15


### PR DESCRIPTION
## Summary

Fixes #418.

The SRD § Playing the Game › Attack Rolls › Armor Class rule says:

> Some spells and class features give characters a different way to calculate their AC. A character with multiple features that give different ways to calculate AC must choose which one to use; only one base calculation can be in effect for a creature.

This PR lands the **guard** for that rule, not any concrete alt-AC feature. There is no Mage Armor / Barbarian Unarmored Defense / Monk Unarmored Defense / Draconic Resilience implementation in the engine today, so the constraint had nothing to violate yet — but the gating SRD test (`TestArmorClass_OnlyOneBaseAC::test_only_one_base_ac_selection_is_enforced`) was a `pytest.skip("LATENT: ...")` so that the rule wouldn't be silently forgotten the moment the first alt-AC feature lands.

### Seam design

- `Creature.register_base_ac_formula(name, formula)` — register an alt base-AC formula. A formula is a `Callable[[Creature], int]`. Registration alone does NOT change AC.
- `Creature.active_base_ac_formula: str | None` — explicit selection field (default `None`). Matches the SRD wording "the character chooses".
- `Creature.get_base_ac()` — returns the active formula's value if one is selected, otherwise falls back to `_base_ac`.
- `Creature.ac` property delegates to `get_base_ac()`; the setter still writes to `_base_ac` (preserved as the fallback).
- `Creature.unregister_base_ac_formula(name)` — clears the active selection if it pointed at the removed formula.
- `Creature.has_base_ac_formula(name)` — predicate.

### Orthogonality with layered modifiers

`GameState.get_effective_ac` now reads `creature.get_base_ac()` instead of `creature._base_ac` directly, so the active alt formula correctly feeds the existing AC bonus stack (Shield +5, Haste +2, etc.). All pre-existing Mage Armor + Shield stacking tests still pass.

### What's next

The next alt-AC feature (Mage Armor / Barbarian Unarmored Defense / etc.) will be its own PR. It hooks into this seam by calling `register_base_ac_formula(...)` when the feature activates and setting `active_base_ac_formula` to its name (or surfacing a choice to the player when another alt formula is already active).

### Out of scope (per the issue)

- Implementing Mage Armor, Barbarian/Monk Unarmored Defense, or Draconic Resilience
- Touching the Shield spell or any other layered AC modifier (verified still orthogonal)

### Tests

- `dnd-engine/tests/srd/playing_the_game/test_attack_rolls.py::TestArmorClass_OnlyOneBaseAC::test_only_one_base_ac_selection_is_enforced` — flipped from `pytest.skip` to a live assertion that registers two competing alt formulas on one creature and verifies the wrong one never leaks through.
- `dnd-engine/tests/test_creature.py::TestAlternateBaseACFormulas` — 11 unit tests covering registration, selection, switching, clearing, unregistering active vs. inactive, re-registering the same name, the setter, and the unknown-active-name fallback.
- `dnd-engine/tests/test_spell_effect_modifiers.py::TestAlternateBaseACComposesWithLayeredModifiers` — 2 integration tests verifying Shield (`AC_BONUS`) stacks correctly on top of an active alt-AC base via `get_effective_ac`.

## Test plan

- [x] Gating SRD test (`test_only_one_base_ac_selection_is_enforced`) flips skip → live and passes
- [x] Existing source-level orthogonality guard (`test_layered_modifiers_are_not_base_ac_alternatives`) still passes
- [x] All pre-existing Mage Armor / Shield / Barkskin tests in `test_spell_effect_modifiers.py` still pass
- [x] `uv run pytest tests/srd/playing_the_game/test_attack_rolls.py tests/test_creature.py tests/test_spell_effect_modifiers.py` — 75/75 green
- [x] `uv run ruff check` clean on touched files