### PR TITLE
No-stacking & order-of-application pipeline (#468) — plan-02

### DIFF
--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -93,30 +93,57 @@ class CombatEngine:
     ) -> int:
         """
         Scale raw damage by the target's per-type Resistance, Immunity,
-        and Vulnerability.
+        Vulnerability, and flat adjustments.
 
         Single chokepoint that the SRD's Resistance, Immunity, and
-        Vulnerability rules key off of. Pipeline order matches the SRD:
-        Immunity (zero) → Resistance (halve, floor) → Vulnerability
-        (double). The pre-Resistance "adjustments" stage and the full
-        no-stacking matrix remain tracked by #468.
+        Vulnerability rules key off of.
+
+        SRD § Playing the Game › Resistance and Vulnerability › Order
+        of Application:
+            "Modifiers to damage are applied in the following order:
+             adjustments such as bonuses, penalties, or multipliers are
+             applied first; Resistance is applied second; and
+             Vulnerability is applied third."
+
+        Pipeline order:
+          1. Immunity (zero) — short-circuits everything else.
+          2. Adjustments (flat bonus / penalty hook).
+          3. Resistance (halve, floor).
+          4. Vulnerability (double).
+
+        Immunity is placed BEFORE the adjustments stage even though the
+        SRD's order-of-application sentence only names the
+        adjustments/Resistance/Vulnerability trio. The SRD defines
+        Immunity as "you don't take damage of that type" — an absolute
+        zero-out, not a multiplier. Running adjustments on an immune
+        target would let a `damage_taken_reduction` of 5 turn into
+        post-immunity "damage" of -5 (then clamped), which contradicts
+        the plain-language reading of Immunity. The SRD's worked
+        example does not mix Immunity with adjustments, so this is a
+        defensible reading rather than a contradiction.
 
         Consults two sources of per-type modifiers, in parity across
         Resistance, Immunity, and Vulnerability:
           1. Creature condition flags — `has_resistance_{type}`,
              `has_immunity_{type}`, and `has_vulnerability_{type}` —
              matching the existing convention used by
-             `systems/item_effects._apply_damage_effect`.
+             `systems/item_effects._apply_damage_effect`. The Resistance
+             stage additionally recognizes `has_resistance_all` as a
+             blanket "Resistance to all damage" source.
           2. Monster catalog fields — `damage_resistances`,
              `damage_immunities`, and `damage_vulnerabilities` list
              attributes on the Creature instance (populated by
-             `DataLoader.create_monster` from `monsters.json`).
+             `DataLoader.create_monster` from `monsters.json`). The
+             Resistance stage additionally recognizes the literal token
+             `"all"` in `damage_resistances` as a blanket source.
 
         SRD § Playing the Game › Resistance and Vulnerability:
             "If you have Resistance to a damage type, damage of that
              type is halved against you (round down)."
             "If you have Vulnerability to a damage type, damage of that
              type is doubled against you."
+            "Multiple instances of Resistance or Vulnerability that
+             affect the same damage type count as only one instance."
         SRD § Playing the Game › Immunity:
             "Immunity to a damage type means you don't take damage of
              that type."
@@ -129,8 +156,7 @@ class CombatEngine:
                 and `raw_damage` is returned unchanged.
 
         Returns:
-            The damage amount after Immunity / Resistance / Vulnerability
-            scaling.
+            The damage amount after the full modifier pipeline.
         """
         # Untyped damage cannot consult per-type modifiers; return as-is.
         if damage_type is None:
@@ -142,6 +168,8 @@ class CombatEngine:
         # --- Immunity stage --------------------------------------------------
         # Immunity zeroes damage of the matching type; both the
         # condition-flag form and the catalog-field form are honored.
