### PR TITLE
SRD audit: exploration + travel

### DIFF
--- a/dnd-engine/tests/srd/playing_the_game/test_exploration.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_exploration.py
@@ -1,0 +1,445 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > Exploration".
+# ABOUTME: Cross-references docs/srd/playing-the-game/exploration.md against engine code.
+
+"""SRD conformance: Exploration.
+
+Maps every rule in `docs/srd/playing-the-game/exploration.md` to a test.
+Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+The Exploration section is short (lines 1511-1536 of SRD_CC_v5.2.1.txt)
+and is mostly a pointer into the Equipment chapter: it asserts that
+adventuring gear (Ladder, Torch, Thieves' Tools, Caltrops, weapons used
+non-combatively) helps adventurers interact with the environment. The
+audit therefore focuses on data-parity — the catalog must carry these
+items so the SRD's "for example, they can reach out-of-the-way places
+with a Ladder..." promises map to real game objects — plus a handful of
+engine-enforcement checks (lock-pick path consumes the Thieves' Tools
+proficiency surface, Torch effect resolves through the item-effects
+system, etc.).
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.game_state import GameState
+from dnd_engine.systems.item_effects import apply_item_effect
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/exploration.md",
+    lines="1511-1536",
+)
+
+
+ITEMS_JSON = (
+    Path(__file__).resolve().parents[3] / "dnd_engine" / "data" / "srd" / "items.json"
+)
+CLASSES_JSON = (
+    Path(__file__).resolve().parents[3] / "dnd_engine" / "data" / "srd" / "classes.json"
+)
+
+
+def _load_items() -> dict:
+    return json.loads(ITEMS_JSON.read_text())
+
+
+def _make_rogue() -> Character:
+    """Rogue with Thieves' Tools proficiency — the lock-pick exemplar."""
+    abilities = Abilities(
+        strength=10,
+        dexterity=16,
+        constitution=10,
+        intelligence=12,
+        wisdom=10,
+        charisma=10,
+    )
+    return Character(
+        name="Picker",
+        character_class=CharacterClass.ROGUE,
+        level=1,
+        abilities=abilities,
+        max_hp=8,
+        ac=14,
+        race="halfling",
+        skill_proficiencies=["stealth"],
+        tool_proficiencies=["thieves_tools"],
+    )
+
+
+class TestExploration_Intro:
+    """SRD § Playing the Game › Exploration › Intro.
+
+    > Exploration involves delving into places that are dangerous and
+    > full of mystery. The rules in this section detail some of the ways
+    > adventurers interact with the environment in such places.
+    """
+
+    def test_engine_has_an_exploration_mode_distinct_from_combat(self) -> None:
+        """`GameState.cast_spell_exploration` is the engine's exploration entry point.
+
+        The SRD frames exploration as a discrete rules mode ("delving
+        into places... interact with the environment"). The engine
+        carries an out-of-combat exploration surface:
+        `GameState.cast_spell_exploration`
+        (`dnd-engine/dnd_engine/core/game_state.py:1897`) handles
+        non-combat spell casting, and
+        `Character.get_out_of_combat_spells`
+        (`dnd-engine/dnd_engine/core/character.py:1750`) filters the
+        spell list for exploration-appropriate utility. This guards
+        the SRD framing has at least one engine attach-point.
+        """
+        assert callable(getattr(GameState, "cast_spell_exploration", None)), (
+            "GameState must expose an out-of-combat / exploration spell "
+            "entry point to honor the SRD's 'exploration involves... "
+            "interact with the environment' framing."
+        )
+        assert callable(getattr(Character, "get_out_of_combat_spells", None)), (
+            "Character must expose an exploration-appropriate spell "
+            "filter so the LLM/UI can offer the right options outside "
+            "of combat."
+        )
+
+    def test_event_taxonomy_distinguishes_exploration_events(self) -> None:
+        """The event bus has a dedicated Exploration event family.
+
+        `dnd_engine/utils/events.py:41` carries the comment
+        "# Exploration events", marking off a discrete category of
+        bus traffic for exploration-time signals (room entry, examine,
+        unlock, etc.). This is the engine's bookkeeping that the SRD's
+        "rules in this section" form their own audience-on-bus
+        bracket.
+        """
+        events_src = (
+            Path(__file__).resolve().parents[3]
+            / "dnd_engine"
+            / "utils"
+            / "events.py"
+        ).read_text()
+        assert "Exploration events" in events_src, (
+            "events.py must continue to label its exploration event "
+            "family so SRD-aligned exploration signals stay greppable."
+        )
+
+
+class TestExploration_AdventuringEquipment_Ladder:
+    """SRD § Playing the Game › Exploration › Adventuring Equipment (Ladder).
+
+    > As adventurers explore, their equipment can help them in many
+    > ways. For example, they can reach out-of-the-way places with a
+    > Ladder...
+    """
+
+    def test_ladder_is_in_the_equipment_catalog(self) -> None:
+        """A Ladder entry exists in `items.json` under `equipment`.
+
+        The SRD's "reach out-of-the-way places with a Ladder" example
+        needs a real ladder object to point at. `data/srd/items.json`
+        carries one with the canonical "Ladder (10-foot)" name.
+        """
+        items = _load_items()
+        assert "ladder" in items["equipment"], (
+            "items.json must catalog a `ladder` under `equipment` so the "
+            "SRD's 'reach out-of-the-way places with a Ladder' example "
+            "has a real game object to reference."
+        )
+        ladder = items["equipment"]["ladder"]
+        assert "Ladder" in ladder["name"], (
+            "Ladder catalog entry must keep the 'Ladder' name so it is "
+            "discoverable by the SRD-aligned vocabulary."
+        )
+
+    def test_ladder_supports_vertical_traversal_in_engine(self) -> None:
+        pytest.skip(
+            "GAP: there is no engine-side ladder traversal action. The "
+            "`ladder` item is catalog-only — no `Capability.LADDER` in "
+            "`dnd_engine/systems/capabilities.py:21`, no per-room "
+            "`vertical_exit` field, no `climb_ladder` action handler. "
+            "Movement to vertically separated rooms is currently "
+            "modeled, if at all, via flat-direction `exits` in dungeon "
+            "JSON. Closing this would let the SRD's 'reach out-of-the-"
+            "way places' clause translate into a real action."
+        )
+
+
+class TestExploration_AdventuringEquipment_Torch:
+    """SRD § Playing the Game › Exploration › Adventuring Equipment (Torch).
+
+    > ...perceive things they wouldn't otherwise notice with a Torch or
+    > another light source...
+    """
+
+    def test_torch_is_in_the_consumables_catalog(self) -> None:
+        """`items.json` carries a `torch` consumable that grants light.
+
+        The SRD's Torch example needs an entry that wires through the
+        engine's light-providing path. The `torch` entry in `items.json`
+        under `consumables` carries `effect_type: light`,
+        `light_level: bright`, and a 60-minute duration — matching the
+        SRD's "burns for 1 hour, bright light in a 20-foot radius and
+        dim light for an additional 20 feet" description.
+        """
+        items = _load_items()
+        assert "torch" in items["consumables"], (
+            "items.json must catalog `torch` under `consumables` to "
+            "back the SRD's 'perceive things with a Torch' example."
+        )
+        torch = items["consumables"]["torch"]
+        assert torch["effect_type"] == "light", (
+            "Torch must declare `effect_type: light` so the item-effects "
+            "dispatcher routes it to the light-source handler."
+        )
+        assert torch["light_level"] == "bright", (
+            "Torch must declare `light_level: bright` per SRD: "
+            "'bright light in a 20-foot radius'."
+        )
+        assert torch["duration_minutes"] == 60, (
+            "Torch must declare `duration_minutes: 60` per SRD: "
+            "'burns for 1 hour'."
+        )
+
+    def test_torch_light_effect_resolves_through_item_effects_dispatch(self) -> None:
+        """`apply_item_effect` recognizes the torch's `light` effect.
+
+        The SRD's "another light source" branch is closed by the
+        item-effects dispatcher: `apply_item_effect` in
+        `dnd_engine/systems/item_effects.py` returns a recognized
+        `effect_type` of "light" rather than the unimplemented-effect
+        fallback. Without a `TimeManager`, the call returns a result
+        flagged as unimplemented (light effects need timed tracking),
+        but the dispatcher itself recognizes the type — which is the
+        engine seam this audit guards.
+        """
+        items = _load_items()
+        torch = items["consumables"]["torch"]
+        char = _make_rogue()
+        # No TimeManager passed — the light handler short-circuits but the
+        # dispatcher still routes to a 'light' effect_type, not 'unknown'.
+        result = apply_item_effect(torch, char, time_manager=None)
+        assert result.effect_type == "light", (
+            "apply_item_effect must dispatch torch to the 'light' "
+            "handler so the SRD's 'Torch or another light source' "
+            "example has a real engine seam."
+        )
+
+    def test_torch_carries_capability_in_capabilities_map(self) -> None:
+        """The capabilities module declares Torch grants `LIGHT_SOURCE`.
+
+        `dnd_engine/systems/capabilities.py:83` maps `"torch"` to
+        `[Capability.LIGHT_SOURCE]`. This is the engine record that
+        Torch is the canonical "perceive things... with a Torch" item
+        from the SRD.
+        """
+        capabilities_src = (
+            Path(__file__).resolve().parents[3]
+            / "dnd_engine"
+            / "systems"
+            / "capabilities.py"
+        ).read_text()
+        assert '"torch"' in capabilities_src or "'torch'" in capabilities_src, (
+            "capabilities.py must list `torch` as a LIGHT_SOURCE "
+            "provider so the SRD's exploration example has a "
+            "capability-layer attach-point."
+        )
+        assert "LIGHT_SOURCE" in capabilities_src, (
+            "capabilities.py must continue to declare the LIGHT_SOURCE "
+            "capability tag."
+        )
+
+
+class TestExploration_AdventuringEquipment_ThievesTools:
+    """SRD § Playing the Game › Exploration › Adventuring Equipment (Thieves' Tools).
+
+    > ...bypass locked doors and containers with Thieves' Tools...
+    """
+
+    def test_thieves_tools_is_in_the_tools_catalog(self) -> None:
+        """`items.json` catalogs Thieves' Tools under `tools`.
+
+        The SRD's "bypass locked doors and containers with Thieves'
+        Tools" example needs a real tool entry. `data/srd/items.json`
+        carries `tools.thieves_tools`.
+        """
+        items = _load_items()
+        assert "thieves_tools" in items["tools"], (
+            "items.json must catalog `thieves_tools` under `tools` to "
+            "back the SRD's 'bypass locked doors and containers with "
+            "Thieves' Tools' example."
+        )
+        tt = items["tools"]["thieves_tools"]
+        assert "Thieves' Tools" in tt["name"]
+        # SRD: "add your proficiency bonus to any ability check you make
+        # to disarm traps or open locks."
+        assert "lock" in tt["description"].lower() or "trap" in tt["description"].lower()
+
+    def test_rogue_class_starts_with_thieves_tools_proficiency(self) -> None:
+        """The Rogue class data lists `thieves_tools` as a tool proficiency.
+
+        SRD-aligned exemplar: the Rogue is the canonical Thieves' Tools
+        user. `data/srd/classes.json` carries `tool_proficiencies` for
+        each class, and the Rogue's list includes `thieves_tools`.
+        """
+        classes = json.loads(CLASSES_JSON.read_text())
+        rogue = classes["rogue"]
+        assert "thieves_tools" in rogue["tool_proficiencies"], (
+            "Rogue class data must list `thieves_tools` so the SRD's "
+            "lock-bypass exemplar has a class-side proficiency."
+        )
+
+    def test_character_carries_tool_proficiencies(self) -> None:
+        """`Character` exposes `tool_proficiencies` as a first-class field.
+
+        The proficiency is read by `GameState._unlock_door`
+        (`game_state.py:1097-1099`) during the skill-based unlock path.
+        """
+        rogue = _make_rogue()
+        assert hasattr(rogue, "tool_proficiencies"), (
+            "Character must carry a `tool_proficiencies` list so "
+            "Thieves' Tools proficiency can be honored at unlock-time."
+        )
+        assert "thieves_tools" in rogue.tool_proficiencies
+
+    def test_unlock_door_path_inspects_thieves_tools_proficiency(self) -> None:
+        """`GameState.attempt_unlock` reads `character.tool_proficiencies`.
+
+        Source-level guard: the SRD's "bypass locked doors... with
+        Thieves' Tools" promise has a real consumer at
+        `dnd-engine/dnd_engine/core/game_state.py:1093-1099`, where the
+        unlock path checks `method.get("tool_proficiency")` against
+        `character.tool_proficiencies` before resolving the skill
+        check.
+
+        The current implementation softens this to "still attempt but
+        without proficiency bonus" rather than blocking the attempt
+        outright — that softer behavior is by design (the SRD does
+        not actually require tool proficiency to make the check; it
+        only adds proficiency bonus). This test pins the
+        consultation, not the rejection.
+        """
+        unlock_src = inspect.getsource(GameState.attempt_unlock)
+        assert "tool_proficiency" in unlock_src, (
+            "GameState.attempt_unlock must consult the unlock method's "
+            "`tool_proficiency` requirement to honor the SRD's "
+            "'bypass locked doors with Thieves' Tools' clause."
+        )
+        assert "tool_proficiencies" in unlock_src, (
+            "GameState.attempt_unlock must check the character's "
+            "`tool_proficiencies` list, not just the requirement."
+        )
+
+
+class TestExploration_AdventuringEquipment_Caltrops:
+    """SRD § Playing the Game › Exploration › Adventuring Equipment (Caltrops).
+
+    > ...and create obstacles for pursuers with Caltrops.
+    """
+
+    def test_caltrops_is_in_the_equipment_catalog(self) -> None:
+        """`items.json` carries a `caltrops` entry under `equipment`.
+
+        The SRD's "create obstacles for pursuers with Caltrops" example
+        is backed by `equipment.caltrops`, whose description carries
+        the canonical "bag of 20", 5-ft square, DC 15 DEX save, 1
+        piercing damage mechanics.
+        """
+        items = _load_items()
+        assert "caltrops" in items["equipment"], (
+            "items.json must catalog `caltrops` under `equipment` to "
+            "back the SRD's 'create obstacles for pursuers with "
+            "Caltrops' example."
+        )
+        ct = items["equipment"]["caltrops"]
+        assert "Caltrops" in ct["name"]
+        # SRD-aligned mechanics in the description:
+        assert "DC 15" in ct["description"] or "dc 15" in ct["description"].lower()
+        assert "Dexterity" in ct["description"] or "dexterity" in ct["description"].lower()
+
+    def test_caltrops_is_consumed_as_an_obstacle_in_engine(self) -> None:
+        pytest.skip(
+            "GAP: there is no engine path that *deploys* caltrops as an "
+            "area obstacle. The catalog entry exists "
+            "(`items.json: equipment.caltrops`) with full SRD text in "
+            "the description, but no action handler, no scenario "
+            "script verb, no MCP tool, and no `apply_item_effect` "
+            "branch consumes caltrops to spawn a per-tile hazard. "
+            "Combat-mode available actions "
+            "(`dnd_engine/core/game_state.py:766`) are `['attack', "
+            "'use_item']`; `use_item` -> `apply_item_effect` "
+            "(`systems/item_effects.py`) handles `healing`, `damage`, "
+            "`condition_removal`, `buff`, `light`, `spell`, "
+            "`information` — no `area_hazard` effect_type. Tracked by "
+            "issue #503-followup: file a new issue if/when caltrops "
+            "become a tactical item."
+        )
+
+
+class TestExploration_AdventuringEquipment_WeaponsAsTools:
+    """SRD § Playing the Game › Exploration › Weapons used non-combatively.
+
+    > The weapons in "Equipment" can also be used for more than battle;
+    > you could use a Quarterstaff, for example, to push a sinister-
+    > looking button that you're reluctant to touch.
+    """
+
+    def test_quarterstaff_exists_in_weapons_catalog(self) -> None:
+        """A Quarterstaff is in the weapons catalog.
+
+        The SRD's "push a sinister-looking button with a Quarterstaff"
+        example needs a real Quarterstaff to wave around. `items.json`
+        carries one.
+        """
+        items = _load_items()
+        weapons = items.get("weapons", {})
+        assert "quarterstaff" in weapons, (
+            "items.json must catalog `quarterstaff` under `weapons` so "
+            "the SRD's 'push a sinister-looking button with a "
+            "Quarterstaff' exploration example has a real game object."
+        )
+
+    def test_weapons_can_be_used_non_combatively_via_examine_action(self) -> None:
+        pytest.skip(
+            "GAP: the SRD's 'weapons used for more than battle' clause "
+            "has no first-class engine surface. Rooms declare "
+            "`examinable_objects` and exits with `examine_checks` "
+            "(`GameState.get_examinable_objects` -> "
+            "`dnd_engine/core/game_state.py:1146`, "
+            "`examine_exit` -> `:1177`), but the examine path does "
+            "not consult held weapons / items to gate or modify the "
+            "interaction. There is no 'reach with a 10-ft pole' "
+            "carve-out, no quarterstaff-as-button-presser handler. "
+            "This is a GM-mediated improvisation in the SRD; the "
+            "engine could surface it via the existing `examine` path "
+            "plus an item-as-reach modifier. Cross-cuts issue #453 "
+            "(Improvised action surface)."
+        )
+
+
+class TestExploration_Coverage:
+    """Coverage map: SRD rules <-> tests in this file.
+
+    Maintainer index. Update both columns when adding a rule.
+
+    | SRD rule (exploration.md)                                    | Test                                                                      |
+    |--------------------------------------------------------------|---------------------------------------------------------------------------|
+    | Intro: exploration is a discrete rules mode                  | TestExploration_Intro                                                     |
+    | Ladder example (reach out-of-the-way places)                 | TestExploration_AdventuringEquipment_Ladder                               |
+    | Torch / light source example (perceive things)               | TestExploration_AdventuringEquipment_Torch                                |
+    | Thieves' Tools example (bypass locked doors/containers)      | TestExploration_AdventuringEquipment_ThievesTools                         |
+    | Caltrops example (create obstacles for pursuers)             | TestExploration_AdventuringEquipment_Caltrops                             |
+    | Weapons used non-combatively (Quarterstaff button-press)     | TestExploration_AdventuringEquipment_WeaponsAsTools                       |
+    """
+
+    def test_coverage_map_present(self) -> None:
+        """Sanity check: this class's docstring carries the rule->test map."""
+        assert TestExploration_Coverage.__doc__ is not None
+        assert "SRD rule" in TestExploration_Coverage.__doc__
+        assert "Ladder example" in TestExploration_Coverage.__doc__

