### PR TITLE
Implement per-type Vulnerability (#463) — plan-02

### DIFF
--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -92,26 +92,31 @@ class CombatEngine:
         self, target: Creature, raw_damage: int, damage_type: str | None
     ) -> int:
         """
-        Scale raw damage by the target's per-type Resistance / Immunity.
+        Scale raw damage by the target's per-type Resistance, Immunity,
+        and Vulnerability.
 
-        Single chokepoint that the SRD's Resistance, Immunity (and
-        later Vulnerability) rules key off of. This slice (#461)
-        implements Resistance + Immunity only; Vulnerability,
-        no-stacking, and order-of-application are tracked separately
-        (#463 / #468) and will plug in here.
+        Single chokepoint that the SRD's Resistance, Immunity, and
+        Vulnerability rules key off of. Pipeline order matches the SRD:
+        Immunity (zero) → Resistance (halve, floor) → Vulnerability
+        (double). The pre-Resistance "adjustments" stage and the full
+        no-stacking matrix remain tracked by #468.
 
-        Consults two sources of per-type modifiers:
-          1. Creature condition flags — `has_resistance_{type}` and
-             `has_immunity_{type}` — matching the existing convention
-             used by `systems/item_effects._apply_damage_effect`.
-          2. Monster catalog fields — `damage_resistances` and
-             `damage_immunities` list attributes on the Creature
-             instance (populated by `DataLoader.create_monster` from
-             `monsters.json`).
+        Consults two sources of per-type modifiers, in parity across
+        Resistance, Immunity, and Vulnerability:
+          1. Creature condition flags — `has_resistance_{type}`,
+             `has_immunity_{type}`, and `has_vulnerability_{type}` —
+             matching the existing convention used by
+             `systems/item_effects._apply_damage_effect`.
+          2. Monster catalog fields — `damage_resistances`,
+             `damage_immunities`, and `damage_vulnerabilities` list
+             attributes on the Creature instance (populated by
+             `DataLoader.create_monster` from `monsters.json`).
 
         SRD § Playing the Game › Resistance and Vulnerability:
             "If you have Resistance to a damage type, damage of that
              type is halved against you (round down)."
+            "If you have Vulnerability to a damage type, damage of that
+             type is doubled against you."
         SRD § Playing the Game › Immunity:
             "Immunity to a damage type means you don't take damage of
              that type."
@@ -124,7 +129,8 @@ class CombatEngine:
                 and `raw_damage` is returned unchanged.
 
         Returns:
-            The damage amount after Resistance / Immunity scaling.
+            The damage amount after Immunity / Resistance / Vulnerability
+            scaling.
         """
         # Untyped damage cannot consult per-type modifiers; return as-is.
         if damage_type is None:
@@ -145,6 +151,8 @@ class CombatEngine:
 
         # --- Resistance stage ------------------------------------------------
         # Resistance halves matching damage with floor rounding.
