### PR TITLE
SRD audit: saving-throws + saving-throws-and-damage

### DIFF
--- a/dnd-engine/tests/srd/playing_the_game/test_saving_throws.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_saving_throws.py
@@ -1,0 +1,384 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > Saving Throws".
+# ABOUTME: Cross-references docs/srd/playing-the-game/saving-throws.md against engine code.
+
+"""SRD conformance: Saving Throws.
+
+Maps every rule in `docs/srd/playing-the-game/saving-throws.md` to a
+test. Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities, Creature
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/saving-throws.md",
+    lines="866-946",
+)
+
+
+def _make_fighter(
+    *,
+    level: int = 1,
+    abilities: Abilities | None = None,
+    saving_throw_proficiencies: list[str] | None = None,
+) -> Character:
+    """Construct a minimal Fighter for save-modifier assertions."""
+    if abilities is None:
+        abilities = Abilities(
+            strength=16,
+            dexterity=14,
+            constitution=15,
+            intelligence=10,
+            wisdom=12,
+            charisma=8,
+        )
+    return Character(
+        name="Fighter",
+        character_class=CharacterClass.FIGHTER,
+        level=level,
+        abilities=abilities,
+        max_hp=12,
+        ac=16,
+        saving_throw_proficiencies=(
+            saving_throw_proficiencies
+            if saving_throw_proficiencies is not None
+            else ["str", "con"]
+        ),
+    )
+
+
+def _make_creature(ac: int = 12) -> Creature:
+    """Construct a vanilla creature for the non-proficient save path."""
+    abilities = Abilities(
+        strength=8,
+        dexterity=14,
+        constitution=10,
+        intelligence=10,
+        wisdom=8,
+        charisma=8,
+    )
+    return Creature(name="Goblin", max_hp=7, ac=ac, abilities=abilities)
+
+
+class TestDefinition_TriggeredByEffect:
+    """SRD § Playing the Game › Saving Throws › Definition.
+
+    > A saving throw—also called a save—represents an attempt to
+    > evade or resist a threat, such as a fiery explosion, a blast of
+    > poisonous gas, or a spell trying to invade your mind. You don't
+    > normally choose to make a save; you must make one because your
+    > character or a monster (if you're the GM) is at risk. A save's
+    > result is detailed in the effect that caused it.
+    """
+
+    def test_make_saving_throw_returns_documented_payload_shape(self):
+        """`Character.make_saving_throw` returns success / roll / total / dc / ability.
+
+        The SRD framing is that a save's result is "detailed in the
+        effect that caused it." The engine's contract for surfacing
+        that result is the dict returned by `make_saving_throw`. This
+        test pins the field set so downstream effect handlers can rely
+        on it.
+        """
+        fighter = _make_fighter()
+
+        result = fighter.make_saving_throw(ability="con", dc=10)
+
+        for key in ("success", "roll", "modifier", "total", "dc", "ability"):
+            assert key in result, f"saving throw result missing field {key!r}"
+        assert isinstance(result["success"], bool)
+        assert result["dc"] == 10
+        assert result["ability"] == "con"
+
+    def test_creatures_can_be_compelled_to_save(self):
+        """Monsters (`Creature`) also expose `make_saving_throw`.
+
+        SRD: "...because your character or a monster (if you're the
+        GM) is at risk." Both sides of the table must be able to be
+        forced into a save by an effect.
+        """
+        creature = _make_creature()
+
+        assert callable(getattr(creature, "make_saving_throw", None))
+
+        result = creature.make_saving_throw(ability="dex", dc=10)
+        assert "success" in result
+        assert result["ability"] == "dex"
+
+
+class TestDefinition_ChooseToFail:
+    """SRD § Playing the Game › Saving Throws › Choose to Fail.
+
+    > If you don't want to resist the effect, you can choose to fail
+    > the save without rolling.
+    """
+
+    def test_save_target_can_opt_to_fail_without_rolling(self):
+        pytest.skip(
+            "GAP: `Character.make_saving_throw` and "
+            "`Creature.make_saving_throw` always roll a d20 — there is "
+            "no `auto_fail`/`choose_to_fail` parameter and no call "
+            "site that lets a target voluntarily forgo the save. "
+            "See dnd_engine/core/character.py:237-339 and "
+            "dnd_engine/core/creature.py:475-578. A search for "
+            "'choose to fail' / 'auto fail' in the engine returns no "
+            "hits. Used in play when a willing target opts into a "
+            "friendly Charm or Polymorph. Tracked by issue #447."
+        )
+
+
+class TestAbilityModifier_NamedForAbility:
+    """SRD § Playing the Game › Saving Throws › Ability Modifier.
+
+    > Saving throws are named for the ability modifiers they use: a
+    > Constitution saving throw, a Wisdom saving throw, and so on.
+    > Different saving throws are used to resist different kinds of
+    > effects, as shown on the Saving Throw Examples table.
+    """
+
+    def test_save_uses_named_ability_modifier(self):
+        """Each named ability's modifier flows through to the save total.
+
+        Spot-checks all six abilities: with no proficiency, the save's
+        `modifier` field must equal the corresponding ability modifier
+        from the `(score - 10) // 2` formula. This is the SRD's
+        "named for the ability modifiers they use" clause made
+        concrete.
+        """
+        abilities = Abilities(
+            strength=18,
+            dexterity=14,
+            constitution=12,
+            intelligence=10,
+            wisdom=8,
+            charisma=6,
+        )
+        fighter = _make_fighter(
+            abilities=abilities,
+            saving_throw_proficiencies=[],  # no profs, so modifier == ability mod
+        )
+
+        expected = {
+            "str": 4,
+            "dex": 2,
+            "con": 1,
+            "int": 0,
+            "wis": -1,
+            "cha": -2,
+        }
+        for ability, mod in expected.items():
+            assert fighter.get_saving_throw_modifier(ability) == mod, (
+                f"{ability} save modifier should equal ability mod {mod}"
+            )
+
+    def test_save_accepts_both_short_and_full_ability_names(self):
+        """`get_saving_throw_modifier` accepts 'str' and 'strength'.
+
+        The SRD names saves by their full ability ("Constitution
+        saving throw"). The engine surface must accept both the
+        catalogue-friendly short form (`con`) and the human-readable
+        full form (`constitution`) so spell/monster data can use
+        whichever reads better.
+        """
+        fighter = _make_fighter()
+
+        # Same fighter, two names — same result.
+        assert (
+            fighter.get_saving_throw_modifier("str")
+            == fighter.get_saving_throw_modifier("strength")
+        )
+        assert (
+            fighter.get_saving_throw_modifier("cha")
+            == fighter.get_saving_throw_modifier("charisma")
+        )
+
+
+class TestAbilityModifier_SaveExamplesTable:
+    """SRD § Playing the Game › Saving Throws › Saving Throw Examples.
+
+    > Saving Throw Examples
+    > Strength — Physically resist direct force
+    > Dexterity — Dodge out of harm's way
+    > Constitution — Endure a toxic hazard
+    > Intelligence — Recognize an illusion as fake
+    > Wisdom — Resist a mental assault
+    > Charisma — Assert your identity
+    """
+
+    def test_effects_default_to_srd_recommended_save_ability(self):
+        pytest.skip(
+            "GAP: The engine has no central mapping from effect "
+            "category (force / dodge / poison / illusion / mental / "
+            "identity) to its recommended save ability. Each spell "
+            "and monster trait hardcodes its save in JSON "
+            "(`dnd_engine/data/srd/spells.json`, "
+            "`dnd_engine/data/srd/monsters.json`), so a content "
+            "author can — and sometimes does — pick a save that "
+            "doesn't match the SRD examples table. No validator "
+            "checks this. The examples table is advisory, not "
+            "normative, so this gap is low-severity but worth a "
+            "lint-style audit. Tracked by issue #450."
+        )
+
+
+class TestProficiencyBonus_AppliedWhenProficient:
+    """SRD § Playing the Game › Saving Throws › Proficiency Bonus.
+
+    > You add your Proficiency Bonus to your saving throw if you have
+    > proficiency in that kind of save. See "Proficiency" later in
+    > "Playing the Game."
+    """
+
+    def test_proficient_save_adds_proficiency_bonus(self):
+        """Fighter proficient in STR saves: modifier = STR + prof.
+
+        STR 16 (+3) at level 1 (prof +2) with STR save proficiency:
+        modifier = +3 + +2 = +5. Drops to +3 if proficiency leaks
+        out, which is the regression this guards.
+        """
+        fighter = _make_fighter(saving_throw_proficiencies=["str", "con"])
+
+        assert fighter.get_saving_throw_modifier("str") == 5
+
+    def test_non_proficient_save_omits_proficiency_bonus(self):
+        """Fighter NOT proficient in DEX saves: modifier = DEX only.
+
+        DEX 14 (+2) with no DEX save proficiency: modifier = +2, not
+        +4. SRD's "if you have proficiency in that kind of save" is
+        a gate, not a default. (character.py:231-233)
+        """
+        fighter = _make_fighter(saving_throw_proficiencies=["str", "con"])
+
+        assert fighter.get_saving_throw_modifier("dex") == 2
+
+    def test_creature_save_does_not_apply_proficiency_bonus_by_default(self):
+        """Vanilla `Creature.make_saving_throw` returns ability-mod only.
+
+        Most monsters' base saves are just the ability modifier — the
+        SRD only adds proficiency when the stat block explicitly
+        lists a save proficiency. The base `Creature` class does not
+        encode per-ability save proficiencies, so the returned
+        modifier should equal the raw ability modifier for any
+        ability. (creature.py:475-578)
+        """
+        creature = _make_creature()
+
+        result = creature.make_saving_throw(ability="dex", dc=10)
+        # DEX 14 → +2; with no proficiency the modifier must equal +2.
+        assert result["modifier"] == 2
+
+    def test_proficiency_bonus_scales_with_level_on_proficient_save(self):
+        """Same fighter at higher level → larger prof bonus on proficient save.
+
+        Level 1 (prof +2) STR-prof save: +3 + +2 = +5.
+        Level 5 (prof +3) STR-prof save: +3 + +3 = +6.
+        Level 9 (prof +4) STR-prof save: +3 + +3 + ... = +7.
+        The proficiency-bonus table is the same one driving attack
+        rolls; this is the save-side guard.
+        """
+        for lvl, expected in ((1, 5), (5, 6), (9, 7)):
+            fighter = _make_fighter(
+                level=lvl, saving_throw_proficiencies=["str"]
+            )
+            assert fighter.get_saving_throw_modifier("str") == expected
+
+
+class TestDifficultyClass_SetByEffect:
+    """SRD § Playing the Game › Saving Throws › Difficulty Class.
+
+    > The Difficulty Class for a saving throw is determined by the
+    > effect that causes it or by the GM. For example, if a spell
+    > forces you to make a save, the DC is determined by the caster's
+    > spellcasting ability and Proficiency Bonus. Monster abilities
+    > that call for saves specify the DC.
+    """
+
+    def test_spell_save_dc_uses_caster_proficiency_and_spellcasting_ability(self):
+        """`get_spell_save_dc()` = 8 + proficiency + spellcasting mod.
+
+        This is the SRD's explicit spell-DC formula (the "example"
+        cited in the rule text). Defends the formula at
+        character.py:1532-1550 against drift.
+        """
+        src = inspect.getsource(Character.get_spell_save_dc)
+
+        assert "8 + self.proficiency_bonus + ability_mod" in src, (
+            "Spell save DC must equal 8 + proficiency bonus + "
+            "spellcasting ability modifier per SRD."
+        )
+
+    def test_save_caller_supplies_dc_not_derived_from_target(self):
+        """`make_saving_throw(dc=...)` requires the DC as a parameter.
+
+        The SRD makes the DC the responsibility of the *effect*, not
+        the target. Engine-side, that means the saver doesn't compute
+        its own DC; the call site (spell handler, monster trait,
+        trap, GM ruling) passes the DC in. This test pins the
+        signature so a future refactor can't accidentally invert it.
+        """
+        sig = inspect.signature(Character.make_saving_throw)
+
+        assert "dc" in sig.parameters, (
+            "make_saving_throw must take the DC as a parameter — the "
+            "SRD assigns the DC to the effect, not the saver."
+        )
+        # DC must be a required positional/keyword param (no default).
+        assert sig.parameters["dc"].default is inspect.Parameter.empty
+
+    def test_monster_ability_saving_throw_dc_is_carried_in_data(self):
+        """Monster `saving_throw` entries specify the DC in monsters.json.
+
+        SRD: "Monster abilities that call for saves specify the DC."
+        Verifies the data-layer encoding — at least one monster
+        action carries an explicit `dc` under its `saving_throw`
+        block — so save-bearing monster abilities can be auditable
+        from the JSON catalog without consulting code.
+        """
+        import json
+        from pathlib import Path
+
+        monsters_path = (
+            Path(__file__).resolve().parents[3]
+            / "dnd_engine"
+            / "data"
+            / "srd"
+            / "monsters.json"
+        )
+        monsters = json.loads(monsters_path.read_text())
+
+        with_save_dc = [
+            (mid, action.get("name"), action["saving_throw"].get("dc"))
+            for mid, mdata in monsters.items()
+            for action in (mdata.get("actions") or [])
+            if action.get("saving_throw") and "dc" in action["saving_throw"]
+        ]
+
+        assert with_save_dc, (
+            "Expected at least one monster action carrying an explicit "
+            "`saving_throw.dc` in monsters.json (e.g., ghoul Claws). "
+            "SRD requires monster save abilities to specify their DC."
+        )
+
+    def test_save_success_uses_total_meets_or_exceeds_dc(self):
+        """`success = total >= dc` — meeting the DC is a success.
+
+        SRD doesn't use "above the DC"; the standard reading and
+        every official rules supplement treat ties as successes. This
+        is the analogue of the `>= AC` rule on the attack side
+        (#attack-rolls.md). Source-level guard against a `>` regression.
+        """
+        src = inspect.getsource(Character.make_saving_throw)
+        assert "success = total >= dc" in src, (
+            "Save success must use `>=` so that a roll exactly equal "
+            "to the DC succeeds. Same convention as attack vs. AC."
+        )

--- a/dnd-engine/tests/srd/playing_the_game/test_saving_throws_and_damage.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_saving_throws_and_damage.py
@@ -1,0 +1,298 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > Saving Throws and Damage".
+# ABOUTME: Cross-references docs/srd/playing-the-game/saving-throws-and-damage.md against engine code.
+
+"""SRD conformance: Saving Throws and Damage.
+
+Maps every rule in `docs/srd/playing-the-game/saving-throws-and-damage.md`
+to a test. Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from dnd_engine.core.combat import CombatEngine
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/saving-throws-and-damage.md",
+    lines="2228-2246",
+)
+
+
+def _make_engine(seed: int = 42) -> CombatEngine:
+    return CombatEngine(DiceRoller(seed=seed))
+
+
+def _make_caster_with_save_dc(dc: int = 13):
+    """Minimal duck-typed caster with `name` and `get_spell_save_dc`."""
+
+    class _Caster:
+        def __init__(self, name: str, save_dc: int) -> None:
+            self.name = name
+            self._save_dc = save_dc
+
+        def get_spell_save_dc(self) -> int:
+            return self._save_dc
+
+    return _Caster("Wizard", dc)
+
+
+def _make_creature(name: str, ac: int = 10) -> Creature:
+    abilities = Abilities(
+        strength=10,
+        dexterity=10,
+        constitution=10,
+        intelligence=10,
+        wisdom=10,
+        charisma=10,
+    )
+    # max_hp high enough that AoE damage doesn't kill anyone in tests.
+    return Creature(name=name, max_hp=200, ac=ac, abilities=abilities)
+
+
+class TestScope_DamageDealtViaSavingThrows:
+    """SRD § Playing the Game › Saving Throws and Damage › Scope.
+
+    > Damage dealt via saving throws uses these rules.
+    """
+
+    def test_save_spell_damage_routes_through_resolve_spell_save(self):
+        """Save-bearing spells dispatch to `CombatEngine.resolve_spell_save`.
+
+        The whole section's rules ("roll once for multiple targets,"
+        "half damage on success") live inside `resolve_spell_save`.
+        This test pins that save-bearing spells go through that path
+        rather than the auto-hit or spell-attack branch.
+        `dnd_engine/core/game_state.py:2169-2172` selects this branch
+        when `spell_data["saving_throw"] is not None`.
+        """
+        src = inspect.getsource(CombatEngine.resolve_spell_save)
+
+        # The method must accept a list of targets (multi-target
+        # scope) and must invoke `make_saving_throw` per target.
+        assert "targets: list" in src
+        assert "make_saving_throw" in src
+
+
+class TestDamageAgainstMultipleTargets_RolledOnce:
+    """SRD § Playing the Game › Saving Throws and Damage › Damage against
+    Multiple Targets.
+
+    > When you create a damaging effect that forces two or more
+    > targets to make saving throws against it at the same time, roll
+    > the damage once for all the targets. For example, when a wizard
+    > casts Fireball, the spell's damage is rolled once for all
+    > creatures caught in the blast.
+    """
+
+    def test_damage_is_rolled_once_outside_the_per_target_loop(self):
+        """`base_damage` is computed before the `for target in targets` loop.
+
+        Source-level guard: the dice roll for spell damage must
+        happen exactly once, *outside* the per-target loop in
+        `resolve_spell_save`. If a future refactor moves the roll
+        inside the loop, each target would roll its own damage —
+        violating the SRD's "roll once for all the targets" rule.
+        (combat.py:641 base_damage assignment precedes the
+        `for target in targets:` loop at 645.)
+        """
+        src = inspect.getsource(CombatEngine.resolve_spell_save)
+
+        base_idx = src.find("base_damage = self._roll_spell_save_damage")
+        loop_idx = src.find("for target in targets:")
+
+        assert base_idx != -1, "expected base_damage assignment in resolve_spell_save"
+        assert loop_idx != -1, "expected per-target for-loop in resolve_spell_save"
+        assert base_idx < loop_idx, (
+            "Damage must be rolled once before the per-target loop. "
+            "SRD: 'roll the damage once for all the targets.'"
+        )
+
+    def test_multi_target_save_uses_same_base_damage_for_all_targets(self):
+        """Each target's damage is derived from one shared roll.
+
+        Behavioral check: against a deterministic seed, the
+        full-damage value (taken on failed save) is identical for
+        every target hit by the same save spell. Uses a Con-save,
+        half-on-success spell against three targets with the same
+        modifiers — failing targets all take exactly the same number,
+        which can only be true if the roll was shared.
+        """
+        engine = _make_engine(seed=1)
+        caster = _make_caster_with_save_dc(dc=100)  # impossibly high → all fail
+        targets = [_make_creature(f"goblin_{i}") for i in range(3)]
+
+        spell = {
+            "name": "Fireball",
+            "level": 3,
+            "id": "fireball_test",
+            "saving_throw": {"ability": "dex", "on_success": "half"},
+            "damage": {"dice": "8d6", "damage_type": "fire"},
+        }
+
+        result = engine.resolve_spell_save(
+            caster=caster,
+            targets=targets,
+            spell=spell,
+            apply_damage=False,
+        )
+
+        damages = [t["damage"] for t in result["targets"]]
+        assert len({*damages}) == 1, (
+            f"All three failed-save targets must take the same damage "
+            f"(rolled once), got {damages}."
+        )
+
+
+class TestHalfDamage_OnSuccessfulSave:
+    """SRD § Playing the Game › Saving Throws and Damage › Half Damage.
+
+    > Many saving throw effects deal half damage (round down) to a
+    > target when the target succeeds on the saving throw. The halved
+    > damage is equal to half the damage that would be dealt on a
+    > failed save.
+    """
+
+    def test_half_damage_on_success_rounds_down(self):
+        """`damage // 2` is the integer halving used for `on_success='half'`.
+
+        Source-level guard: floor division on `base_damage` is the
+        SRD "round down" rule. If a future refactor switches to
+        floating-point math or `round()`, this assertion fires.
+        (combat.py:658 `damage = base_damage // 2`.)
+        """
+        src = inspect.getsource(CombatEngine.resolve_spell_save)
+
+        assert "damage = base_damage // 2" in src, (
+            "Half-damage on save success must use integer floor "
+            "division (`// 2`) to satisfy SRD 'round down'."
+        )
+
+    def test_success_with_half_yields_floor_half_of_failure_damage(self):
+        """Behavioral: success-damage equals failure-damage // 2.
+
+        Splits three targets into a guaranteed-fail group (impossible
+        DC) and a guaranteed-pass group (DC 1), runs the same save
+        spell twice, and asserts the success damage equals
+        `failure_damage // 2`. Confirms the SRD's "halved damage is
+        equal to half the damage that would be dealt on a failed
+        save" wording — success damage is *derived from* failure
+        damage, not rolled independently.
+        """
+        spell = {
+            "name": "Burning Hands",
+            "level": 1,
+            "id": "burning_hands_test",
+            "saving_throw": {"ability": "dex", "on_success": "half"},
+            "damage": {"dice": "3d6", "damage_type": "fire"},
+        }
+
+        # All-fail run.
+        fail_engine = _make_engine(seed=7)
+        fail_caster = _make_caster_with_save_dc(dc=100)
+        fail_targets = [_make_creature("a"), _make_creature("b")]
+        fail_result = fail_engine.resolve_spell_save(
+            caster=fail_caster,
+            targets=fail_targets,
+            spell=spell,
+            apply_damage=False,
+        )
+        fail_damage = fail_result["targets"][0]["damage"]
+
+        # All-pass run with the same seed → same base damage roll.
+        pass_engine = _make_engine(seed=7)
+        pass_caster = _make_caster_with_save_dc(dc=1)
+        pass_targets = [_make_creature("c"), _make_creature("d")]
+        pass_result = pass_engine.resolve_spell_save(
+            caster=pass_caster,
+            targets=pass_targets,
+            spell=spell,
+            apply_damage=False,
+        )
+        pass_damage = pass_result["targets"][0]["damage"]
+
+        # Sanity-check both runs sampled the same dice.
+        assert all(t["success"] is False for t in fail_result["targets"])
+        assert all(t["success"] is True for t in pass_result["targets"])
+
+        assert pass_damage == fail_damage // 2, (
+            f"On-success half-damage must equal floor(fail_damage / 2). "
+            f"failed={fail_damage}, succeeded={pass_damage}."
+        )
+
+    def test_on_success_none_deals_zero_damage(self):
+        """`on_success='none'` (and `'negates'`) → 0 damage on success.
+
+        Some spells specify alternative effects on a successful save
+        (no damage at all). The SRD half-damage rule is the *typical*
+        case; the per-effect spec wins. `dnd_engine/data/srd/spells.json`
+        carries `on_success` values of "half", "none", and "negates"
+        — the latter two must yield zero damage on success.
+        (combat.py:659-660.)
+        """
+        spell = {
+            "name": "Sacred Flame Stand-In",
+            "level": 0,
+            "id": "negates_test",
+            "saving_throw": {"ability": "dex", "on_success": "none"},
+            "damage": {"dice": "1d8", "damage_type": "radiant"},
+        }
+
+        engine = _make_engine(seed=5)
+        caster = _make_caster_with_save_dc(dc=1)  # always succeed
+        targets = [_make_creature("a"), _make_creature("b")]
+
+        result = engine.resolve_spell_save(
+            caster=caster,
+            targets=targets,
+            spell=spell,
+            apply_damage=False,
+        )
+
+        for t in result["targets"]:
+            assert t["success"] is True
+            assert t["damage"] == 0, (
+                "on_success='none' must deal 0 damage on a successful save."
+            )
+
+    def test_failure_takes_full_damage(self):
+        """Failed save → full damage, no halving.
+
+        Pin the negative side of the rule: the half-damage clause
+        applies on success only. A failing target takes the full
+        rolled value. (combat.py:663-664.)
+        """
+        spell = {
+            "name": "Burning Hands",
+            "level": 1,
+            "id": "burning_hands_fail",
+            "saving_throw": {"ability": "dex", "on_success": "half"},
+            "damage": {"dice": "3d6", "damage_type": "fire"},
+        }
+
+        engine = _make_engine(seed=11)
+        caster = _make_caster_with_save_dc(dc=100)  # always fail
+        targets = [_make_creature("a")]
+
+        result = engine.resolve_spell_save(
+            caster=caster,
+            targets=targets,
+            spell=spell,
+            apply_damage=False,
+        )
+
+        target_result = result["targets"][0]
+        assert target_result["success"] is False
+        # 3d6 minimum is 3, maximum is 18; failure must be in [3, 18].
+        assert 3 <= target_result["damage"] <= 18, (
+            f"Failed save must deal the full rolled value (3-18 for "
+            f"3d6), got {target_result['damage']}."
+        )