--- a/dnd-engine/tests/srd/playing_the_game/test_travel.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_travel.py
@@ -1,0 +1,404 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > Travel".
+# ABOUTME: Cross-references docs/srd/playing-the-game/travel.md against engine code.
+
+"""SRD conformance: Travel.
+
+Maps every rule in `docs/srd/playing-the-game/travel.md` (SRD lines
+1662-1733) to a test. Real tests verify enforcement at the engine
+layer; stubs (`pytest.skip("GAP: ...")`) mark known gaps and cite where
+the rule is enforced today (if elsewhere) or that it isn't implemented
+anywhere.
+
+The Travel section is almost entirely unimplemented in the engine today
+— the game is dungeon-crawl-focused and overland travel is summarized
+narratively. The bulk of the rules in this audit therefore land as
+GAPs, with citations to four newly filed issues:
+
+- #504  Travel pace (Fast/Normal/Slow) not modeled
+- #505  Mounted travel doubles pace for 1 hour, then mount needs rest
+- #506  Vehicles and waterborne travel not modeled
+- #507  Travel pace does not gate Perception/Survival/Stealth advantage
+
+The audit pins a few real anchors that do exist (combat-mode movement
+rules are referenced by the SRD as the "every second matters" carve-out
+below) so the cross-references stay live.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.systems.action_economy import TurnState
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/travel.md",
+    lines="1662-1733",
+)
+
+
+SKILLS_JSON = (
+    Path(__file__).resolve().parents[3] / "dnd_engine" / "data" / "srd" / "skills.json"
+)
+ITEMS_JSON = (
+    Path(__file__).resolve().parents[3] / "dnd_engine" / "data" / "srd" / "items.json"
+)
+
+
+def _make_creature(*, speed: int = 30) -> Creature:
+    """Plain Medium humanoid fixture for travel tests."""
+    abilities = Abilities(
+        strength=12,
+        dexterity=12,
+        constitution=12,
+        intelligence=10,
+        wisdom=12,
+        charisma=10,
+    )
+    return Creature(name="Traveler", max_hp=10, ac=12, abilities=abilities, speed=speed)
+
+
+class TestTravel_Intro:
+    """SRD § Playing the Game › Travel › Intro.
+
+    > During an adventure, the characters might travel long distances on
+    > trips that could take hours or days. The GM can summarize this
+    > travel without calculating exact distances or travel times, or the
+    > GM might have you use the travel pace rules below.
+    """
+
+    def test_engine_has_no_overworld_travel_layer(self) -> None:
+        pytest.skip(
+            "GAP: there is no engine-side overworld / long-distance "
+            "travel layer. The game flow is dungeon-room-to-dungeon-"
+            "room (`GameState.move_to_room` and friends in "
+            "`dnd-engine/dnd_engine/core/game_state.py`), and the "
+            "cross-dungeon-travel comment in "
+            "`dnd-engine/dnd_engine/core/save_slot_manager.py:488` "
+            "treats inter-dungeon travel as a save-state transition, "
+            "not a timed journey with distance, pace, or encounters. "
+            "The SRD's 'GM might have you use the travel pace rules "
+            "below' phrasing has no engine analog. Tracked by issue "
+            "#504 and the umbrella architecture issue #28 ('Extend "
+            "location system to support settlements, regions, and "
+            "world navigation')."
+        )
+
+    def test_combat_mode_movement_is_the_explicit_carveout_for_short_distances(self) -> None:
+        """The SRD cross-references "Combat" movement rules for short distances.
+
+        > If you need to know how fast you can move when every second
+        > matters, see the movement rules in "Combat".
+
+        The combat movement rules referenced here *are* implemented —
+        `TurnState.movement_remaining` (see
+        `tests/srd/playing_the_game/test_movement_and_position.py`).
+        Guarding the existence of that mechanic keeps the SRD cross-
+        reference live: when overworld travel ships, it must defer to
+        the combat-movement layer for second-by-second movement.
+        """
+        creature = _make_creature(speed=30)
+        state = TurnState(movement_remaining=creature.speed)
+        assert state.movement_remaining == 30, (
+            "Combat-mode movement rules ('every second matters') must "
+            "continue to seed the per-turn movement pool from a "
+            "creature's Speed, since the Travel chapter explicitly "
+            "defers to them."
+        )
+
+
+class TestTravel_PaceTable:
+    """SRD § Playing the Game › Travel › Travel Pace table.
+
+    > While traveling outside combat, a group can move at a Fast,
+    > Normal, or Slow pace, as shown on the Travel Pace table.
+
+    SRD pace rates (per minute / hour / day):
+
+    | Pace   | Per Minute | Per Hour | Per Day  |
+    |--------|------------|----------|----------|
+    | Fast   | 400 ft     | 4 miles  | 30 miles |
+    | Normal | 300 ft     | 3 miles  | 24 miles |
+    | Slow   | 200 ft     | 2 miles  | 18 miles |
+    """
+
+    def test_travel_pace_enum_exists(self) -> None:
+        pytest.skip(
+            "GAP: no `TravelPace` enum / constant lives anywhere in "
+            "`dnd-engine/dnd_engine/`. `rg -in 'travel|pace' "
+            "dnd-engine/dnd_engine/ --type py` finds only unrelated "
+            "phrasing ('traveling between dungeons' in save_slot_"
+            "manager.py:488, 'fast-paced combat' in llm/prompts.py). "
+            "No data file declares the per-minute/hour/day rates. "
+            "Tracked by issue #504."
+        )
+
+    def test_pace_rates_match_srd_table(self) -> None:
+        pytest.skip(
+            "GAP: there is no `PACE_RATES` table or per-pace rate "
+            "lookup. The SRD's 400/300/200 ft/min, 4/3/2 mi/hr, "
+            "30/24/18 mi/day rates have no engine constant or JSON "
+            "datum to be checked against. Tracked by issue #504."
+        )
+
+    def test_party_carries_active_travel_pace(self) -> None:
+        pytest.skip(
+            "GAP: `Party` (`dnd_engine/core/party.py`) has no "
+            "`travel_pace` attribute. The active pace is the load-"
+            "bearing piece of state for every other Travel-section "
+            "rule (perception/stealth modifiers, vehicle/mount carve-"
+            "outs). Tracked by issue #504."
+        )
+
+
+class TestTravel_FastPaceModifiers:
+    """SRD § Playing the Game › Travel › Fast pace effect.
+
+    > Fast. Traveling at a Fast pace imposes Disadvantage on a
+    > traveler's Wisdom (Perception or Survival) and Dexterity
+    > (Stealth) checks.
+    """
+
+    def test_perception_and_survival_and_stealth_exist_as_skills(self) -> None:
+        """Data-parity: the three skills the Fast pace modifies are catalogued.
+
+        The SRD's Fast-pace clause references Wisdom (Perception),
+        Wisdom (Survival), and Dexterity (Stealth). Each must exist in
+        `data/srd/skills.json` with the correct ability mapping for any
+        later pace-modifier logic to bind to. Without this, the gap is
+        twice as deep.
+        """
+        skills = json.loads(SKILLS_JSON.read_text())
+        assert "perception" in skills, "Perception skill must be catalogued."
+        assert skills["perception"]["ability"] == "wis", (
+            "Perception must be a Wisdom skill (SRD: 'Wisdom (Perception)')."
+        )
+        assert "survival" in skills, "Survival skill must be catalogued."
+        assert skills["survival"]["ability"] == "wis", (
+            "Survival must be a Wisdom skill (SRD: 'Wisdom (Survival)')."
+        )
+        assert "stealth" in skills, "Stealth skill must be catalogued."
+        assert skills["stealth"]["ability"] == "dex", (
+            "Stealth must be a Dexterity skill (SRD: 'Dexterity (Stealth)')."
+        )
+
+    def test_fast_pace_imposes_disadvantage_on_perception(self) -> None:
+        pytest.skip(
+            "GAP: no caller of `Character.make_skill_check` "
+            "(`dnd_engine/core/character.py:726`) derives its "
+            "`disadvantage` flag from a travel pace. The method accepts "
+            "the flag but there is no `pace_modifiers(pace, skill)` "
+            "helper and no `Party.travel_pace` state to drive it. "
+            "Tracked by issues #504 and #507."
+        )
+
+    def test_fast_pace_imposes_disadvantage_on_survival(self) -> None:
+        pytest.skip(
+            "GAP: same root cause as the Perception variant — no pace "
+            "-> check modifier dispatch exists. Tracked by issues #504 "
+            "and #507."
+        )
+
+    def test_fast_pace_imposes_disadvantage_on_stealth(self) -> None:
+        pytest.skip(
+            "GAP: same root cause. The only Stealth call site today is "
+            "`GameState._check_for_surprise` "
+            "(`dnd_engine/core/game_state.py:3014`), which fires "
+            "before combat and does not consult any travel state. "
+            "Tracked by issues #504 and #507."
+        )
+
+
+class TestTravel_NormalPaceModifiers:
+    """SRD § Playing the Game › Travel › Normal pace effect.
+
+    > Normal. Traveling at a Normal pace imposes Disadvantage on
+    > Dexterity (Stealth) checks.
+    """
+
+    def test_normal_pace_imposes_disadvantage_on_stealth(self) -> None:
+        pytest.skip(
+            "GAP: no pace -> check modifier dispatch exists. Without a "
+            "`Party.travel_pace` and a `pace_modifiers` helper, the "
+            "Normal-pace Stealth penalty cannot be applied. Tracked by "
+            "issues #504 and #507."
+        )
+
+    def test_normal_pace_does_not_modify_perception_or_survival(self) -> None:
+        pytest.skip(
+            "GAP: the SRD's Normal pace carve-out (no Perception / "
+            "Survival modifier) needs a default 'no modifier' branch "
+            "in the pace-modifier helper. Without that helper "
+            "(issue #507), there is nothing to encode the default. "
+            "Tracked by issue #507."
+        )
+
+
+class TestTravel_SlowPaceModifiers:
+    """SRD § Playing the Game › Travel › Slow pace effect.
+
+    > Slow. Traveling at a Slow pace grants Advantage on Wisdom
+    > (Perception or Survival) checks.
+    """
+
+    def test_slow_pace_grants_advantage_on_perception(self) -> None:
+        pytest.skip(
+            "GAP: `Character.make_skill_check` accepts an `advantage` "
+            "flag, but no caller derives it from a Slow travel pace. "
+            "No `Party.travel_pace` exists. Tracked by issues #504 "
+            "and #507."
+        )
+
+    def test_slow_pace_grants_advantage_on_survival(self) -> None:
+        pytest.skip(
+            "GAP: same root cause as the Slow/Perception variant. "
+            "Tracked by issues #504 and #507."
+        )
+
+    def test_slow_pace_does_not_modify_stealth(self) -> None:
+        pytest.skip(
+            "GAP: the SRD's Slow-pace carve-out (Advantage on "
+            "Perception/Survival, no Stealth penalty) needs a pace-"
+            "modifier helper that returns `(advantage=True, "
+            "disadvantage=False)` for Perception/Survival and "
+            "`(False, False)` for Stealth. None exists. Tracked by "
+            "issue #507."
+        )
+
+
+class TestTravel_MountedTravel:
+    """SRD § Playing the Game › Travel › Mounted travel.
+
+    > ...if riding horses or other mounts, the group can move twice
+    > that distance for 1 hour, after which the mounts need a Short or
+    > Long Rest before they can move at that increased pace again (see
+    > "Equipment" for a selection of mounts for sale).
+    """
+
+    def test_mount_catalog_exists(self) -> None:
+        pytest.skip(
+            "GAP: no mount entries exist. `jq '.equipment | keys[]' "
+            "dnd-engine/dnd_engine/data/srd/items.json` returns no "
+            "horses, ponies, mules, riding dogs, or any other mount. "
+            "The string 'horse' appears only as flavor text in a "
+            "campaign room description "
+            "(`data/content/campaigns/the_unquiet_dead/dungeons/"
+            "town_of_arden.json:38`). Tracked by issue #505."
+        )
+
+    def test_mounted_travel_doubles_pace_distance_for_one_hour(self) -> None:
+        pytest.skip(
+            "GAP: depends on travel pace existing (#504) and on mounts "
+            "existing (#505). The SRD's 'twice that distance for 1 "
+            "hour' clause has nothing to multiply and no mount-rest "
+            "cooldown to track. Tracked by issue #505."
+        )
+
+    def test_mounts_need_short_or_long_rest_after_one_hour_at_double_pace(self) -> None:
+        pytest.skip(
+            "GAP: rest mechanics exist on Character "
+            "(`Character.take_short_rest` -> "
+            "`dnd-engine/dnd_engine/core/character.py:1202`, "
+            "`take_long_rest` -> :1236), but Creature does not "
+            "participate in them, and there is no Mount model with a "
+            "fatigue counter that those rests would reset. Tracked by "
+            "issue #505."
+        )
+
+
+class TestTravel_Vehicles_LandVehicles:
+    """SRD § Playing the Game › Travel › Land vehicles.
+
+    > Travelers in wagons, carriages, or other land vehicles choose a
+    > pace as normal.
+    """
+
+    def test_land_vehicle_catalog_exists(self) -> None:
+        pytest.skip(
+            "GAP: no land vehicle entries exist in items.json. "
+            "`jq '.equipment | keys[]' dnd-engine/dnd_engine/data/srd/"
+            "items.json | rg -i 'wagon|cart|carriage'` returns no "
+            "matches. Tracked by issue #506."
+        )
+
+    def test_land_vehicle_riders_still_choose_pace(self) -> None:
+        pytest.skip(
+            "GAP: depends on travel pace existing (#504) and on land "
+            "vehicles existing (#506). The SRD's carve-out that land-"
+            "vehicle riders 'choose a pace as normal' has no enforcement "
+            "surface because neither side of the conditional exists yet. "
+            "Tracked by issue #506."
+        )
+
+
+class TestTravel_Vehicles_WaterborneVessels:
+    """SRD § Playing the Game › Travel › Waterborne vessels.
+
+    > Characters in a waterborne vessel are limited to the speed of the
+    > vessel, and they don't choose a travel pace. Depending on the
+    > vessel and the size of the crew, ships might be able to travel
+    > for up to 24 hours per day.
+    """
+
+    def test_waterborne_vessel_catalog_exists(self) -> None:
+        pytest.skip(
+            "GAP: no waterborne vessel entries exist in items.json. "
+            "`jq '.equipment | keys[]' dnd-engine/dnd_engine/data/srd/"
+            "items.json | rg -i 'boat|ship|vessel|rowboat'` returns "
+            "no matches. Tracked by issue #506."
+        )
+
+    def test_waterborne_vessel_locks_pace_to_vessel_speed(self) -> None:
+        pytest.skip(
+            "GAP: depends on pace (#504) and vehicles (#506) existing. "
+            "The SRD's 'limited to the speed of the vessel, and they "
+            "don't choose a travel pace' clause needs a vessel speed "
+            "attribute and a pace-selection guard that consults it. "
+            "Neither exists. Tracked by issue #506."
+        )
+
+    def test_waterborne_vessel_can_travel_up_to_24_hours_per_day(self) -> None:
+        pytest.skip(
+            "GAP: there is no day-length / journey-time model that a "
+            "vessel could opt into. The TimeManager (`dnd_engine/"
+            "systems/time_manager.py`) tracks combat-rounds and spell "
+            "durations but not multi-hour overland journey segments. "
+            "Tracked by issue #506."
+        )
+
+
+class TestTravel_Coverage:
+    """Coverage map: SRD rules <-> tests in this file.
+
+    Maintainer index. Update both columns when adding a rule.
+
+    | SRD rule (travel.md)                                                 | Test                                    |
+    |----------------------------------------------------------------------|-----------------------------------------|
+    | Intro: GM may summarize OR use travel pace rules                     | TestTravel_Intro                        |
+    | Cross-ref: 'every second matters' -> combat movement rules           | TestTravel_Intro                        |
+    | Travel Pace table (Fast/Normal/Slow, ft/min, mi/hr, mi/day)          | TestTravel_PaceTable                    |
+    | Fast pace: Disadv on Perception, Survival, Stealth                   | TestTravel_FastPaceModifiers            |
+    | Normal pace: Disadv on Stealth only                                  | TestTravel_NormalPaceModifiers          |
+    | Slow pace: Adv on Perception, Survival                               | TestTravel_SlowPaceModifiers            |
+    | Mounted travel: double pace for 1 hr, then mount rests               | TestTravel_MountedTravel                |
+    | Land vehicles: riders choose pace as normal                          | TestTravel_Vehicles_LandVehicles        |
+    | Waterborne vessels: locked to vessel speed, up to 24 hr/day          | TestTravel_Vehicles_WaterborneVessels   |
+
+    Gap issues filed for this audit:
+    - #504  Travel pace (Fast/Normal/Slow) not modeled
+    - #505  Mounted travel doubles pace for 1 hour, then mount needs rest
+    - #506  Vehicles and waterborne travel not modeled
+    - #507  Travel pace does not gate Perception/Survival/Stealth advantage
+    """
+
+    def test_coverage_map_present(self) -> None:
+        """Sanity check: this class's docstring carries the rule->test map."""
+        assert TestTravel_Coverage.__doc__ is not None
+        assert "SRD rule" in TestTravel_Coverage.__doc__
+        assert "Travel Pace table" in TestTravel_Coverage.__doc__
+        assert "#504" in TestTravel_Coverage.__doc__


