### PR TITLE
Honor per-monster condition_immunities (#466) — plan-02

### DIFF
--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -171,9 +171,7 @@ class CombatEngine:
         # Placed first because Immunity is absolute ("you don't take
         # damage of that type"), not a multiplier — see method docstring.
         immunity_condition = f"has_immunity_{normalized_type}"
-        catalog_immunities = [
-            t.lower() for t in (getattr(target, "damage_immunities", None) or [])
-        ]
+        catalog_immunities = [t.lower() for t in (getattr(target, "damage_immunities", None) or [])]
         if target.has_condition(immunity_condition) or normalized_type in catalog_immunities:
             return 0
 
@@ -222,9 +220,7 @@ class CombatEngine:
 
         return damage
 
-    def _apply_damage_adjustments(
-        self, target: Creature, damage: int, damage_type: str
-    ) -> int:
+    def _apply_damage_adjustments(self, target: Creature, damage: int, damage_type: str) -> int:
         """
         Apply pre-Resistance flat adjustments (bonuses, penalties,
         multipliers) to the running damage.
@@ -639,6 +635,17 @@ class CombatEngine:
             condition = on_fail.get("condition")
 
             if condition:
+                # SRD § Playing the Game › Immunity: "Immunity to a
+                # condition means you aren't affected by it." Skip the
+                # on-fail condition (and its CONDITION_APPLIED event)
+                # when the defender is immune. The general guard also
+                # lives on `Creature.apply_condition_with_metadata`,
+                # but checking here lets us report the truthful
+                # `condition_applied: None` to callers and avoid
+                # emitting a misleading event.
+                if defender.is_immune_to_condition(condition):
+                    return {"save_result": save_result, "condition_applied": None}
+
                 # Apply condition with metadata
                 defender.apply_condition_with_metadata(
                     condition=condition,

--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -239,15 +239,54 @@ class Creature:
 
         self.current_hp = min(self.max_hp, self.current_hp + amount)
 
+    def is_immune_to_condition(self, condition: str) -> bool:
+        """
+        Check whether this creature is immune to a named condition.
+
+        SRD § Playing the Game › Immunity:
+            "Immunity to a condition means you aren't affected by it."
+
+        Two sources are honored, in parity with the damage-type
+        immunity path in `CombatEngine._apply_damage_modifiers`:
+          1. Catalog field `condition_immunities` — a list attribute
+             populated by `DataLoader.create_monster` from
+             monsters.json (e.g., bearded devil ships ["poisoned"]).
+          2. Condition flag `has_immunity_{condition}` — matches the
+             existing `has_immunity_{type}` convention used for
+             damage-type immunity, so future spells/effects can grant
+             condition immunity by attaching the flag.
+
+        Args:
+            condition: Name of the condition (case-insensitive).
+
+        Returns:
+            True if the creature is immune to the condition.
+        """
+        condition_name = condition.lower()
+        catalog_immunities = [
+            c.lower() for c in (getattr(self, "condition_immunities", None) or [])
+        ]
+        if condition_name in catalog_immunities:
+            return True
+        if self.has_condition(f"has_immunity_{condition_name}"):
+            return True
+        return False
+
     def add_condition(self, condition: str) -> None:
         """
         Add a basic condition to the creature (e.g., 'prone', 'stunned').
         For conditions with duration/repeat saves, use apply_condition_with_metadata().
 
+        Immunity guard: if the creature is immune to the named
+        condition (per `is_immune_to_condition`), the call is a no-op.
+        SRD: "Immunity to a condition means you aren't affected by it."
+
         Args:
             condition: Name of the condition to add
         """
         condition_name = condition.lower()
+        if self.is_immune_to_condition(condition_name):
+            return
         if condition_name not in self.active_conditions:
             self.active_conditions[condition_name] = {}
 
@@ -264,6 +303,10 @@ class Creature:
         """
         Apply a condition with full metadata for duration and repeat saves.
 
+        Immunity guard: if the creature is immune to the named
+        condition (per `is_immune_to_condition`), the call is a no-op.
+        SRD: "Immunity to a condition means you aren't affected by it."
+
         Args:
             condition: Name of the condition (e.g., 'paralyzed', 'poisoned')
             duration_type: Type of duration ('rounds', 'minutes', 'hours', 'permanent')
@@ -274,6 +317,8 @@ class Creature:
             repeat_timing: When repeat saves occur ('end_of_turn', 'start_of_turn')
         """
         condition_name = condition.lower()
+        if self.is_immune_to_condition(condition_name):
+            return
         self.active_conditions[condition_name] = {
             "duration_type": duration_type,
             "duration_remaining": duration,

--- a/dnd-engine/dnd_engine/rules/loader.py
+++ b/dnd-engine/dnd_engine/rules/loader.py
@@ -109,6 +109,14 @@ class DataLoader:
         creature.damage_immunities = list(data.get("damage_immunities") or [])
         creature.damage_vulnerabilities = list(data.get("damage_vulnerabilities") or [])
 
+        # Per-condition immunity list from the monster catalog (e.g.,
+        # bearded devil ships ["poisoned"]). Consulted by
+        # `Creature.is_immune_to_condition` so condition-application
+        # APIs (`add_condition`, `apply_condition_with_metadata`) skip
+        # attachment when the target is immune. SRD: "Immunity to a
+        # condition means you aren't affected by it."
+        creature.condition_immunities = list(data.get("condition_immunities") or [])
+
         return creature
 
     def load_items(self, campaign_id: str | None = None) -> dict[str, Any]:

--- a/dnd-engine/tests/srd/playing_the_game/test_immunity.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_immunity.py
@@ -130,16 +130,10 @@ class TestImmunity_ToDamageType:
 
         engine = CombatEngine(DiceRoller(seed=1))
 
-        fire_scaled = engine._apply_damage_modifiers(
-            target, raw_damage=20, damage_type="fire"
-        )
-        cold_scaled = engine._apply_damage_modifiers(
-            target, raw_damage=20, damage_type="cold"
-        )
+        fire_scaled = engine._apply_damage_modifiers(target, raw_damage=20, damage_type="fire")
+        cold_scaled = engine._apply_damage_modifiers(target, raw_damage=20, damage_type="cold")
 
-        assert fire_scaled == 0, (
-            "Fire-immune target must take 0 fire damage."
-        )
+        assert fire_scaled == 0, "Fire-immune target must take 0 fire damage."
         assert cold_scaled == 20, (
             "Immunity is per-type — a fire-immune target takes full "
             "damage from other types (SRD scopes immunity to the "
@@ -170,15 +164,11 @@ class TestImmunity_ToDamageType:
             wisdom=11,
             charisma=11,
         )
-        bearded_devil = Creature(
-            name="Bearded Devil", max_hp=52, ac=13, abilities=abilities
-        )
+        bearded_devil = Creature(name="Bearded Devil", max_hp=52, ac=13, abilities=abilities)
         bearded_devil.damage_immunities = ["fire", "poison"]
 
         engine = CombatEngine(DiceRoller(seed=1))
-        scaled = engine._apply_damage_modifiers(
-            bearded_devil, raw_damage=22, damage_type="fire"
-        )
+        scaled = engine._apply_damage_modifiers(bearded_devil, raw_damage=22, damage_type="fire")
 
         assert scaled == 0, (
             "Catalog `damage_immunities` must zero damage of the "
@@ -218,39 +208,179 @@ class TestImmunity_ToCondition:
         )
 
     def test_general_saving_throw_path_consults_condition_immunity(self):
-        pytest.skip(
-            "GAP: `CombatEngine._process_saving_throw_effect` (dnd-"
-            "engine/dnd_engine/core/combat.py:371) applies the on-fail "
-            "condition (e.g., ghoul Paralyzed) directly via "
-            "`defender.apply_condition_with_metadata` with no immunity "
-            "check. The only honored condition-immunity path is the "
-            "hard-coded Sleep creature-type list in "
-            "`CombatEngine.resolve_spell_hp_pool` (combat.py:843-864). "
-            "Tracked by issue #466."
+        """The saving-throw effect path must skip on-fail condition
+        application when the defender is immune to that condition.
+
+        SRD acceptance: a bearded devil (condition_immunities:
+        [poisoned]) hit by an action that triggers a Constitution save
+        on hit with on_fail condition "poisoned" must not receive the
+        Poisoned condition, regardless of save success/failure. The
+        guard lives on `Creature.add_condition` /
+        `apply_condition_with_metadata` so any caller benefits.
+        """
+        from dnd_engine.core.combat import CombatEngine
+        from dnd_engine.core.creature import Abilities, Creature
+        from dnd_engine.core.dice import DiceRoller
+
+        attacker = Creature(
+            name="Bearded Devil Attacker",
+            max_hp=52,
+            ac=13,
+            abilities=Abilities(
+                strength=16,
+                dexterity=15,
+                constitution=15,
+                intelligence=9,
+                wisdom=11,
+                charisma=11,
+            ),
+        )
+        defender = Creature(
+            name="Bearded Devil Defender",
+            max_hp=52,
+            ac=13,
+            abilities=Abilities(
+                strength=16,
+                dexterity=15,
+                constitution=15,
+                intelligence=9,
+                wisdom=11,
+                charisma=11,
+            ),
+        )
+        # Mirror what `DataLoader.create_monster` attaches from the
+        # bearded devil's monsters.json entry.
+        defender.condition_immunities = ["poisoned"]
+
+        # Force the saving throw to fail by setting an impossibly high
+        # DC; on a failure the on-fail condition would normally attach.
+        saving_throw_data = {
+            "trigger": "on_hit",
+            "ability": "constitution",
+            "dc": 99,
+            "on_fail": {
+                "condition": "poisoned",
+                "duration_type": "rounds",
+                "duration": 10,
+                "allow_repeat_save": True,
+                "repeat_timing": "end_of_turn",
+            },
+        }
+
+        engine = CombatEngine(DiceRoller(seed=1))
+        result = engine._process_saving_throw_effect(saving_throw_data, attacker, defender)
+
+        assert result is not None
+        assert result["save_result"]["success"] is False, (
+            "DC 99 should force a failed save so the on-fail path runs."
+        )
+        assert result["condition_applied"] is None, (
+            "Condition must not be applied to a defender immune to it "
+            "(SRD: 'Immunity to a condition means you aren't affected "
+            "by it.')."
+        )
+        assert not defender.has_condition("poisoned"), (
+            "Defender immune to Poisoned must not have the condition attached after a failed save."
         )
 
     def test_monster_condition_immunities_field_is_consumed(self):
-        pytest.skip(
-            "GAP: monsters.json `condition_immunities` is data-only "
-            "for the catalog-driven path. The engine's only condition-"
-            "immunity check is hard-coded to creature *type* (undead / "
-            "construct → Sleep) at "
-            "`dnd-engine/dnd_engine/core/combat.py:843-854`, not the "
-            "per-monster `condition_immunities` list. A bearded "
-            "devil's `condition_immunities: [poisoned]` is never "
-            "consulted before applying the Poisoned condition. "
-            "Tracked by issue #466."
+        """A monster's catalog `condition_immunities` blocks the
+        matching condition from attaching via `Creature.add_condition`
+        and `apply_condition_with_metadata`.
+
+        Per #466, `DataLoader.create_monster` threads
+        `condition_immunities` onto the Creature, and the Creature's
+        condition-application APIs consult it via
+        `Creature.is_immune_to_condition`. A bearded devil with
+        `condition_immunities: [poisoned]` therefore cannot be made
+        Poisoned, no matter who calls `add_condition`.
+        """
+        from dnd_engine.core.creature import Abilities, Creature
+
+        abilities = Abilities(
+            strength=16,
+            dexterity=10,
+            constitution=15,
+            intelligence=9,
+            wisdom=11,
+            charisma=11,
+        )
+        bearded_devil = Creature(name="Bearded Devil", max_hp=52, ac=13, abilities=abilities)
+        # Mirror what `DataLoader.create_monster` attaches from the
+        # bearded devil's monsters.json entry.
+        bearded_devil.condition_immunities = ["poisoned"]
+
+        bearded_devil.add_condition("poisoned")
+        assert not bearded_devil.has_condition("poisoned"), (
+            "Catalog `condition_immunities` must block `add_condition` for matching conditions."
+        )
+
+        bearded_devil.apply_condition_with_metadata(
+            condition="poisoned",
+            duration_type="rounds",
+            duration=10,
+        )
+        assert not bearded_devil.has_condition("poisoned"), (
+            "Catalog `condition_immunities` must block "
+            "`apply_condition_with_metadata` for matching conditions."
         )
 
     def test_condition_immunity_blocks_condition_application(self):
-        pytest.skip(
-            "GAP: depends on the per-monster `condition_immunities` "
-            "field being consumed. The general rule "
-            "(`add_condition` / `apply_condition_with_metadata` in "
-            "`dnd-engine/dnd_engine/core/creature.py`) attaches a "
-            "condition unconditionally — there is no guard that "
-            "skips application when the target is immune. Tracked "
-            "by issue #466."
+        """A central guard on `Creature` prevents matching conditions
+        from attaching.
+
+        Two sources are honored in parity with the damage-immunity
+        path:
+          1. Catalog field `condition_immunities` (list attribute)
+          2. Condition flag `has_immunity_{condition}` (matches the
+             existing `has_immunity_{type}` convention used for
+             damage-type immunity).
+        """
+        from dnd_engine.core.creature import Abilities, Creature
+
+        abilities = Abilities(
+            strength=10,
+            dexterity=10,
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
+        )
+
+        # Source 1: catalog field.
+        catalog_immune = Creature(name="Catalog Immune", max_hp=20, ac=10, abilities=abilities)
+        catalog_immune.condition_immunities = ["paralyzed"]
+        catalog_immune.apply_condition_with_metadata(
+            condition="paralyzed",
+            duration_type="rounds",
+            duration=3,
+        )
+        assert not catalog_immune.has_condition("paralyzed"), (
+            "Catalog field `condition_immunities` must block condition application."
+        )
+
+        # Source 2: condition-flag form.
+        flag_immune = Creature(name="Flag Immune", max_hp=20, ac=10, abilities=abilities)
+        flag_immune.add_condition("has_immunity_paralyzed")
+        flag_immune.apply_condition_with_metadata(
+            condition="paralyzed",
+            duration_type="rounds",
+            duration=3,
+        )
+        assert not flag_immune.has_condition("paralyzed"), (
+            "Condition-flag `has_immunity_{condition}` must block "
+            "condition application (parity with damage-immunity path)."
+        )
+
+        # Non-immune control: condition does attach normally.
+        not_immune = Creature(name="Not Immune", max_hp=20, ac=10, abilities=abilities)
+        not_immune.apply_condition_with_metadata(
+            condition="paralyzed",
+            duration_type="rounds",
+            duration=3,
+        )
+        assert not_immune.has_condition("paralyzed"), (
+            "Sanity check: a non-immune creature still receives the condition normally."
         )
 
 
@@ -270,9 +400,7 @@ class TestImmunity_DataParity:
         commitment, independent of whether the engine reads it.
         """
         monsters: dict = json.loads(MONSTERS_JSON.read_text())
-        with_immunity = [
-            mid for mid, mdata in monsters.items() if mdata.get("damage_immunities")
-        ]
+        with_immunity = [mid for mid, mdata in monsters.items() if mdata.get("damage_immunities")]
         assert with_immunity, (
             "Expected at least one monster with `damage_immunities` "
             "in monsters.json (e.g., bearded_devil: fire, poison)."

--- a/dnd-engine/tests/test_creature.py
+++ b/dnd-engine/tests/test_creature.py
@@ -370,6 +370,48 @@ class TestCreature:
         assert creature.has_condition("stunned")
         assert len(creature.conditions) == 2
 
+    def test_is_immune_to_condition_default_false(self):
+        """Without any immunity source, `is_immune_to_condition` is False."""
+        creature = Creature(name="Fighter", max_hp=20, ac=16, abilities=self.abilities)
+        assert creature.is_immune_to_condition("poisoned") is False
+
+    def test_is_immune_to_condition_catalog_field(self):
+        """`condition_immunities` list attribute marks immunity."""
+        creature = Creature(name="Bearded Devil", max_hp=52, ac=13, abilities=self.abilities)
+        creature.condition_immunities = ["poisoned"]
+        assert creature.is_immune_to_condition("poisoned") is True
+        assert creature.is_immune_to_condition("Poisoned") is True  # case-insensitive
+        assert creature.is_immune_to_condition("paralyzed") is False
+
+    def test_is_immune_to_condition_condition_flag(self):
+        """`has_immunity_{condition}` condition flag marks immunity.
+
+        Mirrors the existing `has_immunity_{type}` convention used by
+        the damage-type immunity stage in `_apply_damage_modifiers`.
+        """
+        creature = Creature(name="Paladin", max_hp=30, ac=18, abilities=self.abilities)
+        creature.add_condition("has_immunity_frightened")
+        assert creature.is_immune_to_condition("frightened") is True
+        assert creature.is_immune_to_condition("paralyzed") is False
+
+    def test_add_condition_blocked_by_immunity(self):
+        """`add_condition` is a no-op when the target is immune."""
+        creature = Creature(name="Bearded Devil", max_hp=52, ac=13, abilities=self.abilities)
+        creature.condition_immunities = ["poisoned"]
+        creature.add_condition("poisoned")
+        assert not creature.has_condition("poisoned")
+
+    def test_apply_condition_with_metadata_blocked_by_immunity(self):
+        """`apply_condition_with_metadata` is a no-op when the target is immune."""
+        creature = Creature(name="Bearded Devil", max_hp=52, ac=13, abilities=self.abilities)
+        creature.condition_immunities = ["poisoned"]
+        creature.apply_condition_with_metadata(
+            condition="poisoned",
+            duration_type="rounds",
+            duration=10,
+        )
+        assert not creature.has_condition("poisoned")
+
     def test_creature_initiative_modifier(self):
         """Test that initiative uses dexterity modifier"""
         creature = Creature(name="Goblin", max_hp=7, ac=15, abilities=self.abilities)


### PR DESCRIPTION
## Summary

Slice 8 of plan-02 (#531) — the condition-immunity counterpart to damage-type Immunity (#464). Implements SRD § Playing the Game › Immunity for conditions:

> Immunity to a condition means you aren't affected by it.

A bearded devil (catalog `condition_immunities: [poisoned]`) hit by a beard attack no longer receives the Poisoned condition, even when its Constitution save fails. The same guard transparently extends to any caller of `Creature.add_condition` or `apply_condition_with_metadata`.

## Insertion point chosen

**Option (b) — central guard on `Creature`** (per plan-master design notes).

- New helper `Creature.is_immune_to_condition(name) -> bool` consults two sources, mirroring the damage-immunity stage in `CombatEngine._apply_damage_modifiers`:
  1. Catalog field `condition_immunities` (list attribute on Creature) populated by `DataLoader.create_monster` from monsters.json.
  2. Condition flag `has_immunity_{condition}` — parity with `has_immunity_{type}`.
- Wired into `Creature.add_condition` and `Creature.apply_condition_with_metadata` as a silent no-op guard.
- `DataLoader.create_monster` now threads `condition_immunities` onto the Creature alongside the existing `damage_*` modifier fields.

`CombatEngine._process_saving_throw_effect` also pre-checks the guard so it can return `condition_applied: None` and suppress the misleading `CONDITION_APPLIED` event that would otherwise fire for an immune defender. The general guard on `Creature` is the source of truth; the saving-throw check is just there to keep the return value/event truthful.

## Sleep preservation approach

The hard-coded undead/construct creature-type list in `CombatEngine.resolve_spell_hp_pool` (`immune_types`, `immune_targets`) is **unchanged**. The general guard returns "not immune" for those monsters in the saving-throw path (they don't carry `condition_immunities: ["unconscious"]` in monsters.json), so the two paths coexist without double-counting. The existing `test_creature_type_grants_condition_immunity` source-level assertion and all 10 sleep-spell tests continue to pass.

## Tests flipped (skip → live + passing)

- `test_general_saving_throw_path_consults_condition_immunity`
- `test_monster_condition_immunities_field_is_consumed`
- `test_condition_immunity_blocks_condition_application`

Five new focused unit tests in `test_creature.py` cover `is_immune_to_condition` (default false, catalog field, condition flag, blocked `add_condition`, blocked `apply_condition_with_metadata`).

## Scope

Touches only the condition-immunity path. Damage pipeline (slices 1-7) is untouched. Refs #531.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_immunity.py -v` — 9 passed, 0 skipped
- [x] `cd dnd-engine && uv run pytest -v -k "sleep or Sleep"` — 10 passed (Sleep behavior preserved)
- [x] `cd dnd-engine && uv run pytest tests/srd/ -x` — 429 passed, 260 skipped (other GAPs)
- [x] `cd dnd-engine && uv run pytest tests/ -x` (full suite) — 2708 passed, 261 skipped, no regressions
- [x] `uv run ruff check` + `uv run ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)