### PR TITLE
SRD audit: damage-types + resistance-and-vulnerability + immunity

### DIFF
--- a/dnd-engine/tests/srd/playing_the_game/test_damage_types.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_damage_types.py
@@ -1,0 +1,277 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > Damage Types".
+# ABOUTME: Cross-references docs/srd/playing-the-game/damage-types.md against engine code.
+
+"""SRD conformance: Damage Types.
+
+Maps every rule in `docs/srd/playing-the-game/damage-types.md` to a
+test. Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/damage-types.md",
+    lines="2247-2255",
+)
+
+
+SRD_DATA_DIR = Path(__file__).resolve().parents[3] / "dnd_engine" / "data" / "srd"
+MONSTERS_JSON = SRD_DATA_DIR / "monsters.json"
+SPELLS_JSON = SRD_DATA_DIR / "spells.json"
+ITEMS_JSON = SRD_DATA_DIR / "items.json"
+
+
+# The thirteen SRD damage types (SRD_CC_v5.2.1 Rules Glossary).
+SRD_DAMAGE_TYPES: frozenset[str] = frozenset(
+    {
+        "acid",
+        "bludgeoning",
+        "cold",
+        "fire",
+        "force",
+        "lightning",
+        "necrotic",
+        "piercing",
+        "poison",
+        "psychic",
+        "radiant",
+        "slashing",
+        "thunder",
+    }
+)
+
+
+class TestDamageTypes_EveryInstanceHasAType:
+    """SRD § Playing the Game › Damage Types › Definition.
+
+    > Each instance of damage has a type, like Fire or Slashing.
+    """
+
+    def test_every_damage_carrying_spell_declares_a_damage_type(self):
+        """Each spell with a `damage` block names its `damage_type`.
+
+        The SRD makes damage-type tagging mandatory at the rule layer.
+        Spells are the cleanest data-parity check — every damage-dealing
+        spell in `spells.json` must declare `damage.damage_type` so
+        downstream Resistance / Vulnerability / Immunity logic has a
+        type to key on.
+        """
+        spells: dict = json.loads(SPELLS_JSON.read_text())
+        missing: list[str] = []
+        for spell_id, spell in spells.items():
+            damage = spell.get("damage")
+            if not damage:
+                continue
+            if not damage.get("damage_type"):
+                missing.append(spell_id)
+        assert not missing, (
+            f"Spells with a `damage` block but no `damage_type` "
+            f"(SRD requires each damage instance to have a type): {missing}"
+        )
+
+    def test_every_weapon_with_damage_declares_a_damage_type(self):
+        """Each item with damage dice carries a `damage_type`.
+
+        Mirrors the spell check for weapons / damage-dealing items.
+        Without a tagged type, Resistance / Vulnerability / Immunity
+        cannot key on weapon attacks once they're wired up.
+        """
+        items: dict = json.loads(ITEMS_JSON.read_text())
+        missing: list[str] = []
+        for item_id, item in items.items():
+            if not isinstance(item, dict):
+                continue
+            if item.get("damage") and not item.get("damage_type"):
+                missing.append(item_id)
+        assert not missing, (
+            f"Items with `damage` dice but no `damage_type` "
+            f"(SRD requires each damage instance to have a type): {missing}"
+        )
+
+    def test_monster_attack_actions_declare_a_damage_type(self):
+        """Each monster attack action's damage entry names a type.
+
+        Monsters express their attacks under `actions[*].damage`. Every
+        attack that rolls damage must declare `damage_type` for the
+        same downstream reasons.
+        """
+        pytest.skip(
+            "GAP: monsters.json `actions[*].damage` shape is not "
+            "consistently typed across the catalog. Damage-type "
+            "tagging on monster attacks is required before "
+            "Resistance / Vulnerability / Immunity can apply to "
+            "monster damage output. Tracked by issue #470."
+        )
+
+
+class TestDamageTypes_EnumerationMatchesSRDGlossary:
+    """SRD § Playing the Game › Damage Types › Glossary cross-reference.
+
+    > Damage types are listed in "Rules Glossary" and have no rules of
+    > their own, but other rules, such as Resistance, rely on damage
+    > types.
+
+    The Rules Glossary enumerates the canonical thirteen types: Acid,
+    Bludgeoning, Cold, Fire, Force, Lightning, Necrotic, Piercing,
+    Poison, Psychic, Radiant, Slashing, Thunder. Engine content must
+    not drift from that vocabulary.
+    """
+
+    def test_spell_damage_types_are_drawn_from_the_srd_set(self):
+        """Spells only declare SRD-listed damage types.
+
+        Compound damage strings (e.g. `"bludgeoning and cold"`) are
+        split on common separators so each component must still be a
+        valid SRD type.
+        """
+        spells: dict = json.loads(SPELLS_JSON.read_text())
+        offenders: list[tuple[str, str]] = []
+        for spell_id, spell in spells.items():
+            damage = spell.get("damage") or {}
+            raw = damage.get("damage_type")
+            if not raw:
+                continue
+            components = (
+                raw.replace(" and ", ",").replace("/", ",").replace(" or ", ",").split(",")
+            )
+            for piece in components:
+                token = piece.strip().lower()
+                if not token:
+                    continue
+                if token not in SRD_DAMAGE_TYPES:
+                    offenders.append((spell_id, token))
+        assert not offenders, (
+            f"Spell damage types outside the SRD glossary: {offenders}. "
+            f"SRD set: {sorted(SRD_DAMAGE_TYPES)}."
+        )
+
+    def test_item_damage_types_are_drawn_from_the_srd_set(self):
+        """Items only declare SRD-listed damage types.
+
+        Recursive descent because some items nest damage info (e.g. a
+        `damage` block on a thrown subentry).
+        """
+        items: dict = json.loads(ITEMS_JSON.read_text())
+
+        def _collect_damage_types(node: object, sink: list[str]) -> None:
+            if isinstance(node, dict):
+                if "damage_type" in node and isinstance(node["damage_type"], str):
+                    sink.append(node["damage_type"])
+                for value in node.values():
+                    _collect_damage_types(value, sink)
+            elif isinstance(node, list):
+                for entry in node:
+                    _collect_damage_types(entry, sink)
+
+        raw_types: list[str] = []
+        _collect_damage_types(items, raw_types)
+        offenders = sorted(
+            {t.strip().lower() for t in raw_types if t.strip().lower() not in SRD_DAMAGE_TYPES}
+        )
+        assert not offenders, (
+            f"Item damage types outside the SRD glossary: {offenders}. "
+            f"SRD set: {sorted(SRD_DAMAGE_TYPES)}."
+        )
+
+    def test_monster_damage_modifier_types_are_drawn_from_the_srd_set(self):
+        """Monster damage_immunities / _resistances / _vulnerabilities
+        cite only SRD-listed damage types.
+
+        Compound entries like "bludgeoning, piercing, and slashing
+        from nonmagical attacks that aren't silvered" are skipped
+        because they describe conditional resistance and exceed plain
+        type enumeration. Pure single-type entries (e.g. "fire",
+        "poison") must be SRD-valid.
+        """
+        monsters: dict = json.loads(MONSTERS_JSON.read_text())
+        offenders: list[tuple[str, str, str]] = []
+        for mid, mdata in monsters.items():
+            for field in (
+                "damage_immunities",
+                "damage_resistances",
+                "damage_vulnerabilities",
+            ):
+                entries = mdata.get(field) or []
+                for entry in entries:
+                    token = entry.strip().lower()
+                    # Skip compound clauses; only audit single-word types.
+                    if " " in token or "," in token:
+                        continue
+                    if token not in SRD_DAMAGE_TYPES:
+                        offenders.append((mid, field, token))
+        assert not offenders, (
+            f"Monster damage-modifier entries outside the SRD glossary: "
+            f"{offenders}. SRD set: {sorted(SRD_DAMAGE_TYPES)}."
+        )
+
+
+class TestDamageTypes_NoIntrinsicRules:
+    """SRD § Playing the Game › Damage Types › Behavior.
+
+    > [Damage types] have no rules of their own, but other rules, such
+    > as Resistance, rely on damage types.
+
+    Damage types are purely tags; the engine must not branch on the
+    type itself (e.g. "fire damage triggers X" hard-coded). All
+    behavioral consequences belong in Resistance, Vulnerability,
+    Immunity, or named features that explicitly cite a type.
+    """
+
+    def test_combat_engine_does_not_branch_on_damage_type(self):
+        """`CombatEngine.resolve_attack` does not consult damage_type.
+
+        Source-level guard: damage type is not a parameter or branch
+        condition in the core attack path. This is the SRD's "no rules
+        of their own" clause — the damage-type tag is metadata for
+        downstream systems (Resistance, Vulnerability, Immunity) and
+        must not gate hit / damage calculation at the combat engine
+        layer.
+        """
+        import inspect
+
+        from dnd_engine.core.combat import CombatEngine
+
+        src = inspect.getsource(CombatEngine.resolve_attack)
+        # The current signature does not accept damage_type, and no
+        # branch in resolve_attack reads a damage_type field — which
+        # satisfies the SRD's "no rules of their own" clause for the
+        # core attack path.
+        assert "damage_type" not in src, (
+            "CombatEngine.resolve_attack must not branch on damage_type; "
+            "type-specific behavior belongs in Resistance / Vulnerability "
+            "/ Immunity layers, not the attack path."
+        )
+
+    def test_resistance_system_keys_on_damage_type(self):
+        """Resistance pipeline accepts a `damage_type` to key on.
+
+        Confirms the "but other rules ... rely on damage types" half
+        of the SRD sentence: the resistance code path consumes the
+        type field to decide whether to halve.
+        `systems/item_effects.py:_apply_damage_effect` is the lone
+        production damage path that reads `damage_type` and consults a
+        per-type resistance condition.
+        """
+        import inspect
+
+        from dnd_engine.systems import item_effects
+
+        src = inspect.getsource(item_effects._apply_damage_effect)
+        assert 'item_info.get("damage_type"' in src, (
+            "_apply_damage_effect must read damage_type from the item "
+            "payload so resistance can key on it."
+        )
+        assert "has_resistance_" in src, (
+            "_apply_damage_effect must build a per-type resistance "
+            "condition string (e.g. has_resistance_fire) so type-keyed "
+            "resistance can apply."
+        )

--- a/dnd-engine/tests/srd/playing_the_game/test_immunity.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_immunity.py
@@ -1,0 +1,178 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > Immunity".
+# ABOUTME: Cross-references docs/srd/playing-the-game/immunity.md against engine code.
+
+"""SRD conformance: Immunity.
+
+Maps every rule in `docs/srd/playing-the-game/immunity.md` to a test.
+Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.core.combat import CombatEngine
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/immunity.md",
+    lines="2287-2293",
+)
+
+
+MONSTERS_JSON = (
+    Path(__file__).resolve().parents[3] / "dnd_engine" / "data" / "srd" / "monsters.json"
+)
+
+
+class TestImmunity_ToDamageType:
+    """SRD § Playing the Game › Immunity › Damage-type immunity.
+
+    > Immunity to a damage type means you don't take damage of that
+    > type.
+    """
+
+    def test_damage_type_immunity_zeroes_damage(self):
+        pytest.skip(
+            "GAP: damage-type immunity is not implemented anywhere. "
+            "`systems/item_effects._apply_damage_effect` only halves "
+            "for `has_resistance_{type}` — no `has_immunity_{type}` "
+            "branch zeroes damage. `CombatEngine.resolve_attack` and "
+            "`CombatEngine.resolve_spell_save` don't consult any per-"
+            "type modifier table at all. The bearded devil's "
+            "`damage_immunities: [fire, poison]` (monsters.json) is "
+            "data-only. Tracked by issues #461 (damage_type pipeline "
+            "wiring) and #464 (damage-type Immunity)."
+        )
+
+    def test_damage_type_immunity_is_per_type(self):
+        pytest.skip(
+            "GAP: depends on damage-type immunity being implemented "
+            "first. The SRD scopes immunity per type — a fire-immune "
+            "creature still takes full damage from other types. "
+            "Tracked by issue #464."
+        )
+
+    def test_monster_damage_immunities_field_is_consumed(self):
+        pytest.skip(
+            "GAP: monsters.json `damage_immunities` is data-only "
+            "(e.g., bearded_devil: fire, poison). No engine code "
+            "reads the field — `CombatEngine.resolve_attack` "
+            "(dnd-engine/dnd_engine/core/combat.py:91) doesn't take "
+            "a `damage_type` parameter, and `resolve_spell_save` "
+            "(combat.py:547) applies raw damage. Tracked by issues "
+            "#461 and #464."
+        )
+
+
+class TestImmunity_ToCondition:
+    """SRD § Playing the Game › Immunity › Condition immunity.
+
+    > Immunity to a condition means you aren't affected by it.
+    """
+
+    def test_creature_type_grants_condition_immunity(self):
+        """`CombatEngine.resolve_spell_hp_pool` honors creature-type-
+        based condition immunities for Sleep.
+
+        Today this is the *only* honored condition-immunity path in
+        the engine: undead and constructs are coded as immune to
+        Sleep at `dnd-engine/dnd_engine/core/combat.py:843-864`
+        (inside `resolve_spell_hp_pool`). Source-level guard so the
+        path can't silently regress. The general saving-throw path
+        (`CombatEngine._process_saving_throw_effect`, combat.py:371)
+        does NOT consult any immunity table — see the gap stub below.
+        """
+        src = inspect.getsource(CombatEngine.resolve_spell_hp_pool)
+        assert "immune_types" in src, (
+            "HP-pool spell resolution (Sleep) must declare a list of "
+            "creature-type immunities (SRD: 'Immunity to a condition "
+            "means you aren't affected by it.')."
+        )
+        assert "creature_type" in src and "immune_targets" in src, (
+            "HP-pool spell resolution must filter targets by creature-"
+            "type immunity so immune creatures are not affected."
+        )
+
+    def test_general_saving_throw_path_consults_condition_immunity(self):
+        pytest.skip(
+            "GAP: `CombatEngine._process_saving_throw_effect` (dnd-"
+            "engine/dnd_engine/core/combat.py:371) applies the on-fail "
+            "condition (e.g., ghoul Paralyzed) directly via "
+            "`defender.apply_condition_with_metadata` with no immunity "
+            "check. The only honored condition-immunity path is the "
+            "hard-coded Sleep creature-type list in "
+            "`CombatEngine.resolve_spell_hp_pool` (combat.py:843-864). "
+            "Tracked by issue #466."
+        )
+
+    def test_monster_condition_immunities_field_is_consumed(self):
+        pytest.skip(
+            "GAP: monsters.json `condition_immunities` is data-only "
+            "for the catalog-driven path. The engine's only condition-"
+            "immunity check is hard-coded to creature *type* (undead / "
+            "construct → Sleep) at "
+            "`dnd-engine/dnd_engine/core/combat.py:843-854`, not the "
+            "per-monster `condition_immunities` list. A bearded "
+            "devil's `condition_immunities: [poisoned]` is never "
+            "consulted before applying the Poisoned condition. "
+            "Tracked by issue #466."
+        )
+
+    def test_condition_immunity_blocks_condition_application(self):
+        pytest.skip(
+            "GAP: depends on the per-monster `condition_immunities` "
+            "field being consumed. The general rule "
+            "(`add_condition` / `apply_condition_with_metadata` in "
+            "`dnd-engine/dnd_engine/core/creature.py`) attaches a "
+            "condition unconditionally — there is no guard that "
+            "skips application when the target is immune. Tracked "
+            "by issue #466."
+        )
+
+
+class TestImmunity_DataParity:
+    """SRD § Playing the Game › Immunity › Catalog data parity.
+
+    Immunity rules rely on per-creature data. The catalog must declare
+    the fields even ahead of engine enforcement so the data is
+    available the moment the engine starts consuming it.
+    """
+
+    def test_at_least_one_monster_declares_damage_immunities(self):
+        """Catalog includes at least one monster with damage immunity.
+
+        Bearded Devil, Skeleton, Ghast, Ghoul, and Animated Armor are
+        all expected to carry the field. The test asserts the catalog
+        commitment, independent of whether the engine reads it.
+        """
+        monsters: dict = json.loads(MONSTERS_JSON.read_text())
+        with_immunity = [
+            mid for mid, mdata in monsters.items() if mdata.get("damage_immunities")
+        ]
+        assert with_immunity, (
+            "Expected at least one monster with `damage_immunities` "
+            "in monsters.json (e.g., bearded_devil: fire, poison)."
+        )
+
+    def test_at_least_one_monster_declares_condition_immunities(self):
+        """Catalog includes at least one monster with condition immunity.
+
+        Bearded Devil ships `condition_immunities: [poisoned]`. Same
+        rationale as the damage-immunity field check.
+        """
+        monsters: dict = json.loads(MONSTERS_JSON.read_text())
+        with_immunity = [
+            mid for mid, mdata in monsters.items() if mdata.get("condition_immunities")
+        ]
+        assert with_immunity, (
+            "Expected at least one monster with `condition_immunities` "
+            "in monsters.json (e.g., bearded_devil: poisoned)."
+        )