### PR DESCRIPTION
## Summary

Two new SRD conformance test files cross-referenced against the engine, staking out audit coverage for both halves of the saving-throw rules. **Audit-only** — no implementation changes.

- `dnd-engine/tests/srd/playing_the_game/test_saving_throws.py` — `docs/srd/playing-the-game/saving-throws.md` (lines 866-946).
- `dnd-engine/tests/srd/playing_the_game/test_saving_throws_and_damage.py` — `docs/srd/playing-the-game/saving-throws-and-damage.md` (lines 2228-2246).

Audit coverage script result: **playing-the-game progresses 4 → 6 / 35 audited.**

## Per-doc result

### `saving-throws.md`
| Subsection | Method | Status |
|---|---|---|
| Definition — triggered by effect | `test_make_saving_throw_returns_documented_payload_shape` | PASS |
| Definition — triggered by effect | `test_creatures_can_be_compelled_to_save` | PASS |
| Definition — choose to fail | `test_save_target_can_opt_to_fail_without_rolling` | SKIP / GAP — #447 |
| Ability Modifier — named for ability | `test_save_uses_named_ability_modifier` | PASS |
| Ability Modifier — named for ability | `test_save_accepts_both_short_and_full_ability_names` | PASS |
| Ability Modifier — Save Examples Table | `test_effects_default_to_srd_recommended_save_ability` | SKIP / GAP — #450 |
| Proficiency Bonus — when proficient | `test_proficient_save_adds_proficiency_bonus` | PASS |
| Proficiency Bonus — when proficient | `test_non_proficient_save_omits_proficiency_bonus` | PASS |
| Proficiency Bonus — when proficient | `test_creature_save_does_not_apply_proficiency_bonus_by_default` | PASS |
| Proficiency Bonus — when proficient | `test_proficiency_bonus_scales_with_level_on_proficient_save` | PASS |
| Difficulty Class — set by effect | `test_spell_save_dc_uses_caster_proficiency_and_spellcasting_ability` | PASS |
| Difficulty Class — set by effect | `test_save_caller_supplies_dc_not_derived_from_target` | PASS |
| Difficulty Class — set by effect | `test_monster_ability_saving_throw_dc_is_carried_in_data` | PASS |
| Difficulty Class — set by effect | `test_save_success_uses_total_meets_or_exceeds_dc` | PASS |