+        # Placed first because Immunity is absolute ("you don't take
+        # damage of that type"), not a multiplier — see method docstring.
         immunity_condition = f"has_immunity_{normalized_type}"
         catalog_immunities = [
             t.lower() for t in (getattr(target, "damage_immunities", None) or [])
@@ -149,24 +177,39 @@ class CombatEngine:
         if target.has_condition(immunity_condition) or normalized_type in catalog_immunities:
             return 0
 
+        # --- Adjustments stage ----------------------------------------------
+        # Pre-Resistance flat bonuses / penalties / multipliers. The SRD
+        # worked example uses "a magical aura that reduces all damage
+        # by 5". The extension hook here reads a single
+        # `damage_taken_reduction` attribute (a non-negative int) and
+        # subtracts it from the running damage. Future effect sources
+        # can override `_apply_damage_adjustments` or add new attribute
+        # readers without changing the pipeline shape.
+        damage = self._apply_damage_adjustments(target, raw_damage, normalized_type)
+
         # --- Resistance stage ------------------------------------------------
-        # Resistance halves matching damage with floor rounding.
-        # TODO(#468): The "adjustments" stage (flat bonuses / penalties)
-        # applies BEFORE this Resistance stage per SRD order-of-application.
+        # Resistance halves matching damage with floor rounding. The
+        # No-Stacking rule is satisfied by a single boolean branch:
+        # multiple sources (condition flag, per-type catalog entry,
+        # blanket "all") still halve exactly once.
         resistance_condition = f"has_resistance_{normalized_type}"
         catalog_resistances = [
             t.lower() for t in (getattr(target, "damage_resistances", None) or [])
         ]
-        if target.has_condition(resistance_condition) or normalized_type in catalog_resistances:
-            return raw_damage // 2
+        has_resistance = (
+            target.has_condition(resistance_condition)
+            or target.has_condition("has_resistance_all")
+            or normalized_type in catalog_resistances
+            or "all" in catalog_resistances
+        )
+        if has_resistance:
+            damage = damage // 2
 
         # --- Vulnerability stage --------------------------------------------
         # Vulnerability doubles matching damage. Two sources (condition
         # flag + catalog field) still double exactly once — the SRD's
-        # No-Stacking rule is satisfied by a single boolean branch rather
-        # than a counted multiplier. The full no-stacking matrix
-        # (interaction with Resistance, blanket "Vulnerability to all")
-        # is tracked by #468.
+        # No-Stacking rule is satisfied by a single boolean branch
+        # rather than a counted multiplier.
         vulnerability_condition = f"has_vulnerability_{normalized_type}"
         catalog_vulnerabilities = [
             t.lower() for t in (getattr(target, "damage_vulnerabilities", None) or [])
@@ -175,9 +218,51 @@ class CombatEngine:
             target.has_condition(vulnerability_condition)
             or normalized_type in catalog_vulnerabilities
         ):
-            return raw_damage * 2
+            damage = damage * 2
 
-        return raw_damage
+        return damage
+
+    def _apply_damage_adjustments(
+        self, target: Creature, damage: int, damage_type: str
+    ) -> int:
+        """
+        Apply pre-Resistance flat adjustments (bonuses, penalties,
+        multipliers) to the running damage.
+
+        Extension hook for the "adjustments" stage of the SRD damage
+        modifier pipeline (§ Resistance and Vulnerability › Order of
+        Application). Default behavior reads a single
+        `damage_taken_reduction` attribute on the target — a
+        non-negative integer subtracted from the damage — which covers
+        the SRD's worked example of a "magical aura that reduces all
+        damage by 5".
+
+        Hook contract:
+          - Receives the post-Immunity, pre-Resistance damage and the
+            normalized (lowercase) damage type.
+          - Returns the adjusted damage (must be a non-negative int;
+            the implementation clamps to 0 so a 3-damage hit against a
+            -5 aura cannot become negative damage).
+          - May be overridden or extended by subclasses to read
+            additional sources (auras, conditions with payloads, etc.).
+            New sources should be additive on top of the default
+            reader rather than replacing it, to preserve existing
+            behavior.
+
+        Args:
+            target: The creature taking the damage.
+            damage: Damage after Immunity short-circuit, before
+                Resistance halving.
+            damage_type: Normalized (lowercase) SRD damage type. Passed
+                through for future per-type adjustment sources; the
+                default reader is type-agnostic.
+
+        Returns:
+            The adjusted damage, clamped at 0.
+        """
+        reduction = getattr(target, "damage_taken_reduction", 0) or 0
+        adjusted = damage - reduction
+        return max(adjusted, 0)
 
     def resolve_attack(
         self,

--- a/dnd-engine/tests/srd/playing_the_game/test_resistance_and_vulnerability.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_resistance_and_vulnerability.py
@@ -341,14 +341,26 @@ class TestNoStacking_MultipleInstancesCountAsOne:
         )
 
     def test_resistance_to_all_plus_resistance_to_type_does_not_stack(self):
-        pytest.skip(
-            "GAP: 'Resistance to all damage' is not a recognized "
-            "engine condition. `systems/item_effects."
-            "_apply_damage_effect` only matches the specific "
-            "`has_resistance_{type}` form. The SRD's worked example "
-            "('Resistance to Necrotic as well as Resistance to all "
-            "damage') cannot be exercised end-to-end until a "
-            "blanket-resistance hook exists. Tracked by issue #468."
+        """SRD worked example: per-type Resistance + blanket "Resistance
+        to all" against matching damage halves once, not twice.
+
+        Combines the condition-flag form (`has_resistance_fire`) with
+        the catalog-blanket form (`damage_resistances: ["all"]`). Per
+        SRD No-Stacking the result must be `floor(raw / 2)`, never
+        `floor(raw / 4)`.
+        """
+        from dnd_engine.core.combat import CombatEngine
+
+        target = _make_target()
+        target.add_condition("has_resistance_fire")  # source 1
+        target.damage_resistances = ["all"]  # source 2 (blanket)
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        scaled = engine._apply_damage_modifiers(target, raw_damage=10, damage_type="fire")
+
+        assert scaled == 5, (
+            "Per-type Resistance + 'Resistance to all' must halve once, "
+            "not stack to quarter (SRD No Stacking rule)."
         )
 
     def test_two_sources_of_vulnerability_double_only_once(self):
@@ -385,38 +397,82 @@ class TestOrderOfApplication_AdjustmentsFirst:
     """
 
     def test_flat_adjustments_apply_before_resistance(self):
-        pytest.skip(
-            "GAP: the engine has no notion of pre-resistance damage "
-            "adjustments (the SRD's 'magical aura that reduces all "
-            "damage by 5' worked example). `systems/item_effects."
-            "_apply_damage_effect` rolls dice, then halves once if "
-            "resistant, then applies — no upstream bonus/penalty hook. "
-            "Tracked by issue #468."
+        """A flat damage-taken reduction (e.g., the SRD's "magical aura
+        that reduces all damage by 5") must apply BEFORE Resistance.
+
+        Target has Resistance to fire and a `damage_taken_reduction`
+        of 5. Taking 20 fire damage: first reduced by 5 (to 15), then
+        halved by Resistance (to 7, floor of 15/2).
+        """
+        from dnd_engine.core.combat import CombatEngine
+
+        target = _make_target()
+        target.add_condition("has_resistance_fire")
+        target.damage_taken_reduction = 5
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        scaled = engine._apply_damage_modifiers(target, raw_damage=20, damage_type="fire")
+
+        assert scaled == 7, (
+            "Adjustments apply before Resistance (SRD order): "
+            "20 - 5 = 15, then floor(15/2) = 7."
         )
 
     def test_resistance_applies_before_vulnerability(self):
-        pytest.skip(
-            "GAP: Vulnerability is not implemented (see issue #463), "
-            "so the SRD's stated ordering "
-            "(adjustments → Resistance → Vulnerability) cannot be "
-            "exercised. The canonical SRD worked example — Resistance "
-            "to all + Vulnerability to Fire + a magical aura that "
-            "reduces all damage by 5 against 28 fire damage → 22 — "
-            "needs all three layers in the pipeline before it can be "
-            "asserted. Tracked by issue #468."
+        """Resistance halves BEFORE Vulnerability doubles.
+
+        Target has both Resistance and Vulnerability to fire. Taking
+        20 fire damage: halved by Resistance (to 10), then doubled by
+        Vulnerability (to 20). The SRD order matters because integer
+        floor rounding at the halve step means resist-then-double on
+        an odd raw amount is not the same as raw amount itself.
+        """
+        from dnd_engine.core.combat import CombatEngine
+
+        target = _make_target()
+        target.add_condition("has_resistance_fire")
+        target.add_condition("has_vulnerability_fire")
+
+        engine = CombatEngine(DiceRoller(seed=1))
+
+        # Even raw: 20 → halve → 10 → double → 20 (round-trip in even case).
+        scaled_even = engine._apply_damage_modifiers(target, raw_damage=20, damage_type="fire")
+        assert scaled_even == 20
+
+        # Odd raw exposes the ordering: 21 → halve (floor) → 10 → double → 20.
+        # If Vulnerability ran first the answer would be 42 → halve → 21.
+        scaled_odd = engine._apply_damage_modifiers(target, raw_damage=21, damage_type="fire")
+        assert scaled_odd == 20, (
+            "Resistance must apply before Vulnerability (SRD order): "
+            "floor(21/2) = 10, then 10 * 2 = 20 (not 21)."
         )
 
     def test_srd_worked_example_28_fire_damage_yields_22(self):
-        pytest.skip(
-            "GAP: full SRD worked example. 'A creature has Resistance "
-            "to all damage and Vulnerability to Fire damage, and it's "
-            "within a magical aura that reduces all damage by 5. If "
-            "it takes 28 Fire damage, the damage is first reduced by "
-            "5 (to 23), then halved for the creature's Resistance "
-            "(and rounded down to 11), then doubled for its "
-            "Vulnerability (to 22).' Requires the full pipeline "
-            "(adjustments + Vulnerability + blanket Resistance) to "
-            "exist. Tracked by issue #468."
+        """SRD canonical worked example:
+
+        > A creature has Resistance to all damage and Vulnerability to
+        > Fire damage, and it's within a magical aura that reduces all
+        > damage by 5. If it takes 28 Fire damage, the damage is first
+        > reduced by 5 (to 23), then halved for the creature's
+        > Resistance (and rounded down to 11), then doubled for its
+        > Vulnerability (to 22).
+
+        Exercises the full pipeline: adjustments → Resistance (blanket
+        "all") → Vulnerability (per-type fire) in order, end-to-end.
+        """
+        from dnd_engine.core.combat import CombatEngine
+
+        target = _make_target()
+        target.damage_resistances = ["all"]  # Resistance to all damage
+        target.add_condition("has_vulnerability_fire")  # Vulnerability to fire
+        target.damage_taken_reduction = 5  # magical aura
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        scaled = engine._apply_damage_modifiers(target, raw_damage=28, damage_type="fire")
+
+        assert scaled == 22, (
+            "SRD worked example: 28 - 5 = 23, floor(23/2) = 11, "
+            "11 * 2 = 22."
         )
 
 

--- a/dnd-engine/tests/test_combat.py
+++ b/dnd-engine/tests/test_combat.py
@@ -577,6 +577,175 @@ class TestApplyDamageModifiers:
         assert result == 40
 
 
+class TestDamageAdjustmentsStage:
+    """Tests for the pre-Resistance adjustments hook (#468).
+
+    SRD § Playing the Game › Resistance and Vulnerability › Order of
+    Application:
+        "Modifiers to damage are applied in the following order:
+         adjustments such as bonuses, penalties, or multipliers are
+         applied first; Resistance is applied second; and Vulnerability
+         is applied third."
+
+    The adjustments stage reads `damage_taken_reduction` on the target
+    by default. Subclasses can override `_apply_damage_adjustments`
+    to add per-aura / per-condition payloads without changing the
+    pipeline shape.
+    """
+
+    def setup_method(self):
+        self.engine = CombatEngine(DiceRoller(seed=1))
+        abilities = Abilities(
+            strength=10, dexterity=10, constitution=10, intelligence=10, wisdom=10, charisma=10
+        )
+        self.target = Creature(name="Target", max_hp=100, ac=10, abilities=abilities)
+
+    def test_no_adjustments_returns_damage_unchanged(self):
+        """A target with no adjustments attribute passes damage through."""
+        result = self.engine._apply_damage_adjustments(
+            self.target, damage=10, damage_type="fire"
+        )
+        assert result == 10
+
+    def test_damage_taken_reduction_subtracts_flat_amount(self):
+        """`damage_taken_reduction = 5` subtracts 5 from damage."""
+        self.target.damage_taken_reduction = 5
+        result = self.engine._apply_damage_adjustments(
+            self.target, damage=20, damage_type="fire"
+        )
+        assert result == 15
+
+    def test_damage_taken_reduction_clamps_at_zero(self):
+        """Adjustment can't drive damage below 0 (SRD: no negative damage)."""
+        self.target.damage_taken_reduction = 10
+        result = self.engine._apply_damage_adjustments(
+            self.target, damage=3, damage_type="fire"
+        )
+        assert result == 0
+
+    def test_adjustments_apply_before_resistance(self):
+        """Pipeline order: adjustments first, then Resistance halves.
+
+        20 fire damage, fire-resistant, aura -5:
+            20 - 5 = 15, floor(15 / 2) = 7.
+        If Resistance ran first: floor(20/2) = 10, 10 - 5 = 5.
+        """
+        self.target.add_condition("has_resistance_fire")
+        self.target.damage_taken_reduction = 5
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=20, damage_type="fire"
+        )
+        assert result == 7
+
+    def test_adjustments_do_not_run_when_immune(self):
+        """Immunity short-circuits before adjustments.
+
+        Without this guard, an immune target with a -5 adjustment would
+        still end up at 0 via the clamp, so observably the outcome is
+        the same. The guard is conceptually right: Immunity is "no
+        damage of that type", not "damage minus an adjustment".
+        """
+        self.target.damage_immunities = ["fire"]
+        self.target.damage_taken_reduction = 5
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=20, damage_type="fire"
+        )
+        assert result == 0
+
+    def test_adjustments_combine_with_resistance_and_vulnerability(self):
+        """SRD worked example end-to-end via the chokepoint:
+
+        28 fire damage, Resistance to all, Vulnerability to fire, aura -5:
+            28 - 5 = 23, floor(23 / 2) = 11, 11 * 2 = 22.
+        """
+        self.target.damage_resistances = ["all"]
+        self.target.add_condition("has_vulnerability_fire")
+        self.target.damage_taken_reduction = 5
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=28, damage_type="fire"
+        )
+        assert result == 22
+
+
+class TestBlanketResistance:
+    """Tests for 'Resistance to all damage' recognition (#468).
+
+    SRD § Playing the Game › Resistance and Vulnerability › No Stacking
+    cites a creature with "Resistance to Necrotic damage as well as
+    Resistance to all damage": both sources halve only once.
+
+    Blanket resistance is recognized in two parallel forms:
+      - Condition flag: `has_resistance_all`
+      - Catalog entry: `damage_resistances: ["all"]`
+    """
+
+    def setup_method(self):
+        self.engine = CombatEngine(DiceRoller(seed=1))
+        abilities = Abilities(
+            strength=10, dexterity=10, constitution=10, intelligence=10, wisdom=10, charisma=10
+        )
+        self.target = Creature(name="Target", max_hp=100, ac=10, abilities=abilities)
+
+    def test_condition_flag_blanket_resistance_halves_any_damage(self):
+        """`has_resistance_all` halves damage of every type."""
+        self.target.add_condition("has_resistance_all")
+        assert (
+            self.engine._apply_damage_modifiers(self.target, raw_damage=10, damage_type="fire")
+            == 5
+        )
+        assert (
+            self.engine._apply_damage_modifiers(
+                self.target, raw_damage=20, damage_type="bludgeoning"
+            )
+            == 10
+        )
+
+    def test_catalog_blanket_resistance_halves_any_damage(self):
+        """`damage_resistances: ["all"]` halves damage of every type."""
+        self.target.damage_resistances = ["all"]
+        assert (
+            self.engine._apply_damage_modifiers(self.target, raw_damage=10, damage_type="fire")
+            == 5
+        )
+        assert (
+            self.engine._apply_damage_modifiers(
+                self.target, raw_damage=20, damage_type="bludgeoning"
+            )
+            == 10
+        )
+
+    def test_blanket_plus_per_type_resistance_halves_only_once(self):
+        """No Stacking: blanket + per-type resistance still halves once."""
+        self.target.add_condition("has_resistance_fire")
+        self.target.damage_resistances = ["all"]
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=10, damage_type="fire"
+        )
+        assert result == 5
+
+    def test_blanket_resistance_does_not_block_immunity(self):
+        """Immunity still zeros even when blanket resistance is set."""
+        self.target.add_condition("has_resistance_all")
+        self.target.damage_immunities = ["fire"]
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=10, damage_type="fire"
+        )
+        assert result == 0
+
+    def test_blanket_resistance_interacts_with_vulnerability(self):
+        """Per SRD order: Resistance halves, then Vulnerability doubles.
+
+        Blanket Resistance + fire Vulnerability against odd-raw fire:
+            21 → floor(21/2) = 10 → 10 * 2 = 20.
+        """
+        self.target.damage_resistances = ["all"]
+        self.target.add_condition("has_vulnerability_fire")
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=21, damage_type="fire"
+        )
+        assert result == 20
+
+
 class TestResolveAttackDamageType:
     """Tests for `damage_type` plumbing through `resolve_attack`."""
 


