### PR TITLE
SRD audit: hazards + underwater-combat

### DIFF
--- a/dnd-engine/tests/srd/playing_the_game/test_hazards.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_hazards.py
@@ -1,0 +1,345 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > Hazards".
+# ABOUTME: Cross-references docs/srd/playing-the-game/hazards.md against engine code.
+
+"""SRD conformance: Hazards.
+
+Maps every rule in `docs/srd/playing-the-game/hazards.md` to a test.
+Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+The Hazards section is a *cataloging* section: it enumerates five
+hazards (Burning, Dehydration, Falling, Malnutrition, Suffocation) that
+the SRD's Rules Glossary then defines in detail. The section's only
+direct content is the catalog — so the audit's job is to verify that
+the engine has a real model for each named hazard, or to mark the gap.
+
+A common finding: of the five hazards, only **Burning** has any engine
+presence at all (the `on_fire` condition in `conditions.json`), and even
+that is a personal *condition* rather than an environmental *hazard
+zone* — there is no per-room or per-tile "this area inflicts the
+hazard" data field. The other four hazards have zero engine surface.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.systems.condition_manager import ConditionManager
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/hazards.md",
+    lines="1650-1661",
+)
+
+
+CONDITIONS_JSON = (
+    Path(__file__).resolve().parents[3]
+    / "dnd_engine"
+    / "data"
+    / "srd"
+    / "conditions.json"
+)
+
+
+def _make_creature(name: str = "Subject", hp: int = 20) -> Creature:
+    """Build a plain creature for hazard-damage tests."""
+    abilities = Abilities(
+        strength=10,
+        dexterity=10,
+        constitution=10,
+        intelligence=10,
+        wisdom=10,
+        charisma=10,
+    )
+    return Creature(name=name, max_hp=hp, ac=10, abilities=abilities)
+
+
+class TestHazards_IntroFraming:
+    """SRD § Playing the Game › Hazards › Intro framing.
+
+    > Monsters are the main perils characters face, but other dangers
+    > await. "Rules Glossary" defines the following hazards: ...
+    """
+
+    def test_hazards_catalog_is_finite_and_enumerated(self) -> None:
+        """Source-level guard: the SRD lists exactly five hazards.
+
+        The conformance file enumerates these explicitly so a future
+        SRD revision that adds or removes a hazard surfaces here as a
+        failing assertion rather than silently drifting from the
+        document.
+        """
+        srd_doc = (
+            Path(__file__).resolve().parents[3].parent
+            / "docs"
+            / "srd"
+            / "playing-the-game"
+            / "hazards.md"
+        )
+        body = srd_doc.read_text()
+        for hazard in ("Burning", "Dehydration", "Falling", "Malnutrition", "Suffocation"):
+            assert hazard in body, (
+                f"Hazards SRD doc must enumerate {hazard!r}. If this "
+                "fails, the SRD has been re-issued; bump the audit and "
+                "issues #508/#509/#510/#512."
+            )
+
+
+class TestHazards_Burning:
+    """SRD § Playing the Game › Hazards › Burning.
+
+    > Burning [hazard, defined in Rules Glossary]
+
+    Per the Rules Glossary, a creature subjected to the Burning hazard
+    takes ongoing fire damage at the start of each of its turns until
+    it ends the effect (typically a Dex check action to put out the
+    flames). The engine models the personal `on_fire` *condition* but
+    not the environmental *hazard zone* that would inflict it.
+    """
+
+    def test_on_fire_condition_is_catalogued(self) -> None:
+        """`on_fire` is the engine's encoding of the SRD Burning rule.
+
+        Data-parity check: `dnd_engine/data/srd/conditions.json` must
+        carry an `on_fire` entry with a turn-start fire-damage effect
+        and a Dex-check escape, matching the SRD's "burning" hazard
+        shape.
+        """
+        conditions = json.loads(CONDITIONS_JSON.read_text())["conditions"]
+        assert "on_fire" in conditions, (
+            "Conditions catalog must declare `on_fire` so the SRD's "
+            "Burning hazard has a real engine encoding."
+        )
+        on_fire = conditions["on_fire"]
+        effect = on_fire.get("turn_start_effect", {})
+        assert effect.get("type") == "damage"
+        assert effect.get("damage_type") == "fire", (
+            "Burning must deal fire-type damage per the SRD."
+        )
+        escape = on_fire.get("can_end_early", {})
+        assert escape.get("method") == "ability_check"
+        assert escape.get("ability") == "dexterity", (
+            "SRD specifies the escape is a Dex check (douse the flames)."
+        )
+
+    def test_on_fire_damage_is_applied_at_turn_start(self) -> None:
+        """`ConditionManager.process_turn_start_effects` applies the damage.
+
+        End-to-end on the production path: a creature with `on_fire`
+        takes fire damage on each turn-start tick, matching the SRD
+        Burning hazard's "ongoing damage" shape.
+        """
+        manager = ConditionManager(dice_roller=DiceRoller(seed=42))
+        creature = _make_creature(hp=20)
+        creature.add_condition("on_fire")
+        hp_before = creature.current_hp
+
+        results = manager.process_turn_start_effects(creature)
+
+        assert len(results) == 1
+        assert results[0].condition_id == "on_fire"
+        assert results[0].effect_type == "damage"
+        assert 1 <= results[0].amount <= 4, "1d4 fire damage per SRD."
+        assert creature.current_hp == hp_before - results[0].amount
+
+    def test_environmental_burning_zone_applies_on_fire_on_entry(self) -> None:
+        pytest.skip(
+            "GAP: there is no environmental Burning hazard. The engine "
+            "models `on_fire` as a personal *condition* applied by "
+            "items (Alchemist's Fire via `systems/item_effects._apply_"
+            "damage_effect`) but has no per-room or per-tile 'this "
+            "area is on fire' data field. `GameState.move_to_room` "
+            "does not consult any hazard list when a creature enters "
+            "a room. The SRD's Hazards section treats Burning as an "
+            "environment-level hazard, which the engine cannot "
+            "represent. Tracked by issue #508."
+        )
+
+    def test_burning_hazard_severity_levels_are_data_driven(self) -> None:
+        pytest.skip(
+            "GAP: the SRD Rules Glossary entry for Burning carries "
+            "severity tiers (e.g., 1d4 for a torch / brazier, 1d6+ for "
+            "larger flames). The engine collapses this to a single "
+            "hard-coded `damage: '1d4'` in `dnd_engine/data/srd/"
+            "conditions.json:11`. There is no way to express a more "
+            "severe burning hazard short of editing the condition "
+            "data file. Tracked by issue #508."
+        )
+
+
+class TestHazards_Dehydration:
+    """SRD § Playing the Game › Hazards › Dehydration.
+
+    > Dehydration [hazard, defined in Rules Glossary]
+
+    Per the Rules Glossary, a creature that does not drink enough
+    water per day suffers levels of Exhaustion. Requires a long-
+    duration day-tick tracker and an Exhaustion condition.
+    """
+
+    def test_dehydration_concept_exists_in_engine(self) -> None:
+        pytest.skip(
+            "GAP: Dehydration is not modeled. `rg -i 'dehydrat|thirst' "
+            "dnd_engine/` returns zero matches. No per-creature "
+            "water-intake tracker, no day-tick clock, no Exhaustion "
+            "condition in `dnd_engine/data/srd/conditions.json` (only "
+            "`on_fire` and `surprised` are catalogued). Tracked by "
+            "issue #512."
+        )
+
+    def test_dehydration_imposes_exhaustion_levels(self) -> None:
+        pytest.skip(
+            "GAP: the Exhaustion condition does not exist as an "
+            "engine concept. With no Exhaustion catalog entry there is "
+            "no consequence layer for Dehydration to escalate into. "
+            "Tracked by issue #512 (and a downstream Exhaustion "
+            "issue if/when this lands)."
+        )
+
+
+class TestHazards_Falling:
+    """SRD § Playing the Game › Hazards › Falling.
+
+    > Falling [hazard, defined in Rules Glossary]
+
+    Per the Rules Glossary, a creature that falls more than 10 ft
+    takes 1d6 bludgeoning damage per 10 ft fallen (cap 20d6) and
+    lands Prone.
+    """
+
+    def test_falling_damage_calculation_helper_exists(self) -> None:
+        pytest.skip(
+            "GAP: there is no `resolve_fall(distance_ft)` helper "
+            "anywhere in `dnd_engine/`. `rg -i 'falling|fall_damage|"
+            "fall_distance' dnd_engine/` returns only unrelated "
+            "'fallback' matches. No falling system exists because no "
+            "campaign content has verticality today — the 2D client "
+            "is tile-grid with no z-axis. Tracked by issue #509."
+        )
+
+    def test_falling_applies_prone_condition(self) -> None:
+        pytest.skip(
+            "GAP: the Prone condition is not catalogued in "
+            "`dnd_engine/data/srd/conditions.json` (only `on_fire` "
+            "and `surprised`). Even if a fall helper existed, there is "
+            "no Prone state to apply. Tracked by issue #509."
+        )
+
+    def test_falling_damage_is_bludgeoning_type(self) -> None:
+        pytest.skip(
+            "GAP: `Creature.take_damage` (`dnd_engine/core/creature.py`) "
+            "accepts a raw `amount: int` with no `damage_type` "
+            "parameter. Bludgeoning damage cannot be typed through the "
+            "current API — every damage event is untyped at the "
+            "creature-receive layer. Tracked by issues #509 (falling) "
+            "and #461 (damage_type pipeline)."
+        )
+
+
+class TestHazards_Malnutrition:
+    """SRD § Playing the Game › Hazards › Malnutrition.
+
+    > Malnutrition [hazard, defined in Rules Glossary]
+
+    Per the Rules Glossary, a creature that goes without food longer
+    than its CON modifier of days begins accruing Exhaustion levels.
+    """
+
+    def test_malnutrition_concept_exists_in_engine(self) -> None:
+        pytest.skip(
+            "GAP: Malnutrition is not modeled. `rg -i 'malnutri|starv|"
+            "rations' dnd_engine/` returns zero matches. No "
+            "per-creature food-intake tracker, no day-tick clock. "
+            "Same root gap as Dehydration. Tracked by issue #512."
+        )
+
+    def test_malnutrition_consumes_days_until_constitution_threshold(self) -> None:
+        pytest.skip(
+            "GAP: the SRD ties Malnutrition's grace period to the "
+            "creature's CON modifier (creatures with high CON can "
+            "skip more days without food). The engine has no "
+            "per-creature day-counter and no daily tick hook to "
+            "consult `creature.abilities.constitution`. Tracked by "
+            "issue #512."
+        )
+
+
+class TestHazards_Suffocation:
+    """SRD § Playing the Game › Hazards › Suffocation.
+
+    > Suffocation [hazard, defined in Rules Glossary]
+
+    Per the Rules Glossary, a creature can hold its breath for
+    `1 + CON modifier` minutes (min 30 seconds). After that, on each
+    turn it must make a CON save or drop to 0 HP. Cross-cuts the
+    Underwater Combat section: a creature without a Swim Speed or
+    Water Breathing eventually suffocates underwater.
+    """
+
+    def test_suffocation_concept_exists_in_engine(self) -> None:
+        pytest.skip(
+            "GAP: Suffocation is not modeled. `rg -i 'suffocat|drown|"
+            "hold.breath' dnd_engine/` returns zero matches. No "
+            "`breath_remaining_seconds` field on `Creature` or "
+            "`Character`, no turn-start hook that decrements breath. "
+            "Tracked by issue #510."
+        )
+
+    def test_water_breathing_capability_is_consumed_to_prevent_suffocation(self) -> None:
+        pytest.skip(
+            "GAP: `Capability.WATER_BREATHING` is declared "
+            "(`dnd_engine/systems/capabilities.py:25`) but no code "
+            "reads it — `rg 'WATER_BREATHING|water_breathing' "
+            "dnd_engine/` returns only the declaration. The Water "
+            "Breathing spell is not in `dnd_engine/data/srd/spells."
+            "json`. Without a suffocation system there is nothing for "
+            "this capability to gate. Tracked by issue #510."
+        )
+
+    def test_suffocation_forces_con_save_or_zero_hp(self) -> None:
+        pytest.skip(
+            "GAP: there is no auto-drop-to-0 path keyed on a failed "
+            "CON save. The existing auto-fail logic — `GameState."
+            "_apply_lighting_penalties` (`dnd_engine/core/game_state."
+            "py:698-756`) — is hard-coded for sight-based Perception "
+            "in darkness and is not a reusable 'auto-fail-and-apply-"
+            "consequence' primitive. Tracked by issue #510."
+        )
+
+
+class TestHazards_EngineSurface_NoEnvironmentalHazardSystem:
+    """Cross-cut: there is no environmental Hazard system at all.
+
+    The SRD Hazards section presumes the engine can attach a hazard to
+    a place (a room of fire, a stretch of desert, a flooded vault).
+    The engine cannot. Pin the absence here so the moment a Hazard
+    registry lands the next consumer can find it.
+    """
+
+    def test_room_data_can_declare_hazards(self) -> None:
+        pytest.skip(
+            "GAP: room schema in `dnd_engine/data/campaigns/` does not "
+            "carry a `hazards` field. The Burning condition exists as "
+            "a personal effect from items only; no campaign room "
+            "inflicts it on entry. Tracked by issue #508 (Burning) — "
+            "but the room-schema seam is shared by all five hazards "
+            "and is the root architectural gap surfaced by this audit."
+        )
+
+    def test_game_state_applies_room_hazards_on_entry(self) -> None:
+        pytest.skip(
+            "GAP: `GameState.move_to_room` does not consult any "
+            "hazard list when a creature enters a room. With no "
+            "`hazards` schema on rooms and no application hook, all "
+            "five SRD hazards have no entry point into the engine. "
+            "Tracked by issue #508 (architectural seam shared across "
+            "#508, #509, #510, #512)."
+        )

--- a/dnd-engine/tests/srd/playing_the_game/test_underwater_combat.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_underwater_combat.py
@@ -1,0 +1,400 @@
+# ABOUTME: SRD conformance audit for "Playing the Game > Underwater Combat".
+# ABOUTME: Cross-references docs/srd/playing-the-game/underwater-combat.md against engine code.
+
+"""SRD conformance: Underwater Combat.
+
+Maps every rule in `docs/srd/playing-the-game/underwater-combat.md` to
+a test. Real tests verify enforcement at the engine layer; stubs
+(`pytest.skip("GAP: ...")`) mark known gaps and cite where the rule is
+enforced today (if elsewhere) or that it isn't implemented anywhere.
+
+A common finding for this section: the engine has no concept of an
+"underwater" environment. Rooms carry `lighting` but no `environment`
+field; `Creature` exposes a single scalar `speed` with no Swim Speed
+split (tracked by #432); weapon catalog data carries `damage_type` but
+no caller filters on the Piercing carve-out for underwater melee. All
+three SRD rules in this section share the same root architectural gap:
+no environment flag, no swim-speed model.
+
+The conformance "report" is `pytest --collect-only -q tests/srd/`.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.core.combat import CombatEngine
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.systems.item_effects import _apply_damage_effect
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/underwater-combat.md",
+    lines="2153-2171",
+)
+
+
+ITEMS_JSON = (
+    Path(__file__).resolve().parents[3]
+    / "dnd_engine"
+    / "data"
+    / "srd"
+    / "items.json"
+)
+
+
+def _make_creature(name: str = "Subject", hp: int = 50) -> Creature:
+    """Plain creature with no special speeds, no resistances."""
+    abilities = Abilities(
+        strength=14,
+        dexterity=14,
+        constitution=12,
+        intelligence=10,
+        wisdom=10,
+        charisma=10,
+    )
+    return Creature(name=name, max_hp=hp, ac=14, abilities=abilities)
+
+
+def _all_weapon_entries(items: dict) -> list[dict]:
+    """Walk items.json and return every entry that carries a damage_type.
+
+    `items.json` is keyed by category (weapons, armor, consumables, …);
+    weapons live at varying nesting depths. Collect all entries that
+    declare both `name` and `damage_type` so the tests can filter by
+    Piercing vs other types.
+    """
+    found: list[dict] = []
+
+    def walk(obj):
+        if isinstance(obj, dict):
+            if "damage_type" in obj and "name" in obj:
+                found.append(obj)
+            for v in obj.values():
+                walk(v)
+        elif isinstance(obj, list):
+            for entry in obj:
+                walk(entry)
+
+    walk(items)
+    return found
+
+
+class TestUnderwaterCombat_Intro:
+    """SRD § Playing the Game › Underwater Combat › Intro.
+
+    > A fight underwater follows these rules.
+    """
+
+    def test_engine_has_an_underwater_environment_flag(self) -> None:
+        pytest.skip(
+            "GAP: there is no 'underwater' environment in the engine. "
+            "`rg -i underwater dnd_engine/` returns zero hits, and "
+            "room schemas under `dnd_engine/data/campaigns/` carry "
+            "`lighting` but no `environment` field. Without an "
+            "environment flag, none of the three Underwater Combat "
+            "rules can fire. Tracked by issue #514 (root architectural "
+            "seam shared with #516 and #518)."
+        )
+
+
+class TestUnderwaterCombat_ImpededMelee:
+    """SRD § Playing the Game › Underwater Combat › Impeded Weapons (melee).
+
+    > When making a melee attack roll with a weapon underwater, a
+    > creature that lacks a Swim Speed has Disadvantage on the attack
+    > roll unless the weapon deals Piercing damage.
+    """
+
+    def test_weapon_damage_type_data_exists_for_piercing_carveout(self) -> None:
+        """Data-parity: `items.json` declares `damage_type: piercing`.
+
+        The SRD's "unless the weapon deals Piercing damage" carve-out
+        requires per-weapon damage-type data. The catalog already
+        carries it: at least one weapon entry in `items.json` declares
+        `damage_type: 'piercing'` (e.g., dagger, spear). This guards
+        the data layer that an underwater-melee rule would consume.
+        """
+        items = json.loads(ITEMS_JSON.read_text())
+        weapons = _all_weapon_entries(items)
+        piercing = [w for w in weapons if w["damage_type"] == "piercing"]
+        non_piercing = [
+            w for w in weapons if w["damage_type"] in {"slashing", "bludgeoning"}
+        ]
+        assert piercing, (
+            "Expected at least one weapon with damage_type='piercing' "
+            "in items.json so the SRD's underwater piercing carve-out "
+            "has a real data anchor."
+        )
+        assert non_piercing, (
+            "Expected at least one weapon with damage_type in "
+            "{slashing, bludgeoning} so the SRD's 'disadvantage unless "
+            "piercing' rule has a contrastable counter-example."
+        )
+
+    def test_creature_lacks_a_swim_speed_attribute(self) -> None:
+        """Source-level guard: `Creature` does not separate Swim Speed.
+
+        The SRD melee-underwater rule keys on "a creature that lacks a
+        Swim Speed." `Creature.__init__` exposes a single scalar
+        `speed` (`dnd_engine/core/creature.py`) with no Swim Speed
+        split, so the engine cannot answer "does this creature have a
+        Swim Speed?" — making the carve-out unenforceable. This test
+        pins the absence so that the moment a `swim_speed` field is
+        added, the test will fail and prompt removing the related
+        skips below.
+
+        Closing this gap is issue #432 (Special speeds modeling).
+        """
+        creature = _make_creature()
+        assert not hasattr(creature, "swim_speed"), (
+            "Creature now has a `swim_speed` attribute — the special-"
+            "speeds gap (#432) appears to be closing. Flip the related "
+            "underwater-melee skips into real assertions."
+        )
+
+    def test_melee_underwater_imposes_disadvantage_without_swim_speed(self) -> None:
+        pytest.skip(
+            "GAP: `CombatEngine.resolve_attack` (`dnd_engine/core/"
+            "combat.py:91-115`) does not derive `disadvantage` from "
+            "environment + creature swim-speed + weapon damage type. "
+            "It accepts a `disadvantage: bool = False` flag, but no "
+            "caller computes the underwater-melee condition. The "
+            "weapon data exists (`items.json` carries `damage_type`) "
+            "and the engine surface accepts the flag — only the "
+            "underwater-resolver helper is missing. Tracked by issue "
+            "#514 (depends on #432 swim speed)."
+        )
+
+    def test_piercing_weapon_avoids_underwater_disadvantage(self) -> None:
+        pytest.skip(
+            "GAP: same as above — no underwater-melee resolver to "
+            "implement the piercing carve-out. The weapon catalog "
+            "already carries `damage_type: 'piercing'` for daggers, "
+            "spears, etc. (validated by "
+            "`test_weapon_damage_type_data_exists_for_piercing_"
+            "carveout` above), so the data is ready. Tracked by "
+            "issue #514."
+        )
+
+    def test_creature_with_swim_speed_avoids_underwater_disadvantage(self) -> None:
+        pytest.skip(
+            "GAP: same as above — `Creature` has no Swim Speed "
+            "concept (`dnd_engine/core/creature.py`). Monster catalog "
+            "`speed` is a single int. Aquatic monsters (e.g., sahuagin "
+            "in the SRD bestiary) cannot declare a separate Swim "
+            "Speed today. Tracked by issues #432 (swim speed model) "
+            "and #514 (underwater carve-out)."
+        )
+
+    def test_resolve_attack_accepts_a_disadvantage_flag(self) -> None:
+        """Engine surface honors `disadvantage=True` on resolve_attack().
+
+        The plumbing for the underwater-melee rule's *effect* is in
+        place: `CombatEngine.resolve_attack` reads the `disadvantage`
+        flag and produces a disadvantaged roll. Only the upstream
+        caller that *sets* the flag based on underwater context is
+        missing. This test guards the seam so when the underwater
+        helper lands it can rely on the existing flag.
+        """
+        engine = CombatEngine(DiceRoller(seed=7))
+        attacker = _make_creature("Attacker")
+        defender = _make_creature("Defender")
+
+        result = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=4,
+            damage_dice="1d6+2",
+            disadvantage=True,
+        )
+
+        assert result.disadvantage is True
+        assert 1 <= result.attack_roll <= 20
+
+
+class TestUnderwaterCombat_ImpededRanged:
+    """SRD § Playing the Game › Underwater Combat › Impeded Weapons (ranged).
+
+    > A ranged attack roll with a weapon underwater automatically
+    > misses a target beyond the weapon's normal range, and the attack
+    > roll has Disadvantage against a target within normal range.
+    """
+
+    def test_ranged_underwater_auto_miss_beyond_normal_range(self) -> None:
+        pytest.skip(
+            "GAP: the 'auto-miss beyond normal range underwater' "
+            "override does not exist. Normal vs long range is "
+            "computed at the client layer — `client-2d/src/client_2d/"
+            "session.py:993` and `dnd_engine/scenarios/script_executor."
+            "py:270` both set `in_long_range = distance > normal_"
+            "range` and merely impose disadvantage. Neither short-"
+            "circuits to a miss the way underwater requires. "
+            "`CombatEngine.resolve_attack` has no auto-miss code path "
+            "at all — even the `disadvantage` flag just re-rolls, it "
+            "doesn't force a missed `AttackResult`. Tracked by issue "
+            "#516 (depends on #514 environment seam)."
+        )
+
+    def test_ranged_underwater_imposes_disadvantage_within_normal_range(self) -> None:
+        pytest.skip(
+            "GAP: no underwater context is consulted when deriving "
+            "ranged disadvantage. The existing close-combat helper "
+            "`is_close_combat_ranged_disadvantage` (`dnd_engine/"
+            "systems/ranged_attacks.py:22`) imposes disadvantage for "
+            "adjacent threatening enemies but is silent on underwater. "
+            "There is no `is_underwater_ranged_disadvantage` parallel. "
+            "Tracked by issue #516."
+        )
+
+    def test_normal_range_is_known_per_weapon(self) -> None:
+        """Source-level guard: weapon data exposes a range string.
+
+        The underwater ranged rule keys on "normal range." The
+        existing range-parsing path lives in
+        `dnd_engine/scenarios/script_executor._parse_weapon_range`,
+        which extracts `(normal_range, max_range)` from a weapon's
+        `range` data field. This is the seam an underwater ranged
+        resolver would consume. Pin the helper's existence so the
+        underwater-rule citation stays accurate.
+        """
+        from dnd_engine.scenarios import script_executor
+
+        assert callable(getattr(script_executor, "_parse_weapon_range", None)), (
+            "Weapon-range parsing helper must remain available so the "
+            "underwater ranged rule has a normal-range source to "
+            "consume."
+        )
+        src = inspect.getsource(script_executor._parse_weapon_range)
+        assert "normal" in src.lower() or "range" in src.lower(), (
+            "`_parse_weapon_range` must surface a normal-range value "
+            "for the SRD's 'beyond the weapon's normal range' clause "
+            "to have something to read."
+        )
+
+    def test_engine_has_no_auto_miss_path_in_resolve_attack(self) -> None:
+        """Source-level guard: `resolve_attack` cannot short-circuit a miss.
+
+        The SRD's auto-miss override needs the engine to be able to
+        return a missed `AttackResult` *without rolling*. The current
+        `CombatEngine.resolve_attack` signature accepts `advantage` /
+        `disadvantage` flags but no `auto_miss` parameter. This guard
+        pins the absence so the moment an `auto_miss` path is added,
+        the related skips above can be turned into real assertions.
+        """
+        sig = inspect.signature(CombatEngine.resolve_attack)
+        assert "auto_miss" not in sig.parameters, (
+            "`CombatEngine.resolve_attack` now accepts `auto_miss` — "
+            "the underwater-ranged gap (#516) is closing. Flip the "
+            "skips above to real assertions."
+        )
+
+
+class TestUnderwaterCombat_FireResistance:
+    """SRD § Playing the Game › Underwater Combat › Fire Resistance.
+
+    > Anything underwater has Resistance to Fire damage (explained in
+    > "Damage and Healing").
+    """
+
+    def test_resistance_pipeline_halves_fire_damage_with_resistance_condition(self) -> None:
+        """The Resistance *mechanism* exists — fire is halved if flagged.
+
+        `systems/item_effects._apply_damage_effect` halves fire damage
+        when the target carries the `has_resistance_fire` condition.
+        This is the mechanism an underwater-fire-resistance rule would
+        consume — only the *automatic application* of the condition
+        in an underwater environment is missing.
+        """
+        target = _make_creature(hp=50)
+        target.add_condition("has_resistance_fire")
+
+        result = _apply_damage_effect(
+            item_info={
+                "name": "Alchemist's Fire",
+                "damage": "0d4+10",  # fixed 10 fire damage
+                "damage_type": "fire",
+            },
+            target=target,
+            dice_roller=DiceRoller(seed=1),
+            event_bus=None,
+        )
+        assert result.amount == 5, (
+            "SRD: Resistance halves damage of that type (floor). "
+            "10 fire → 5 with the condition active."
+        )
+
+    def test_underwater_creature_automatically_gains_fire_resistance(self) -> None:
+        pytest.skip(
+            "GAP: there is no automatic 'underwater grants Fire "
+            "Resistance' application. The resistance pipeline keys on "
+            "the `has_resistance_fire` *condition* (consumed at "
+            "`systems/item_effects.py` in `_apply_damage_effect`) but "
+            "no code path adds that condition based on environment. "
+            "`GameState.move_to_room` does not consult any "
+            "environment-grants-resistance table. The SRD's 'anything "
+            "underwater has Resistance to Fire' is unique among "
+            "resistance sources because it is environmental, not "
+            "creature-typed (#462) or condition-applied. Tracked by "
+            "issue #518 (depends on #514 environment seam)."
+        )
+
+    def test_fire_resistance_in_attack_pipeline_underwater(self) -> None:
+        pytest.skip(
+            "GAP: even if the underwater environment applied "
+            "`has_resistance_fire`, attack-pipeline fire damage would "
+            "not honor it. `CombatEngine.resolve_attack` (`dnd_engine/"
+            "core/combat.py:91`) and `CombatEngine.resolve_spell_save` "
+            "(combat.py:547) do not consult any per-type resistance — "
+            "they call `target.take_damage(amount)` with a raw integer. "
+            "The resistance halving lives only in `systems/item_"
+            "effects._apply_damage_effect`. Tracked by issues #461 "
+            "(damage_type pipeline) and #518 (this rule's environment "
+            "seam)."
+        )
+
+
+class TestUnderwaterCombat_EngineSurface_NoEnvironmentalContext:
+    """Cross-cut: combat does not consult environmental context.
+
+    All three Underwater Combat rules share a root: `CombatEngine` and
+    its callers have no notion of where the combat is taking place. A
+    single source-level guard pins that absence so future audits can
+    cite this anchor.
+    """
+
+    def test_resolve_attack_signature_takes_no_environment_or_room(self) -> None:
+        """`CombatEngine.resolve_attack` has no environment parameter.
+
+        SRD rules that key on environment (Underwater Combat, future
+        Mounted Combat, future Aerial Combat) all need an `environment`
+        or `room` parameter that doesn't exist today.
+        """
+        sig = inspect.signature(CombatEngine.resolve_attack)
+        for forbidden in ("environment", "room", "terrain", "underwater"):
+            assert forbidden not in sig.parameters, (
+                f"`resolve_attack` now takes `{forbidden}` — the "
+                "environment seam appears to be opening up. Flip the "
+                "underwater skips into real assertions."
+            )
+
+    def test_apply_damage_effect_signature_takes_no_environment(self) -> None:
+        """`_apply_damage_effect` has no environment parameter either.
+
+        The other damage path — used by alchemist's fire and other
+        item-driven damage — likewise carries no environment hook.
+        This guards the absence so the moment underwater context is
+        threaded through, the fire-resistance skip above can become a
+        real test.
+        """
+        sig = inspect.signature(_apply_damage_effect)
+        for forbidden in ("environment", "room", "underwater"):
+            assert forbidden not in sig.parameters, (
+                f"`_apply_damage_effect` now takes `{forbidden}` — the "
+                "environment seam appears to be opening up. Flip the "
+                "underwater-fire-resistance skip into a real assertion."
+            )


