### PR TITLE
SRD audit: the-six-abilities + proficiency

### DIFF
--- a/dnd-engine/tests/srd/playing_the_game/test_proficiency.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_proficiency.py
@@ -1,0 +1,684 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > Proficiency".
+# ABOUTME: Cross-references docs/srd/playing-the-game/proficiency.md against engine code.
+
+"""SRD conformance: Proficiency.
+
+Maps every rule in `docs/srd/playing-the-game/proficiency.md` to a test.
+Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/proficiency.md",
+    lines="1012-1316",
+)
+
+
+DATA_DIR = Path(__file__).resolve().parents[3] / "dnd_engine" / "data" / "srd"
+CLASSES_JSON = DATA_DIR / "classes.json"
+SKILLS_JSON = DATA_DIR / "skills.json"
+PROGRESSION_JSON = DATA_DIR / "progression.json"
+RACES_JSON = DATA_DIR / "races.json"
+
+
+def _make_fighter(level: int = 1, abilities: Abilities | None = None) -> Character:
+    """Construct a baseline fighter at a given level for PB tests."""
+    if abilities is None:
+        abilities = Abilities(
+            strength=16,
+            dexterity=12,
+            constitution=14,
+            intelligence=10,
+            wisdom=10,
+            charisma=8,
+        )
+    return Character(
+        name="Tester",
+        character_class=CharacterClass.FIGHTER,
+        level=level,
+        abilities=abilities,
+        max_hp=10 + level,
+        ac=16,
+        saving_throw_proficiencies=["str", "con"],
+        skill_proficiencies=["athletics"],
+        weapon_proficiencies=["simple", "martial"],
+        armor_proficiencies=["light", "medium", "heavy", "shields"],
+        tool_proficiencies=[],
+    )
+
+
+class TestProficiency_HeroicInspiration:
+    """SRD § Playing the Game › Proficiency › Heroic Inspiration sidebar.
+
+    > If you have Heroic Inspiration, you can expend it to reroll any
+    > die immediately after rolling it, and you must use the new roll.
+    """
+
+    def test_heroic_inspiration_lets_you_reroll_any_die(self) -> None:
+        pytest.skip(
+            "GAP: Heroic Inspiration is not implemented anywhere. No "
+            "`has_heroic_inspiration` flag on `Character` (dnd-engine/"
+            "dnd_engine/core/character.py:23), and `DiceRoller` "
+            "(dnd-engine/dnd_engine/core/dice.py) has no consume-to-"
+            "reroll API. Tracked by issue #478."
+        )
+
+    def test_heroic_inspiration_cap_of_one_instance(self) -> None:
+        pytest.skip(
+            "GAP: SRD: 'You can never have more than one instance of "
+            "Heroic Inspiration. If something gives you Heroic "
+            "Inspiration and you already have it, you can give it to a "
+            "player character in your group who lacks it.' No cap-and-"
+            "transfer surface on `Character`. Tracked by issue #478."
+        )
+
+    def test_human_starts_each_day_with_heroic_inspiration(self) -> None:
+        pytest.skip(
+            "GAP: SRD: 'Human characters start each day with Heroic "
+            "Inspiration.' `races.json` defines a Human entry but no "
+            "engine code grants the flag at session start or after a "
+            "long rest. Tracked by issue #478."
+        )
+
+
+class TestProficiency_BonusByLevel:
+    """SRD § Playing the Game › Proficiency › Proficiency Bonus table (PC).
+
+    > A character's Proficiency Bonus increases as the character gains
+    > levels.
+    >
+    > | Level | Bonus |
+    > |-------|-------|
+    > | 1-4   | +2    |
+    > | 5-8   | +3    |
+    > | 9-12  | +4    |
+    > | 13-16 | +5    |
+    > | 17-20 | +6    |
+    """
+
+    @pytest.mark.parametrize(
+        "level,expected_pb",
+        [
+            (1, 2),
+            (2, 2),
+            (3, 2),
+            (4, 2),
+            (5, 3),
+            (6, 3),
+            (7, 3),
+            (8, 3),
+            (9, 4),
+            (10, 4),
+            (11, 4),
+            (12, 4),
+            (13, 5),
+            (14, 5),
+            (15, 5),
+            (16, 5),
+            (17, 6),
+            (18, 6),
+            (19, 6),
+            (20, 6),
+        ],
+    )
+    def test_character_proficiency_bonus_matches_srd_table(
+        self, level: int, expected_pb: int
+    ) -> None:
+        """`Character.proficiency_bonus` returns +2..+6 by SRD bands.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        129-143. The formula `2 + (level - 1) // 4` reproduces the SRD
+        table for levels 1-20.
+        """
+        char = _make_fighter(level=level)
+        assert char.proficiency_bonus == expected_pb
+
+    def test_progression_data_matches_srd_table_for_pc_levels(self) -> None:
+        """Catalog parity: progression.json mirrors the SRD PB table.
+
+        The JSON-driven proficiency-by-level lookup must agree with the
+        SRD's banded values for levels 1-20.
+        """
+        progression: dict = json.loads(PROGRESSION_JSON.read_text())
+        pb_by_level = progression["proficiency_by_level"]
+        expected = {
+            **dict.fromkeys(range(1, 5), 2),
+            **dict.fromkeys(range(5, 9), 3),
+            **dict.fromkeys(range(9, 13), 4),
+            **dict.fromkeys(range(13, 17), 5),
+            **dict.fromkeys(range(17, 21), 6),
+        }
+        for level, want in expected.items():
+            assert int(pb_by_level[str(level)]) == want, (
+                f"progression.proficiency_by_level[{level}] = "
+                f"{pb_by_level[str(level)]}, expected {want}"
+            )
+
+
+class TestProficiency_BonusByCR:
+    """SRD § Playing the Game › Proficiency › Proficiency Bonus table (monster).
+
+    > A monster's Proficiency Bonus is based on its Challenge Rating.
+    """
+
+    def test_creature_does_not_expose_proficiency_bonus_from_cr(self) -> None:
+        pytest.skip(
+            "GAP: `Creature` (dnd-engine/dnd_engine/core/creature.py:"
+            "57) has no `proficiency_bonus` property. Only `Character."
+            "proficiency_bonus` (character.py:130) exists, derived from "
+            "PC level. Nothing maps the `cr` field in monsters.json to "
+            "the SRD PB band. Tracked by issue #480."
+        )
+
+    def test_monster_save_totals_decompose_to_ability_mod_plus_pb(self) -> None:
+        pytest.skip(
+            "GAP: monsters.json stores `saving_throws` as raw final "
+            "totals (e.g., bearded_devil: str=5, con=4, wis=2 at "
+            "dnd_engine/data/srd/monsters.json:969). Without a "
+            "CR->PB mapping on `Creature`, the engine cannot validate "
+            "that those totals equal `ability_mod + PB` for the "
+            "proficient saves. Tracked by issue #480."
+        )
+
+
+class TestProficiency_BonusApplication:
+    """SRD § Playing the Game › Proficiency › Bonus Application.
+
+    > This bonus is applied to a D20 Test when the creature has
+    > proficiency in a skill, in a saving throw, or with an item that
+    > the creature uses to make the D20 Test. The bonus is also used
+    > for spell attacks and for calculating the DC of saving throws
+    > for spells.
+    """
+
+    def test_save_proficiency_adds_pb_to_saving_throw_modifier(self) -> None:
+        """Proficient saves include PB; non-proficient saves don't.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        169-235. STR/CON are proficient for the test fighter; INT/DEX
+        are not.
+        """
+        char = _make_fighter(level=5)  # PB = +3
+        # STR mod = +3 (16), proficient → +3 + 3 = +6
+        assert char.get_saving_throw_modifier("str") == 6
+        # INT mod = 0 (10), not proficient → 0
+        assert char.get_saving_throw_modifier("int") == 0
+        # DEX mod = +1 (12), not proficient → +1
+        assert char.get_saving_throw_modifier("dex") == 1
+        # CON mod = +2 (14), proficient → +2 + 3 = +5
+        assert char.get_saving_throw_modifier("con") == 5
+
+    def test_skill_proficiency_adds_pb_to_skill_modifier(self) -> None:
+        """Proficient skills include PB; non-proficient skills don't.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        689-724.
+        """
+        skills_data = json.loads(SKILLS_JSON.read_text())
+        char = _make_fighter(level=5)  # PB = +3
+        # Athletics (STR): proficient → STR mod (+3) + PB (+3) = +6
+        assert char.get_skill_modifier("athletics", skills_data) == 6
+        # Stealth (DEX): not proficient → DEX mod (+1) = +1
+        assert char.get_skill_modifier("stealth", skills_data) == 1
+
+    def test_weapon_proficiency_adds_pb_to_attack_roll(self) -> None:
+        """Weapon proficiency surfaces PB on the attack roll.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        366-412 (`get_attack_bonus` adds PB only when proficient).
+        """
+        # Fighter is proficient with simple and martial weapons,
+        # so a longsword (martial) attack should include PB.
+        char = _make_fighter(level=5)  # PB = +3, STR mod = +3
+        items_data = {
+            "weapons": {
+                "longsword": {
+                    "weapon_type": "martial",
+                    "category": "melee",
+                    "properties": [],
+                }
+            }
+        }
+        # PB (+3) + STR mod (+3) = +6
+        assert char.get_attack_bonus("longsword", items_data) == 6
+
+    def test_non_proficient_weapon_excludes_pb(self) -> None:
+        """Without weapon proficiency the engine omits PB.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        408-412 (the `is_proficient` branch). Locks the negative case
+        so the SRD's conditional ("when the creature has proficiency")
+        can't drift to "always add PB."
+        """
+        char = _make_fighter(level=5)
+        # Override proficiencies so the test weapon is not covered.
+        char.weapon_proficiencies = ["simple"]
+        items_data = {
+            "weapons": {
+                "exotic_blade": {
+                    "weapon_type": "exotic",
+                    "category": "melee",
+                    "properties": [],
+                }
+            }
+        }
+        # Just STR mod (+3), no PB
+        assert char.get_attack_bonus("exotic_blade", items_data) == 3
+
+    def test_spell_attack_bonus_includes_pb(self) -> None:
+        """Spell attack bonus = PB + spellcasting ability modifier.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        907-960 (`get_spell_attack_bonus`).
+        """
+        abilities = Abilities(
+            strength=8,
+            dexterity=14,
+            constitution=12,
+            intelligence=18,  # +4
+            wisdom=10,
+            charisma=10,
+        )
+        wiz = Character(
+            name="Magus",
+            character_class=CharacterClass.WIZARD,
+            level=5,  # PB = +3
+            abilities=abilities,
+            max_hp=20,
+            ac=12,
+            spellcasting_ability="int",
+        )
+        # PB (+3) + INT mod (+4) = +7
+        assert wiz.get_spell_attack_bonus("int") == 7
+
+    def test_spell_save_dc_includes_pb(self) -> None:
+        """Spell save DC = 8 + PB + spellcasting ability modifier.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        1532-1550 (`get_spell_save_dc`).
+        """
+        abilities = Abilities(
+            strength=8,
+            dexterity=14,
+            constitution=12,
+            intelligence=18,  # +4
+            wisdom=10,
+            charisma=10,
+        )
+        wiz = Character(
+            name="Magus",
+            character_class=CharacterClass.WIZARD,
+            level=5,  # PB = +3
+            abilities=abilities,
+            max_hp=20,
+            ac=12,
+            spellcasting_ability="int",
+        )
+        # 8 + PB (+3) + INT mod (+4) = 15
+        assert wiz.get_spell_save_dc() == 15
+
+
+class TestProficiency_BonusDoesntStack:
+    """SRD § Playing the Game › Proficiency › The Bonus Doesn't Stack.
+
+    > Your Proficiency Bonus can't be added to a die roll or another
+    > number more than once. For example, if a rule allows you to make
+    > a Charisma (Deception or Persuasion) check, you add your
+    > Proficiency Bonus if you're proficient in either skill, but you
+    > don't add it twice if you're proficient in both skills.
+    """
+
+    def test_either_or_skill_check_helper_is_not_implemented(self) -> None:
+        pytest.skip(
+            "GAP: no helper takes a *set* of applicable skills and "
+            "applies PB once. `Character.get_skill_modifier` (dnd-"
+            "engine/dnd_engine/core/character.py:689) is per-skill. "
+            "Callers happen to pick one skill, but there is no rule-"
+            "level guard for the SRD's 'Deception or Persuasion' "
+            "pattern. Tracked by issue #481."
+        )
+
+    def test_proficiency_bonus_multiplied_only_once_guard(self) -> None:
+        pytest.skip(
+            "GAP: SRD: 'Whenever the bonus is used, it can be "
+            "multiplied only once and divided only once.' Expertise "
+            "doubles PB in `Character.get_skill_modifier` (dnd-engine/"
+            "dnd_engine/core/character.py:719-722), but no engine "
+            "guard prevents a second multiplier from stacking on top. "
+            "Tracked by issue #481."
+        )
+
+
+class TestProficiency_Skills:
+    """SRD § Playing the Game › Proficiency › Skill Proficiencies.
+
+    > If a creature is proficient in a skill, the creature applies its
+    > Proficiency Bonus to ability checks involving that skill.
+    > Without proficiency in a skill, a creature can still make ability
+    > checks involving that skill but doesn't add its Proficiency Bonus.
+    """
+
+    def test_skills_json_carries_all_eighteen_srd_skills(self) -> None:
+        """Catalog parity: skills.json lists every SRD skill.
+
+        The SRD Skills table names 18 skills. The data file is the
+        canonical lookup for ability mapping.
+        """
+        skills: dict = json.loads(SKILLS_JSON.read_text())
+        expected = {
+            "acrobatics",
+            "animal_handling",
+            "arcana",
+            "athletics",
+            "deception",
+            "history",
+            "insight",
+            "intimidation",
+            "investigation",
+            "medicine",
+            "nature",
+            "perception",
+            "performance",
+            "persuasion",
+            "religion",
+            "sleight_of_hand",
+            "stealth",
+            "survival",
+        }
+        assert set(skills.keys()) == expected
+
+    def test_skills_json_ability_assignments_match_srd_table(self) -> None:
+        """Catalog parity: every skill's ability matches the SRD table.
+
+        Locked SRD Skills table:
+        - Acrobatics, Sleight of Hand, Stealth → DEX
+        - Athletics → STR
+        - Animal Handling, Insight, Medicine, Perception, Survival → WIS
+        - Arcana, History, Investigation, Nature, Religion → INT
+        - Deception, Intimidation, Performance, Persuasion → CHA
+        """
+        skills: dict = json.loads(SKILLS_JSON.read_text())
+        expected = {
+            "acrobatics": "dex",
+            "animal_handling": "wis",
+            "arcana": "int",
+            "athletics": "str",
+            "deception": "cha",
+            "history": "int",
+            "insight": "wis",
+            "intimidation": "cha",
+            "investigation": "int",
+            "medicine": "wis",
+            "nature": "int",
+            "perception": "wis",
+            "performance": "cha",
+            "persuasion": "cha",
+            "religion": "int",
+            "sleight_of_hand": "dex",
+            "stealth": "dex",
+            "survival": "wis",
+        }
+        for skill_id, want_ability in expected.items():
+            assert skills[skill_id]["ability"] == want_ability, skill_id
+
+    def test_non_proficient_skill_check_omits_pb(self) -> None:
+        """Without skill proficiency the engine omits PB.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        715-722. The non-proficient branch falls through to `modifier =
+        ability_mod` only.
+        """
+        skills_data = json.loads(SKILLS_JSON.read_text())
+        char = _make_fighter(level=5)  # PB = +3
+        # Stealth (DEX): not proficient → DEX mod (+1), no PB
+        assert char.get_skill_modifier("stealth", skills_data) == 1
+
+
+class TestProficiency_DeterminingSkills:
+    """SRD § Playing the Game › Proficiency › Determining Skills.
+
+    > A character's starting skill proficiencies are determined at
+    > character creation, and a monster's skill proficiencies appear in
+    > its stat block.
+    """
+
+    def test_classes_declare_starting_skill_proficiency_choices(self) -> None:
+        """Catalog parity: each class declares a skill-proficiency choice.
+
+        The PC's "skill proficiencies are determined at character
+        creation" requires the catalog to provide the menu. Tests the
+        classes.json shape that drives the character factory.
+        """
+        classes: dict = json.loads(CLASSES_JSON.read_text())
+        for class_id, cdata in classes.items():
+            choice = cdata.get("skill_proficiencies")
+            assert choice is not None, (
+                f"class {class_id} is missing skill_proficiencies"
+            )
+            assert "choose" in choice and "from" in choice, (
+                f"class {class_id}.skill_proficiencies must declare "
+                f"a {{choose, from}} block"
+            )
+
+    def test_monster_skill_proficiencies_appear_in_stat_block(self) -> None:
+        """Catalog parity: monsters declare a `skills` block.
+
+        The SRD says a monster's skill proficiencies "appear in its
+        stat block." The catalog represents the stat block as JSON, and
+        every monster entry must carry a `skills` key (even if empty).
+        """
+        monsters_path = DATA_DIR / "monsters.json"
+        monsters: dict = json.loads(monsters_path.read_text())
+        for monster_id, mdata in monsters.items():
+            assert "skills" in mdata, (
+                f"monster {monster_id} is missing a `skills` block"
+            )
+
+
+class TestProficiency_SavingThrows:
+    """SRD § Playing the Game › Proficiency › Saving Throw Proficiencies.
+
+    > Proficiency in a saving throw lets a character add their
+    > Proficiency Bonus to saves that use a particular ability.
+    > Each class gives proficiency in at least two saving throws.
+    """
+
+    def test_each_class_declares_at_least_two_save_proficiencies(self) -> None:
+        """Catalog parity: every class lists >= 2 save proficiencies.
+
+        Source: dnd_engine/data/srd/classes.json.
+        """
+        classes: dict = json.loads(CLASSES_JSON.read_text())
+        for class_id, cdata in classes.items():
+            saves = cdata.get("saving_throw_proficiencies", [])
+            assert len(saves) >= 2, (
+                f"class {class_id} declares {len(saves)} save "
+                f"proficiencies; SRD requires at least 2"
+            )
+
+    def test_save_proficiency_grants_pb_to_that_ability_only(self) -> None:
+        """Save proficiency is per-ability.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        231-235 (only the matching `ability_short` adds PB).
+        """
+        char = _make_fighter(level=5)  # PB +3; proficient STR, CON
+        # STR proficient
+        assert char.get_saving_throw_modifier("str") == 6
+        # WIS not proficient — even though it's a valid save
+        # ability, it gets no PB.
+        wis_mod = char.abilities.wis_mod
+        assert char.get_saving_throw_modifier("wis") == wis_mod
+
+
+class TestProficiency_Weapons:
+    """SRD § Playing the Game › Proficiency › Equipment Proficiencies › Weapons.
+
+    > Anyone can wield a weapon, but proficiency makes you better at
+    > wielding it. If you have proficiency with a weapon, you add your
+    > Proficiency Bonus to attack rolls you make with it.
+    """
+
+    def test_weapon_proficiency_adds_pb_to_attack(self) -> None:
+        """Proficient weapon → PB added to attack roll.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        408-412. Mirrors the SRD line "you add your Proficiency Bonus
+        to attack rolls you make with it."
+        """
+        char = _make_fighter(level=5)  # PB +3, STR mod +3, proficient martial
+        items_data = {
+            "weapons": {
+                "longsword": {
+                    "weapon_type": "martial",
+                    "category": "melee",
+                    "properties": [],
+                }
+            }
+        }
+        assert char.get_attack_bonus("longsword", items_data) == 6
+
+    def test_anyone_can_wield_a_weapon_without_proficiency(self) -> None:
+        """Non-proficient wielders still get the ability modifier.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        408-412 — the non-proficient branch returns `ability_mod` only,
+        not zero. SRD: "Anyone can wield a weapon."
+        """
+        char = _make_fighter(level=5)
+        char.weapon_proficiencies = []  # strip all
+        items_data = {
+            "weapons": {
+                "longsword": {
+                    "weapon_type": "martial",
+                    "category": "melee",
+                    "properties": [],
+                }
+            }
+        }
+        # STR mod (+3), no PB
+        assert char.get_attack_bonus("longsword", items_data) == 3
+
+
+class TestProficiency_Tools:
+    """SRD § Playing the Game › Proficiency › Equipment Proficiencies › Tools.
+
+    > If you have proficiency with a tool, you can add your Proficiency
+    > Bonus to any ability check you make that uses the tool. If you
+    > have proficiency in the skill that's also used with that check,
+    > you have Advantage on the check too.
+    """
+
+    def test_character_tracks_tool_proficiencies(self) -> None:
+        """`Character.tool_proficiencies` exists and is settable.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        109. Locks the storage so the data is available the moment the
+        engine starts consuming it.
+        """
+        char = _make_fighter(level=1)
+        char.tool_proficiencies = ["thieves_tools"]
+        assert "thieves_tools" in char.tool_proficiencies
+
+    def test_tool_check_adds_pb_when_proficient(self) -> None:
+        pytest.skip(
+            "GAP: `Character.tool_proficiencies` is stored (dnd-engine/"
+            "dnd_engine/core/character.py:109) but no `make_tool_check` "
+            "or `is_proficient_with_tool` API exists. No ability-check "
+            "surface adds PB based on the tool being used. Tracked by "
+            "issue #483."
+        )
+
+    def test_tool_plus_skill_proficiency_grants_advantage(self) -> None:
+        pytest.skip(
+            "GAP: SRD: 'If you have proficiency in the skill that's "
+            "also used with that check, you have Advantage on the "
+            "check too.' `Character.make_skill_check` (dnd-engine/"
+            "dnd_engine/core/character.py:726) accepts advantage flags "
+            "but never auto-derives advantage from tool+skill overlap. "
+            "Tracked by issue #483."
+        )
+
+
+class TestProficiency_Expertise:
+    """SRD § Playing the Game › Proficiency › Expertise (multiplier example).
+
+    The SRD line "Occasionally, a Proficiency Bonus might be multiplied
+    or divided (doubled or halved, for example) before being added" is
+    illustrated by the Expertise feature (referenced from this section
+    and defined in Rules Glossary). `Character` supports it for skills.
+    """
+
+    def test_expertise_doubles_pb_for_skill(self) -> None:
+        """Expertise in a skill doubles PB on that skill's check.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        718-722. Locks the doubling so the SRD multiplier example has a
+        callable proof.
+        """
+        skills_data = json.loads(SKILLS_JSON.read_text())
+        abilities = Abilities(
+            strength=10,
+            dexterity=16,  # +3
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
+        )
+        rogue = Character(
+            name="Pickpocket",
+            character_class=CharacterClass.ROGUE,
+            level=5,  # PB +3
+            abilities=abilities,
+            max_hp=20,
+            ac=14,
+            skill_proficiencies=["stealth"],
+            expertise_skills=["stealth"],
+        )
+        # DEX mod (+3) + PB doubled (+6) = +9
+        assert rogue.get_skill_modifier("stealth", skills_data) == 9
+
+    def test_expertise_only_applies_when_already_proficient(self) -> None:
+        """Expertise is a *multiplier* on PB, not a grant of PB.
+
+        Source-level binding at dnd-engine/dnd_engine/core/character.py:
+        718-722: the doubled-PB branch is inside the `if skill in
+        self.skill_proficiencies:` block. A character listed in
+        `expertise_skills` for a skill they aren't proficient in gets
+        no PB at all. Mirrors the SRD's framing of expertise as
+        "multiplying" the bonus, not creating it.
+        """
+        skills_data = json.loads(SKILLS_JSON.read_text())
+        abilities = Abilities(
+            strength=10,
+            dexterity=16,  # +3
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
+        )
+        rogue = Character(
+            name="Pickpocket",
+            character_class=CharacterClass.ROGUE,
+            level=5,  # PB +3
+            abilities=abilities,
+            max_hp=20,
+            ac=14,
+            skill_proficiencies=[],  # not proficient
+            expertise_skills=["stealth"],  # but listed for expertise
+        )
+        # Just DEX mod (+3), no PB doubled or otherwise
+        assert rogue.get_skill_modifier("stealth", skills_data) == 3

--- a/dnd-engine/tests/srd/playing_the_game/test_the_six_abilities.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_the_six_abilities.py
@@ -1,0 +1,406 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > The Six Abilities".
+# ABOUTME: Cross-references docs/srd/playing-the-game/the-six-abilities.md against engine code.
+
+"""SRD conformance: The Six Abilities.
+
+Maps every rule in `docs/srd/playing-the-game/the-six-abilities.md` to a
+test. Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.core.creature import Abilities, Creature
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/the-six-abilities.md",
+    lines="567-655",
+)
+
+
+SKILLS_JSON = (
+    Path(__file__).resolve().parents[3] / "dnd_engine" / "data" / "srd" / "skills.json"
+)
+
+
+class TestSixAbilities_Roster:
+    """SRD § Playing the Game › The Six Abilities › Ability Descriptions table.
+
+    > All creatures—characters and monsters—have six abilities that
+    > measure physical and mental characteristics.
+    """
+
+    def test_abilities_dataclass_carries_all_six(self) -> None:
+        """`Abilities` exposes the SRD's six and only those six.
+
+        The dataclass (dnd-engine/dnd_engine/core/creature.py:11) is the
+        sole carrier of STR/DEX/CON/INT/WIS/CHA. Any future drift to a
+        different roster (e.g., a seventh ability) would silently break
+        SRD conformance, so the field set is locked here.
+        """
+        names = {f.name for f in fields(Abilities)}
+        assert names == {
+            "strength",
+            "dexterity",
+            "constitution",
+            "intelligence",
+            "wisdom",
+            "charisma",
+        }
+
+    def test_creature_carries_an_abilities_instance(self) -> None:
+        """Every Creature instance carries the SRD ability block.
+
+        The SRD line "All creatures—characters and monsters—have six
+        abilities" maps directly to `Creature.__init__` requiring an
+        `abilities: Abilities` parameter (creature.py:64).
+        """
+        abilities = Abilities(
+            strength=10,
+            dexterity=10,
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
+        )
+        c = Creature(name="Anyone", max_hp=10, ac=10, abilities=abilities)
+        assert isinstance(c.abilities, Abilities)
+
+
+class TestSixAbilities_Strength:
+    """SRD § Playing the Game › The Six Abilities › Strength.
+
+    > Strength measures physical might.
+
+    The SRD's "Skills" table (in proficiency.md) pins Strength as the
+    ability for Athletics. Cross-checked here as the canonical data
+    parity for what Strength governs.
+    """
+
+    def test_athletics_is_strength_based(self) -> None:
+        skills: dict = json.loads(SKILLS_JSON.read_text())
+        assert skills["athletics"]["ability"] == "str"
+
+
+class TestSixAbilities_Dexterity:
+    """SRD § Playing the Game › The Six Abilities › Dexterity.
+
+    > Dexterity measures agility, reflexes, and balance.
+
+    Per the Skills table, Dexterity governs Acrobatics, Sleight of Hand,
+    and Stealth. Dexterity also drives the Initiative modifier.
+    """
+
+    def test_dex_skills_are_dexterity_based(self) -> None:
+        skills: dict = json.loads(SKILLS_JSON.read_text())
+        for skill_id in ("acrobatics", "sleight_of_hand", "stealth"):
+            assert skills[skill_id]["ability"] == "dex", skill_id
+
+    def test_initiative_uses_dex_modifier(self) -> None:
+        """`Creature.initiative_modifier` returns the DEX modifier.
+
+        Source-level binding at dnd-engine/dnd_engine/core/creature.py:
+        110-112. The SRD frames Dexterity as "reflexes," which the
+        initiative rule (in a later chapter) consumes — we lock the
+        modifier source here.
+        """
+        abilities = Abilities(
+            strength=8,
+            dexterity=18,
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
+        )
+        c = Creature(name="Quick", max_hp=10, ac=10, abilities=abilities)
+        assert c.initiative_modifier == abilities.dex_mod == 4
+
+
+class TestSixAbilities_Constitution:
+    """SRD § Playing the Game › The Six Abilities › Constitution.
+
+    > Constitution measures health and stamina.
+
+    No SRD skill is CON-based; CON's primary mechanical surface is HP
+    on level-up and CON saving throws.
+    """
+
+    def test_no_skill_is_constitution_based(self) -> None:
+        skills: dict = json.loads(SKILLS_JSON.read_text())
+        con_skills = [
+            sid for sid, sdata in skills.items() if sdata["ability"] == "con"
+        ]
+        assert con_skills == [], (
+            "SRD: no skill is CON-based; CON drives HP and CON saves."
+        )
+
+
+class TestSixAbilities_Intelligence:
+    """SRD § Playing the Game › The Six Abilities › Intelligence.
+
+    > Intelligence measures reasoning and memory.
+
+    Per the Skills table, Intelligence governs Arcana, History,
+    Investigation, Nature, and Religion.
+    """
+
+    def test_int_skills_are_intelligence_based(self) -> None:
+        skills: dict = json.loads(SKILLS_JSON.read_text())
+        for skill_id in (
+            "arcana",
+            "history",
+            "investigation",
+            "nature",
+            "religion",
+        ):
+            assert skills[skill_id]["ability"] == "int", skill_id
+
+
+class TestSixAbilities_Wisdom:
+    """SRD § Playing the Game › The Six Abilities › Wisdom.
+
+    > Wisdom measures perceptiveness and mental fortitude.
+
+    Per the Skills table, Wisdom governs Animal Handling, Insight,
+    Medicine, Perception, and Survival.
+    """
+
+    def test_wis_skills_are_wisdom_based(self) -> None:
+        skills: dict = json.loads(SKILLS_JSON.read_text())
+        for skill_id in (
+            "animal_handling",
+            "insight",
+            "medicine",
+            "perception",
+            "survival",
+        ):
+            assert skills[skill_id]["ability"] == "wis", skill_id
+
+
+class TestSixAbilities_Charisma:
+    """SRD § Playing the Game › The Six Abilities › Charisma.
+
+    > Charisma measures confidence, poise, and charm.
+
+    Per the Skills table, Charisma governs Deception, Intimidation,
+    Performance, and Persuasion.
+    """
+
+    def test_cha_skills_are_charisma_based(self) -> None:
+        skills: dict = json.loads(SKILLS_JSON.read_text())
+        for skill_id in (
+            "deception",
+            "intimidation",
+            "performance",
+            "persuasion",
+        ):
+            assert skills[skill_id]["ability"] == "cha", skill_id
+
+
+class TestSixAbilities_ScoreRange:
+    """SRD § Playing the Game › The Six Abilities › Ability Scores.
+
+    > Each ability has a score from 1 to 20, although some monsters
+    > have a score as high as 30.
+    """
+
+    def test_score_floor_of_one_is_not_enforced_at_construction(self) -> None:
+        pytest.skip(
+            "GAP: `Abilities` (dnd-engine/dnd_engine/core/creature.py:"
+            "10-24) is a plain dataclass with no `__post_init__` "
+            "validation. Constructing `Abilities(strength=0, ...)` "
+            "succeeds, violating the SRD floor of 1. Tracked by "
+            "issue #486."
+        )
+
+    def test_adventurer_score_cap_of_20_is_not_enforced(self) -> None:
+        pytest.skip(
+            "GAP: SRD pins a soft cap of 20 for adventurers (player "
+            "characters), with 21-30 reserved for extraordinary "
+            "creatures (typically monsters). `Character.__init__` "
+            "(dnd-engine/dnd_engine/core/character.py:35) accepts any "
+            "`Abilities` instance without checking whether a feature "
+            "permits exceeding 20. Tracked by issue #486."
+        )
+
+    def test_hard_score_cap_of_30_is_not_enforced(self) -> None:
+        pytest.skip(
+            "GAP: SRD pins an absolute ceiling of 30 for any creature. "
+            "`Abilities` (dnd-engine/dnd_engine/core/creature.py:10-24) "
+            "does not validate this — `Abilities(strength=99, ...)` "
+            "succeeds silently. Tracked by issue #486."
+        )
+
+    def test_monster_ability_scores_are_within_one_to_thirty(self) -> None:
+        """Catalog parity: every monster's ability scores are in [1, 30].
+
+        Even ahead of engine enforcement, the data must respect the
+        SRD's 1-30 range. This is a forward-compatible lint that the
+        catalog won't seed an out-of-range value.
+        """
+        monsters_path = (
+            Path(__file__).resolve().parents[3]
+            / "dnd_engine"
+            / "data"
+            / "srd"
+            / "monsters.json"
+        )
+        monsters: dict = json.loads(monsters_path.read_text())
+        for monster_id, mdata in monsters.items():
+            abilities = mdata.get("abilities", {})
+            for key, value in abilities.items():
+                assert 1 <= value <= 30, (
+                    f"{monster_id}.abilities.{key} = {value} is outside "
+                    f"SRD's 1-30 range (the-six-abilities.md)."
+                )
+
+
+class TestSixAbilities_ScoreReducedToZero:
+    """SRD § Playing the Game › The Six Abilities › Ability Scores › Score 1.
+
+    > If an effect reduces a score to 0, that effect explains what
+    > happens.
+    """
+
+    def test_no_general_zero_reduction_pathway_exists(self) -> None:
+        pytest.skip(
+            "GAP: no engine code path lets an effect 'reduce a score "
+            "to 0' — `Abilities` (dnd-engine/dnd_engine/core/creature.py:"
+            "10-24) has no mutator API at all; scores are set once at "
+            "construction. The SRD requires that the *effect* explain "
+            "the consequences, which presupposes the mutator exists. "
+            "Tracked by issue #486."
+        )
+
+
+class TestSixAbilities_Modifiers:
+    """SRD § Playing the Game › The Six Abilities › Ability Modifiers.
+
+    > An ability modifier is derived from its score, as shown in the
+    > Ability Modifiers table.
+
+    SRD modifier formula: `(score - 10) // 2`, floored (see Round Down).
+    """
+
+    def test_modifier_formula_matches_score_minus_ten_div_two(self) -> None:
+        """All six modifier properties use `(score - 10) // 2`.
+
+        Source-level binding at dnd-engine/dnd_engine/core/creature.py:
+        26-54. Exhaustive over the canonical SRD value examples.
+        """
+        # SRD Ability Modifiers table examples (score: expected modifier)
+        cases = {
+            1: -5,
+            2: -4,
+            3: -4,
+            4: -3,
+            5: -3,
+            6: -2,
+            7: -2,
+            8: -1,
+            9: -1,
+            10: 0,
+            11: 0,
+            12: 1,
+            13: 1,
+            14: 2,
+            15: 2,
+            16: 3,
+            17: 3,
+            18: 4,
+            19: 4,
+            20: 5,
+            30: 10,
+        }
+        for score, expected in cases.items():
+            a = Abilities(
+                strength=score,
+                dexterity=score,
+                constitution=score,
+                intelligence=score,
+                wisdom=score,
+                charisma=score,
+            )
+            assert a.str_mod == expected, f"STR {score} → expected {expected}"
+            assert a.dex_mod == expected, f"DEX {score} → expected {expected}"
+            assert a.con_mod == expected, f"CON {score} → expected {expected}"
+            assert a.int_mod == expected, f"INT {score} → expected {expected}"
+            assert a.wis_mod == expected, f"WIS {score} → expected {expected}"
+            assert a.cha_mod == expected, f"CHA {score} → expected {expected}"
+
+    def test_modifier_is_applied_to_d20_tests(self) -> None:
+        """Ability modifiers feed into the D20-Test surfaces.
+
+        Source-level: `Character.get_saving_throw_modifier` (dnd-engine/
+        dnd_engine/core/character.py:169) adds an ability modifier, and
+        `Character.get_skill_modifier` (character.py:689) does likewise.
+        Locked here so the SRD line "you apply [the modifier] whenever
+        you make a D20 Test with that ability" has a callable proof.
+        """
+        from dnd_engine.core.character import Character, CharacterClass
+
+        abilities = Abilities(
+            strength=18,  # +4
+            dexterity=10,
+            constitution=14,  # +2
+            intelligence=8,  # -1
+            wisdom=10,
+            charisma=10,
+        )
+        char = Character(
+            name="Tester",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=abilities,
+            max_hp=12,
+            ac=15,
+        )
+        # STR save w/o proficiency = STR mod
+        assert char.get_saving_throw_modifier("str") == 4
+        # CON save w/o proficiency = CON mod
+        assert char.get_saving_throw_modifier("con") == 2
+        # INT save w/o proficiency = INT mod
+        assert char.get_saving_throw_modifier("int") == -1
+
+
+class TestSixAbilities_RoundDown:
+    """SRD § Playing the Game › The Six Abilities › Round Down sidebar.
+
+    > Whenever you divide or multiply a number in the game, round down
+    > if you end up with a fraction, even if the fraction is one-half
+    > or greater. Some rules make an exception and tell you to round up.
+    """
+
+    def test_modifier_division_rounds_down_for_odd_scores(self) -> None:
+        """Odd ability scores round their modifier *down*.
+
+        SRD example: score 9 → modifier -1 (not 0). The use of `//` in
+        `Abilities.*_mod` (creature.py:26-54) enforces this for every
+        ability. Source-level binding so the formula can't silently
+        drift to `round()` (banker's rounding) or `int()` (toward 0).
+        """
+        # Odd negative-bracket scores: SRD says floor, not toward-zero.
+        # Python's `//` already floors for negatives.
+        a = Abilities(
+            strength=9,  # (9-10)//2 = -1
+            dexterity=7,  # (7-10)//2 = -2
+            constitution=5,  # (5-10)//2 = -3
+            intelligence=3,  # (3-10)//2 = -4
+            wisdom=11,  # (11-10)//2 = 0 (floor of 0.5)
+            charisma=13,  # (13-10)//2 = 1
+        )
+        assert a.str_mod == -1
+        assert a.dex_mod == -2
+        assert a.con_mod == -3
+        assert a.int_mod == -4
+        assert a.wis_mod == 0
+        assert a.cha_mod == 1