--- a/dnd-engine/tests/srd/playing_the_game/test_resistance_and_vulnerability.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_resistance_and_vulnerability.py
@@ -1,0 +1,321 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > Resistance and Vulnerability".
+# ABOUTME: Cross-references docs/srd/playing-the-game/resistance-and-vulnerability.md against engine.
+
+"""SRD conformance: Resistance and Vulnerability.
+
+Maps every rule in
+`docs/srd/playing-the-game/resistance-and-vulnerability.md` to a test.
+Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.systems.item_effects import _apply_damage_effect
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/resistance-and-vulnerability.md",
+    lines="2256-2286",
+)
+
+
+MONSTERS_JSON = (
+    Path(__file__).resolve().parents[3] / "dnd_engine" / "data" / "srd" / "monsters.json"
+)
+
+
+def _make_target(name: str = "Target", hp: int = 100) -> Creature:
+    """Build a generic creature with enough HP to absorb test damage."""
+    abilities = Abilities(
+        strength=10, dexterity=10, constitution=10, intelligence=10, wisdom=10, charisma=10
+    )
+    return Creature(name=name, max_hp=hp, ac=10, abilities=abilities)
+
+
+class TestResistance_HalvesDamage:
+    """SRD § Playing the Game › Resistance and Vulnerability › Resistance.
+
+    > If you have Resistance to a damage type, damage of that type is
+    > halved against you (round down).
+    """
+
+    def test_resistance_halves_damage_with_floor_rounding(self):
+        """A resistant target takes `floor(raw / 2)` damage.
+
+        Uses `_apply_damage_effect`, the only production path that
+        consults a per-type resistance flag, with a fixed-roll dice
+        notation ("0d4+5") to keep the test deterministic. Without
+        resistance the target would take 5; with resistance it takes 2
+        (floor of 2.5).
+        """
+        target = _make_target()
+        target.add_condition("has_resistance_fire")
+
+        result = _apply_damage_effect(
+            item_info={
+                "name": "Alchemist's Fire",
+                "damage": "0d4+5",
+                "damage_type": "fire",
+            },
+            target=target,
+            dice_roller=DiceRoller(seed=1),
+            event_bus=None,
+        )
+
+        assert result.amount == 2, "Resistance must halve 5 fire damage to floor(5/2) = 2."
+        assert target.current_hp == 98
+
+    def test_resistance_keys_on_the_specific_damage_type(self):
+        """Resistance to one type does not reduce another type.
+
+        Target has fire resistance only; a poison hit must land at
+        full damage. Confirms the resistance pipeline scopes by type.
+        """
+        target = _make_target()
+        target.add_condition("has_resistance_fire")
+
+        result = _apply_damage_effect(
+            item_info={
+                "name": "Vial of Poison",
+                "damage": "0d4+6",
+                "damage_type": "poison",
+            },
+            target=target,
+            dice_roller=DiceRoller(seed=1),
+            event_bus=None,
+        )
+
+        assert result.amount == 6, (
+            "Fire resistance must not reduce poison damage; SRD "
+            "resistance is per-type."
+        )
+
+    def test_resistance_data_exists_for_monsters(self):
+        """At least one monster declares `damage_resistances`.
+
+        Data-parity check: the catalog must carry the field so future
+        engine work has something to enforce against. Today the field
+        is read by no consumer (see GAP test below).
+        """
+        monsters: dict = json.loads(MONSTERS_JSON.read_text())
+        with_resistance = [
+            mid for mid, mdata in monsters.items() if mdata.get("damage_resistances")
+        ]
+        assert with_resistance, (
+            "Expected at least one monster with `damage_resistances` "
+            "in monsters.json (e.g., bearded_devil: cold)."
+        )
+
+    def test_monster_damage_resistances_field_is_consumed_by_damage_pipeline(self):
+        pytest.skip(
+            "GAP: monsters.json `damage_resistances` is data-only. "
+            "No engine code reads the field — `CombatEngine."
+            "resolve_attack` (dnd-engine/dnd_engine/core/combat.py:91) "
+            "doesn't take a `damage_type` parameter, and "
+            "`CombatEngine.resolve_spell_save` (combat.py:547) applies "
+            "raw damage without consulting any per-type modifier. The "
+            "only production resistance path is "
+            "`systems/item_effects._apply_damage_effect`, which keys "
+            "on creature *conditions* (e.g. has_resistance_fire), not "
+            "on the monster's catalog field. Tracked by issues "
+            "#461 (damage_type pipeline wiring) and #462 (per-type "
+            "Resistance from catalog)."
+        )
+
+
+class TestVulnerability_DoublesDamage:
+    """SRD § Playing the Game › Resistance and Vulnerability › Vulnerability.
+
+    > If you have Vulnerability to a damage type, damage of that type
+    > is doubled against you.
+    """
+
+    def test_vulnerability_doubles_damage(self):
+        pytest.skip(
+            "GAP: Vulnerability is not implemented anywhere. No "
+            "`has_vulnerability_*` condition is honored by the damage "
+            "pipeline (`systems/item_effects._apply_damage_effect` "
+            "only checks `has_resistance_*`). Monster catalog "
+            "vulnerability data exists (e.g., Skeleton: bludgeoning) "
+            "but is never read. Tracked by issue #463."
+        )
+
+    def test_vulnerability_keys_on_the_specific_damage_type(self):
+        pytest.skip(
+            "GAP: depends on the Vulnerability system being implemented "
+            "first. SRD scopes Vulnerability per damage type, identical "
+            "to Resistance. Tracked by issue #463."
+        )
+
+    def test_monster_damage_vulnerabilities_field_is_consumed(self):
+        pytest.skip(
+            "GAP: monsters.json `damage_vulnerabilities` is data-only "
+            "(Skeleton has `bludgeoning`). No engine code reads the "
+            "field — same shape of gap as the resistances field. "
+            "Tracked by issue #463."
+        )
+
+
+class TestNoStacking_MultipleInstancesCountAsOne:
+    """SRD § Playing the Game › Resistance and Vulnerability › No Stacking.
+
+    > Multiple instances of Resistance or Vulnerability that affect the
+    > same damage type count as only one instance. For example, if you
+    > have Resistance to Necrotic damage as well as Resistance to all
+    > damage, Necrotic damage is reduced by half against you.
+    """
+
+    def test_two_sources_of_resistance_halve_only_once(self):
+        """Two stacked resistance conditions still halve, not quarter.
+
+        Applies both a per-type and a hypothetical "all damage"
+        resistance condition to the target; the resulting damage must
+        be `floor(raw / 2)`, not `floor(raw / 4)`.
+        """
+        target = _make_target()
+        target.add_condition("has_resistance_fire")
+        target.add_condition("has_resistance_all")  # second source
+
+        result = _apply_damage_effect(
+            item_info={
+                "name": "Alchemist's Fire",
+                "damage": "0d4+8",
+                "damage_type": "fire",
+            },
+            target=target,
+            dice_roller=DiceRoller(seed=1),
+            event_bus=None,
+        )
+
+        # NOTE: today the production path doesn't recognize
+        # `has_resistance_all` so the second source has no effect
+        # anyway. The assertion captures the SRD invariant either way:
+        # damage must be halved, not quartered.
+        assert result.amount == 4, (
+            "Two sources of resistance must halve damage once, not "
+            "stack to quarter it (SRD No Stacking rule)."
+        )
+
+    def test_resistance_to_all_plus_resistance_to_type_does_not_stack(self):
+        pytest.skip(
+            "GAP: 'Resistance to all damage' is not a recognized "
+            "engine condition. `systems/item_effects."
+            "_apply_damage_effect` only matches the specific "
+            "`has_resistance_{type}` form. The SRD's worked example "
+            "('Resistance to Necrotic as well as Resistance to all "
+            "damage') cannot be exercised end-to-end until a "
+            "blanket-resistance hook exists. Tracked by issue #468."
+        )
+
+    def test_two_sources_of_vulnerability_double_only_once(self):
+        pytest.skip(
+            "GAP: depends on Vulnerability being implemented first. "
+            "Once it lands, two sources of Vulnerability to the same "
+            "type must double damage exactly once, not quadruple it. "
+            "Tracked by issues #463 (Vulnerability) and #468 "
+            "(No-Stacking)."
+        )
+
+
+class TestOrderOfApplication_AdjustmentsFirst:
+    """SRD § Playing the Game › Resistance and Vulnerability › Order of Application.
+
+    > Modifiers to damage are applied in the following order:
+    > adjustments such as bonuses, penalties, or multipliers are
+    > applied first; Resistance is applied second; and Vulnerability
+    > is applied third.
+    """
+
+    def test_flat_adjustments_apply_before_resistance(self):
+        pytest.skip(
+            "GAP: the engine has no notion of pre-resistance damage "
+            "adjustments (the SRD's 'magical aura that reduces all "
+            "damage by 5' worked example). `systems/item_effects."
+            "_apply_damage_effect` rolls dice, then halves once if "
+            "resistant, then applies — no upstream bonus/penalty hook. "
+            "Tracked by issue #468."
+        )
+
+    def test_resistance_applies_before_vulnerability(self):
+        pytest.skip(
+            "GAP: Vulnerability is not implemented (see issue #463), "
+            "so the SRD's stated ordering "
+            "(adjustments → Resistance → Vulnerability) cannot be "
+            "exercised. The canonical SRD worked example — Resistance "
+            "to all + Vulnerability to Fire + a magical aura that "
+            "reduces all damage by 5 against 28 fire damage → 22 — "
+            "needs all three layers in the pipeline before it can be "
+            "asserted. Tracked by issue #468."
+        )
+
+    def test_srd_worked_example_28_fire_damage_yields_22(self):
+        pytest.skip(
+            "GAP: full SRD worked example. 'A creature has Resistance "
+            "to all damage and Vulnerability to Fire damage, and it's "
+            "within a magical aura that reduces all damage by 5. If "
+            "it takes 28 Fire damage, the damage is first reduced by "
+            "5 (to 23), then halved for the creature's Resistance "
+            "(and rounded down to 11), then doubled for its "
+            "Vulnerability (to 22).' Requires the full pipeline "
+            "(adjustments + Vulnerability + blanket Resistance) to "
+            "exist. Tracked by issue #468."
+        )
+
+
+class TestPipelineSurface_DamagePathReadsTypeAndModifiers:
+    """SRD § Playing the Game › Resistance and Vulnerability › Pipeline.
+
+    The SRD's rules in this section all assume the damage pipeline
+    *knows* a damage's type and can therefore look up per-type
+    modifiers. These tests guard the seam where that knowledge lives
+    today, and call out the seams that don't yet exist.
+    """
+
+    def test_item_damage_pipeline_consults_resistance(self):
+        """`_apply_damage_effect` halves when the target is resistant.
+
+        Source-level guard: the production path that implements the
+        SRD's per-type halving lives in `systems/item_effects.py`.
+        Defends the `has_resistance` branch from silent regression.
+        """
+        src = inspect.getsource(_apply_damage_effect)
+        assert "has_resistance" in src, (
+            "Item damage pipeline must check per-type resistance "
+            "(SRD: 'damage of that type is halved against you')."
+        )
+        assert "// 2" in src, (
+            "Item damage pipeline must halve via integer division so "
+            "rounding is floor (SRD: 'round down')."
+        )
+
+    def test_attack_damage_pipeline_consults_resistance(self):
+        pytest.skip(
+            "GAP: `CombatEngine.resolve_attack` (dnd-engine/dnd_engine/"
+            "core/combat.py:91) does not accept a `damage_type` "
+            "parameter and does not consult any resistance / "
+            "vulnerability / immunity table. Weapon and spell-attack "
+            "damage bypasses the per-type modifier system entirely. "
+            "Tracked by issue #461."
+        )
+
+    def test_spell_save_damage_pipeline_consults_resistance(self):
+        pytest.skip(
+            "GAP: `CombatEngine.resolve_spell_save` (combat.py:547) "
+            "applies `target.take_damage(damage)` without consulting "
+            "the target's resistance / vulnerability / immunity to "
+            "the spell's `damage_type`. The spell knows its type (it "
+            "flows through to `CombatSpellResult.damage_type` at "
+            "game_state.py:2405 and 2476) but the value is never used "
+            "to scale the damage. Tracked by issue #461."
+        )


### PR DESCRIPTION
## Summary

Stake-out SRD conformance audit for the three docs that together define
the damage-type system:

- `docs/srd/playing-the-game/damage-types.md` (lines 2247-2255) — enumeration + metadata role
- `docs/srd/playing-the-game/resistance-and-vulnerability.md` (lines 2256-2286) — halve / double, no-stacking, ordering
- `docs/srd/playing-the-game/immunity.md` (lines 2287-2293) — zero damage / unaffected by condition

**Audit-only**: no engine changes. Three new test files, one per doc,
each with its own `pytestmark` linking to the SRD source. Real
assertions verify enforcement; `pytest.skip("GAP: ... Tracked by #N.")`
stubs surface gaps and cite the exact code location they live (or
fail to live) today.

## Conformance progress

`scripts/srd_audit_coverage.py` confirms `playing-the-game` advances
from `4 / 35` to `7 / 35` audited files.

## Per-doc results

| Doc | Rules total | Enforced | Gapped (skipped) |
|---|---|---|---|
| damage-types.md | 8 | 7 | 1 |
| resistance-and-vulnerability.md | 14 | 4 | 10 |
| immunity.md | 8 | 4 | 4 |
| **Total** | **30** | **15** | **15** |

## Test files

- `dnd-engine/tests/srd/playing_the_game/test_damage_types.py`
- `dnd-engine/tests/srd/playing_the_game/test_resistance_and_vulnerability.py`
- `dnd-engine/tests/srd/playing_the_game/test_immunity.py`

## Gap issues filed

| # | Issue | Tests it gates |
|---|---|---|
| #461 | Wire `damage_type` through CombatEngine attack and spell-save pipelines | `TestPipelineSurface::test_attack_damage_pipeline_consults_resistance`, `…::test_spell_save_damage_pipeline_consults_resistance`, plus all downstream gaps |
| #462 | Apply per-type Resistance from monster catalog in damage pipeline | `TestResistance_HalvesDamage::test_monster_damage_resistances_field_is_consumed_by_damage_pipeline` |
| #463 | Implement per-type Vulnerability (damage doubling) | `TestVulnerability_DoublesDamage::*`, `TestNoStacking::test_two_sources_of_vulnerability_double_only_once` |
| #464 | Implement damage-type Immunity (zero damage of that type) | `TestImmunity_ToDamageType::*` |
| #466 | Honor per-monster `condition_immunities` in saving-throw effect path | `TestImmunity_ToCondition::test_general_saving_throw_path_consults_condition_immunity`, `…::test_monster_condition_immunities_field_is_consumed`, `…::test_condition_immunity_blocks_condition_application` |
| #468 | Damage modifier No-Stacking and Order-of-Application pipeline | `TestNoStacking::test_resistance_to_all_plus_resistance_to_type_does_not_stack`, `TestOrderOfApplication::*` |
| #470 | Data parity: tag monster `actions[*].damage` with `damage_type` | `TestDamageTypes_EveryInstanceHasAType::test_monster_attack_actions_declare_a_damage_type` |

## Audit findings (one-line summary)

- **Damage-type tagging** is present and SRD-valid on spells and items. Monster `actions[*].damage` is inconsistent (#470).
- The **only** production damage path that scales by per-type Resistance is `systems/item_effects._apply_damage_effect`, which keys on creature *conditions* (`has_resistance_fire`). Weapon and spell-save damage bypasses any per-type modifier entirely.
- **Vulnerability** is not implemented anywhere. `damage_vulnerabilities` catalog data (e.g., Skeleton: bludgeoning) is unread.
- **Damage-type Immunity** is not implemented anywhere. `damage_immunities` catalog data is unread.
- **Condition Immunity** is honored *only* via a hard-coded creature-type list for Sleep in `CombatEngine.resolve_spell_hp_pool`. The general saving-throw path applies on-fail conditions unconditionally; per-monster `condition_immunities` is unread.
- The SRD "No Stacking" rule and "Order of Application" (adjustments → Resistance → Vulnerability) cannot be exercised end-to-end until the layers above exist.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_damage_types.py tests/srd/playing_the_game/test_resistance_and_vulnerability.py tests/srd/playing_the_game/test_immunity.py -v` — 15 passed, 18 skipped, pristine output.
- [x] `uv run python scripts/srd_audit_coverage.py` — `playing-the-game` 7/35 (was 4/35); three new files listed under "Audited rule files".
- [x] `pytest --collect-only -q` shows the three modules with one class per SRD subsection.