+        # TODO(#468): The "adjustments" stage (flat bonuses / penalties)
+        # applies BEFORE this Resistance stage per SRD order-of-application.
         resistance_condition = f"has_resistance_{normalized_type}"
         catalog_resistances = [
             t.lower() for t in (getattr(target, "damage_resistances", None) or [])
@@ -152,10 +160,23 @@ class CombatEngine:
         if target.has_condition(resistance_condition) or normalized_type in catalog_resistances:
             return raw_damage // 2
 
-        # TODO(#463): Vulnerability stage inserts here (double matching
-        # damage). TODO(#468): Order-of-application — flat adjustments
-        # apply BEFORE this Resistance stage; Vulnerability applies
-        # AFTER it. Both are out of scope for #461.
+        # --- Vulnerability stage --------------------------------------------
+        # Vulnerability doubles matching damage. Two sources (condition
+        # flag + catalog field) still double exactly once — the SRD's
+        # No-Stacking rule is satisfied by a single boolean branch rather
+        # than a counted multiplier. The full no-stacking matrix
+        # (interaction with Resistance, blanket "Vulnerability to all")
+        # is tracked by #468.
+        vulnerability_condition = f"has_vulnerability_{normalized_type}"
+        catalog_vulnerabilities = [
+            t.lower() for t in (getattr(target, "damage_vulnerabilities", None) or [])
+        ]
+        if (
+            target.has_condition(vulnerability_condition)
+            or normalized_type in catalog_vulnerabilities
+        ):
+            return raw_damage * 2
+
         return raw_damage
 
     def resolve_attack(

--- a/dnd-engine/tests/srd/playing_the_game/test_resistance_and_vulnerability.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_resistance_and_vulnerability.py
@@ -233,28 +233,70 @@ class TestVulnerability_DoublesDamage:
     """
 
     def test_vulnerability_doubles_damage(self):
-        pytest.skip(
-            "GAP: Vulnerability is not implemented anywhere. No "
-            "`has_vulnerability_*` condition is honored by the damage "
-            "pipeline (`systems/item_effects._apply_damage_effect` "
-            "only checks `has_resistance_*`). Monster catalog "
-            "vulnerability data exists (e.g., Skeleton: bludgeoning) "
-            "but is never read. Tracked by issue #463."
+        """A vulnerable target takes `raw * 2` damage via the chokepoint.
+
+        Mirrors the Resistance shape: a creature flagged with
+        `has_vulnerability_{type}` must take double damage of that
+        type when routed through `CombatEngine._apply_damage_modifiers`.
+        """
+        from dnd_engine.core.combat import CombatEngine
+
+        target = _make_target()
+        target.add_condition("has_vulnerability_fire")
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        scaled = engine._apply_damage_modifiers(target, raw_damage=10, damage_type="fire")
+
+        assert scaled == 20, (
+            "Vulnerability must double matching damage (SRD: 'damage "
+            "of that type is doubled against you')."
         )
 
     def test_vulnerability_keys_on_the_specific_damage_type(self):
-        pytest.skip(
-            "GAP: depends on the Vulnerability system being implemented "
-            "first. SRD scopes Vulnerability per damage type, identical "
-            "to Resistance. Tracked by issue #463."
+        """Vulnerability to one type does not amplify another type.
+
+        Target has fire vulnerability only; a poison hit must land at
+        the full unmultiplied damage. Confirms the vulnerability
+        pipeline scopes by type, identical to Resistance.
+        """
+        from dnd_engine.core.combat import CombatEngine
+
+        target = _make_target()
+        target.add_condition("has_vulnerability_fire")
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        scaled = engine._apply_damage_modifiers(target, raw_damage=10, damage_type="poison")
+
+        assert scaled == 10, (
+            "Fire vulnerability must not double poison damage; SRD "
+            "vulnerability is per-type."
         )
 
     def test_monster_damage_vulnerabilities_field_is_consumed(self):
-        pytest.skip(
-            "GAP: monsters.json `damage_vulnerabilities` is data-only "
-            "(Skeleton has `bludgeoning`). No engine code reads the "
-            "field — same shape of gap as the resistances field. "
-            "Tracked by issue #463."
+        """The chokepoint reads a Creature's `damage_vulnerabilities`
+        list (catalog parity with Resistance / Immunity).
+
+        SRD acceptance for the Skeleton: a 20-damage bludgeoning swing
+        becomes 40 because `monsters.json` ships
+        `damage_vulnerabilities: ["bludgeoning"]` and `DataLoader.create_monster`
+        attaches it to the Creature instance.
+        """
+        from dnd_engine.core.combat import CombatEngine
+
+        target = _make_target()
+        # Mirrors what `DataLoader.create_monster` attaches from the
+        # monsters.json catalog (e.g., skeleton ships `bludgeoning`).
+        target.damage_vulnerabilities = ["bludgeoning"]
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        scaled = engine._apply_damage_modifiers(
+            target, raw_damage=20, damage_type="bludgeoning"
+        )
+
+        assert scaled == 40, (
+            "Catalog `damage_vulnerabilities` must double damage of the "
+            "matching type via the engine chokepoint (SRD: 'damage of "
+            "that type is doubled against you')."
         )
 
 
@@ -310,12 +352,26 @@ class TestNoStacking_MultipleInstancesCountAsOne:
         )
 
     def test_two_sources_of_vulnerability_double_only_once(self):
-        pytest.skip(
-            "GAP: depends on Vulnerability being implemented first. "
-            "Once it lands, two sources of Vulnerability to the same "
-            "type must double damage exactly once, not quadruple it. "
-            "Tracked by issues #463 (Vulnerability) and #468 "
-            "(No-Stacking)."
+        """Two stacked vulnerability sources still double, not quadruple.
+
+        Combines the condition-flag form (`has_vulnerability_fire`) with
+        the monster-catalog form (`damage_vulnerabilities: ["fire"]`).
+        Per SRD No-Stacking the result must be `raw * 2`, never
+        `raw * 4`. The full no-stacking matrix (blanket "Vulnerability
+        to all", interaction with Resistance) is tracked by #468.
+        """
+        from dnd_engine.core.combat import CombatEngine
+
+        target = _make_target()
+        target.add_condition("has_vulnerability_fire")  # source 1
+        target.damage_vulnerabilities = ["fire"]  # source 2
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        scaled = engine._apply_damage_modifiers(target, raw_damage=10, damage_type="fire")
+
+        assert scaled == 20, (
+            "Two sources of vulnerability must double damage once, not "
+            "stack to quadruple it (SRD No Stacking rule)."
         )
 
 

--- a/dnd-engine/tests/test_combat.py
+++ b/dnd-engine/tests/test_combat.py
@@ -519,6 +519,63 @@ class TestApplyDamageModifiers:
         result = self.engine._apply_damage_modifiers(self.target, raw_damage=10, damage_type="Fire")
         assert result == 0
 
+    def test_condition_flag_vulnerability_doubles_damage(self):
+        """`has_vulnerability_{type}` condition doubles matching damage."""
+        self.target.add_condition("has_vulnerability_fire")
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=10, damage_type="fire"
+        )
+        assert result == 20
+
+    def test_condition_flag_vulnerability_is_per_type(self):
+        """Fire vulnerability does not amplify poison damage."""
+        self.target.add_condition("has_vulnerability_fire")
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=10, damage_type="poison"
+        )
+        assert result == 10
+
+    def test_monster_catalog_vulnerability_doubles_damage(self):
+        """`damage_vulnerabilities` list attribute doubles matching damage.
+
+        SRD acceptance for the Skeleton: catalog ships
+        `damage_vulnerabilities: ["bludgeoning"]`, so a 20-damage
+        bludgeoning swing becomes 40.
+        """
+        self.target.damage_vulnerabilities = ["bludgeoning"]
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=20, damage_type="bludgeoning"
+        )
+        assert result == 40
+
+    def test_vulnerability_no_stacking_two_sources_double_once(self):
+        """Condition flag + catalog field combined still double once."""
+        self.target.add_condition("has_vulnerability_fire")
+        self.target.damage_vulnerabilities = ["fire"]
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=10, damage_type="fire"
+        )
+        assert result == 20
+
+    def test_immunity_takes_precedence_over_vulnerability(self):
+        """Immunity zero-out beats Vulnerability doubling (SRD order:
+        Immunity, then Resistance, then Vulnerability)."""
+        self.target.damage_immunities = ["fire"]
+        self.target.add_condition("has_vulnerability_fire")
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=10, damage_type="fire"
+        )
+        assert result == 0
+
+    def test_vulnerability_damage_type_is_normalized_case_insensitively(self):
+        """Vulnerability matches even when the incoming damage type is
+        mixed-case (SRD types are lowercase in the catalog)."""
+        self.target.damage_vulnerabilities = ["bludgeoning"]
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=20, damage_type="Bludgeoning"
+        )
+        assert result == 40
+
 
 class TestResolveAttackDamageType:
     """Tests for `damage_type` plumbing through `resolve_attack`."""


### PR DESCRIPTION
## Summary

Slice 6 of plan-master #531. Adds the **Vulnerability** stage to the
`CombatEngine._apply_damage_modifiers` chokepoint so a defender takes
double damage of a matching damage type. SRD § Playing the Game ›
Resistance and Vulnerability: _"If you have Vulnerability to a damage
type, damage of that type is doubled against you."_

### Doubling-stage placement & ordering

The Vulnerability check sits **after** Resistance in the chokepoint:

1. Immunity (zero) — existing
2. Resistance (halve, floor) — existing
3. **Vulnerability (double) — this slice**

This satisfies the SRD's stated order-of-application for these three
layers. The pre-Resistance "adjustments" stage and the full
no-stacking matrix (Resistance + Vulnerability composing on the same
call, blanket "Vulnerability to all", the worked-example end-to-end)
remain tracked by **#468** — those tests stay skipped with that
citation, and a `TODO(#468)` marker stays in `combat.py` for the
adjustments hook.

### Sources consulted (parity with Resistance / Immunity)

- Condition flag: `has_vulnerability_{type}`
- Monster catalog field: `damage_vulnerabilities: [...]` (already
  attached by `DataLoader.create_monster` from `monsters.json`; #470)

### No-stacking guard

Two sources of vulnerability on the same target (condition + catalog)
still double exactly once — single boolean branch, no counted
multiplier. The full no-stacking matrix is out of scope and stays in
#468.

### SRD acceptance

Skeleton (`damage_vulnerabilities: ["bludgeoning"]`) takes 40 damage
from a 20-bludgeoning swing through the chokepoint — covered by the
flipped `test_monster_damage_vulnerabilities_field_is_consumed`.

## Tests flipped skip → live

- `tests/srd/playing_the_game/test_resistance_and_vulnerability.py::TestVulnerability_DoublesDamage::test_vulnerability_doubles_damage`
- `…::test_vulnerability_keys_on_the_specific_damage_type`
- `…::test_monster_damage_vulnerabilities_field_is_consumed`
- `…::TestNoStacking_MultipleInstancesCountAsOne::test_two_sources_of_vulnerability_double_only_once`

## New chokepoint unit tests (`tests/test_combat.py::TestApplyDamageModifiers`)

- `test_condition_flag_vulnerability_doubles_damage`
- `test_condition_flag_vulnerability_is_per_type`
- `test_monster_catalog_vulnerability_doubles_damage`
- `test_vulnerability_no_stacking_two_sources_double_once`
- `test_immunity_takes_precedence_over_vulnerability`
- `test_vulnerability_damage_type_is_normalized_case_insensitively`

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_resistance_and_vulnerability.py -v` — 13 passed, 4 skipped (#468)
- [x] `cd dnd-engine && uv run pytest tests/test_combat.py -v -k "DamageModifier or Vulnerab"` — 16 passed
- [x] `cd dnd-engine && uv run pytest tests/test_combat.py` — 47 passed
- [x] `cd dnd-engine && uv run pytest tests/srd/ -x` — 422 passed, 267 skipped

Closes #463 (consolidated into plan-master #531).

🤖 Generated with [Claude Code](https://claude.com/claude-code)