### PR DESCRIPTION
## Summary

Stake-out SRD conformance audit for the two docs that together define
how ability scores and proficiency drive every D20 Test in the game:

- `docs/srd/playing-the-game/the-six-abilities.md` (lines 567-655) — the six abilities, score range (1-30), modifier formula, Round Down
- `docs/srd/playing-the-game/proficiency.md` (lines 1012-1316) — Heroic Inspiration, PB by level / by CR, bonus application, no-stacking, skills/saves/weapons/tools, Expertise

**Audit-only**: no engine changes. Two new test files, one per doc,
each with its own `pytestmark` linking to the SRD source. Real
assertions verify enforcement; `pytest.skip("GAP: ... Tracked by #N.")`
stubs surface gaps and cite the exact code location they live (or
fail to live) today.

## Conformance progress

`scripts/srd_audit_coverage.py` confirms `playing-the-game` advances
from `14 / 35` to `16 / 35` audited files.

## Per-doc results

| Doc | Rules total | Enforced | Gapped (skipped) |
|---|---|---|---|
| the-six-abilities.md | 13 | 9 | 4 |
| proficiency.md | 28 | 19 | 9 |
| **Total** | **41** | **28** | **13** |

(Rules totals count discrete test methods; the parameterized PC-PB-by-level test counts as one rule covering all 20 bands.)

