### PR TITLE
Implement damage-type Immunity (#464) — plan-02

### DIFF
--- a/dnd-engine/tests/srd/playing_the_game/test_immunity.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_immunity.py
@@ -40,24 +40,110 @@ class TestImmunity_ToDamageType:
     """
 
     def test_damage_type_immunity_zeroes_damage(self):
-        pytest.skip(
-            "GAP: damage-type immunity is not implemented anywhere. "
-            "`systems/item_effects._apply_damage_effect` only halves "
-            "for `has_resistance_{type}` — no `has_immunity_{type}` "
-            "branch zeroes damage. `CombatEngine.resolve_attack` and "
-            "`CombatEngine.resolve_spell_save` don't consult any per-"
-            "type modifier table at all. The bearded devil's "
-            "`damage_immunities: [fire, poison]` (monsters.json) is "
-            "data-only. Tracked by issues #461 (damage_type pipeline "
-            "wiring) and #464 (damage-type Immunity)."
+        """A creature immune to a damage type takes 0 damage of that
+        type from an attack that hits.
+
+        SRD acceptance: a fire-immune bearded devil takes 0 damage from
+        a fire-typed attack (e.g., Fire Bolt), regardless of the attack
+        roll, because `_apply_damage_modifiers` zeroes the rolled
+        damage in the chokepoint before it is applied to HP.
+        """
+        from dnd_engine.core.combat import CombatEngine
+        from dnd_engine.core.creature import Abilities, Creature
+        from dnd_engine.core.dice import DiceRoller
+
+        attacker = Creature(
+            name="Wizard",
+            max_hp=20,
+            ac=12,
+            abilities=Abilities(
+                strength=10,
+                dexterity=10,
+                constitution=10,
+                intelligence=16,
+                wisdom=10,
+                charisma=10,
+            ),
+        )
+        bearded_devil = Creature(
+            name="Bearded Devil",
+            max_hp=52,
+            ac=13,
+            abilities=Abilities(
+                strength=16,
+                dexterity=15,
+                constitution=15,
+                intelligence=9,
+                wisdom=11,
+                charisma=11,
+            ),
+        )
+        # Mirror what `DataLoader.create_monster` attaches from the
+        # bearded devil's monsters.json entry.
+        bearded_devil.damage_immunities = ["fire", "poison"]
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        # `attack_bonus=20` against AC 13 guarantees a hit so the
+        # damage pipeline runs — the assertion is on the post-modifier
+        # damage, not on hit/miss probability.
+        result = engine.resolve_attack(
+            attacker=attacker,
+            defender=bearded_devil,
+            attack_bonus=20,
+            damage_dice="1d10",  # Fire Bolt at level 1
+            damage_type="fire",
+            apply_damage=True,
+        )
+
+        assert result.hit is True
+        assert result.damage == 0, (
+            "Fire-immune defender must take 0 fire damage (SRD: "
+            "'Immunity to a damage type means you don't take damage of "
+            "that type.')."
+        )
+        assert bearded_devil.current_hp == bearded_devil.max_hp, (
+            "Immunity must prevent any HP loss from the matching type."
         )
 
     def test_damage_type_immunity_is_per_type(self):
-        pytest.skip(
-            "GAP: depends on damage-type immunity being implemented "
-            "first. The SRD scopes immunity per type — a fire-immune "
-            "creature still takes full damage from other types. "
-            "Tracked by issue #464."
+        """Immunity is scoped per damage type — a fire-immune creature
+        still takes full damage from a different type (e.g., cold).
+        """
+        from dnd_engine.core.combat import CombatEngine
+        from dnd_engine.core.creature import Abilities, Creature
+        from dnd_engine.core.dice import DiceRoller
+
+        target = Creature(
+            name="Fire-Immune Target",
+            max_hp=100,
+            ac=10,
+            abilities=Abilities(
+                strength=10,
+                dexterity=10,
+                constitution=10,
+                intelligence=10,
+                wisdom=10,
+                charisma=10,
+            ),
+        )
+        target.damage_immunities = ["fire"]
+
+        engine = CombatEngine(DiceRoller(seed=1))
+
+        fire_scaled = engine._apply_damage_modifiers(
+            target, raw_damage=20, damage_type="fire"
+        )
+        cold_scaled = engine._apply_damage_modifiers(
+            target, raw_damage=20, damage_type="cold"
+        )
+
+        assert fire_scaled == 0, (
+            "Fire-immune target must take 0 fire damage."
+        )
+        assert cold_scaled == 20, (
+            "Immunity is per-type — a fire-immune target takes full "
+            "damage from other types (SRD scopes immunity to the "
+            "named damage type)."
         )
 
     def test_monster_damage_immunities_field_is_consumed(self):


### PR DESCRIPTION
## Summary

Slice 4 of plan-02 (#531) for issue #464 — damage-type Immunity (SRD § Playing the Game › Immunity: "Immunity to a damage type means you don't take damage of that type.").

**Audit finding:** slice 1 (PR #540 / #461) already implemented the full damage-type Immunity behavior:
- `CombatEngine._apply_damage_modifiers` is the single chokepoint and zeroes damage when either the `has_immunity_{type}` condition flag matches OR the target's catalog `damage_immunities` list contains the normalized damage type.
- Immunity is checked **before** Resistance (short-circuit), satisfying the ordering requirement.
- `resolve_attack` and `resolve_spell_save` both route post-roll damage through the chokepoint (verified by `tests/test_combat.py::TestResolveAttackDamageType::test_resolve_attack_immunity_zeroes_damage` and `TestResolveSpellSaveDamageType::test_spell_save_immunity_zeroes_damage`).
- `DataLoader.create_monster` attaches `damage_immunities` from the catalog onto the `Creature` instance.
- Damage rolls clamp at 0 per PR #542 (#490), so Immunity → 0 cannot be re-amplified.

This slice is therefore **pure test flips + SRD-conformance verification** — no engine code change required. The two remaining damage-type Immunity skips in `tests/srd/playing_the_game/test_immunity.py` are replaced with live tests that exercise the chokepoint end-to-end against acceptance criteria #3 (bearded devil + fire bolt) and #4 (per-type scoping).

## What changed vs. slice 1

| Acceptance criterion | Where covered |
|---|---|
| 1. Chokepoint reads catalog `damage_immunities` AND `has_immunity_{type}` condition | slice 1 (#540) — `combat.py:_apply_damage_modifiers` |
| 2. Immunity applied at start of pipeline, short-circuits | slice 1 (#540) — immunity branch precedes resistance |
| 3. Bearded devil takes 0 fire damage from `fire_bolt` regardless of attack roll | **this slice** — `test_damage_type_immunity_zeroes_damage` (end-to-end via `resolve_attack`) |
| 4. Per-type scoping (fire-immune still takes cold) | **this slice** — `test_damage_type_immunity_is_per_type` |
| 5. All damage-type Immunity skips flipped to live + passing | **this slice** |

Condition-immunity tests in `TestImmunity_ToCondition` remain skipped — those are tracked by #466 and are explicitly out of scope per the slice guardrails.

## Flipped tests

- `TestImmunity_ToDamageType::test_damage_type_immunity_zeroes_damage` (was `pytest.skip("GAP: damage-type immunity is not implemented anywhere...")`) → live, end-to-end via `resolve_attack` with `attack_bonus=20` guaranteeing a hit.
- `TestImmunity_ToDamageType::test_damage_type_immunity_is_per_type` (was `pytest.skip("GAP: depends on damage-type immunity being implemented first...")`) → live, checks both fire (immune → 0) and cold (full damage) on the same creature.

`TestImmunity_ToDamageType::test_monster_damage_immunities_field_is_consumed` was already live under slice 1 — no change.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_immunity.py -v` → 6 passed, 3 skipped (the 3 skips are all condition-immunity / #466).
- [x] `cd dnd-engine && uv run pytest tests/srd/ -x` → 417 passed, 271 skipped (no regressions).
- [x] `cd dnd-engine && uv run pytest tests/test_combat.py -k "Immunity or DamageType or DamageModifier"` → 16 passed (chokepoint regression check).

Refs #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)