### PR TITLE
Underwater auto-Fire-Resistance (#518) — plan-02

### DIFF
--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -89,7 +89,11 @@ class CombatEngine:
         self.dice_roller = dice_roller if dice_roller is not None else DiceRoller()
 
     def _apply_damage_modifiers(
-        self, target: Creature, raw_damage: int, damage_type: str | None
+        self,
+        target: Creature,
+        raw_damage: int,
+        damage_type: str | None,
+        environment: str | None = None,
     ) -> int:
         """
         Scale raw damage by the target's per-type Resistance, Immunity,
@@ -137,6 +141,15 @@ class CombatEngine:
              Resistance stage additionally recognizes the literal token
              `"all"` in `damage_resistances` as a blanket source.
 
+        Environment-granted Resistance:
+            SRD § Playing the Game › Underwater Combat carves out a
+            third Resistance source: "Anything underwater has
+            Resistance to Fire damage." This is environmental, not
+            creature-typed or condition-applied. When `environment ==
+            "underwater"` and `damage_type == "fire"`, the Resistance
+            stage halves the damage exactly once (No Stacking still
+            holds with any other Fire-Resistance source).
+
         SRD § Playing the Game › Resistance and Vulnerability:
             "If you have Resistance to a damage type, damage of that
              type is halved against you (round down)."
@@ -154,6 +167,12 @@ class CombatEngine:
             damage_type: SRD damage type (e.g. "fire", "cold",
                 "slashing"). If None, no per-type scaling can apply
                 and `raw_damage` is returned unchanged.
+            environment: Optional environment tag for the target's
+                current room (e.g. "underwater"). When provided, the
+                Resistance stage consults SRD environment carve-outs
+                (currently: underwater → Fire Resistance). Defaults to
+                None for callers that have no environment context;
+                this preserves legacy behavior.
 
         Returns:
             The damage amount after the full modifier pipeline.
@@ -189,16 +208,22 @@ class CombatEngine:
         # Resistance halves matching damage with floor rounding. The
         # No-Stacking rule is satisfied by a single boolean branch:
         # multiple sources (condition flag, per-type catalog entry,
-        # blanket "all") still halve exactly once.
+        # blanket "all", environment carve-out) still halve exactly once.
         resistance_condition = f"has_resistance_{normalized_type}"
         catalog_resistances = [
             t.lower() for t in (getattr(target, "damage_resistances", None) or [])
         ]
+        # SRD § Underwater Combat: "Anything underwater has Resistance
+        # to Fire damage." Environment-granted, not catalog or condition.
+        environment_grants_resistance = (
+            environment == "underwater" and normalized_type == "fire"
+        )
         has_resistance = (
             target.has_condition(resistance_condition)
             or target.has_condition("has_resistance_all")
             or normalized_type in catalog_resistances
             or "all" in catalog_resistances
+            or environment_grants_resistance
         )
         if has_resistance:
             damage = damage // 2
@@ -378,9 +403,18 @@ class CombatEngine:
             # so both summands route through the same chokepoint as a
             # single total. When `damage_type` is None this is a no-op
             # and the legacy untyped behavior is preserved.
+            # Environment context (SRD § Underwater Combat: underwater
+            # grants Fire Resistance, #518) is sourced from game_state
+            # when available; unit tests without a game_state see the
+            # legacy no-environment behavior.
+            environment = (
+                game_state.creature_environment(defender)
+                if game_state is not None and hasattr(game_state, "creature_environment")
+                else None
+            )
             total_pre_modifier = damage + sneak_attack_damage
             total_post_modifier = self._apply_damage_modifiers(
-                defender, total_pre_modifier, damage_type
+                defender, total_pre_modifier, damage_type, environment=environment
             )
             # Reflect the post-modifier values back onto the AttackResult.
             # When the target is immune both summands collapse to zero;
@@ -783,6 +817,7 @@ class CombatEngine:
         upcast_level: int | None = None,
         apply_damage: bool = False,
         event_bus=None,
+        game_state=None,
     ) -> dict[str, Any]:
         """
         Resolve a spell that requires saving throws.
@@ -805,6 +840,12 @@ class CombatEngine:
             upcast_level: Spell slot level used (for upcasting), defaults to spell's base level
             apply_damage: If True, apply damage to targets' HP
             event_bus: Optional EventBus instance for event emission
+            game_state: Optional GameState used to source per-target
+                environment context for the damage-modifier chokepoint
+                (SRD § Underwater Combat: anything underwater has
+                Resistance to Fire damage, #518). Optional for backward
+                compatibility — callers without a game_state see the
+                legacy no-environment behavior.
 
         Returns:
             Dictionary with spell cast results:
@@ -913,7 +954,17 @@ class CombatEngine:
             # that applies BEFORE Resistance per the Order-of-
             # Application rule; #468 will codify the ordering across
             # the full pipeline.
-            damage = self._apply_damage_modifiers(target, damage, spell_damage_type)
+            # Environment context (SRD § Underwater Combat: underwater
+            # grants Fire Resistance, #518) is sourced from game_state
+            # when available.
+            target_environment = (
+                game_state.creature_environment(target)
+                if game_state is not None and hasattr(game_state, "creature_environment")
+                else None
+            )
+            damage = self._apply_damage_modifiers(
+                target, damage, spell_damage_type, environment=target_environment
+            )
 
             # Apply damage if requested
             if apply_damage and damage > 0:

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -648,6 +648,38 @@ class GameState:
         """
         return self.dungeon["rooms"][self.current_room_id]
 
+    def creature_environment(self, creature: "Creature") -> str | None:
+        """
+        Return the environment tag of the room containing `creature`.
+
+        Used by the combat damage-modifier chokepoint to consult
+        environment-granted carve-outs (SRD § Underwater Combat:
+        anything underwater has Resistance to Fire damage; #518).
+
+        Today the engine has no per-creature room tracking — both the
+        party and the `active_enemies` in a combat encounter share the
+        current room (enemies are instantiated from
+        `room["enemies"]` when combat starts; see
+        `_check_for_enemies`). This method therefore returns the
+        current room's `environment` for any creature, regardless of
+        identity. When per-creature room tracking lands (#514), this is
+        the single seam to update.
+
+        Args:
+            creature: The creature whose environment is being queried.
+                Currently unused but kept in the signature for forward
+                compatibility with per-creature room tracking.
+
+        Returns:
+            The room's `environment` value (e.g. `"underwater"`) or
+            `None` when the current room declares no environment tag.
+        """
+        room = self.get_current_room()
+        env = room.get("environment")
+        if env is None:
+            return None
+        return str(env).lower()
+
     def mark_room_displayed(self) -> None:
         """
         Mark current room as displayed for narrative transition tracking.
@@ -2419,13 +2451,17 @@ class GameState:
         broke_concentration: str | None,
     ) -> "CombatSpellResult":
         """Resolve saving throw spell via combat_engine.resolve_spell_save()."""
-        # Delegate to existing combat engine method
+        # Delegate to existing combat engine method.
+        # game_state is threaded through so the chokepoint can source
+        # per-target environment context (SRD § Underwater Combat
+        # auto-Fire-Resistance, #518).
         save_result = self.combat_engine.resolve_spell_save(
             caster=caster,
             targets=targets,
             spell=spell_data,
             apply_damage=True,
             event_bus=self.event_bus,
+            game_state=self,
         )
 
         # Check concentration breaks for each target that took damage

--- a/dnd-engine/tests/srd/playing_the_game/test_underwater_combat.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_underwater_combat.py
@@ -329,32 +329,68 @@ class TestUnderwaterCombat_FireResistance:
         )
 
     def test_underwater_creature_automatically_gains_fire_resistance(self) -> None:
-        pytest.skip(
-            "GAP: there is no automatic 'underwater grants Fire "
-            "Resistance' application. The resistance pipeline keys on "
-            "the `has_resistance_fire` *condition* (consumed at "
-            "`systems/item_effects.py` in `_apply_damage_effect`) but "
-            "no code path adds that condition based on environment. "
-            "`GameState.move_to_room` does not consult any "
-            "environment-grants-resistance table. The SRD's 'anything "
-            "underwater has Resistance to Fire' is unique among "
-            "resistance sources because it is environmental, not "
-            "creature-typed (#462) or condition-applied. Tracked by "
-            "issue #518 (depends on #514 environment seam)."
+        """Environment-granted Fire Resistance via the chokepoint (#518).
+
+        The chokepoint `CombatEngine._apply_damage_modifiers` takes an
+        optional `environment` argument. When that argument is
+        "underwater" and the damage type is fire, the Resistance stage
+        halves the damage — without the target carrying any
+        `has_resistance_fire` condition or catalog entry.
+        """
+        target = _make_creature(hp=50)
+        engine = CombatEngine(DiceRoller(seed=1))
+
+        # No condition, no catalog entry — only the environment.
+        assert not target.has_condition("has_resistance_fire")
+        assert not getattr(target, "damage_resistances", None)
+
+        result = engine._apply_damage_modifiers(
+            target, raw_damage=10, damage_type="fire", environment="underwater"
+        )
+        assert result == 5, (
+            "SRD: Anything underwater has Resistance to Fire damage — "
+            "10 fire damage should halve to 5 from the environment "
+            "alone."
         )
 
     def test_fire_resistance_in_attack_pipeline_underwater(self) -> None:
-        pytest.skip(
-            "GAP: even if the underwater environment applied "
-            "`has_resistance_fire`, attack-pipeline fire damage would "
-            "not honor it. `CombatEngine.resolve_attack` (`dnd_engine/"
-            "core/combat.py:91`) and `CombatEngine.resolve_spell_save` "
-            "(combat.py:547) do not consult any per-type resistance — "
-            "they call `target.take_damage(amount)` with a raw integer. "
-            "The resistance halving lives only in `systems/item_"
-            "effects._apply_damage_effect`. Tracked by issues #461 "
-            "(damage_type pipeline) and #518 (this rule's environment "
-            "seam)."
+        """End-to-end: a fire weapon attack in an underwater room halves.
+
+        Driving `CombatEngine.resolve_attack` with a stub `game_state`
+        whose `creature_environment` returns "underwater" exercises the
+        full integration path: the chokepoint is consulted, environment
+        is sourced via the game_state seam, and the damage applied to
+        the defender is halved.
+        """
+        engine = CombatEngine(DiceRoller(seed=7))
+        attacker = _make_creature("Attacker")
+        defender = _make_creature("Defender", hp=50)
+
+        class _StubGameState:
+            """Minimal game_state stub for the chokepoint env seam."""
+
+            def get_effective_ac(self, creature):
+                return creature._base_ac
+
+            def creature_environment(self, creature):
+                return "underwater"
+
+        # Fixed 10 fire damage ("0d4+10") removes the dice-roll
+        # noise; we care that 10 underwater fire halves to 5.
+        starting_hp = defender.current_hp
+        engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=100,  # guarantee a hit
+            damage_dice="0d4+10",
+            apply_damage=True,
+            damage_type="fire",
+            game_state=_StubGameState(),
+        )
+        # Underwater env grants Fire Resistance → 10 halves to 5.
+        assert starting_hp - defender.current_hp == 5, (
+            "SRD: Fire damage against a creature in an underwater room "
+            "must route through Resistance halving via the chokepoint."
         )
 
 

--- a/dnd-engine/tests/test_combat.py
+++ b/dnd-engine/tests/test_combat.py
@@ -746,6 +746,98 @@ class TestBlanketResistance:
         assert result == 20
 
 
+class TestUnderwaterFireResistance:
+    """Tests for environment-granted Fire Resistance underwater (#518).
+
+    SRD § Playing the Game › Underwater Combat:
+        "Anything underwater has Resistance to Fire damage (explained in
+         'Damage and Healing')."
+
+    Unlike the condition-flag and monster-catalog Resistance sources,
+    this Resistance is *environmental* — it applies to any creature in
+    a room whose `environment` is "underwater", without mutating the
+    creature's conditions or catalog fields. The chokepoint reads the
+    environment via an optional `environment` parameter so the call
+    sites (`resolve_attack`, `resolve_spell_save`) can pass it in and
+    direct-chokepoint tests can exercise it without spinning up a full
+    `GameState`.
+    """
+
+    def setup_method(self):
+        self.engine = CombatEngine(DiceRoller(seed=1))
+        abilities = Abilities(
+            strength=10, dexterity=10, constitution=10, intelligence=10, wisdom=10, charisma=10
+        )
+        self.target = Creature(name="Target", max_hp=100, ac=10, abilities=abilities)
+
+    def test_underwater_environment_halves_fire_damage(self):
+        """SRD: anything underwater has Resistance to Fire damage."""
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=10, damage_type="fire", environment="underwater"
+        )
+        assert result == 5
+
+    def test_underwater_environment_floors_odd_fire_damage(self):
+        """Resistance halves with floor rounding even when environment-granted."""
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=7, damage_type="fire", environment="underwater"
+        )
+        assert result == 3
+
+    def test_non_underwater_environment_leaves_fire_damage_untouched(self):
+        """A creature on land takes full fire damage (no false-positive)."""
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=10, damage_type="fire", environment=None
+        )
+        assert result == 10
+
+    def test_underwater_environment_does_not_resist_cold(self):
+        """Per-type scoping: underwater grants Fire Resistance only."""
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=10, damage_type="cold", environment="underwater"
+        )
+        assert result == 10
+
+    def test_underwater_environment_does_not_resist_lightning(self):
+        """Per-type scoping: underwater grants Fire Resistance only.
+
+        Lightning underwater could plausibly be *worse* in fiction, but
+        SRD only carves out Fire Resistance. Anything else is untouched.
+        """
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=10, damage_type="lightning", environment="underwater"
+        )
+        assert result == 10
+
+    def test_underwater_fire_resistance_does_not_stack_with_condition_flag(self):
+        """No Stacking: env + `has_resistance_fire` still halves once."""
+        self.target.add_condition("has_resistance_fire")
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=10, damage_type="fire", environment="underwater"
+        )
+        assert result == 5
+
+    def test_underwater_fire_immunity_still_zeroes_damage(self):
+        """Immunity precedence: a fire-immune creature underwater still takes 0."""
+        self.target.damage_immunities = ["fire"]
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=20, damage_type="fire", environment="underwater"
+        )
+        assert result == 0
+
+    def test_underwater_fire_resistance_then_vulnerability_doubles_after_halving(self):
+        """Pipeline ordering: env-Resistance halves, then Vulnerability doubles.
+
+        21 fire, fire-Vulnerable, underwater (env-granted Fire Resistance):
+            floor(21 / 2) = 10, then 10 * 2 = 20.
+        """
+        self.target.add_condition("has_vulnerability_fire")
+        result = self.engine._apply_damage_modifiers(
+            self.target, raw_damage=21, damage_type="fire", environment="underwater"
+        )
+        assert result == 20
+
+
 class TestResolveAttackDamageType:
     """Tests for `damage_type` plumbing through `resolve_attack`."""
 

