### PR TITLE
Fix #427: Clear ctx.last_attack on out-of-range rejection in _action_attack

### DIFF
--- a/dnd-engine/dnd_engine/scenarios/script_executor.py
+++ b/dnd-engine/dnd_engine/scenarios/script_executor.py
@@ -264,6 +264,7 @@ class ScriptExecutor:
                 f"out of range: {distance} ft > max {max_range} ft "
                 f"({weapon_data.get('name') if weapon_data else 'unarmed'})"
             )
+            self.ctx.last_attack = None
             return
 
         in_long_range = distance > normal_range

--- a/dnd-engine/tests/test_script_executor.py
+++ b/dnd-engine/tests/test_script_executor.py
@@ -93,6 +93,30 @@ enemies:
     position: [20, 5]
 """
 
+# Chained scenario: one goblin in normal dagger range (2 tiles = 10 ft)
+# and one past max range (17 tiles = 85 ft > 60 ft). Used to verify the
+# rejection path clears `ctx.last_attack` so a previous landed attack
+# can't masquerade as the rejected attack's result.
+LAND_THEN_REJECT_YAML = """
+name: exec_land_then_reject
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.entrance
+party:
+  - class: fighter
+    race: high_elf
+    weapons: [dagger]
+    position: [3, 5]
+    name: Archy
+enemies:
+  - monster_id: goblin
+    position: [5, 5]
+  - monster_id: goblin
+    position: [20, 5]
+"""
+
 # Adjacent enemy for melee: distance 1 tile = 5 ft, well within
 # longsword's melee reach.
 MELEE_ADJACENT_YAML = """
@@ -277,6 +301,30 @@ def test_attack_out_of_range_rejects_without_resolving(tmp_path: Path) -> None:
     # and turn passed".
     assert ctx.turn_count == 0
     assert goblin.current_hp == starting_hp
+
+
+def test_attack_out_of_range_clears_prior_last_attack(tmp_path: Path) -> None:
+    """Rejection must blank `ctx.last_attack` so a prior landed attack
+    can't masquerade as the rejected attack's result. Mirrors the fix
+    applied to `_action_monster_attack` in PR #424 (#427).
+    """
+    path = _write(tmp_path, LAND_THEN_REJECT_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    # Two intervening waits cycle initiative back to the fighter:
+    # fighter → goblin_0 → goblin_1 → fighter.
+    ctx = ScriptExecutor(loaded).run(
+        [
+            {"action": "attack", "target": "goblin_0"},
+            {"action": "wait"},
+            {"action": "wait"},
+            {"action": "attack", "target": "goblin_1"},
+        ]
+    )
+
+    assert ctx.last_attack is None
+    assert ctx.last_attack_error is not None
+    assert "range" in ctx.last_attack_error.lower()
 
 
 # --- attack: long-range disadvantage flag ----------------------------------


### PR DESCRIPTION
## Summary

Mirror the fix applied to `_action_monster_attack` in PR #424 (`#411`).
On the range-rejection branch in `_action_attack`, also clear
`ctx.last_attack` so a previous landed attack can't masquerade as the
rejected attack's result.

Closes #427.

## The bug

`dnd-engine/dnd_engine/scenarios/script_executor.py:262-267` set
`last_attack_error` on rejection but left `last_attack` untouched. A
chained scenario like:

1. `attack` — lands, populates `ctx.last_attack`
2. `attack` — out of range, sets `ctx.last_attack_error`

…left `ctx.last_attack` pointing at attack #1's `AttackResult`. A test
or downstream caller reading `ctx.last_attack` after step 2 could
misread step 1's hit/damage as the result of step 2.

## The fix

One line in `_action_attack`:

```python
if distance > max_range:
    self.ctx.last_attack_error = (...)
    self.ctx.last_attack = None  # added
    return
```

The sibling `_action_monster_attack` already does this (PR #424,
script_executor.py:351).

## Test

`tests/test_script_executor.py::test_attack_out_of_range_clears_prior_last_attack`
— constructs a two-goblin scenario (one in dagger normal range, one past
max range), runs `attack → wait → wait → attack` so initiative cycles
back to the fighter, and asserts:

- `ctx.last_attack is None` after rejection
- `ctx.last_attack_error is not None` and mentions range

The test fails on `main` (catches the bug) and passes with the fix.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/test_script_executor.py -v` — 26 passed, no regression.
- [x] New test fails without the fix; passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)