### PR DESCRIPTION
## Summary

Wave-3 SRD conformance audit for two `docs/srd/playing-the-game/` documents:

- `exploration.md` (SRD lines 1511-1536)
- `travel.md` (SRD lines 1662-1733)

Adds two new test files under `dnd-engine/tests/srd/playing_the_game/`
that map every rule in those docs to a pytest case. Real assertions
verify enforcement at the engine layer; `pytest.skip("GAP: ...")` stubs
mark known gaps and cite where the rule would be enforced.

## Rules enforced via real assertions

**Exploration (13 passing):**
- Engine has an exploration mode distinct from combat (`GameState.cast_spell_exploration`, `Character.get_out_of_combat_spells`, "Exploration events" tag in `events.py`).
- Adventuring-equipment catalog parity for Ladder, Torch, Thieves' Tools, Caltrops, Quarterstaff entries in `data/srd/items.json`.
- Torch effect routes through `apply_item_effect` with `effect_type: light` (SRD-aligned 60-min/bright/20-ft).
- `capabilities.py` lists `torch` as a `LIGHT_SOURCE` provider.
- Rogue class data declares `thieves_tools` tool proficiency; `Character` exposes a `tool_proficiencies` list; `GameState.attempt_unlock` consults both the method's `tool_proficiency` requirement and the character's `tool_proficiencies` list.
- Caltrops catalog entry carries SRD-aligned DC 15 DEX-save mechanics.

