### PR TITLE
Fixed-damage weapons (#492) — plan-02

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -436,6 +436,14 @@ class Character(Creature):
         properties = weapon_data.get("properties", [])
         category = weapon_data.get("category", "melee")
 
+        # SRD § Playing the Game › Damage Rolls (lines 2205-2219):
+        # "Unless a rule says otherwise, you don't add your ability
+        #  modifier to a fixed damage amount that doesn't use a roll,
+        #  such as the damage of a Blowgun."
+        # Fixed-damage weapons short-circuit before any STR/DEX branch.
+        if weapon_data.get("fixed_damage"):
+            return 0
+
         # Determine damage bonus based on weapon type
         if "finesse" in properties:
             # Finesse weapon: use highest of STR or DEX

--- a/dnd-engine/dnd_engine/data/srd/items.json
+++ b/dnd-engine/dnd_engine/data/srd/items.json
@@ -82,6 +82,19 @@
       "range": "80/320",
       "value": 25
     },
+    "blowgun": {
+      "name": "Blowgun",
+      "source": "D&D 5E SRD (CC BY 4.0)",
+      "type": "weapon",
+      "weapon_type": "martial",
+      "category": "ranged",
+      "damage": "1d1",
+      "damage_type": "piercing",
+      "fixed_damage": true,
+      "properties": ["ammunition", "loading"],
+      "range": "25/100",
+      "value": 10
+    },
     "longbow": {
       "name": "Longbow",
       "source": "D&D 5E SRD (CC BY 4.0)",

--- a/dnd-engine/tests/srd/playing_the_game/test_damage_rolls.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_damage_rolls.py
@@ -246,17 +246,31 @@ class TestDamageRolls_FixedDamageNoModifier:
     """
 
     def test_fixed_damage_weapon_skips_ability_modifier(self) -> None:
-        pytest.skip(
-            "GAP: There is no fixed-damage weapon in the catalog and no "
-            "code path that suppresses the ability modifier for one. "
-            "`dnd_engine/data/srd/items.json:744-751` only carries "
-            "'Blowgun Needles' (ammunition) — the Blowgun weapon itself "
-            "is absent. `Character.get_damage_bonus` "
-            "(dnd_engine/core/character.py:414-448) returns "
-            "`ability_mod` unconditionally for ranged weapons; there is "
-            "no `fixed_damage` branch returning 0. Tracked by "
-            "issue #492."
+        """`Character.get_damage_bonus` returns 0 for fixed-damage weapons.
+
+        Source-level proof at `dnd_engine/core/character.py`: the
+        `get_damage_bonus` method short-circuits to `0` when the weapon
+        entry in items.json carries `"fixed_damage": true`. The Blowgun
+        (1 piercing, no roll, no ability modifier) is the canonical
+        SRD example; its catalog entry sits in
+        `dnd_engine/data/srd/items.json` alongside the other simple
+        ranged weapons. With DEX 18 (mod +4) a normal ranged weapon
+        would yield +4; the Blowgun yields 0 regardless.
+        """
+        character = _make_character(strength=10, dexterity=18)
+        items_data = json.loads(ITEMS_JSON.read_text())
+        assert "blowgun" in items_data["weapons"], (
+            "Expected blowgun in items.json for fixed-damage assertion."
         )
+        blowgun = items_data["weapons"]["blowgun"]
+        assert blowgun.get("fixed_damage") is True, (
+            "Blowgun catalog entry must declare `fixed_damage: true` so "
+            "the damage path can suppress the ability modifier."
+        )
+        # DEX +4 would normally apply for a ranged weapon; fixed_damage
+        # weapons must skip the ability modifier entirely.
+        damage_bonus = character.get_damage_bonus("blowgun", items_data)
+        assert damage_bonus == 0
 
 
 class TestDamageRolls_CatalogParity:

--- a/dnd-engine/tests/test_attack_bonus.py
+++ b/dnd-engine/tests/test_attack_bonus.py
@@ -247,6 +247,17 @@ class TestGetDamageBonus:
         with pytest.raises(KeyError):
             fighter_str_high.get_damage_bonus("fake_weapon", items_data)
 
+    def test_fixed_damage_weapon_returns_zero(self, fighter_dex_high, items_data):
+        """Verify fixed-damage weapons (e.g., Blowgun) suppress the ability modifier.
+
+        SRD § Playing the Game › Damage Rolls: "Unless a rule says
+        otherwise, you don't add your ability modifier to a fixed damage
+        amount that doesn't use a roll, such as the damage of a Blowgun."
+        """
+        # Blowgun: ranged, fixed_damage. DEX +3 would otherwise apply.
+        bonus = fighter_dex_high.get_damage_bonus("blowgun", items_data)
+        assert bonus == 0
+
 
 class TestBackwardCompatibility:
     """Test that old attack bonus properties still work"""


### PR DESCRIPTION
## Summary

Slice 9 of plan-master #531 (closes #492). Honors SRD § Playing the Game › Damage Rolls (lines 2205-2219):

> Unless a rule says otherwise, you don't add your ability modifier to a fixed damage amount that doesn't use a roll, such as the damage of a Blowgun.

Two gaps closed:

1. **Catalog gap** — Blowgun was missing entirely from `dnd_engine/data/srd/items.json` (only its ammunition, "Blowgun Needles", existed). Added the Blowgun entry: simple/martial classification per the SRD mastery table (martial ranged), 1 piercing damage, 25/100 range, `ammunition` + `loading` properties.
2. **Damage-path gap** — `Character.get_damage_bonus` returned DEX mod unconditionally for any ranged weapon. Added a short-circuit branch at the top of the method that returns `0` when `weapon_data["fixed_damage"]` is truthy, before any STR/DEX/finesse routing runs.

### Catalog flag shape chosen

Kept `"damage"` as a dice-notation string ("1d1" — always rolls 1) to match every other weapon entry; **no schema split**. Added a sibling boolean `"fixed_damage": true` on the weapon. Rationale: matches the established items.json shape, is explicit rather than inferred from notation, and survives future refactors (e.g., if someone adds a 2-damage fixed weapon they don't have to remember that "2" means "no modifier"). The damage line for the Blowgun renders as bare `"1d1"` because `format_dice_with_modifier("1d1", 0)` already collapses to bare notation when the bonus is 0.

### Where the bonus branch sits

`dnd-engine/dnd_engine/core/character.py` — at the top of `get_damage_bonus`, immediately after the weapon-data lookup and before the finesse/ranged/melee dispatch. The fix is at the **bonus-calculation stage**, not the damage chokepoint, so `_calculate_damage` and the SRD damage pipeline are untouched.

### TDD trail

- `04536c4` — flips SRD audit stub `test_fixed_damage_weapon_skips_ability_modifier` from `skip` → live, adds focused unit test `TestGetDamageBonus::test_fixed_damage_weapon_returns_zero`. Red.
- `ff88c1f` — adds Blowgun to items.json with `fixed_damage: true`. Still red (no code branch yet).
- `bdd8d1a` — adds the `fixed_damage` short-circuit. Green.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_damage_rolls.py -v` → 11 passed
- [x] `cd dnd-engine && uv run pytest tests/ -k "damage_bonus or ranged"` → 56 passed, 5 skipped (unrelated)
- [x] `cd dnd-engine && uv run pytest tests/srd/ -x` → 430 passed, 259 skipped (other gap stubs)
- [x] Full suite `uv run pytest tests/` → 2710 passed, 260 skipped, 0 failures

Refs #531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)