## Test files

- `dnd-engine/tests/srd/playing_the_game/test_the_six_abilities.py`
- `dnd-engine/tests/srd/playing_the_game/test_proficiency.py`

## Gap issues filed

| # | Issue | Tests it gates |
|---|---|---|
| #478 | Heroic Inspiration not implemented | `TestProficiency_HeroicInspiration::*` |
| #480 | Monster Proficiency Bonus is not derived from Challenge Rating | `TestProficiency_BonusByCR::*` |
| #481 | Proficiency Bonus stacking + multiplier-once guards | `TestProficiency_BonusDoesntStack::*` |
| #483 | Tool + skill proficiency grants Advantage on the check | `TestProficiency_Tools::test_tool_check_adds_pb_when_proficient`, `…::test_tool_plus_skill_proficiency_grants_advantage` |
| #486 | Ability score caps (1, 20-adventurer, 30-hard) and zero-reduction not enforced | `TestSixAbilities_ScoreRange::test_score_floor_of_one_is_not_enforced_at_construction`, `…::test_adventurer_score_cap_of_20_is_not_enforced`, `…::test_hard_score_cap_of_30_is_not_enforced`, `TestSixAbilities_ScoreReducedToZero::*` |

## Audit findings (one-line summary)

- The **Abilities** dataclass carries all six SRD abilities with the SRD modifier formula `(score - 10) // 2`; Round Down is enforced for negative and positive odd scores. No score-range validation at construction.
- **Skills-to-ability mapping** in `skills.json` matches the SRD Skills table on all 18 skills, locked here as catalog parity.
- **PC Proficiency Bonus by level** is correct for every level 1-20 (parameterized) and matches `progression.json`. Source: `Character.proficiency_bonus` (`dnd-engine/dnd_engine/core/character.py:130`).
- **Bonus application** is verified on saving throws, skill checks, weapon attacks (proficient and non-proficient branches), spell attack rolls, and spell save DCs.
- **Expertise** doubles PB on skill checks and only when already proficient.
- Gaps: Heroic Inspiration, monster PB from CR, either-or skill stacking guard, multiplier-once guard, tool+skill advantage, and ability score caps.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_the_six_abilities.py tests/srd/playing_the_game/test_proficiency.py -v` — 52 passed, 13 skipped, pristine output.
- [x] `uv run python scripts/srd_audit_coverage.py` — `playing-the-game` 16/35 (was 14/35); both new files listed under "Audited rule files".
- [x] `pytest --collect-only -q` shows the two modules with one class per SRD subsection.