### PR TITLE
Wire damage_type through CombatEngine pipelines (#461) — plan-02

### DIFF
--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -88,6 +88,76 @@ class CombatEngine:
         """
         self.dice_roller = dice_roller if dice_roller is not None else DiceRoller()
 
+    def _apply_damage_modifiers(
+        self, target: Creature, raw_damage: int, damage_type: str | None
+    ) -> int:
+        """
+        Scale raw damage by the target's per-type Resistance / Immunity.
+
+        Single chokepoint that the SRD's Resistance, Immunity (and
+        later Vulnerability) rules key off of. This slice (#461)
+        implements Resistance + Immunity only; Vulnerability,
+        no-stacking, and order-of-application are tracked separately
+        (#463 / #468) and will plug in here.
+
+        Consults two sources of per-type modifiers:
+          1. Creature condition flags — `has_resistance_{type}` and
+             `has_immunity_{type}` — matching the existing convention
+             used by `systems/item_effects._apply_damage_effect`.
+          2. Monster catalog fields — `damage_resistances` and
+             `damage_immunities` list attributes on the Creature
+             instance (populated by `DataLoader.create_monster` from
+             `monsters.json`).
+
+        SRD § Playing the Game › Resistance and Vulnerability:
+            "If you have Resistance to a damage type, damage of that
+             type is halved against you (round down)."
+        SRD § Playing the Game › Immunity:
+            "Immunity to a damage type means you don't take damage of
+             that type."
+
+        Args:
+            target: The creature taking the damage.
+            raw_damage: Damage rolled before per-type scaling.
+            damage_type: SRD damage type (e.g. "fire", "cold",
+                "slashing"). If None, no per-type scaling can apply
+                and `raw_damage` is returned unchanged.
+
+        Returns:
+            The damage amount after Resistance / Immunity scaling.
+        """
+        # Untyped damage cannot consult per-type modifiers; return as-is.
+        if damage_type is None:
+            return raw_damage
+
+        # Normalize: SRD damage-type tokens are lowercase in the catalog.
+        normalized_type = damage_type.lower()
+
+        # --- Immunity stage --------------------------------------------------
+        # Immunity zeroes damage of the matching type; both the
+        # condition-flag form and the catalog-field form are honored.
+        immunity_condition = f"has_immunity_{normalized_type}"
+        catalog_immunities = [
+            t.lower() for t in (getattr(target, "damage_immunities", None) or [])
+        ]
+        if target.has_condition(immunity_condition) or normalized_type in catalog_immunities:
+            return 0
+
+        # --- Resistance stage ------------------------------------------------
+        # Resistance halves matching damage with floor rounding.
+        resistance_condition = f"has_resistance_{normalized_type}"
+        catalog_resistances = [
+            t.lower() for t in (getattr(target, "damage_resistances", None) or [])
+        ]
+        if target.has_condition(resistance_condition) or normalized_type in catalog_resistances:
+            return raw_damage // 2
+
+        # TODO(#463): Vulnerability stage inserts here (double matching
+        # damage). TODO(#468): Order-of-application — flat adjustments
+        # apply BEFORE this Resistance stage; Vulnerability applies
+        # AFTER it. Both are out of scope for #461.
+        return raw_damage
+
     def resolve_attack(
         self,
         attacker: Creature,
@@ -100,6 +170,7 @@ class CombatEngine:
         event_bus=None,
         action: dict | None = None,
         game_state=None,
+        damage_type: str | None = None,
     ) -> AttackResult:
         """
         Resolve a complete attack.
@@ -112,7 +183,9 @@ class CombatEngine:
         5. If hit: roll damage dice
         6. If critical hit: double the damage dice (not the modifier)
         7. Apply sneak attack damage if applicable (Rogue with advantage/ally nearby)
-        8. Apply damage if requested
+        8. Scale damage by target's per-type Resistance / Immunity via
+           `_apply_damage_modifiers` (only when `damage_type` is given)
+        9. Apply damage if requested
 
         Args:
             attacker: The attacking creature
@@ -123,6 +196,18 @@ class CombatEngine:
             disadvantage: Roll with disadvantage (take lower of 2d20)
             apply_damage: If True, apply damage to defender's HP
             event_bus: Optional EventBus instance for event emission
+            damage_type: SRD damage type (e.g. "fire", "slashing"). When
+                provided, damage is routed through
+                `_apply_damage_modifiers` so the defender's per-type
+                Resistance / Immunity (from condition flags or the
+                monster-catalog `damage_resistances` / `damage_immunities`
+                fields) scales the final amount. Optional for backward
+                compatibility — callers that haven't been migrated to
+                tagged damage see the legacy untyped behavior. The
+                damage_type itself does not branch any other logic in
+                this method (SRD: "Damage types ... have no rules of
+                their own"); it is purely a key for the modifier
+                chokepoint.
 
         Returns:
             AttackResult containing full attack details including sneak attack if applicable
@@ -185,6 +270,25 @@ class CombatEngine:
                             )
                             event_bus.emit(event)
 
+            # Scale damage by target's per-type Resistance / Immunity.
+            # Sneak-attack damage shares the weapon's damage type per
+            # SRD ("Sneak Attack damage isn't a separate damage type"),
+            # so both summands route through the same chokepoint as a
+            # single total. When `damage_type` is None this is a no-op
+            # and the legacy untyped behavior is preserved.
+            total_pre_modifier = damage + sneak_attack_damage
+            total_post_modifier = self._apply_damage_modifiers(
+                defender, total_pre_modifier, damage_type
+            )
+            # Reflect the post-modifier values back onto the AttackResult.
+            # When the target is immune both summands collapse to zero;
+            # otherwise we scale them proportionally so the breakdown
+            # (damage vs sneak_attack_damage) remains meaningful.
+            if total_pre_modifier != total_post_modifier and total_pre_modifier > 0:
+                damage_share = round(damage * total_post_modifier / total_pre_modifier)
+                sneak_attack_damage = total_post_modifier - damage_share
+                damage = damage_share
+
             if apply_damage:
                 # Pass event_bus to take_damage for Character instances (death save handling)
                 if hasattr(defender, "take_damage") and hasattr(defender.__class__, "take_damage"):
@@ -193,11 +297,11 @@ class CombatEngine:
 
                     sig = inspect.signature(defender.take_damage)
                     if "event_bus" in sig.parameters:
-                        defender.take_damage(damage + sneak_attack_damage, event_bus=event_bus)
+                        defender.take_damage(total_post_modifier, event_bus=event_bus)
                     else:
-                        defender.take_damage(damage + sneak_attack_damage)
+                        defender.take_damage(total_post_modifier)
                 else:
-                    defender.take_damage(damage + sneak_attack_damage)
+                    defender.take_damage(total_post_modifier)
 
             # Process saving throw effects (e.g., ghoul paralysis)
             if action and "saving_throw" in action:
@@ -509,7 +613,10 @@ class CombatEngine:
         else:
             damage_dice = base_damage_dice
 
-        # Use the existing resolve_attack method for the mechanics
+        # Use the existing resolve_attack method for the mechanics.
+        # Pass through `damage_type` so the target's per-type
+        # Resistance / Immunity scales spell-attack damage (e.g.,
+        # Fire Bolt vs a bearded devil's fire immunity).
         result = self.resolve_attack(
             attacker=caster,
             defender=target,
@@ -519,6 +626,7 @@ class CombatEngine:
             disadvantage=disadvantage,
             apply_damage=apply_damage,
             event_bus=event_bus,
+            damage_type=damage_type,
         )
 
         # Emit spell-specific attack event
@@ -640,6 +748,18 @@ class CombatEngine:
         # Roll damage once for the spell
         base_damage = self._roll_spell_save_damage(spell, damage_info, spell_level, actual_level)
 
+        # Resolve the spell's damage type once. The same tag is routed
+        # to every target's per-type modifier chokepoint and surfaced
+        # on each row of `target_results` for downstream consumers.
+        if damage_info:
+            spell_damage_type = (
+                damage_info.get("damage_type")
+                if isinstance(damage_info, dict)
+                else damage_info.damage_type
+            )
+        else:
+            spell_damage_type = None
+
         # Process each target
         target_results = []
         for target in targets:
@@ -663,6 +783,15 @@ class CombatEngine:
             else:
                 damage = base_damage
 
+            # Route the post-save damage through the per-type modifier
+            # chokepoint so the target's Resistance / Immunity to the
+            # spell's `damage_type` scales the final amount. SRD: the
+            # save reduction (half-on-success) is a damage adjustment
+            # that applies BEFORE Resistance per the Order-of-
+            # Application rule; #468 will codify the ordering across
+            # the full pipeline.
+            damage = self._apply_damage_modifiers(target, damage, spell_damage_type)
+
             # Apply damage if requested
             if apply_damage and damage > 0:
                 # Check if target's take_damage accepts event_bus (Character) or not (Creature)
@@ -674,16 +803,6 @@ class CombatEngine:
                 else:
                     target.take_damage(damage)
 
-            # Get damage type
-            if damage_info:
-                damage_type = (
-                    damage_info.get("damage_type")
-                    if isinstance(damage_info, dict)
-                    else damage_info.damage_type
-                )
-            else:
-                damage_type = None
-
             target_results.append(
                 {
                     "name": target.name,
@@ -692,7 +811,7 @@ class CombatEngine:
                     "total": save_result["total"],
                     "success": save_result["success"],
                     "damage": damage,
-                    "damage_type": damage_type,
+                    "damage_type": spell_damage_type,
                 }
             )
 

--- a/dnd-engine/dnd_engine/rules/loader.py
+++ b/dnd-engine/dnd_engine/rules/loader.py
@@ -96,6 +96,19 @@ class DataLoader:
             speed=speed,
         )
 
+        # Attach per-type damage modifier fields from the monster catalog.
+        # These attributes are consulted by
+        # `CombatEngine._apply_damage_modifiers` so Resistance / Immunity
+        # rules can key on a monster's catalog data without needing
+        # manually-applied conditions. SRD: each instance of damage has
+        # a type, and Resistance / Immunity scale damage of matching
+        # types (see playing-the-game/resistance-and-vulnerability.md
+        # and playing-the-game/immunity.md). Defaults to empty lists so
+        # downstream code can iterate without None checks.
+        creature.damage_resistances = list(data.get("damage_resistances") or [])
+        creature.damage_immunities = list(data.get("damage_immunities") or [])
+        creature.damage_vulnerabilities = list(data.get("damage_vulnerabilities") or [])
+
         return creature
 
     def load_items(self, campaign_id: str | None = None) -> dict[str, Any]:

--- a/dnd-engine/tests/srd/playing_the_game/test_damage_types.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_damage_types.py
@@ -227,28 +227,40 @@ class TestDamageTypes_NoIntrinsicRules:
     """
 
     def test_combat_engine_does_not_branch_on_damage_type(self):
-        """`CombatEngine.resolve_attack` does not consult damage_type.
+        """`CombatEngine.resolve_attack` does not branch on damage_type.
 
-        Source-level guard: damage type is not a parameter or branch
-        condition in the core attack path. This is the SRD's "no rules
-        of their own" clause — the damage-type tag is metadata for
-        downstream systems (Resistance, Vulnerability, Immunity) and
-        must not gate hit / damage calculation at the combat engine
-        layer.
+        The SRD's "no rules of their own" clause means the damage-type
+        tag is metadata for downstream systems (Resistance,
+        Vulnerability, Immunity) and must not gate hit / damage
+        calculation at the combat engine layer.
+
+        `resolve_attack` now accepts a `damage_type` keyword (#461) so
+        the per-type modifier chokepoint can scale damage, but the
+        method itself must not conditionally branch on the *value* of
+        damage_type (e.g., no `if damage_type == "fire": ...` inside
+        the attack path). All type-keyed behaviour belongs in
+        `_apply_damage_modifiers`.
         """
         import inspect
+        import re
 
         from dnd_engine.core.combat import CombatEngine
 
         src = inspect.getsource(CombatEngine.resolve_attack)
-        # The current signature does not accept damage_type, and no
-        # branch in resolve_attack reads a damage_type field — which
-        # satisfies the SRD's "no rules of their own" clause for the
-        # core attack path.
-        assert "damage_type" not in src, (
-            "CombatEngine.resolve_attack must not branch on damage_type; "
-            "type-specific behavior belongs in Resistance / Vulnerability "
-            "/ Immunity layers, not the attack path."
+        # The chokepoint is allowed to consume `damage_type`, but
+        # resolve_attack itself must not test the value with an
+        # equality / membership comparison against a literal type
+        # name. This regex catches `damage_type == "fire"`,
+        # `damage_type in ("fire",)`, etc.
+        offenders = re.findall(
+            r"damage_type\s*(?:==|in|!=)\s*[\"'(\[]", src
+        )
+        assert not offenders, (
+            "CombatEngine.resolve_attack must not branch on the value "
+            "of damage_type; type-specific behavior belongs in "
+            "Resistance / Vulnerability / Immunity layers, not the "
+            "attack path. Found: "
+            f"{offenders}"
         )
 
     def test_resistance_system_keys_on_damage_type(self):

--- a/dnd-engine/tests/srd/playing_the_game/test_immunity.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_immunity.py
@@ -61,14 +61,44 @@ class TestImmunity_ToDamageType:
         )
 
     def test_monster_damage_immunities_field_is_consumed(self):
-        pytest.skip(
-            "GAP: monsters.json `damage_immunities` is data-only "
-            "(e.g., bearded_devil: fire, poison). No engine code "
-            "reads the field — `CombatEngine.resolve_attack` "
-            "(dnd-engine/dnd_engine/core/combat.py:91) doesn't take "
-            "a `damage_type` parameter, and `resolve_spell_save` "
-            "(combat.py:547) applies raw damage. Tracked by issues "
-            "#461 and #464."
+        """A monster's catalog `damage_immunities` zeroes damage of
+        that type via the engine chokepoint.
+
+        Per #461, `CombatEngine._apply_damage_modifiers` reads the
+        Creature's `damage_immunities` list attribute (populated by
+        `DataLoader.create_monster` from monsters.json). A bearded
+        devil with `["fire", "poison"]` therefore takes 0 damage from
+        a fire-typed attack without needing a manual condition.
+        """
+        from dnd_engine.core.combat import CombatEngine
+        from dnd_engine.core.creature import Abilities, Creature
+        from dnd_engine.core.dice import DiceRoller
+
+        # Mirror what `DataLoader.create_monster` would attach for the
+        # bearded devil (`monsters.json` ships `[fire, poison]`).
+        abilities = Abilities(
+            strength=16,
+            dexterity=10,
+            constitution=15,
+            intelligence=9,
+            wisdom=11,
+            charisma=11,
+        )
+        bearded_devil = Creature(
+            name="Bearded Devil", max_hp=52, ac=13, abilities=abilities
+        )
+        bearded_devil.damage_immunities = ["fire", "poison"]
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        scaled = engine._apply_damage_modifiers(
+            bearded_devil, raw_damage=22, damage_type="fire"
+        )
+
+        assert scaled == 0, (
+            "Catalog `damage_immunities` must zero damage of the "
+            "matching type via the engine chokepoint (SRD: 'Immunity "
+            "to a damage type means you don't take damage of that "
+            "type.')."
         )
 
 

--- a/dnd-engine/tests/srd/playing_the_game/test_resistance_and_vulnerability.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_resistance_and_vulnerability.py
@@ -118,19 +118,29 @@ class TestResistance_HalvesDamage:
         )
 
     def test_monster_damage_resistances_field_is_consumed_by_damage_pipeline(self):
-        pytest.skip(
-            "GAP: monsters.json `damage_resistances` is data-only. "
-            "No engine code reads the field — `CombatEngine."
-            "resolve_attack` (dnd-engine/dnd_engine/core/combat.py:91) "
-            "doesn't take a `damage_type` parameter, and "
-            "`CombatEngine.resolve_spell_save` (combat.py:547) applies "
-            "raw damage without consulting any per-type modifier. The "
-            "only production resistance path is "
-            "`systems/item_effects._apply_damage_effect`, which keys "
-            "on creature *conditions* (e.g. has_resistance_fire), not "
-            "on the monster's catalog field. Tracked by issues "
-            "#461 (damage_type pipeline wiring) and #462 (per-type "
-            "Resistance from catalog)."
+        """The chokepoint reads a Creature's `damage_resistances` list.
+
+        Per #461, `CombatEngine._apply_damage_modifiers` consults the
+        same per-type catalog attribute that `DataLoader.create_monster`
+        populates from `monsters.json`. A creature with `cold` in its
+        `damage_resistances` therefore takes floor(damage/2) cold
+        damage without needing a manual `has_resistance_cold`
+        condition.
+        """
+        from dnd_engine.core.combat import CombatEngine
+
+        target = _make_target()
+        # Mirrors what `DataLoader.create_monster` attaches from the
+        # monsters.json catalog (e.g., bearded devil ships `cold`).
+        target.damage_resistances = ["cold"]
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        scaled = engine._apply_damage_modifiers(target, raw_damage=10, damage_type="cold")
+
+        assert scaled == 5, (
+            "Catalog `damage_resistances` must halve damage of the "
+            "matching type via the engine chokepoint (SRD: 'damage of "
+            "that type is halved against you')."
         )
 
 
@@ -300,22 +310,109 @@ class TestPipelineSurface_DamagePathReadsTypeAndModifiers:
         )
 
     def test_attack_damage_pipeline_consults_resistance(self):
-        pytest.skip(
-            "GAP: `CombatEngine.resolve_attack` (dnd-engine/dnd_engine/"
-            "core/combat.py:91) does not accept a `damage_type` "
-            "parameter and does not consult any resistance / "
-            "vulnerability / immunity table. Weapon and spell-attack "
-            "damage bypasses the per-type modifier system entirely. "
-            "Tracked by issue #461."
+        """`resolve_attack` accepts `damage_type` and routes it through
+        the per-type modifier chokepoint.
+
+        Source-level guard plus a behavioural check: the method's
+        signature includes the new parameter, and a fire-resistant
+        defender takes floor(damage/2) from a fire-typed attack.
+        """
+        from dnd_engine.core.combat import CombatEngine
+        from dnd_engine.core.creature import Abilities
+
+        # Source-level guard — the parameter exists and the chokepoint
+        # is invoked.
+        src = inspect.getsource(CombatEngine.resolve_attack)
+        assert "damage_type" in inspect.signature(CombatEngine.resolve_attack).parameters, (
+            "resolve_attack must accept a `damage_type` parameter so "
+            "Resistance / Immunity can key off weapon damage type."
+        )
+        assert "_apply_damage_modifiers" in src, (
+            "resolve_attack must route damage through "
+            "`_apply_damage_modifiers` so per-type scaling applies."
         )
 
-    def test_spell_save_damage_pipeline_consults_resistance(self):
-        pytest.skip(
-            "GAP: `CombatEngine.resolve_spell_save` (combat.py:547) "
-            "applies `target.take_damage(damage)` without consulting "
-            "the target's resistance / vulnerability / immunity to "
-            "the spell's `damage_type`. The spell knows its type (it "
-            "flows through to `CombatSpellResult.damage_type` at "
-            "game_state.py:2405 and 2476) but the value is never used "
-            "to scale the damage. Tracked by issue #461."
+        # Behavioural check — fire resistance halves a fire attack.
+        attacker = Creature(
+            name="Attacker",
+            max_hp=20,
+            ac=10,
+            abilities=Abilities(
+                strength=10, dexterity=10, constitution=10, intelligence=10, wisdom=10, charisma=10
+            ),
         )
+        defender = _make_target()
+        defender.add_condition("has_resistance_fire")
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        result = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=20,  # always hits
+            damage_dice="0d4+10",
+            damage_type="fire",
+            apply_damage=True,
+        )
+        assert result.hit is True
+        assert result.damage == 5, (
+            "resolve_attack must consult per-type Resistance via the "
+            "chokepoint (SRD: 'damage of that type is halved against "
+            "you')."
+        )
+        assert defender.current_hp == 100 - 5
+
+    def test_spell_save_damage_pipeline_consults_resistance(self):
+        """`resolve_spell_save` routes `damage_info["damage_type"]`
+        through the chokepoint before applying damage.
+
+        Source-level guard plus a behavioural check on a fire-immune
+        target taking 0 damage from a save-based spell even on a
+        failed save.
+        """
+        from dnd_engine.core.combat import CombatEngine
+        from dnd_engine.core.creature import Abilities
+
+        # Source-level guard — the chokepoint is invoked inside the
+        # spell-save flow.
+        src = inspect.getsource(CombatEngine.resolve_spell_save)
+        assert "_apply_damage_modifiers" in src, (
+            "resolve_spell_save must route post-save damage through "
+            "`_apply_damage_modifiers` so Resistance / Immunity to "
+            "the spell's damage_type scales the final amount."
+        )
+
+        # Behavioural check — fire-immune target on an impossible DC.
+        caster = Creature(
+            name="Caster",
+            max_hp=20,
+            ac=10,
+            abilities=Abilities(
+                strength=10, dexterity=10, constitution=10, intelligence=16, wisdom=10, charisma=10
+            ),
+        )
+        caster.get_spell_save_dc = lambda: 99  # type: ignore[attr-defined]
+
+        target = _make_target()
+        target.damage_immunities = ["fire"]
+
+        spell = {
+            "name": "Fireball",
+            "level": 3,
+            "id": "fireball",
+            "damage": {"dice": "0d6+30", "damage_type": "fire"},
+            "saving_throw": {"ability": "dex", "on_success": "half"},
+        }
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        result = engine.resolve_spell_save(
+            caster=caster, targets=[target], spell=spell, apply_damage=True
+        )
+
+        target_row = next(r for r in result["targets"] if r["name"] == target.name)
+        assert target_row["success"] is False
+        assert target_row["damage"] == 0, (
+            "resolve_spell_save must zero damage when the target is "
+            "immune to the spell's damage type (SRD: 'Immunity to a "
+            "damage type means you don't take damage of that type.')."
+        )
+        assert target.current_hp == 100

--- a/dnd-engine/tests/test_combat.py
+++ b/dnd-engine/tests/test_combat.py
@@ -430,3 +430,235 @@ class TestSavingThrowEffects:
         else:
             assert not self.fighter.has_condition("paralyzed")
             assert result["condition_applied"] is None
+
+
+class TestApplyDamageModifiers:
+    """Tests for the per-type damage modifier chokepoint.
+
+    `CombatEngine._apply_damage_modifiers` is the single seam that
+    scales raw damage by the target's per-type Resistance / Immunity.
+    It must consult BOTH creature-condition flags (the legacy item-
+    effects path) AND the monster catalog fields (`damage_resistances`,
+    `damage_immunities`) attached to the Creature instance.
+
+    This slice (#461) wires Resistance + Immunity only. Vulnerability,
+    No-Stacking, Order-of-Application, and clamp-at-zero are tracked
+    by follow-up slices (#463, #468, #490).
+    """
+
+    def setup_method(self):
+        self.engine = CombatEngine(DiceRoller(seed=1))
+        abilities = Abilities(
+            strength=10, dexterity=10, constitution=10, intelligence=10, wisdom=10, charisma=10
+        )
+        self.target = Creature(name="Target", max_hp=100, ac=10, abilities=abilities)
+
+    def test_no_modifiers_returns_raw_damage(self):
+        """A target with no per-type modifiers takes the raw amount."""
+        result = self.engine._apply_damage_modifiers(self.target, raw_damage=10, damage_type="fire")
+        assert result == 10
+
+    def test_no_damage_type_returns_raw_damage(self):
+        """When damage_type is None, modifiers cannot apply."""
+        self.target.add_condition("has_resistance_fire")
+        result = self.engine._apply_damage_modifiers(self.target, raw_damage=10, damage_type=None)
+        assert result == 10
+
+    def test_condition_flag_resistance_halves_damage(self):
+        """`has_resistance_{type}` condition halves matching damage."""
+        self.target.add_condition("has_resistance_fire")
+        result = self.engine._apply_damage_modifiers(self.target, raw_damage=10, damage_type="fire")
+        assert result == 5
+
+    def test_condition_flag_resistance_floors_odd_damage(self):
+        """Resistance halves with floor rounding (SRD: 'round down')."""
+        self.target.add_condition("has_resistance_fire")
+        result = self.engine._apply_damage_modifiers(self.target, raw_damage=5, damage_type="fire")
+        assert result == 2
+
+    def test_condition_flag_resistance_is_per_type(self):
+        """Fire resistance does not reduce poison damage."""
+        self.target.add_condition("has_resistance_fire")
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=10, damage_type="poison"
+        )
+        assert result == 10
+
+    def test_monster_catalog_resistance_halves_damage(self):
+        """`damage_resistances` list attribute halves matching damage."""
+        self.target.damage_resistances = ["cold"]
+        result = self.engine._apply_damage_modifiers(self.target, raw_damage=10, damage_type="cold")
+        assert result == 5
+
+    def test_monster_catalog_immunity_zeroes_damage(self):
+        """`damage_immunities` list attribute zeroes matching damage."""
+        self.target.damage_immunities = ["fire", "poison"]
+        result = self.engine._apply_damage_modifiers(self.target, raw_damage=20, damage_type="fire")
+        assert result == 0
+
+    def test_monster_catalog_immunity_is_per_type(self):
+        """A fire-immune creature still takes other damage types."""
+        self.target.damage_immunities = ["fire"]
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=20, damage_type="slashing"
+        )
+        assert result == 20
+
+    def test_immunity_takes_precedence_over_resistance(self):
+        """If both immunity and resistance match the type, damage is 0."""
+        self.target.damage_immunities = ["fire"]
+        self.target.add_condition("has_resistance_fire")
+        result = self.engine._apply_damage_modifiers(self.target, raw_damage=10, damage_type="fire")
+        assert result == 0
+
+    def test_damage_type_is_normalized_case_insensitively(self):
+        """Mixed-case damage types match the modifier list (SRD types
+        are lowercased in the catalog)."""
+        self.target.damage_immunities = ["fire"]
+        result = self.engine._apply_damage_modifiers(self.target, raw_damage=10, damage_type="Fire")
+        assert result == 0
+
+
+class TestResolveAttackDamageType:
+    """Tests for `damage_type` plumbing through `resolve_attack`."""
+
+    def setup_method(self):
+        self.engine = CombatEngine(DiceRoller(seed=42))
+        attacker_abilities = Abilities(
+            strength=16, dexterity=14, constitution=15, intelligence=10, wisdom=12, charisma=8
+        )
+        self.attacker = Creature(
+            name="Attacker", max_hp=20, ac=16, abilities=attacker_abilities
+        )
+        defender_abilities = Abilities(
+            strength=10, dexterity=10, constitution=10, intelligence=10, wisdom=10, charisma=10
+        )
+        self.defender = Creature(name="Defender", max_hp=100, ac=10, abilities=defender_abilities)
+
+    def test_resolve_attack_accepts_damage_type_parameter(self):
+        """`resolve_attack` accepts an optional `damage_type` kwarg
+        without behavior change when target has no modifiers."""
+        result = self.engine.resolve_attack(
+            attacker=self.attacker,
+            defender=self.defender,
+            attack_bonus=20,  # always hits
+            damage_dice="0d4+10",
+            damage_type="fire",
+        )
+        assert result.hit is True
+        assert result.damage == 10  # No modifiers, full damage
+
+    def test_resolve_attack_immunity_zeroes_damage(self):
+        """A fire-immune monster takes 0 damage from a fire-typed attack."""
+        self.defender.damage_immunities = ["fire"]
+        result = self.engine.resolve_attack(
+            attacker=self.attacker,
+            defender=self.defender,
+            attack_bonus=20,
+            damage_dice="0d4+10",
+            damage_type="fire",
+            apply_damage=True,
+        )
+        assert result.hit is True
+        assert result.damage == 0
+        assert self.defender.current_hp == 100  # No HP lost
+
+    def test_resolve_attack_resistance_halves_damage(self):
+        """A cold-resistant target takes half damage from cold attacks."""
+        self.defender.damage_resistances = ["cold"]
+        result = self.engine.resolve_attack(
+            attacker=self.attacker,
+            defender=self.defender,
+            attack_bonus=20,
+            damage_dice="0d4+10",
+            damage_type="cold",
+            apply_damage=True,
+        )
+        assert result.hit is True
+        assert result.damage == 5
+        assert self.defender.current_hp == 95
+
+    def test_resolve_attack_without_damage_type_is_backward_compatible(self):
+        """Existing callers that don't pass `damage_type` see no change."""
+        # Even if the defender has fire immunity, it shouldn't apply when
+        # the attack has no damage_type tag.
+        self.defender.damage_immunities = ["fire"]
+        result = self.engine.resolve_attack(
+            attacker=self.attacker,
+            defender=self.defender,
+            attack_bonus=20,
+            damage_dice="0d4+10",
+            apply_damage=True,
+        )
+        assert result.hit is True
+        assert result.damage == 10
+        assert self.defender.current_hp == 90
+
+
+class TestResolveSpellSaveDamageType:
+    """Tests for damage_type wiring in `resolve_spell_save`."""
+
+    def setup_method(self):
+        self.engine = CombatEngine(DiceRoller(seed=42))
+
+    def _make_caster(self, dc: int = 15) -> Creature:
+        """Build a minimal caster that exposes `get_spell_save_dc`."""
+        abilities = Abilities(
+            strength=10, dexterity=10, constitution=10, intelligence=16, wisdom=10, charisma=10
+        )
+        caster = Creature(name="Caster", max_hp=20, ac=12, abilities=abilities)
+        caster.get_spell_save_dc = lambda: dc  # type: ignore[attr-defined]
+        return caster
+
+    def _make_target(self, name: str = "Target") -> Creature:
+        abilities = Abilities(
+            strength=10, dexterity=10, constitution=10, intelligence=10, wisdom=10, charisma=10
+        )
+        return Creature(name=name, max_hp=100, ac=10, abilities=abilities)
+
+    def test_spell_save_immunity_zeroes_damage(self):
+        """A fire-immune target takes 0 damage from a Fireball-style
+        save spell, even on a failed save."""
+        caster = self._make_caster(dc=99)  # impossible DC → always fails
+        target = self._make_target()
+        target.damage_immunities = ["fire"]
+
+        spell = {
+            "name": "Fireball",
+            "level": 3,
+            "id": "fireball",
+            "damage": {"dice": "0d6+30", "damage_type": "fire"},
+            "saving_throw": {"ability": "dex", "on_success": "half"},
+        }
+
+        result = self.engine.resolve_spell_save(
+            caster=caster, targets=[target], spell=spell, apply_damage=True
+        )
+        # Find the result row for our target
+        target_row = next(r for r in result["targets"] if r["name"] == target.name)
+        assert target_row["success"] is False  # failed the impossible save
+        assert target_row["damage"] == 0
+        assert target.current_hp == 100
+
+    def test_spell_save_resistance_halves_damage(self):
+        """A cold-resistant target takes half damage from a cold spell
+        on a failed save."""
+        caster = self._make_caster(dc=99)  # always fail
+        target = self._make_target()
+        target.damage_resistances = ["cold"]
+
+        spell = {
+            "name": "Ray of Frost (save variant)",
+            "level": 1,
+            "id": "rof_save",
+            "damage": {"dice": "0d6+10", "damage_type": "cold"},
+            "saving_throw": {"ability": "con", "on_success": "half"},
+        }
+
+        result = self.engine.resolve_spell_save(
+            caster=caster, targets=[target], spell=spell, apply_damage=True
+        )
+        target_row = next(r for r in result["targets"] if r["name"] == target.name)
+        assert target_row["success"] is False
+        assert target_row["damage"] == 5
+        assert target.current_hp == 95


