### PR TITLE
SRD audit: d20-tests + advantage-disadvantage + ability-checks

### DIFF
--- a/dnd-engine/tests/srd/playing_the_game/test_ability_checks.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_ability_checks.py
@@ -1,0 +1,371 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > Ability Checks".
+# ABOUTME: Cross-references docs/srd/playing-the-game/ability-checks.md against engine code.
+
+"""SRD conformance: Ability Checks.
+
+Maps every rule in `docs/srd/playing-the-game/ability-checks.md` to a
+test. Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.dice import DiceRoller
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/ability-checks.md",
+    lines="656-730",
+)
+
+
+def _make_fighter(level: int = 1) -> Character:
+    """Construct a minimal Fighter for ability-check assertions."""
+    abilities = Abilities(
+        strength=16,
+        dexterity=14,
+        constitution=15,
+        intelligence=10,
+        wisdom=12,
+        charisma=8,
+    )
+    return Character(
+        name="Fighter",
+        character_class=CharacterClass.FIGHTER,
+        level=level,
+        abilities=abilities,
+        max_hp=12,
+        ac=16,
+        saving_throw_proficiencies=["str", "con"],
+        skill_proficiencies=["athletics"],
+        expertise_skills=[],
+    )
+
+
+class TestAbilityModifierTable:
+    """SRD § Playing the Game › Ability Checks › Ability Modifier table.
+
+    The SRD's Ability Modifiers table pairs each ability score with its
+    modifier. The whole-table contract is `(score - 10) // 2`, but with
+    the SRD bounds documented at 1 → -5 and 30 → +10 and the table
+    rounding pairs (e.g., scores 14-15 both → +2). The engine encodes
+    this as integer floor-divide-by-2 on `Abilities`
+    (dnd-engine/dnd_engine/core/creature.py:26-54).
+    """
+
+    def test_score_1_yields_minus_5(self):
+        """Score 1 → -5 modifier (SRD lower bound).
+
+        `Abilities.str_mod` returns `(1 - 10) // 2 = -5`
+        (dnd-engine/dnd_engine/core/creature.py:26-29).
+        """
+        abilities = Abilities(
+            strength=1,
+            dexterity=10,
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
+        )
+        assert abilities.str_mod == -5
+
+    def test_score_10_to_11_yields_zero(self):
+        """Scores 10 and 11 both → +0.
+
+        Floor-divide of (0 or 1) by 2 → 0
+        (dnd-engine/dnd_engine/core/creature.py:36-39).
+        """
+        a10 = Abilities(
+            strength=10, dexterity=10, constitution=10,
+            intelligence=10, wisdom=10, charisma=10,
+        )
+        a11 = Abilities(
+            strength=11, dexterity=11, constitution=11,
+            intelligence=11, wisdom=11, charisma=11,
+        )
+        assert a10.con_mod == 0
+        assert a11.con_mod == 0
+
+    def test_score_14_to_15_yields_plus_2(self):
+        """Scores 14 and 15 both → +2 (SRD pair)."""
+        a14 = Abilities(
+            strength=14, dexterity=14, constitution=14,
+            intelligence=14, wisdom=14, charisma=14,
+        )
+        a15 = Abilities(
+            strength=15, dexterity=15, constitution=15,
+            intelligence=15, wisdom=15, charisma=15,
+        )
+        assert a14.dex_mod == 2
+        assert a15.dex_mod == 2
+
+    def test_score_20_to_21_yields_plus_5(self):
+        """Scores 20 and 21 both → +5 (PC cap pair)."""
+        a20 = Abilities(
+            strength=20, dexterity=20, constitution=20,
+            intelligence=20, wisdom=20, charisma=20,
+        )
+        a21 = Abilities(
+            strength=21, dexterity=21, constitution=21,
+            intelligence=21, wisdom=21, charisma=21,
+        )
+        assert a20.str_mod == 5
+        assert a21.str_mod == 5
+
+    def test_score_30_yields_plus_10(self):
+        """Score 30 → +10 (SRD upper bound).
+
+        `(30 - 10) // 2 == 10`
+        (dnd-engine/dnd_engine/core/creature.py:36-39).
+        """
+        abilities = Abilities(
+            strength=30, dexterity=10, constitution=10,
+            intelligence=10, wisdom=10, charisma=10,
+        )
+        assert abilities.str_mod == 10
+
+    def test_all_six_abilities_have_modifier_properties(self):
+        """`Abilities` exposes one `_mod` property per SRD ability.
+
+        SRD names the six abilities (STR / DEX / CON / INT / WIS /
+        CHA). The dataclass declares all six fields and a `_mod`
+        property each (dnd-engine/dnd_engine/core/creature.py:18-54).
+        """
+        abilities = Abilities(
+            strength=12, dexterity=14, constitution=10,
+            intelligence=8, wisdom=16, charisma=11,
+        )
+        assert abilities.str_mod == 1
+        assert abilities.dex_mod == 2
+        assert abilities.con_mod == 0
+        assert abilities.int_mod == -1
+        assert abilities.wis_mod == 3
+        assert abilities.cha_mod == 0
+
+
+class TestAbilityCheck_Primitive:
+    """SRD § Playing the Game › Ability Checks › Naming + ability.
+
+    > An ability check is named for the ability modifier it uses: a
+    > Strength check, an Intelligence check, and so on. Different
+    > ability checks are called for in different situations, depending
+    > on which ability is most relevant.
+    """
+
+    def test_skill_check_uses_named_ability_modifier(self):
+        """An Athletics check uses the Strength modifier.
+
+        The SRD says the check is "named for the ability modifier it
+        uses." `Character.make_skill_check` looks up the skill's
+        ability and reads that modifier from `Abilities`
+        (dnd-engine/dnd_engine/core/character.py:705-722). For an
+        Athletics check, the ability is Strength.
+        """
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=11)
+        skills = {"athletics": {"ability": "str"}}
+        result = fighter.make_skill_check("athletics", dc=10, skills_data=skills)
+        # STR mod (+3) + proficiency (+2) = +5
+        assert result["modifier"] == 5
+        assert result["ability"] == "str"
+
+    def test_skill_check_for_different_ability_uses_that_modifier(self):
+        """A Stealth check uses the Dexterity modifier.
+
+        Same plumbing as Athletics, different ability. Confirms the
+        "named for the ability modifier" rule generalizes.
+        """
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=11)
+        skills = {"stealth": {"ability": "dex"}}
+        result = fighter.make_skill_check("stealth", dc=10, skills_data=skills)
+        # DEX mod (+2), not proficient
+        assert result["modifier"] == 2
+        assert result["ability"] == "dex"
+
+    def test_ability_check_primitive_exists_for_non_skill_checks(self):
+        pytest.skip(
+            "GAP: there is no `make_ability_check(ability, dc)` "
+            "primitive. The SRD's canonical examples (Strength to "
+            "force open a door, Intelligence to recall lore) are not "
+            "skill checks. Only `make_skill_check` "
+            "(dnd-engine/dnd_engine/core/character.py:726) and "
+            "`ConditionManager.attempt_condition_removal` "
+            "(systems/condition_manager.py:220) roll an ability "
+            "check. Neither is general-purpose. Tracked by issue #484."
+        )
+
+
+class TestAbilityCheck_ProficiencyBonusOptional:
+    """SRD § Playing the Game › Ability Checks › Proficiency Bonus.
+
+    > Add your Proficiency Bonus to an ability check when the GM
+    > determines that a skill or tool proficiency is relevant to the
+    > check and you have that proficiency. For example, if a rule
+    > refers to a Strength (Acrobatics or Athletics) check, you can
+    > add your Proficiency Bonus to the check if you have proficiency
+    > in the Acrobatics or Athletics skill.
+    """
+
+    def test_proficiency_added_when_skill_is_proficient(self):
+        """Proficient skill check adds proficiency bonus.
+
+        `get_skill_modifier` adds `self.proficiency_bonus` when the
+        skill is in `skill_proficiencies`
+        (dnd-engine/dnd_engine/core/character.py:715-722).
+        """
+        fighter = _make_fighter()
+        skills = {"athletics": {"ability": "str"}}
+        mod = fighter.get_skill_modifier("athletics", skills)
+        # STR (+3) + proficiency (+2) = +5
+        assert mod == 5
+
+    def test_proficiency_not_added_when_skill_is_not_proficient(self):
+        """Non-proficient skill check uses ability modifier only.
+
+        `get_skill_modifier` skips the proficiency add when the skill
+        is absent from `skill_proficiencies`
+        (dnd-engine/dnd_engine/core/character.py:716-722).
+        """
+        fighter = _make_fighter()
+        skills = {"stealth": {"ability": "dex"}}
+        mod = fighter.get_skill_modifier("stealth", skills)
+        # DEX (+2) only — no proficiency
+        assert mod == 2
+
+    def test_expertise_doubles_proficiency_bonus(self):
+        """Expertise skills double the proficiency bonus on the check.
+
+        SRD rule (paraphrased — full text in Rules Glossary):
+        Expertise in a skill doubles the proficiency bonus. Engine
+        implements this at
+        `dnd-engine/dnd_engine/core/character.py:718-720`.
+        """
+        abilities = Abilities(
+            strength=10, dexterity=16, constitution=10,
+            intelligence=10, wisdom=10, charisma=10,
+        )
+        rogue = Character(
+            name="Rogue",
+            character_class=CharacterClass.ROGUE,
+            level=1,
+            abilities=abilities,
+            max_hp=8,
+            ac=14,
+            skill_proficiencies=["stealth"],
+            expertise_skills=["stealth"],
+        )
+        skills = {"stealth": {"ability": "dex"}}
+        mod = rogue.get_skill_modifier("stealth", skills)
+        # DEX (+3) + proficiency (+2) * 2 = +7
+        assert mod == 7
+
+    def test_proficiency_bonus_scales_with_level(self):
+        """Proficiency bonus follows the SRD level→PB table.
+
+        `Character.proficiency_bonus` returns
+        `2 + (level - 1) // 4` (dnd-engine/dnd_engine/core/character.py:130-143),
+        giving +2 at 1-4, +3 at 5-8, +4 at 9-12, etc.
+        """
+        for level, expected in [(1, 2), (4, 2), (5, 3), (8, 3), (9, 4), (12, 4)]:
+            fighter = _make_fighter(level=level)
+            assert fighter.proficiency_bonus == expected, (
+                f"level {level} expected PB {expected}, got {fighter.proficiency_bonus}"
+            )
+
+    def test_ability_check_with_tool_proficiency(self):
+        pytest.skip(
+            "GAP: the SRD names *skill or tool* proficiency as "
+            "relevance gates. Skill proficiencies are honored "
+            "(dnd-engine/dnd_engine/core/character.py:715-722). Tool "
+            "proficiencies are stored on `Character` "
+            "(character.py:109, `tool_proficiencies`) but no ability-"
+            "check call site consults them. A 'Dexterity (thieves' "
+            "tools) check' adds proficiency only if Thieves' Tools is "
+            "in `tool_proficiencies` — that wiring doesn't exist. "
+            "Tracked by issue #484."
+        )
+
+
+class TestAbilityCheck_DifficultyClass:
+    """SRD § Playing the Game › Ability Checks › Difficulty Class.
+
+    > The Difficulty Class of an ability check represents the task's
+    > difficulty. The more difficult the task, the higher its DC. The
+    > rules provide DCs for certain checks, but the GM ultimately sets
+    > them.
+    """
+
+    def test_skill_check_takes_caller_supplied_dc(self):
+        """`make_skill_check` takes a DC and uses it for success.
+
+        The SRD framing is that the GM provides the DC. The engine's
+        surface accepts it as a parameter and returns
+        `success = total >= dc`
+        (dnd-engine/dnd_engine/core/character.py:778).
+        """
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=2)
+        skills = {"athletics": {"ability": "str"}}
+        result = fighter.make_skill_check("athletics", dc=20, skills_data=skills)
+        assert result["dc"] == 20
+        assert result["success"] == (result["total"] >= 20)
+
+    def test_skill_check_unknown_skill_raises(self):
+        """`make_skill_check` raises `KeyError` for an unknown skill.
+
+        Defensive contract at
+        `dnd-engine/dnd_engine/core/character.py:758-759`. Prevents
+        silent miscategorization (e.g., a typo in a scenario YAML).
+        """
+        fighter = _make_fighter()
+        skills = {"athletics": {"ability": "str"}}
+        with pytest.raises(KeyError):
+            fighter.make_skill_check("athleticism", dc=10, skills_data=skills)
+
+
+class TestAbilityCheck_CreatureParity:
+    """SRD § Playing the Game › Ability Checks › Creature parity.
+
+    The SRD doesn't carve PCs out from monsters for ability checks.
+    Both should be able to make a Strength check to push a boulder, a
+    Wisdom check to spot something, etc.
+    """
+
+    def test_creature_can_make_ability_check_for_condition_removal(self):
+        """`ConditionManager.attempt_condition_removal` makes an ability check.
+
+        This is the *only* general-creature ability-check surface
+        today (dnd-engine/dnd_engine/systems/condition_manager.py:220-292).
+        It rolls 1d20 + ability modifier vs DC and emits an
+        `ABILITY_CHECK` event. Source-level guard so the path doesn't
+        regress.
+        """
+        src = inspect.getsource(
+            __import__(
+                "dnd_engine.systems.condition_manager",
+                fromlist=["ConditionManager"],
+            ).ConditionManager.attempt_condition_removal
+        )
+        assert "1d20" in src
+        assert "ability_mod" in src or "_get_ability_modifier" in src
+        assert ">= dc" in src or "roll_total >= dc" in src
+
+    def test_creature_has_general_purpose_ability_check_primitive(self):
+        pytest.skip(
+            "GAP: `Creature` exposes `make_saving_throw` "
+            "(dnd-engine/dnd_engine/core/creature.py:478) but no "
+            "`make_ability_check` — a monster cannot roll a Strength "
+            "check to escape a pit, an Intelligence check to puzzle "
+            "out a glyph, etc. The condition-removal helper "
+            "(systems/condition_manager.py:220) is dedicated. Tracked "
+            "by issue #484."
+        )

--- a/dnd-engine/tests/srd/playing_the_game/test_advantage_disadvantage.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_advantage_disadvantage.py
@@ -1,0 +1,265 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > Advantage/Disadvantage".
+# ABOUTME: Cross-references docs/srd/playing-the-game/advantage-disadvantage.md against engine code.
+
+"""SRD conformance: Advantage / Disadvantage.
+
+Maps every rule in `docs/srd/playing-the-game/advantage-disadvantage.md`
+to a test. Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.combat import CombatEngine
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/advantage-disadvantage.md",
+    lines="1002-1011",
+)
+
+
+def _make_fighter() -> Character:
+    """Construct a minimal Fighter for advantage/disadvantage tests."""
+    abilities = Abilities(
+        strength=16,
+        dexterity=14,
+        constitution=15,
+        intelligence=10,
+        wisdom=12,
+        charisma=8,
+    )
+    return Character(
+        name="Fighter",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=abilities,
+        max_hp=12,
+        ac=16,
+        saving_throw_proficiencies=["str", "con"],
+        skill_proficiencies=["athletics"],
+    )
+
+
+class TestDefinition_ModifiesD20Test:
+    """SRD § Playing the Game › Advantage/Disadvantage › Definition.
+
+    > Sometimes a D20 Test is modified by Advantage or Disadvantage.
+    > Advantage reflects the positive circumstances surrounding a d20
+    > roll, while Disadvantage reflects negative circumstances.
+    """
+
+    def test_dice_roller_supports_advantage_flag(self):
+        """`DiceRoller.roll` accepts an `advantage=True` flag.
+
+        The advantage mechanic is implemented at the `DiceRoller` level
+        (dnd-engine/dnd_engine/core/dice.py:85-140) and surfaced
+        through the d20-test entry points that wrap it.
+        """
+        roller = DiceRoller(seed=42)
+        result = roller.roll("1d20", advantage=True)
+        assert result.advantage is True
+        assert len(result.rolls) == 2
+
+    def test_dice_roller_supports_disadvantage_flag(self):
+        """`DiceRoller.roll` accepts a `disadvantage=True` flag.
+
+        Same plumbing as advantage, opposite math
+        (dnd-engine/dnd_engine/core/dice.py:39-44).
+        """
+        roller = DiceRoller(seed=42)
+        result = roller.roll("1d20", disadvantage=True)
+        assert result.disadvantage is True
+        assert len(result.rolls) == 2
+
+    def test_advantage_picks_higher_of_two_d20s(self):
+        """`DiceRoll.total` returns `max(rolls) + modifier` with advantage.
+
+        Implementation: `DiceRoll.total`
+        (dnd-engine/dnd_engine/core/dice.py:39-46). Confirmed by
+        construction: with seed=42 the two dice are deterministic and
+        we assert the total equals their max.
+        """
+        roller = DiceRoller(seed=42)
+        result = roller.roll("1d20", advantage=True)
+        assert result.total == max(result.rolls)
+        # Sanity: the modifier path is also exercised under +5.
+        roller2 = DiceRoller(seed=42)
+        with_mod = roller2.roll("1d20+5", advantage=True)
+        assert with_mod.total == max(with_mod.rolls) + 5
+
+    def test_disadvantage_picks_lower_of_two_d20s(self):
+        """`DiceRoll.total` returns `min(rolls) + modifier` with disadvantage.
+
+        Implementation: `DiceRoll.total`
+        (dnd-engine/dnd_engine/core/dice.py:41-44). Same construction
+        as the advantage test, opposite math.
+        """
+        roller = DiceRoller(seed=42)
+        result = roller.roll("1d20", disadvantage=True)
+        assert result.total == min(result.rolls)
+        roller2 = DiceRoller(seed=42)
+        with_mod = roller2.roll("1d20-2", disadvantage=True)
+        assert with_mod.total == min(with_mod.rolls) - 2
+
+
+class TestAcquisition_FromSpecialAbilitiesAndActions:
+    """SRD § Playing the Game › Advantage/Disadvantage › Acquisition.
+
+    > You usually acquire Advantage or Disadvantage through the use of
+    > special abilities and actions.
+    """
+
+    def test_advantage_propagates_through_attack_roll(self):
+        """`CombatEngine.resolve_attack` accepts and uses `advantage=True`.
+
+        The attack-roll surface threads the flag down to the dice
+        roller (`dnd-engine/dnd_engine/core/combat.py:130-133`). This
+        is the primary site where "special abilities and actions"
+        confer advantage on attacks (Pack Tactics, prone targets within
+        5 ft, etc.).
+        """
+        src = inspect.getsource(CombatEngine.resolve_attack)
+        assert "advantage=advantage" in src and "disadvantage=disadvantage" in src
+
+    def test_advantage_propagates_through_saving_throw(self):
+        """`Character.make_saving_throw` accepts `advantage=True`.
+
+        Used by spells / class features that grant advantage on a
+        save (e.g., Dodge action gives advantage on DEX saves).
+        Implementation: `dnd-engine/dnd_engine/core/character.py:297-298`.
+        """
+        src = inspect.getsource(Character.make_saving_throw)
+        assert "advantage=advantage" in src
+        # And confirm the dice path actually rolls 2d20 under advantage.
+        fighter = _make_fighter()
+        result = fighter.make_saving_throw(ability="con", dc=10, advantage=True)
+        # Result dict carries the same shape regardless of advantage,
+        # but the "roll" surfaced should be the higher of the pair.
+        assert "roll" in result
+        assert isinstance(result["roll"], int)
+
+    def test_advantage_propagates_through_skill_check(self):
+        """`Character.make_skill_check` accepts `advantage=True`.
+
+        Used by Help action (advantage on the helped creature's next
+        ability check). Implementation:
+        `dnd-engine/dnd_engine/core/character.py:765`.
+        """
+        src = inspect.getsource(Character.make_skill_check)
+        assert "advantage=advantage" in src
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=3)
+        skills = {"athletics": {"ability": "str"}}
+        result = fighter.make_skill_check(
+            "athletics", dc=10, skills_data=skills, advantage=True
+        )
+        assert "roll" in result
+
+    def test_disadvantage_propagates_through_all_three_surfaces(self):
+        """All three D20-test surfaces accept `disadvantage=True`.
+
+        Symmetric to the advantage tests above. Confirms the SRD's
+        opposite-direction case is wired through.
+        """
+        for func in (
+            CombatEngine.resolve_attack,
+            Character.make_saving_throw,
+            Character.make_skill_check,
+        ):
+            src = inspect.getsource(func)
+            assert "disadvantage=disadvantage" in src, (
+                f"{func.__qualname__} must thread disadvantage to the dice."
+            )
+
+
+class TestHeroicInspiration:
+    """SRD § Playing the Game › Advantage/Disadvantage › Heroic Inspiration.
+
+    > [Sidebar callout — full mechanic defined in Rules Glossary:]
+    > spend Heroic Inspiration to reroll any d20 and use either result.
+    """
+
+    def test_character_carries_heroic_inspiration_state(self):
+        pytest.skip(
+            "GAP: Heroic Inspiration is not implemented. No "
+            "`heroic_inspiration` field on `Character` "
+            "(dnd-engine/dnd_engine/core/character.py:35-127). "
+            "`dnd_engine/systems/resources.py` manages spell slots, "
+            "ki, rage uses, and bardic inspiration — Heroic "
+            "Inspiration is absent. Tracked by issue #489."
+        )
+
+    def test_heroic_inspiration_can_be_spent_to_reroll_d20(self):
+        pytest.skip(
+            "GAP: no hook on `make_skill_check` / `make_saving_throw` "
+            "/ `resolve_attack` to spend Heroic Inspiration for a "
+            "reroll. The dice roller's advantage path "
+            "(dnd-engine/dnd_engine/core/dice.py:111-113) is the "
+            "closest mechanic but it picks max(d1,d2) — Heroic "
+            "Inspiration picks *either* die, which is different. "
+            "Tracked by issue #489."
+        )
+
+    def test_heroic_inspiration_is_consumed_on_use(self):
+        pytest.skip(
+            "GAP: depends on the field existing. The SRD rule is that "
+            "Heroic Inspiration is a one-shot per character — once "
+            "spent it's gone until granted again. Tracked by issue "
+            "#489."
+        )
+
+
+class TestSurfaceParity_NotPropagatedOnCreature:
+    """SRD § Playing the Game › Advantage/Disadvantage › Creature parity.
+
+    The SRD doesn't distinguish PCs from monsters for D20 Tests — a
+    monster making a save under Bless / Bane gets the same
+    advantage/disadvantage math. This test confirms the engine surface
+    that monsters use also accepts the flag.
+    """
+
+    def test_creature_saving_throw_accepts_advantage(self):
+        """`Creature.make_saving_throw` threads advantage to the roller.
+
+        Monsters (non-Character) make saves via this method
+        (dnd-engine/dnd_engine/core/creature.py:478-578). The flag
+        passes through to `DiceRoller.roll`.
+        """
+        abilities = Abilities(
+            strength=10,
+            dexterity=14,
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
+        )
+        goblin = Creature(name="Goblin", max_hp=7, ac=13, abilities=abilities)
+        result = goblin.make_saving_throw(ability="dex", dc=10, advantage=True)
+        assert "roll" in result
+        assert "total" in result
+        assert isinstance(result["success"], bool)
+
+    def test_creature_saving_throw_accepts_disadvantage(self):
+        """`Creature.make_saving_throw` threads disadvantage."""
+        abilities = Abilities(
+            strength=10,
+            dexterity=14,
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
+        )
+        goblin = Creature(name="Goblin", max_hp=7, ac=13, abilities=abilities)
+        result = goblin.make_saving_throw(ability="dex", dc=10, disadvantage=True)
+        assert "roll" in result
+        assert isinstance(result["success"], bool)