--- a/dnd-engine/tests/test_lighting.py
+++ b/dnd-engine/tests/test_lighting.py
@@ -256,3 +256,47 @@ class TestPerceptionPenalties:
         assert effective_lighting == "dim"
 
         # So they get disadvantage (-5 for passive) instead of auto-fail
+
+
+class TestCreatureEnvironment:
+    """Test the `GameState.creature_environment` seam (#518).
+
+    The combat damage-modifier chokepoint reads a creature's environment
+    via this method to apply SRD environment carve-outs (underwater →
+    Fire Resistance). The method reads the current room's `environment`
+    field (the minimal schema addition for #518; full environment-flag
+    work — schema validation, per-creature room tracking — lives in
+    #514).
+    """
+
+    def test_returns_none_when_room_has_no_environment(self, human_character):
+        """A room without an `environment` field yields None."""
+        party = Party([human_character])
+        game_state = GameState(party, "test_dungeon")
+
+        room = game_state.get_current_room()
+        assert "environment" not in room
+
+        assert game_state.creature_environment(human_character) is None
+
+    def test_returns_underwater_when_room_environment_is_underwater(self, human_character):
+        """A room tagged `environment: "underwater"` yields "underwater"."""
+        party = Party([human_character])
+        game_state = GameState(party, "test_dungeon")
+
+        # Minimal schema addition for #518: rooms may carry an
+        # `environment` tag alongside `lighting`.
+        room = game_state.get_current_room()
+        room["environment"] = "underwater"
+
+        assert game_state.creature_environment(human_character) == "underwater"
+
+    def test_environment_lookup_is_case_insensitive(self, human_character):
+        """`Underwater` data normalizes to `underwater`."""
+        party = Party([human_character])
+        game_state = GameState(party, "test_dungeon")
+
+        room = game_state.get_current_room()
+        room["environment"] = "Underwater"
+
+        assert game_state.creature_environment(human_character) == "underwater"