### PR DESCRIPTION
## Summary

Locks down the SRD damage-modifier pipeline so the canonical worked example holds end-to-end: **Resistance to all + Vulnerability to Fire + a -5 aura against 28 fire damage → 22**.

Refs plan-master #531. Closes the substantive remaining work for #468.

## Pipeline shape

The chokepoint `CombatEngine._apply_damage_modifiers` now applies stages **cumulatively** (replacing the prior short-circuit `return`s that prevented Resistance and Vulnerability from composing):

```
Immunity → Adjustments → Resistance → Vulnerability
```

### Ordering decision — Immunity placement

The SRD § Resistance and Vulnerability › Order of Application sentence only governs the multiplicative trio (adjustments / Resistance / Vulnerability). Immunity is defined in a separate section as **"you don't take damage of that type"** — an absolute zero-out, not a multiplier. We keep Immunity **first** in the pipeline:

- The plain-language reading of "you don't take damage of that type" is incompatible with first subtracting a `-5` aura adjustment and then declaring the result "damage".
- The SRD's worked example does not mix Immunity with adjustments, so this is a defensible reading rather than a contradiction.
- This is documented in the method docstring.

## Extension hook contract — `_apply_damage_adjustments`

New method on `CombatEngine`:

```python
def _apply_damage_adjustments(self, target, damage, damage_type) -> int:
    reduction = getattr(target, "damage_taken_reduction", 0) or 0
    adjusted = damage - reduction
    return max(adjusted, 0)
```

