### PR TITLE
Apply per-type Resistance from monster catalog (#462) — plan-02

### DIFF
--- a/dnd-engine/tests/srd/playing_the_game/test_resistance_and_vulnerability.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_resistance_and_vulnerability.py
@@ -143,6 +143,87 @@ class TestResistance_HalvesDamage:
             "that type is halved against you')."
         )
 
+    def test_bearded_devil_takes_half_cold_damage_from_spell_save(self):
+        """SRD acceptance: a cold-resistant bearded devil takes
+        `floor(20 / 2) = 10` damage from a 20-cold-damage spell save.
+
+        Mirrors the bearded-devil immunity acceptance case but exercises
+        the Resistance branch via `resolve_spell_save`. The catalog
+        `damage_resistances` list is what `DataLoader.create_monster`
+        attaches from `monsters.json` (the bearded devil ships
+        `["cold", ...]`). With a forced save failure the target eats
+        the full 20-point spell roll, then the chokepoint halves it.
+        """
+        from dnd_engine.core.combat import CombatEngine
+        from dnd_engine.core.creature import Abilities, Creature
+
+        caster = Creature(
+            name="Caster",
+            max_hp=20,
+            ac=10,
+            abilities=Abilities(
+                strength=10,
+                dexterity=10,
+                constitution=10,
+                intelligence=16,
+                wisdom=10,
+                charisma=10,
+            ),
+        )
+        # Drive the save to fail unconditionally so the test asserts on
+        # post-save scaling, not on dice luck.
+        caster.get_spell_save_dc = lambda: 99  # type: ignore[attr-defined]
+
+        bearded_devil = Creature(
+            name="Bearded Devil",
+            max_hp=52,
+            ac=13,
+            abilities=Abilities(
+                strength=16,
+                dexterity=15,
+                constitution=15,
+                intelligence=9,
+                wisdom=11,
+                charisma=11,
+            ),
+        )
+        # Mirror what `DataLoader.create_monster` attaches from the
+        # bearded devil's monsters.json entry (cold resistance).
+        bearded_devil.damage_resistances = ["cold"]
+
+        # `0d6+20` rolls to exactly 20 — keeps the assertion crisp on
+        # the post-Resistance halving rather than dice variance.
+        spell = {
+            "name": "Cone of Cold",
+            "level": 5,
+            "id": "cone_of_cold",
+            "damage": {"dice": "0d6+20", "damage_type": "cold"},
+            "saving_throw": {"ability": "con", "on_success": "half"},
+        }
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        result = engine.resolve_spell_save(
+            caster=caster,
+            targets=[bearded_devil],
+            spell=spell,
+            apply_damage=True,
+        )
+
+        target_row = next(
+            r for r in result["targets"] if r["name"] == bearded_devil.name
+        )
+        assert target_row["success"] is False, (
+            "DC 99 must force the bearded devil to fail the save; the "
+            "test asserts on post-save Resistance scaling, not on the "
+            "half-on-success branch."
+        )
+        assert target_row["damage"] == 10, (
+            "Cold-resistant bearded devil must take floor(20/2) = 10 "
+            "cold damage (SRD: 'damage of that type is halved against "
+            "you')."
+        )
+        assert bearded_devil.current_hp == bearded_devil.max_hp - 10
+
 
 class TestVulnerability_DoublesDamage:
     """SRD § Playing the Game › Resistance and Vulnerability › Vulnerability.


### PR DESCRIPTION
## Summary

Slice 5 of plan-master #531. Verifies and seals per-type Resistance in the damage chokepoint.

**What slice 1 (#461 / PR #540) already covered:**
- `CombatEngine._apply_damage_modifiers` reads catalog `damage_resistances` AND condition `has_resistance_{type}` flags.
- Halves matching damage once via integer division (floor rounding) — SRD compliant.
- `damage_type` is threaded through both `resolve_attack` and `resolve_spell_save`.

**What this slice adds:**
- One focused SRD acceptance test mirroring the worked example in #462: a cold-resistant bearded devil takes `floor(20 / 2) = 10` damage from a 20-cold spell save via `resolve_spell_save` (DC forced to fail to isolate the Resistance branch from half-on-success).
- Mirrors the existing immunity acceptance pattern in `test_immunity.py`.

**Tests flipped/added in `test_resistance_and_vulnerability.py`:**
- `TestResistance_HalvesDamage::test_bearded_devil_takes_half_cold_damage_from_spell_save` — NEW (live).

**Tests already live from slice 1 (no flip needed):**
- `test_resistance_halves_damage_with_floor_rounding`
- `test_resistance_keys_on_the_specific_damage_type`
- `test_resistance_data_exists_for_monsters`
- `test_monster_damage_resistances_field_is_consumed_by_damage_pipeline`
- `test_two_sources_of_resistance_halve_only_once` (the Resistance-only no-stacking case — broader cross-source ordering remains #468)
- `test_item_damage_pipeline_consults_resistance`
- `test_attack_damage_pipeline_consults_resistance`
- `test_spell_save_damage_pipeline_consults_resistance`

**Out of scope (intentionally kept skipped):**
- All 3 `TestVulnerability_DoublesDamage` tests → #463
- `test_resistance_to_all_plus_resistance_to_type_does_not_stack` → #468 (needs `has_resistance_all` blanket hook)
- `test_two_sources_of_vulnerability_double_only_once` → #463 / #468
- All 3 `TestOrderOfApplication_AdjustmentsFirst` tests → #468 (needs Vulnerability + flat-adjustment hooks)

**Acceptance criteria — status:**
1. Chokepoint reads catalog + condition forms, single halving → done (slice 1).
2. Two-source no-stacking for Resistance → live test passes; full no-stacking deferred to #468 with citation.
3. Bearded devil takes `floor(20/2) = 10` from 20 cold spell save → new test added and passing.
4. `test_monster_damage_resistances_field_is_consumed_by_damage_pipeline` live → already live from slice 1.

Refs #531.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_resistance_and_vulnerability.py -v` — 9 passed, 8 skipped (all #463 / #468 with citations)
- [x] `cd dnd-engine && uv run pytest tests/srd/ -x` — 418 passed, 271 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)