### PR DESCRIPTION
## Summary

Wires SRD § Playing the Game › Underwater Combat's "anything underwater has Resistance to Fire damage" into the damage-modifier chokepoint. Slice 10 of plan-master #531.

- `CombatEngine._apply_damage_modifiers` takes an optional `environment` kwarg; the Resistance stage gains an OR-clause: `environment == "underwater" and damage_type == "fire"`.
- `resolve_attack` and `resolve_spell_save` source environment via the existing `game_state` seam (no new direct env params, so the SRD structural guards stay green).
- New helper `GameState.creature_environment(creature)` reads the current room's `environment` field.

## Environment-flag approach

#518 listed #514 (broader underwater environment flag) as a dependency. To keep this slice tight, I introduced the **minimum** needed:

- Rooms can carry an `environment` field (read via `room.get("environment")`). No schema validation, no data-file updates — the engine just consults it when present.
- `GameState.creature_environment` returns the current room's environment for any creature (party and `active_enemies` already share the current room).

Broader environment-flag work — per-creature room tracking, swim speed (#432), schema validation, the umbrella "engine recognizes underwater" test stub — stays under **#514**. The two melee/ranged underwater rules also remain unimplemented (separate plans per the issue body).

## What changed

- `dnd-engine/dnd_engine/core/combat.py` — chokepoint env param + Resistance OR-clause; `resolve_attack` and `resolve_spell_save` thread env via `game_state.creature_environment`.
- `dnd-engine/dnd_engine/core/game_state.py` — new `creature_environment()` method; spell-save callsite threads `game_state=self`.
- `dnd-engine/tests/test_combat.py` — `TestUnderwaterFireResistance` (8 tests: halve, floor, per-type scoping, no-stacking, immunity precedence, vulnerability ordering).
- `dnd-engine/tests/test_lighting.py` — `TestCreatureEnvironment` (3 tests: None, underwater, case-insensitive).
- `dnd-engine/tests/srd/playing_the_game/test_underwater_combat.py` — flipped two skips into real tests (`test_underwater_creature_automatically_gains_fire_resistance`, `test_fire_resistance_in_attack_pipeline_underwater`).

## Test plan

- [x] New chokepoint tests — 8 pass
- [x] New env-seam tests — 3 pass
- [x] SRD underwater-combat fire-resistance section — 2 stubs flipped, both green
- [x] Full chokepoint suite (`DamageModifier or Underwater or Environment`) — 24 pass
- [x] SRD regression (`tests/srd/ -x`) — 432 pass, 257 expected skips
- [x] Full `dnd-engine` suite — 2723 pass, 258 expected skips

## Refs

- Closes #518
- Plan-master: #531
- Follow-up: #514 still tracks the broader environment-flag work (room schema, per-creature room tracking, swim speed, melee/ranged underwater carve-outs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)