--- a/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
@@ -1,0 +1,395 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > D20 Tests".
+# ABOUTME: Cross-references docs/srd/playing-the-game/d20-tests.md against engine code.
+
+"""SRD conformance: D20 Tests.
+
+Maps every rule in `docs/srd/playing-the-game/d20-tests.md` to a test.
+Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.combat import CombatEngine
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoll, DiceRoller
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/d20-tests.md",
+    lines="731-865",
+)
+
+
+def _make_fighter(level: int = 1) -> Character:
+    """Construct a minimal Fighter for D20-test assertions."""
+    abilities = Abilities(
+        strength=16,
+        dexterity=14,
+        constitution=15,
+        intelligence=10,
+        wisdom=12,
+        charisma=8,
+    )
+    return Character(
+        name="Fighter",
+        character_class=CharacterClass.FIGHTER,
+        level=level,
+        abilities=abilities,
+        max_hp=12,
+        ac=16,
+        saving_throw_proficiencies=["str", "con"],
+        skill_proficiencies=["athletics"],
+    )
+
+
+def _make_creature() -> Creature:
+    """Construct a vanilla creature for the no-proficiency path."""
+    abilities = Abilities(
+        strength=10,
+        dexterity=14,
+        constitution=10,
+        intelligence=10,
+        wisdom=10,
+        charisma=10,
+    )
+    return Creature(name="Goblin", max_hp=7, ac=13, abilities=abilities)
+
+
+class TestDefinition_ThreeKinds:
+    """SRD § Playing the Game › D20 Tests › Definition.
+
+    > When the outcome of an action is uncertain, the game uses a d20
+    > roll to determine success or failure. These rolls are called D20
+    > Tests, and they come in three kinds: ability checks, saving
+    > throws, and attack rolls.
+    """
+
+    def test_ability_check_surface_exists(self):
+        """Skill checks are the only general ability-check surface today.
+
+        The closest implementation of an ability check primitive is
+        `Character.make_skill_check`
+        (dnd-engine/dnd_engine/core/character.py:726), which couples
+        the d20 + ability modifier + (optional) proficiency bonus into
+        one call. There is no plain `make_ability_check(ability, dc)`
+        primitive — see GAP test below.
+        """
+        assert hasattr(Character, "make_skill_check"), (
+            "Character must expose make_skill_check as its ability-check surface."
+        )
+        src = inspect.getsource(Character.make_skill_check)
+        assert "advantage" in src and "disadvantage" in src
+        assert "1d20" in src
+
+    def test_saving_throw_surface_exists(self):
+        """Saving throws are exposed on both Character and Creature.
+
+        `Character.make_saving_throw`
+        (dnd-engine/dnd_engine/core/character.py:237) and
+        `Creature.make_saving_throw`
+        (dnd-engine/dnd_engine/core/creature.py:478) both roll 1d20 +
+        modifier vs DC, satisfying SRD step 4 + step 5 for the saving
+        throw kind.
+        """
+        assert hasattr(Character, "make_saving_throw")
+        assert hasattr(Creature, "make_saving_throw")
+        for func in (Character.make_saving_throw, Creature.make_saving_throw):
+            src = inspect.getsource(func)
+            assert "d20" in src
+
+    def test_attack_roll_surface_exists(self):
+        """Attack rolls are resolved by `CombatEngine.resolve_attack`.
+
+        `CombatEngine.resolve_attack`
+        (dnd-engine/dnd_engine/core/combat.py:91) rolls 1d20 + attack
+        bonus vs AC and is the third leg of the SRD's "three kinds" of
+        D20 tests.
+        """
+        src = inspect.getsource(CombatEngine.resolve_attack)
+        assert '"1d20"' in src or "'1d20'" in src
+
+    def test_general_ability_check_primitive_is_unified(self):
+        pytest.skip(
+            "GAP: there is no general-purpose `make_ability_check` "
+            "primitive on Creature or Character. The d20 mechanic is "
+            "implemented three times in parallel: "
+            "`Character.make_skill_check` "
+            "(dnd-engine/dnd_engine/core/character.py:726), "
+            "`Character.make_saving_throw` (character.py:237), and "
+            "`CombatEngine.resolve_attack` "
+            "(dnd-engine/dnd_engine/core/combat.py:91). A Strength "
+            "check to force open a stuck door (the SRD's canonical "
+            "example) has no dedicated entry point — the only "
+            "ability-check-flavored helper, "
+            "`ConditionManager.attempt_condition_removal` "
+            "(systems/condition_manager.py:220), is hard-wired to "
+            "ending conditions. Tracked by issue #484."
+        )
+
+
+class TestStep4_RollD20:
+    """SRD § Playing the Game › D20 Tests › Step 4.
+
+    > Roll 1d20. You always want to roll high. If the roll has
+    > Advantage or Disadvantage (described later in "Playing the
+    > Game"), you roll two d20s, but you use the number from only one
+    > of them — the higher one if you have Advantage or the lower one
+    > if you have Disadvantage.
+    """
+
+    def test_normal_roll_uses_one_d20(self):
+        """`DiceRoller.roll("1d20")` returns exactly one die result.
+
+        The SRD's default case for a D20 test is a single d20. The
+        `DiceRoll.rolls` list must have length 1 when neither
+        advantage nor disadvantage is requested
+        (dnd-engine/dnd_engine/core/dice.py:111-116).
+        """
+        roller = DiceRoller(seed=42)
+        result = roller.roll("1d20")
+        assert isinstance(result, DiceRoll)
+        assert len(result.rolls) == 1
+        assert 1 <= result.rolls[0] <= 20
+
+    def test_advantage_rolls_two_d20s_takes_higher(self):
+        """Advantage rolls 2d20 and uses `max()`.
+
+        `DiceRoll.total` returns `max(self.rolls) + self.modifier`
+        when `advantage=True`
+        (dnd-engine/dnd_engine/core/dice.py:39-44). Roller produces
+        two dice
+        (dnd-engine/dnd_engine/core/dice.py:111-113).
+        """
+        roller = DiceRoller(seed=42)
+        result = roller.roll("1d20", advantage=True)
+        assert result.advantage is True
+        assert len(result.rolls) == 2
+        # Advantage keeps the higher of the two rolls.
+        assert result.total == max(result.rolls)
+
+    def test_disadvantage_rolls_two_d20s_takes_lower(self):
+        """Disadvantage rolls 2d20 and uses `min()`.
+
+        `DiceRoll.total` returns `min(self.rolls) + self.modifier`
+        when `disadvantage=True`
+        (dnd-engine/dnd_engine/core/dice.py:41-44).
+        """
+        roller = DiceRoller(seed=42)
+        result = roller.roll("1d20", disadvantage=True)
+        assert result.disadvantage is True
+        assert len(result.rolls) == 2
+        # Disadvantage keeps the lower of the two rolls.
+        assert result.total == min(result.rolls)
+
+    def test_advantage_and_disadvantage_are_mutually_exclusive(self):
+        """`DiceRoller.roll` rejects both flags set at once.
+
+        SRD wording lets only one of Advantage/Disadvantage apply at a
+        time. `DiceRoller.roll` raises `ValueError` if both are passed
+        (dnd-engine/dnd_engine/core/dice.py:100-101).
+        """
+        roller = DiceRoller(seed=42)
+        with pytest.raises(ValueError):
+            roller.roll("1d20", advantage=True, disadvantage=True)
+
+
+class TestStep5_AddModifiers:
+    """SRD § Playing the Game › D20 Tests › Step 5.
+
+    > Add Modifiers. Add these modifiers to the number rolled on the
+    > d20: the Relevant Ability Modifier; your Proficiency Bonus If
+    > Relevant; Circumstantial Bonuses and Penalties.
+    """
+
+    def test_ability_modifier_is_added_to_skill_check(self):
+        """`make_skill_check` adds the relevant ability modifier.
+
+        For an Athletics check, the modifier is the Strength modifier
+        plus proficiency bonus when proficient. Verified by reading
+        the returned `modifier` field
+        (dnd-engine/dnd_engine/core/character.py:762).
+        """
+        fighter = _make_fighter()
+        # Patch with deterministic dice
+        fighter._dice_roller = DiceRoller(seed=1)
+        skills = {"athletics": {"ability": "str"}}
+        result = fighter.make_skill_check("athletics", dc=10, skills_data=skills)
+        # STR mod (+3) + proficiency (+2) = +5
+        assert result["modifier"] == 5
+        assert result["total"] == result["roll"] + 5
+
+    def test_ability_modifier_is_added_to_saving_throw(self):
+        """`make_saving_throw` adds ability modifier + proficiency.
+
+        Constitution save on a proficient Fighter: CON mod (+2) +
+        proficiency (+2) = +4
+        (dnd-engine/dnd_engine/core/character.py:300-304).
+        """
+        fighter = _make_fighter()
+        result = fighter.make_saving_throw(ability="con", dc=10)
+        # CON mod (+2) + proficiency (+2) = +4
+        assert result["modifier"] == 4
+        assert result["total"] == result["roll"] + 4
+
+    def test_proficiency_bonus_added_only_when_relevant(self):
+        """Proficiency bonus skipped when the character isn't proficient.
+
+        A Fighter with no Stealth proficiency makes a Stealth check
+        and gets only their DEX modifier
+        (dnd-engine/dnd_engine/core/character.py:715-722). The SRD's
+        "If Relevant" wording is enforced.
+        """
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=1)
+        skills = {"stealth": {"ability": "dex"}}
+        # Fighter is not proficient in stealth → modifier == DEX mod (+2) only
+        result = fighter.make_skill_check("stealth", dc=10, skills_data=skills)
+        assert result["modifier"] == 2
+        assert result["proficient"] is False
+
+    def test_circumstantial_bonuses_can_be_added(self):
+        pytest.skip(
+            "GAP: the third additive channel from SRD step 5 — "
+            "Circumstantial Bonuses and Penalties from class features, "
+            "spells, or 'another rule' — has no caller-supplied "
+            "parameter on `make_skill_check`, `make_saving_throw`, or "
+            "`resolve_attack`. Bless / Bane / Guidance / Bardic "
+            "Inspiration cannot be plumbed without bolting onto each "
+            "call site. See `Character.make_skill_check` "
+            "(dnd-engine/dnd_engine/core/character.py:726) and "
+            "`make_saving_throw` (character.py:237) — both accept "
+            "only advantage/disadvantage flags. Tracked by issue #487."
+        )
+
+
+class TestStep6_TargetNumber:
+    """SRD § Playing the Game › D20 Tests › Step 6.
+
+    > Compare the Total to a Target Number. If the total of the d20
+    > and its modifiers equals or exceeds the target number, the D20
+    > Test succeeds. Otherwise, it fails. … The target number for an
+    > ability check or a saving throw is called a Difficulty Class
+    > (DC). The target number for an attack roll is called an Armor
+    > Class (AC).
+    """
+
+    def test_skill_check_success_is_total_meets_or_exceeds_dc(self):
+        """Skill check succeeds when total >= DC.
+
+        `make_skill_check` returns `success = total >= dc`
+        (dnd-engine/dnd_engine/core/character.py:778). Test by
+        choosing a DC that the highest-possible roll (20+5=25) can
+        meet but the lowest-possible (1+5=6) cannot — then assert the
+        success flag matches the inequality.
+        """
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=7)
+        skills = {"athletics": {"ability": "str"}}
+        result = fighter.make_skill_check("athletics", dc=10, skills_data=skills)
+        assert result["success"] == (result["total"] >= 10)
+
+    def test_saving_throw_success_is_total_meets_or_exceeds_dc(self):
+        """Saving throw succeeds when total >= DC.
+
+        Same SRD inequality as ability checks
+        (dnd-engine/dnd_engine/core/character.py:307).
+        """
+        fighter = _make_fighter()
+        result = fighter.make_saving_throw(ability="con", dc=10)
+        assert result["success"] == (result["total"] >= 10)
+
+    def test_attack_roll_uses_ac_as_target(self):
+        """`CombatEngine.resolve_attack` compares total vs defender AC.
+
+        SRD: the attack target number is AC, not DC. Verified by
+        reading the comparison in
+        `dnd-engine/dnd_engine/core/combat.py:148-149` where
+        `total_attack = attack_roll + attack_bonus; hit = total_attack >= defender_ac`.
+        """
+        engine = CombatEngine(DiceRoller(seed=42))
+        abilities = Abilities(
+            strength=16,
+            dexterity=14,
+            constitution=15,
+            intelligence=10,
+            wisdom=12,
+            charisma=8,
+        )
+        attacker = Creature(name="A", max_hp=20, ac=16, abilities=abilities)
+        defender = Creature(name="D", max_hp=10, ac=13, abilities=abilities)
+        result = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=5,
+            damage_dice="1d8+3",
+        )
+        # The attack-roll path produced a hit/miss decision against AC.
+        assert hasattr(result, "hit")
+        assert hasattr(result, "attack_roll")
+
+    def test_typical_difficulty_class_ladder_is_documented(self):
+        pytest.skip(
+            "GAP: the SRD's Typical Difficulty Classes ladder (Very "
+            "easy 5 / Easy 10 / Medium 15 / Hard 20 / Very hard 25 / "
+            "Nearly impossible 30) is not exposed as a named enum or "
+            "constant. DCs are scattered as integer literals in "
+            "conditions.json, scenario YAMLs, and spells.json. No "
+            "central reference exists. Tracked by issue #491."
+        )
+
+
+class TestKinds_AbilityCheckExamples:
+    """SRD § Playing the Game › D20 Tests › Ability Check Examples.
+
+    > An ability check represents a creature using talent and training
+    > to try to overcome a challenge, such as forcing open a stuck
+    > door, picking a lock, entertaining a crowd, or deciphering a
+    > cipher. … When the outcome is uncertain and narratively
+    > interesting, the dice determine the result.
+    """
+
+    def test_ability_check_returns_documented_payload_shape(self):
+        """`make_skill_check` returns success / roll / modifier / total / dc.
+
+        The SRD's framing is that the d20 test produces a pass/fail
+        plus the raw roll for narration. The engine contract for that
+        payload is the dict returned by `make_skill_check`
+        (dnd-engine/dnd_engine/core/character.py:771-780).
+        """
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=1)
+        skills = {"athletics": {"ability": "str"}}
+        result = fighter.make_skill_check("athletics", dc=10, skills_data=skills)
+        for key in ("success", "roll", "modifier", "total", "dc", "skill"):
+            assert key in result, f"missing field {key!r}"
+        assert isinstance(result["success"], bool)
+        assert result["dc"] == 10
+
+    def test_strength_check_to_force_open_stuck_door(self):
+        pytest.skip(
+            "GAP: the SRD's canonical Strength check (force open a "
+            "stuck door) has no dedicated call site. The only paths "
+            "into an ability-check roll are `make_skill_check` "
+            "(athletics — narrows STR checks to climbing/jumping/"
+            "swimming/grappling) and "
+            "`ConditionManager.attempt_condition_removal` "
+            "(systems/condition_manager.py:220, condition-removal "
+            "only). A non-skill ability check requires the new "
+            "primitive. Tracked by issue #484."
+        )
+
+    def test_intelligence_check_to_remember_lore(self):
+        pytest.skip(
+            "GAP: same root cause — no primitive for a non-skill "
+            "ability check. An INT check to recall lore would need "
+            "`Creature.make_ability_check('int', dc, skill=None)`. "
+            "Tracked by issue #484."
+        )


### PR DESCRIPTION
## Summary

Audit-only PR for the **D20 mechanic stack** — the foundation under every D20 Test in the SRD:

- `docs/srd/playing-the-game/d20-tests.md` (lines 731-865) — the three kinds, roll-then-modify-then-compare procedure
- `docs/srd/playing-the-game/advantage-disadvantage.md` (lines 1002-1011) — 2d20-pick-max/min, Heroic Inspiration sidebar
- `docs/srd/playing-the-game/ability-checks.md` (lines 656-730) — ability modifier table, proficiency-when-relevant, DC framing

**Audit-only**: no engine changes. Three new test files, one per doc, each with its own `pytestmark` linking to the SRD source. Real assertions verify enforcement; `pytest.skip("GAP: ... Tracked by #N.")` stubs surface gaps and cite the exact code location they live (or fail to live) today.

## Conformance progress

`scripts/srd_audit_coverage.py` confirms `playing-the-game` advances from `14 / 35` to `17 / 35` audited files.

## Per-doc results

| Doc | Rules total | Enforced | Gapped (skipped) |
|---|---|---|---|
| d20-tests.md | 19 | 14 | 5 |
| advantage-disadvantage.md | 13 | 10 | 3 |
| ability-checks.md | 18 | 15 | 3 |
| **Total** | **50** | **39** | **11** |

## Test files

- `dnd-engine/tests/srd/playing_the_game/test_d20_tests.py`
- `dnd-engine/tests/srd/playing_the_game/test_advantage_disadvantage.py`
- `dnd-engine/tests/srd/playing_the_game/test_ability_checks.py`

## Gap issues filed

| # | Issue | Tests it gates |
|---|---|---|
| #484 | Unify D20 Test surface — single `make_ability_check` primitive | `test_d20_tests.py::TestDefinition_ThreeKinds::test_general_ability_check_primitive_is_unified`, `…::TestKinds_AbilityCheckExamples::test_strength_check_to_force_open_stuck_door`, `…::test_intelligence_check_to_remember_lore`, `test_ability_checks.py::TestAbilityCheck_Primitive::test_ability_check_primitive_exists_for_non_skill_checks`, `…::TestAbilityCheck_ProficiencyBonusOptional::test_ability_check_with_tool_proficiency`, `…::TestAbilityCheck_CreatureParity::test_creature_has_general_purpose_ability_check_primitive` |
| #487 | Support circumstantial bonuses/penalties on D20 Tests (Bless/Bane/Guidance) | `test_d20_tests.py::TestStep5_AddModifiers::test_circumstantial_bonuses_can_be_added` |
| #489 | Implement Heroic Inspiration (spend to reroll a d20) | `test_advantage_disadvantage.py::TestHeroicInspiration::*` (3 tests) |
| #491 | Document Typical Difficulty Class table as enum/constants | `test_d20_tests.py::TestStep6_TargetNumber::test_typical_difficulty_class_ladder_is_documented` |

## Audit findings (one-line summary)

- **The d20 mechanic is correctly implemented at the dice layer**: `DiceRoller.roll` rolls one d20 in the normal case, two d20s under advantage/disadvantage, picks max/min via `DiceRoll.total`, and rejects both flags at once (`dnd-engine/dnd_engine/core/dice.py:85-140`).
- **Three parallel D20-test surfaces exist** — `Character.make_skill_check`, `Character.make_saving_throw`, `CombatEngine.resolve_attack` — but there is no unified `make_ability_check` primitive. The SRD's canonical Strength-check-to-force-open-a-door has no dedicated call site (#484).
- **Ability Modifier table conforms exactly** to the SRD: 1→-5, 10/11→+0, 14/15→+2, 20/21→+5, 30→+10 (`Abilities.*_mod`, `creature.py:26-54`).
- **Proficiency Bonus "if relevant"** is enforced for skill proficiencies and saving-throw proficiencies. Tool proficiency is stored on `Character` but **never consulted** as an ability-check relevance gate (#484).
- **Circumstantial bonuses** (Bless/Bane/Guidance channel) are not pluggable — no `extra_modifier` parameter on any d20-test surface (#487).
- **Heroic Inspiration** is named in the advantage/disadvantage doc but is **not implemented anywhere** — no `heroic_inspiration` state on `Character`, no reroll plumbing (#489).
- **Typical DC ladder** (5/10/15/20/25/30) is not exposed as named constants — DCs are scattered integer literals (#491).

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_d20_tests.py tests/srd/playing_the_game/test_advantage_disadvantage.py tests/srd/playing_the_game/test_ability_checks.py -v --no-cov` — 39 passed, 11 skipped, pristine output.
- [x] `uv run python scripts/srd_audit_coverage.py` — `playing-the-game` 17/35 (was 14/35); three new files listed under "Audited rule files".
- [x] `pytest --collect-only -q` shows the three modules with one class per SRD subsection.