**14 tests / 12 enforced / 2 gaps**

### `saving-throws-and-damage.md`
| Subsection | Method | Status |
|---|---|---|
| Scope | `test_save_spell_damage_routes_through_resolve_spell_save` | PASS |
| Multi-target — rolled once | `test_damage_is_rolled_once_outside_the_per_target_loop` | PASS |
| Multi-target — rolled once | `test_multi_target_save_uses_same_base_damage_for_all_targets` | PASS |
| Half Damage — round down | `test_half_damage_on_success_rounds_down` | PASS |
| Half Damage — round down | `test_success_with_half_yields_floor_half_of_failure_damage` | PASS |
| Half Damage — alt effects | `test_on_success_none_deals_zero_damage` | PASS |
| Half Damage — failure | `test_failure_takes_full_damage` | PASS |

**7 tests / 7 enforced / 0 gaps**

## New gap issues

- **#447** — SRD: Allow target to choose to fail a saving throw (the willing-target case; spec gating test `TestDefinition_ChooseToFail`).
- **#450** — SRD: Lint monster/spell save abilities against the Saving Throw Examples table (advisory data-quality lint; gating test `TestAbilityModifier_SaveExamplesTable`).

## Notable findings

- The half-damage and roll-once-for-multi-target rules are both already enforced inside `CombatEngine.resolve_spell_save` (`dnd-engine/dnd_engine/core/combat.py:547-722`) — `base_damage` is computed *before* the per-target loop, and floor division (`//`) handles SRD "round down."
- `Character.make_saving_throw` cleanly separates DC ownership (parameter, supplied by the effect) from save resolution. Source-level guards pin the `>=` comparison and the spell-DC formula against regression.
- Saving-throws-and-damage has zero gaps — the engine's spell-save pipeline is fully conformant with the rules in this section, which was a pleasant surprise.

## Test plan

- [ ] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_saving_throws.py tests/srd/playing_the_game/test_saving_throws_and_damage.py -v` → 19 passed, 2 skipped
- [ ] `uv run python scripts/srd_audit_coverage.py` → playing-the-game shows 6 / 35 audited, both new files listed
- [ ] Verify gap issues #447 and #450 cite the correct gating test paths