### PR DESCRIPTION
## Summary

Wave-3 SRD conformance audit for two short but architecturally revealing sections:

- `docs/srd/playing-the-game/hazards.md`
- `docs/srd/playing-the-game/underwater-combat.md`

Adds two pytest conformance files under `dnd-engine/tests/srd/playing_the_game/` following the established Wave-3 pattern (real assertion vs `pytest.skip('GAP: ...')` with full citation back to engine code and a tracked GitHub issue).

## Test counts

| File | Passed | Skipped |
|---|---|---|
| `test_hazards.py` | 3 | 14 |
| `test_underwater_combat.py` | 8 | 8 |
| **Total** | **11** | **22** |

Zero failures, zero errors.

## Rules enforced via real assertions

- The `on_fire` condition is catalogued in `conditions.json` with the SRD-correct damage type, dice (1d4), and Dex-check escape — the engine's encoding of the Burning hazard.
- `ConditionManager.process_turn_start_effects` actually applies fire damage at turn start (production end-to-end path).
- Weapon `damage_type` data exists in `items.json` for piercing weapons (the data anchor for the SRD's underwater-melee piercing carve-out).
- `Creature` does not yet carry a `swim_speed` attribute (pin, will flip when #432 lands).
- `CombatEngine.resolve_attack` honors the `disadvantage=True` flag end-to-end (the plumbing an underwater rule would consume).
- `_parse_weapon_range` in `script_executor` still exposes the normal-range source the SRD's ranged underwater rule needs.
- `_apply_damage_effect` halves fire damage when `has_resistance_fire` is set (the mechanism an underwater fire-resistance rule would consume).
- `CombatEngine.resolve_attack` has no `auto_miss`, `environment`, `room`, `terrain`, or `underwater` parameter today (pin, will flip when the environment seam opens).
- `_apply_damage_effect` likewise has no environment parameter (pin).

## Rules gapped

Each gap cites the engine code that would enforce it and references a freshly-filed issue.

| Rule | Issue |
|---|---|
| Burning hazard as environmental zone (vs. personal `on_fire` condition) | #508 |
| Falling hazard: damage calculation, Prone condition, bludgeoning type | #509 |
| Suffocation hazard: breath tracker, CON-save-or-0HP, `WATER_BREATHING` consumer | #510 |
| Dehydration + Malnutrition: long-duration day-tick tracker, Exhaustion condition | #512 |
| Underwater melee: swim-speed-aware disadvantage with piercing carve-out | #514 |
| Underwater ranged: auto-miss beyond normal range, disadvantage within | #516 |
| Underwater Fire Resistance: automatic environmental application | #518 |

## Root architectural finding

All five Hazards and all three Underwater Combat rules ultimately depend on a single missing seam: the engine has no per-room `environment` or `hazards` field, and `GameState.move_to_room` consults no environmental list when a creature enters a room. The cross-cut test classes `TestHazards_EngineSurface_NoEnvironmentalHazardSystem` and `TestUnderwaterCombat_EngineSurface_NoEnvironmentalContext` pin that absence so future audits can cite this anchor.

Secondary finding: `Creature.take_damage(amount: int)` is currently untyped, so every damage-type-keyed rule (resistance, vulnerability, immunity, AND falling-bludgeoning, AND underwater fire-resistance) lives downstream of #461's `damage_type` pipeline wiring.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_hazards.py tests/srd/playing_the_game/test_underwater_combat.py -v` (11 passed, 22 skipped)
- [x] Pre-commit hook (ruff) passes
- [ ] Manual review of skip citations for accuracy against current engine code

🤖 Generated with [Claude Code](https://claude.com/claude-code)