### PR DESCRIPTION
## Summary

Slice for plan-02 (#531) implementing **#461 — Wire damage_type through CombatEngine attack and spell-save pipelines**. Closes the foundational gap where Resistance / Immunity could not key on weapon or spell-save damage because `damage_type` was not a parameter on the engine's two main damage paths.

> Note: child issue #461 is already CLOSED (consolidated into plan-master #531). This PR is `part of #531` and does the implementation work that #461 specified.

## Changes

- **New chokepoint** — `CombatEngine._apply_damage_modifiers(target, raw_damage, damage_type)` is the single seam that scales raw damage by per-type Resistance / Immunity. Consults **both**:
  - Creature condition flags (`has_resistance_{type}`, `has_immunity_{type}`) — matches the legacy `systems/item_effects._apply_damage_effect` convention.
  - Monster catalog list attributes (`damage_resistances`, `damage_immunities`) on the Creature instance.
- **`resolve_attack`** accepts an optional `damage_type: str | None` keyword and routes total damage (including sneak attack, which shares the weapon's type per SRD) through the chokepoint. Default `None` preserves legacy untyped behavior for un-migrated callers.
- **`resolve_spell_save`** extracts `damage_info["damage_type"]` once per cast and routes each target's post-save damage through the chokepoint, so e.g. a bearded devil takes 0 fire damage from Fireball on a failed save.
- **`resolve_spell_attack`** forwards `damage_type` into `resolve_attack` so spell-attack rolls participate too.
- **`DataLoader.create_monster`** now attaches `damage_resistances`, `damage_immunities`, `damage_vulnerabilities` lists from `monsters.json` onto the Creature instance.

## Acceptance criteria satisfied

| # | Criterion | Status |
|---|---|---|
| 1 | `resolve_attack` accepts optional `damage_type` and uses it via single chokepoint | done |
| 2 | `resolve_spell_save` routes `damage_info["damage_type"]` into chokepoint | done |
| 3 | Chokepoint consumes condition flags AND catalog fields (bearded devil ↔ fire bolt → 0) | done |
| 4 | Existing tests still pass | 2663 passed / 276 skipped / 0 failed |
| 5a | `test_monster_damage_resistances_field_is_consumed_by_damage_pipeline` | flipped skip → live, passing |
| 5b | `test_attack_damage_pipeline_consults_resistance` | flipped skip → live, passing |
| 5c | `test_spell_save_damage_pipeline_consults_resistance` | flipped skip → live, passing |
| 5d | `test_monster_damage_immunities_field_is_consumed` | flipped skip → live, passing |

## Scope guardrails honored

This PR wires Resistance + Immunity only. Out of scope (separate slices):

- **#463** — Vulnerability stage (TODO marker placed at the chokepoint).
- **#468** — Order-of-application (flat adjustments → Resistance → Vulnerability) and no-stacking. TODO marker placed where these layers will plug in.
- **#490** — Clamp at zero.
- **#492** — Fixed-damage weapons.
- **#518** — Underwater auto-Fire-Resistance.
- **#466** — Condition-immunities via saving throws.
- **#426** — AC_SET_BASE / alt-formula seam migration.

`test_combat_engine_does_not_branch_on_damage_type` was refined from a coarse "string not present in source" check to a regex that catches actual value-branching (`damage_type == "fire"`, `damage_type in (...)`). The SRD's "no rules of their own" clause is about not branching on the value, not about the parameter's presence; `resolve_attack` may carry the tag as long as it doesn't gate hit/damage logic on it. All type-keyed behavior lives inside `_apply_damage_modifiers`.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_resistance_and_vulnerability.py tests/srd/playing_the_game/test_immunity.py -v`
- [x] `cd dnd-engine && uv run pytest tests/srd/ -x` (412 passed, 275 skipped)
- [x] `cd dnd-engine && uv run pytest tests/` full sweep (2663 passed, 276 skipped, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)