**Travel (3 passing):**
- Combat-mode movement is the SRD-cited "every second matters" carve-out — guards that `TurnState.movement_remaining` continues to seed from `Creature.speed`.
- Data-parity check for Perception (wis), Survival (wis), Stealth (dex) skill catalog entries.

## Rules gapped (with citations)

**Exploration (3 skips):** ladder vertical traversal, caltrops deployment as area obstacle, weapons-used-non-combatively examine path.

**Travel (20 skips):** travel pace enum / table / party attribute; Fast/Normal/Slow pace skill-check modifiers; mount catalog & double-pace cooldown; land vehicles & waterborne vessels including 24-hour-per-day clause.

## Issues filed for travel gaps

- #504 SRD gap: Travel Pace (Fast/Normal/Slow) not modeled (travel)
- #505 SRD gap: Mounted travel doubles pace for 1 hour, then mount needs rest (travel)
- #506 SRD gap: Vehicles and waterborne travel not modeled (travel)
- #507 SRD gap: Travel pace does not gate Perception/Survival/Stealth check advantage (travel)

## Test results

- `tests/srd/playing_the_game/test_exploration.py`: **13 passed, 3 skipped**
- `tests/srd/playing_the_game/test_travel.py`: **3 passed, 20 skipped**
- Zero failures, zero errors.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_exploration.py tests/srd/playing_the_game/test_travel.py -v` — all pass or clean SKIP
- [ ] Optional: re-run the full SRD conformance suite to confirm no regression in adjacent audits

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>