**Contract:**
- Receives the post-Immunity, pre-Resistance damage and the normalized (lowercase) damage type.
- Returns the adjusted damage; clamps at 0 (SRD: no negative damage).
- Default reader is type-agnostic and reads a single `damage_taken_reduction` attribute on the target — enough to exercise the SRD's "magical aura that reduces all damage by 5" worked example.
- Subclasses can override to add per-aura / per-condition payloads without changing the pipeline shape. New sources should be additive on top of the default reader.

Intentionally minimal — does **not** speculatively wire to every effect / aura / condition. Future slices can extend it.

## Blanket Resistance design

Two parallel forms, matching the existing condition / catalog parity:

- **Condition flag:** `has_resistance_all`
- **Catalog entry:** `damage_resistances: ["all"]`

Both are recognized in the Resistance stage. The No-Stacking rule is satisfied by a single boolean OR branch: per-type + blanket still halves exactly once, never quarters.

## Tests flipped skip → live + passing

In `tests/srd/playing_the_game/test_resistance_and_vulnerability.py`:

- `TestNoStacking_MultipleInstancesCountAsOne::test_resistance_to_all_plus_resistance_to_type_does_not_stack`
- `TestOrderOfApplication_AdjustmentsFirst::test_flat_adjustments_apply_before_resistance`
- `TestOrderOfApplication_AdjustmentsFirst::test_resistance_applies_before_vulnerability`
- `TestOrderOfApplication_AdjustmentsFirst::test_srd_worked_example_28_fire_damage_yields_22`

Added chokepoint coverage in `tests/test_combat.py`:

- `TestDamageAdjustmentsStage` — 6 tests covering the new hook (default no-op, flat reduction, clamp-at-0, order vs. Resistance, Immunity short-circuit, combined with R+V).
- `TestBlanketResistance` — 5 tests covering condition-flag form, catalog form, no-stacking with per-type, interaction with Immunity, and interaction with Vulnerability.

## Test plan

- [x] `uv run pytest tests/srd/playing_the_game/test_resistance_and_vulnerability.py -v` — 17 passed, 0 skipped (was 13 passed, 4 skipped).
- [x] `uv run pytest tests/test_combat.py -v -k "DamageModifier or Vulnerab or Resist or Adjust or Blanket"` — 29 passed.
- [x] `uv run pytest tests/srd/ -x` — 426 passed, 263 skipped (no regression).
- [x] Full suite: 2700 passed, 264 skipped.

## Out of scope (later slices)

- Condition immunities (#466)
- Fixed-damage weapons (#492)
- Underwater fire (#518)
- AC unification (#426)

🤖 Generated with [Claude Code](https://claude.com/claude-code)