### PR TITLE
Migrate AC_SET_BASE to alt base-AC formula seam (#426) — plan-02

### DIFF
--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -150,14 +150,15 @@ class Creature:
         effect at a time even when several are registered — the active
         selection is the single source of truth.
 
-        Interplay with `ModifierType.AC_SET_BASE`: `GameState.get_effective_ac`
-        seeds its layered-modifier stack with this value, then applies
-        `AC_SET_BASE` effects (Mage Armor, Barkskin) on top with
-        "first-wins" semantics. If an `AC_SET_BASE` effect is active on
-        the same creature as an alt-formula selection, the effect will
-        overwrite the alt formula's base. Migrating the remaining
-        `AC_SET_BASE` consumers onto this seam (issue #426) collapses
-        the two mechanisms into one and removes that footgun.
+        Interplay with `GameState.get_effective_ac`: that method seeds
+        its layered-modifier stack with this value, then layers on
+        `ModifierType.AC_BONUS` effects (Shield, Haste) — there is no
+        longer a separate base-AC override path. Spells that change
+        the base AC (Mage Armor, Barkskin) register a formula here and
+        select it via `active_base_ac_formula`; layered bonuses stack
+        on top of whichever base is active. Per SRD § Playing the Game
+        › Attack Rolls › "Only One Base AC", the active alt-formula
+        selection is the single source of truth for the base value.
 
         Returns:
             The base AC value to use for this creature.

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -606,6 +606,13 @@ class GameState:
         # Subscribe to quest completion for dungeon unlocking
         self.event_bus.subscribe(EventType.QUEST_COMPLETED, self._on_quest_completed)
 
+        # Subscribe to effect expiration so alt base-AC formula
+        # registrations from spells (Mage Armor, Barkskin) are torn
+        # down when the underlying ActiveEffect ends. See
+        # `_revert_base_ac_formula_from_effect_data` and SRD § Playing
+        # the Game › Attack Rolls › Armor Class ("Only One Base AC").
+        self.event_bus.subscribe(EventType.EFFECT_EXPIRED, self._on_effect_expired)
+
         # Combat state
         self.in_combat = False
         self.initiative_tracker: InitiativeTracker | None = None
@@ -2756,7 +2763,100 @@ class GameState:
             effect_data=effect_data,
         )
 
+        # If the spell registers an alternate base-AC formula (Mage
+        # Armor, Barkskin), wire it into the target creature now so
+        # `get_effective_ac` picks it up via `Creature.get_base_ac()`.
+        # See SRD § Playing the Game › Attack Rolls › Armor Class
+        # ("Only One Base AC") and `dnd_engine.rules.ac_formulas`.
+        self._apply_base_ac_formula_from_effect_data(target_name, effect_data)
+
         return effect
+
+    def _resolve_creature_by_name(self, name: str) -> "Creature | None":
+        """Find a Creature in the party or active enemies by name.
+
+        Spell effects reference targets by string name. Base-AC formula
+        registration must locate the actual Creature object to call
+        `register_base_ac_formula` / clear `active_base_ac_formula`.
+        """
+        character = self.party.get_character_by_name(name)
+        if character is not None:
+            return character
+        for enemy in self.active_enemies:
+            if enemy.name == name:
+                return enemy
+        return None
+
+    def _apply_base_ac_formula_from_effect_data(
+        self, target_name: str, effect_data: dict[str, Any]
+    ) -> None:
+        """Register and activate an alternate base-AC formula on target.
+
+        Looks for `modifier_type == "register_base_ac_formula"` and a
+        `formula_id` key in `effect_data`; if present, resolves the
+        formula via `dnd_engine.rules.ac_formulas.get_base_ac_formula`
+        and installs it on the target creature.
+        """
+        from dnd_engine.rules.ac_formulas import get_base_ac_formula
+        from dnd_engine.systems.time_manager import ModifierType
+
+        if effect_data.get("modifier_type") != ModifierType.REGISTER_BASE_AC_FORMULA.value:
+            return
+
+        formula_id = effect_data.get("formula_id")
+        if not formula_id:
+            logger.warning(
+                "Effect has modifier_type 'register_base_ac_formula' but no 'formula_id' key"
+            )
+            return
+
+        formula = get_base_ac_formula(formula_id)
+        if formula is None:
+            logger.warning(f"Unknown base-AC formula id: {formula_id}")
+            return
+
+        target = self._resolve_creature_by_name(target_name)
+        if target is None:
+            return
+
+        target.register_base_ac_formula(formula_id, formula)
+        target.active_base_ac_formula = formula_id
+
+    def _revert_base_ac_formula_from_effect_data(
+        self, target_name: str, effect_data: dict[str, Any]
+    ) -> None:
+        """Unregister an alternate base-AC formula when its effect ends.
+
+        Mirror of `_apply_base_ac_formula_from_effect_data`. If the
+        active selection still names this formula, clearing it via
+        `unregister_base_ac_formula` (which also wipes the selection)
+        is correct. If the player rotated to a different alt formula
+        in the meantime (Mage Armor → Barkskin), unregistering the
+        old name leaves the new selection intact.
+        """
+        from dnd_engine.systems.time_manager import ModifierType
+
+        if effect_data.get("modifier_type") != ModifierType.REGISTER_BASE_AC_FORMULA.value:
+            return
+
+        formula_id = effect_data.get("formula_id")
+        if not formula_id:
+            return
+
+        target = self._resolve_creature_by_name(target_name)
+        if target is None:
+            return
+
+        target.unregister_base_ac_formula(formula_id)
+
+    def _on_effect_expired(self, event: "Event") -> None:
+        """Handle EFFECT_EXPIRED: undo any alt base-AC formula registration."""
+        effect = event.data.get("effect")
+        if effect is None:
+            return
+        self._revert_base_ac_formula_from_effect_data(
+            effect.target_name, effect.effect_data or {}
+        )
 
     def _get_item_category(self, item_id: str) -> str | None:
         """
@@ -2818,9 +2918,22 @@ class GameState:
 
         This is the single source of truth for AC calculations. It applies
         modifiers from active effects (spells, items, conditions) in the correct order:
-        1. Base AC from armor/natural armor
-        2. AC set effects (Mage Armor, Barkskin) - only first applies
-        3. AC bonus effects (Shield, Haste) - all stack
+        1. Base AC from `creature.get_base_ac()` — honors the SRD "Only
+           One Base AC" rule via any active alternate base-AC formula
+           (Mage Armor, Barkskin, Unarmored Defense). When no alt
+           formula is selected, this is the stored `_base_ac` (armor or
+           natural-armor default).
+        2. AC bonus effects (Shield, Haste) — all stack on top.
+
+        Spells that previously set the base AC via a `modifier_type:
+        "ac_set_base"` active-effect entry are now expected to migrate
+        to the alt-formula seam (issue #426): the spell cast registers
+        and activates a named formula on the target via
+        `Creature.register_base_ac_formula` / `active_base_ac_formula`,
+        and on expiry the selection is cleared. This collapses two
+        previously competing mechanisms into one and removes the silent-
+        overwrite footgun where an `AC_SET_BASE` effect would clobber
+        an alt-formula base.
 
         Args:
             creature: Creature to calculate AC for
@@ -2841,7 +2954,6 @@ class GameState:
 
         # Apply AC modifiers in order
         final_ac = base_ac
-        has_set_base = False
 
         for effect in effects:
             effect_data = effect.effect_data
@@ -2850,14 +2962,7 @@ class GameState:
 
             modifier_type = effect_data.get("modifier_type", "")
 
-            if modifier_type == ModifierType.AC_SET_BASE.value and not has_set_base:
-                # Only first ac_set_base applies (Mage Armor, Barkskin)
-                # These spells set a minimum AC or replace base calculation
-                formula = effect_data.get("formula", "")
-                if formula:
-                    final_ac = self._evaluate_ac_formula(formula, creature)
-                    has_set_base = True
-            elif modifier_type == ModifierType.AC_BONUS.value:
+            if modifier_type == ModifierType.AC_BONUS.value:
                 # Bonuses stack (Shield: +5, Haste: +2, etc.)
                 final_ac += effect_data.get("value", 0)
 

--- a/dnd-engine/dnd_engine/data/srd/spells.json
+++ b/dnd-engine/dnd_engine/data/srd/spells.json
@@ -446,8 +446,42 @@
       "defense"
     ],
     "effect": {
-      "modifier_type": "ac_set_base",
-      "formula": "13 + dex_mod"
+      "modifier_type": "register_base_ac_formula",
+      "formula_id": "mage_armor"
+    }
+  },
+  "barkskin": {
+    "id": "barkskin",
+    "name": "Barkskin",
+    "level": 2,
+    "school": "transmutation",
+    "casting_time": "1 bonus action",
+    "range_ft": -1,
+    "target_type": "ally",
+    "components": {
+      "verbal": true,
+      "somatic": true,
+      "material": true,
+      "material_description": "a handful of bark"
+    },
+    "duration": "Timed",
+    "duration_value": "1 hour",
+    "concentration": false,
+    "ritual": false,
+    "description": "You touch a willing creature. Until the spell ends, the target's skin assumes a bark-like appearance, and the target has an Armor Class of 17 if its AC is lower than that.",
+    "classes": [
+      "druid",
+      "ranger"
+    ],
+    "source": "D&D 5E SRD (CC BY 4.0)",
+    "tags": [
+      "combat",
+      "buff",
+      "defense"
+    ],
+    "effect": {
+      "modifier_type": "register_base_ac_formula",
+      "formula_id": "barkskin"
     }
   },
   "identify": {

--- a/dnd-engine/dnd_engine/rules/ac_formulas.py
+++ b/dnd-engine/dnd_engine/rules/ac_formulas.py
@@ -1,0 +1,82 @@
+# ABOUTME: Registry mapping alternate base-AC formula identifiers to callables.
+# ABOUTME: Used by data-driven spells (Mage Armor, Barkskin) and class features.
+
+"""Alternate base-AC formula registry.
+
+SRD § Playing the Game › Attack Rolls › Armor Class › "Only One Base AC"
+states that a creature with multiple ways to calculate its AC must choose
+which one to use. The engine honors that rule via
+`Creature.register_base_ac_formula` (which stores a callable) and
+`Creature.active_base_ac_formula` (which names the single live selection).
+
+This module provides the named formulas that spell data refers to by ID
+so spells.json / items.json can stay data-driven without embedding Python
+callables. A spell effect of shape::
+
+    {"modifier_type": "register_base_ac_formula", "formula_id": "mage_armor"}
+
+instructs `GameState` to look up the callable here, register it on the
+target, and activate it for the duration of the effect.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+
+
+def _mage_armor_formula(creature: Creature) -> int:
+    """Mage Armor: target's base AC becomes 13 + Dexterity modifier.
+
+    SRD § Spell Descriptions › Mage Armor (docs/srd/spells/mage-armor.md):
+
+        "You touch a willing creature who isn't wearing armor. Until the
+        spell ends, the target's base AC becomes 13 plus its Dexterity
+        modifier."
+    """
+    return 13 + creature.abilities.dex_mod
+
+
+def _barkskin_formula(creature: Creature) -> int:
+    """Barkskin: target's AC becomes 17 if its AC is lower than that.
+
+    SRD § Spell Descriptions › Barkskin (docs/srd/spells/barkskin.md):
+
+        "You touch a willing creature. Until the spell ends, the target's
+        skin assumes a bark-like appearance, and the target has an Armor
+        Class of 17 if its AC is lower than that."
+
+    Barkskin is an AC floor rather than a hard replacement: it only
+    raises the target's AC. We honor that by returning the maximum of
+    the creature's stored `_base_ac` and 17. Because layered modifiers
+    (Shield, magic-item bonuses, Haste) are applied on top of the base
+    in `GameState.get_effective_ac`, the floor here is correctly
+    evaluated against the unarmored / armor-derived base — not against
+    a base already inflated by temporary spells.
+    """
+    return max(creature._base_ac, 17)
+
+
+# Identifier → formula. Add entries here when introducing new
+# alt-base-AC mechanics (e.g., Barbarian / Monk Unarmored Defense,
+# Draconic Resilience). Keys must be stable strings used in spell /
+# class data; values are pure functions of the creature.
+BASE_AC_FORMULAS: dict[str, Callable[[Creature], int]] = {
+    "mage_armor": _mage_armor_formula,
+    "barkskin": _barkskin_formula,
+}
+
+
+def get_base_ac_formula(formula_id: str) -> Callable[[Creature], int] | None:
+    """Return the formula callable for `formula_id`, or None if unknown.
+
+    Args:
+        formula_id: Identifier as it appears in spell / item effect data.
+
+    Returns:
+        Callable taking a `Creature` and returning its base AC, or None.
+    """
+    return BASE_AC_FORMULAS.get(formula_id)

--- a/dnd-engine/dnd_engine/systems/time_manager.py
+++ b/dnd-engine/dnd_engine/systems/time_manager.py
@@ -27,7 +27,12 @@ class EffectType(str, Enum):
 class ModifierType(str, Enum):
     """Types of stat modifiers that effects can apply."""
 
-    AC_SET_BASE = "ac_set_base"  # Set base AC (Mage Armor: 13 + DEX)
+    # Register an alternate base-AC formula on the target and activate
+    # it. SRD § Playing the Game › Attack Rolls › Armor Class › "Only
+    # One Base AC". Used by Mage Armor (13 + DEX) and Barkskin
+    # (minimum AC 17). The effect_data must carry `formula_id`, which
+    # is looked up in `dnd_engine.rules.ac_formulas.BASE_AC_FORMULAS`.
+    REGISTER_BASE_AC_FORMULA = "register_base_ac_formula"
     AC_BONUS = "ac_bonus"  # Add to AC (Shield: +5)
     ATTACK_BONUS = "attack_bonus"  # Add to attack rolls (Bless: +1d4)
     SAVE_BONUS = "save_bonus"  # Add to saves (Bless: +1d4)

--- a/dnd-engine/tests/test_ac_seam_unification.py
+++ b/dnd-engine/tests/test_ac_seam_unification.py
@@ -1,0 +1,225 @@
+# ABOUTME: Tests for AC seam unification migrating AC_SET_BASE to the alt base-AC formula seam.
+# ABOUTME: Validates that Mage Armor and Barkskin register/activate formulas instead of using AC_SET_BASE.
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.rules.ac_formulas import (
+    BASE_AC_FORMULAS,
+    _barkskin_formula,
+    _mage_armor_formula,
+    get_base_ac_formula,
+)
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.systems.resources import ResourcePool
+from dnd_engine.utils.events import EventBus
+
+
+@pytest.fixture
+def wizard():
+    """Wizard with no armor: base AC 10, DEX 14 (+2)."""
+    abilities = Abilities(
+        strength=8,
+        dexterity=14,
+        constitution=12,
+        intelligence=16,
+        wisdom=10,
+        charisma=10,
+    )
+    wiz = Character(
+        name="Gandalf",
+        character_class=CharacterClass.WIZARD,
+        level=3,
+        abilities=abilities,
+        max_hp=18,
+        ac=10,
+        spellcasting_ability="intelligence",
+        known_spells=["mage_armor"],
+        prepared_spells=["mage_armor"],
+    )
+    wiz.add_resource_pool(
+        ResourcePool(name="spell_slots_level_1", current=4, maximum=4, recovery_type="long_rest")
+    )
+    return wiz
+
+
+@pytest.fixture
+def game_state(wizard):
+    data_loader = DataLoader()
+    event_bus = EventBus()
+    dice_roller = DiceRoller()
+    party = Party()
+    party.add_character(wizard)
+    return GameState(
+        party=party,
+        dungeon_name="test_dungeon",
+        event_bus=event_bus,
+        data_loader=data_loader,
+        dice_roller=dice_roller,
+    )
+
+
+class TestACFormulaRegistry:
+    """The named formula registry is the single source of truth for alt base-AC math."""
+
+    def test_mage_armor_formula_returns_13_plus_dex(self, wizard):
+        """SRD: Mage Armor sets base AC to 13 + Dexterity modifier."""
+        assert _mage_armor_formula(wizard) == 15  # 13 + 2
+
+    def test_barkskin_formula_acts_as_floor_of_17(self, wizard):
+        """SRD: Barkskin gives AC 17 if creature's AC is lower than that."""
+        # Wizard's stored base AC is 10, so floor raises it to 17.
+        assert _barkskin_formula(wizard) == 17
+
+    def test_barkskin_formula_does_not_lower_higher_base_ac(self):
+        """A heavily armored creature's higher base AC isn't lowered to 17."""
+        abilities = Abilities(
+            strength=14, dexterity=10, constitution=14, intelligence=10, wisdom=10, charisma=10
+        )
+        # Plate-armor base AC 18 is higher than 17.
+        knight = Character(
+            name="Knight",
+            character_class=CharacterClass.FIGHTER,
+            level=3,
+            abilities=abilities,
+            max_hp=30,
+            ac=18,
+        )
+        assert _barkskin_formula(knight) == 18
+
+    def test_registry_contains_mage_armor_and_barkskin(self):
+        """spells.json data refers to these formula IDs."""
+        assert "mage_armor" in BASE_AC_FORMULAS
+        assert "barkskin" in BASE_AC_FORMULAS
+
+    def test_get_base_ac_formula_returns_none_for_unknown(self):
+        assert get_base_ac_formula("not_a_real_formula") is None
+
+
+class TestCastingMageArmorUsesAltFormulaSeam:
+    """Casting Mage Armor must register/activate the alt formula on the target."""
+
+    def test_casting_mage_armor_activates_alt_formula(self, game_state, wizard):
+        """After cast, `active_base_ac_formula == 'mage_armor'`."""
+        assert wizard.active_base_ac_formula is None
+
+        result = game_state.cast_spell_exploration("Gandalf", "mage_armor")
+        assert result["success"] is True
+
+        assert wizard.active_base_ac_formula == "mage_armor"
+        assert wizard.has_base_ac_formula("mage_armor")
+
+    def test_mage_armor_yields_expected_effective_ac(self, game_state, wizard):
+        """End-to-end: effective AC reflects 13 + DEX after cast."""
+        assert game_state.get_effective_ac(wizard) == 10
+
+        game_state.cast_spell_exploration("Gandalf", "mage_armor")
+
+        # 13 + 2 (DEX) = 15
+        assert game_state.get_effective_ac(wizard) == 15
+
+
+class TestMageArmorExpiryClearsAltFormula:
+    """When Mage Armor expires the alt selection must be cleared."""
+
+    def test_mage_armor_expiry_deactivates_formula(self, game_state, wizard):
+        """Advancing past 8 hours removes Mage Armor and clears the selection."""
+        game_state.cast_spell_exploration("Gandalf", "mage_armor")
+        assert wizard.active_base_ac_formula == "mage_armor"
+        assert game_state.get_effective_ac(wizard) == 15
+
+        # Mage Armor lasts 8 hours; advance 9 hours = 540 minutes.
+        expired = game_state.time_manager.advance_time(60 * 9, reason="long_rest")
+
+        assert any(e.source == "Mage Armor" for e in expired)
+        assert wizard.active_base_ac_formula is None
+        assert game_state.get_effective_ac(wizard) == 10
+
+
+class TestAltFormulaWinsOverACSetBaseLegacy:
+    """SRD § 'Only One Base AC' — the alt-formula selection is the single source of truth.
+
+    Regression guard against the silent-overwrite footgun the AC_SET_BASE
+    consumer used to introduce: with `get_effective_ac` consulting only
+    `Creature.get_base_ac()`, a manually pre-registered alt formula on a
+    creature must determine the base AC even if the migrated spell would
+    also try to register a different formula. This test pins down the
+    invariant that the seam (not the effect stack) is authoritative.
+    """
+
+    def test_alt_formula_replaces_pre_existing_base(self, game_state, wizard):
+        """A registered+selected alt formula is the only base AC source."""
+        wizard.register_base_ac_formula(
+            "dragonborn_resilience", lambda c: 13 + c.abilities.con_mod
+        )
+        wizard.active_base_ac_formula = "dragonborn_resilience"
+
+        # 13 + 1 (CON 12 = +1) = 14
+        assert game_state.get_effective_ac(wizard) == 14
+
+        # Casting Mage Armor switches the selection to mage_armor (one
+        # base AC at a time). 13 + 2 (DEX) = 15.
+        game_state.cast_spell_exploration("Gandalf", "mage_armor")
+        assert wizard.active_base_ac_formula == "mage_armor"
+        assert game_state.get_effective_ac(wizard) == 15
+
+
+class TestACSetBaseLintData:
+    """No new effect data may use the removed `ac_set_base` modifier_type.
+
+    The migration moves Mage Armor (and Barkskin) onto the alt-formula
+    seam. To prevent regressions, scan spells.json / items.json for
+    `ac_set_base` modifier_type entries.
+    """
+
+    DATA_ROOT = Path(__file__).resolve().parents[1] / "dnd_engine" / "data" / "srd"
+
+    def _scan_for_ac_set_base(self, data: object) -> list[str]:
+        """Recursively collect any object with modifier_type == 'ac_set_base'."""
+        hits: list[str] = []
+
+        def walk(node, path):
+            if isinstance(node, dict):
+                if node.get("modifier_type") == "ac_set_base":
+                    hits.append(path)
+                for k, v in node.items():
+                    walk(v, f"{path}.{k}")
+            elif isinstance(node, list):
+                for i, item in enumerate(node):
+                    walk(item, f"{path}[{i}]")
+
+        walk(data, "<root>")
+        return hits
+
+    def test_no_ac_set_base_modifier_in_spells_json(self):
+        spells_file = self.DATA_ROOT / "spells.json"
+        with open(spells_file) as f:
+            spells = json.load(f)
+        hits = self._scan_for_ac_set_base(spells)
+        assert not hits, (
+            "spells.json must not use the removed 'ac_set_base' modifier_type; "
+            "use 'register_base_ac_formula' with a 'formula_id' referencing "
+            "dnd_engine.rules.ac_formulas.BASE_AC_FORMULAS instead. Found at: "
+            f"{hits}"
+        )
+
+    def test_no_ac_set_base_modifier_in_items_json(self):
+        items_file = self.DATA_ROOT / "items.json"
+        if not items_file.exists():
+            return
+        with open(items_file) as f:
+            items = json.load(f)
+        hits = self._scan_for_ac_set_base(items)
+        assert not hits, (
+            "items.json must not use the removed 'ac_set_base' modifier_type; "
+            "use 'register_base_ac_formula' with a 'formula_id' referencing "
+            "dnd_engine.rules.ac_formulas.BASE_AC_FORMULAS instead. Found at: "
+            f"{hits}"
+        )

--- a/dnd-engine/tests/test_spell_effect_modifiers.py
+++ b/dnd-engine/tests/test_spell_effect_modifiers.py
@@ -64,23 +64,19 @@ class TestEffectiveACCalculation:
         assert effective_ac == 10
 
     def test_mage_armor_sets_ac(self, game_state_with_wizard, wizard):
-        """Test that Mage Armor sets AC to 13 + DEX"""
-        # Add Mage Armor effect (8 hours duration)
-        effect = ActiveEffect(
-            effect_type=EffectType.SPELL,
-            source="Mage Armor",
-            duration_type="hours",
-            duration_value=8,
-            remaining_value=8,
-            target_name=wizard.name,
-            description="Base AC becomes 13 + DEX",
-            concentration=False,
-            effect_data={
-                "modifier_type": ModifierType.AC_SET_BASE.value,
-                "formula": "13 + dex_mod",
-            },
-        )
-        game_state_with_wizard.time_manager.add_effect(effect)
+        """Test that Mage Armor sets AC to 13 + DEX.
+
+        Mage Armor migrated from the legacy `AC_SET_BASE` effect path
+        to the alt base-AC formula seam (issue #426). Setting the
+        alt formula directly here covers the same observable behavior
+        without re-creating the `ActiveEffect` wiring that
+        `_create_spell_effect` now performs end-to-end (see
+        `TestSpellCastingACModifierIntegration::test_casting_mage_armor_sets_ac`).
+        """
+        from dnd_engine.rules.ac_formulas import BASE_AC_FORMULAS
+
+        wizard.register_base_ac_formula("mage_armor", BASE_AC_FORMULAS["mage_armor"])
+        wizard.active_base_ac_formula = "mage_armor"
 
         # Effective AC should be 13 + 2 (DEX) = 15
         effective_ac = game_state_with_wizard.get_effective_ac(wizard)
@@ -107,23 +103,17 @@ class TestEffectiveACCalculation:
         assert effective_ac == 15
 
     def test_mage_armor_plus_shield(self, game_state_with_wizard, wizard):
-        """Test that Mage Armor and Shield stack correctly"""
-        # Add Mage Armor
-        mage_armor = ActiveEffect(
-            effect_type=EffectType.SPELL,
-            source="Mage Armor",
-            duration_type="hours",
-            duration_value=8,
-            remaining_value=8,
-            target_name=wizard.name,
-            description="Base AC becomes 13 + DEX",
-            concentration=False,
-            effect_data={
-                "modifier_type": ModifierType.AC_SET_BASE.value,
-                "formula": "13 + dex_mod",
-            },
-        )
-        game_state_with_wizard.time_manager.add_effect(mage_armor)
+        """Test that Mage Armor and Shield stack correctly.
+
+        Mage Armor's base now flows through the alt-formula seam;
+        Shield's +5 layers on top as an `AC_BONUS` effect. See
+        `TestAlternateBaseACComposesWithLayeredModifiers` for the
+        general invariant.
+        """
+        from dnd_engine.rules.ac_formulas import BASE_AC_FORMULAS
+
+        wizard.register_base_ac_formula("mage_armor", BASE_AC_FORMULAS["mage_armor"])
+        wizard.active_base_ac_formula = "mage_armor"
 
         # Add Shield
         shield = ActiveEffect(
@@ -143,43 +133,32 @@ class TestEffectiveACCalculation:
         effective_ac = game_state_with_wizard.get_effective_ac(wizard)
         assert effective_ac == 20
 
-    def test_multiple_ac_set_base_only_first_applies(self, game_state_with_wizard, wizard):
-        """Test that only the first AC set_base effect applies"""
-        # Add Mage Armor (13 + DEX)
-        mage_armor = ActiveEffect(
-            effect_type=EffectType.SPELL,
-            source="Mage Armor",
-            duration_type="hours",
-            duration_value=8,
-            remaining_value=8,
-            target_name=wizard.name,
-            description="Base AC becomes 13 + DEX",
-            concentration=False,
-            effect_data={
-                "modifier_type": ModifierType.AC_SET_BASE.value,
-                "formula": "13 + dex_mod",
-            },
-        )
-        game_state_with_wizard.time_manager.add_effect(mage_armor)
+    def test_only_one_active_base_ac_formula(self, game_state_with_wizard, wizard):
+        """Test that only one alternate base-AC formula is in effect at a time.
 
-        # Add a second set_base effect (should be ignored)
-        barkskin = ActiveEffect(
-            effect_type=EffectType.SPELL,
-            source="Barkskin",
-            duration_type="minutes",
-            duration_value=60,
-            remaining_value=60,
-            target_name=wizard.name,
-            description="Base AC becomes 16",
-            concentration=True,
-            caster_name=wizard.name,
-            effect_data={"modifier_type": ModifierType.AC_SET_BASE.value, "formula": "16"},
-        )
-        game_state_with_wizard.time_manager.add_effect(barkskin)
+        SRD § Playing the Game › Attack Rolls › Armor Class › "Only
+        One Base AC". With the migration to the alt-formula seam,
+        registering several formulas is allowed but only the named
+        `active_base_ac_formula` participates in `get_base_ac`. This
+        is the post-#426 replacement for the legacy "first-wins"
+        AC_SET_BASE semantics that the layered effect stack used to
+        enforce in `get_effective_ac`.
+        """
+        from dnd_engine.rules.ac_formulas import BASE_AC_FORMULAS
 
-        # Only Mage Armor should apply: 13 + 2 = 15
-        effective_ac = game_state_with_wizard.get_effective_ac(wizard)
-        assert effective_ac == 15
+        # Register both Mage Armor (13 + DEX = 15) and a competing
+        # alt formula (Barkskin floor = 17 since base 10 < 17).
+        wizard.register_base_ac_formula("mage_armor", BASE_AC_FORMULAS["mage_armor"])
+        wizard.register_base_ac_formula("barkskin", BASE_AC_FORMULAS["barkskin"])
+
+        # Select Mage Armor first: AC reflects that formula only.
+        wizard.active_base_ac_formula = "mage_armor"
+        assert game_state_with_wizard.get_effective_ac(wizard) == 15
+
+        # Switching the selection flips AC to the other formula's
+        # output (no stacking with the previous one).
+        wizard.active_base_ac_formula = "barkskin"
+        assert game_state_with_wizard.get_effective_ac(wizard) == 17
 
     def test_shield_expires_after_one_round(self, game_state_with_wizard, wizard):
         """Test that Shield effect expires after 1 combat round"""
@@ -210,7 +189,11 @@ class TestEffectiveACCalculation:
 
     def test_mage_armor_not_affected_by_rounds(self, game_state_with_wizard, wizard):
         """Test that time-based effects (Mage Armor) don't expire with round advancement"""
-        # Add Mage Armor (time-based, not round-based)
+        from dnd_engine.systems.time_manager import ModifierType
+
+        # Add Mage Armor (time-based, not round-based). Post-#426
+        # the effect_data registers a base-AC formula by id instead
+        # of carrying an inline `formula` string.
         effect = ActiveEffect(
             effect_type=EffectType.SPELL,
             source="Mage Armor",
@@ -221,10 +204,17 @@ class TestEffectiveACCalculation:
             description="Base AC becomes 13 + DEX",
             concentration=False,
             effect_data={
-                "modifier_type": ModifierType.AC_SET_BASE.value,
-                "formula": "13 + dex_mod",
+                "modifier_type": ModifierType.REGISTER_BASE_AC_FORMULA.value,
+                "formula_id": "mage_armor",
             },
         )
+        # Activate the alt formula directly so this unit test stays
+        # narrowly focused on time-vs-round advancement semantics
+        # without requiring the spell-cast pathway.
+        from dnd_engine.rules.ac_formulas import BASE_AC_FORMULAS
+
+        wizard.register_base_ac_formula("mage_armor", BASE_AC_FORMULAS["mage_armor"])
+        wizard.active_base_ac_formula = "mage_armor"
         game_state_with_wizard.time_manager.add_effect(effect)
 
         # AC should be boosted


### PR DESCRIPTION
## Summary

Final slice of **plan-02 (#531)**. Closes the AC seam unification half of plan-02's defect: collapses the two competing base-AC mechanisms introduced in #418/#425 into a single seam.

Before: `GameState.get_effective_ac` consulted **both** the new `Creature.get_base_ac()` alt-formula path AND the legacy `ModifierType.AC_SET_BASE` effect-stack path. The legacy path applied AFTER the alt formula and used "first-wins" semantics — silently overwriting any active alt-formula AC. SRD § Playing the Game › Attack Rolls › "Only One Base AC" was enforced in two places with different semantics.

After: `get_effective_ac` consults only `Creature.get_base_ac()` for the base value, then layers `AC_BONUS` effects (Shield, Haste) on top. Mage Armor and Barkskin migrate to the alt-formula seam.

Resolves #426. Part of #531.

## Design — formula-id registry

Spells stay data-driven. A new `dnd_engine/rules/ac_formulas.py` exposes a `BASE_AC_FORMULAS: dict[str, Callable[[Creature], int]]` mapping stable identifiers to pure functions:

- `mage_armor` → `13 + creature.abilities.dex_mod` (SRD `spells/mage-armor.md`)
- `barkskin` → `max(creature._base_ac, 17)` — see Barkskin notes below

A new `ModifierType.REGISTER_BASE_AC_FORMULA` replaces `AC_SET_BASE`. Spell `effect` blocks now look like:

```json
{"modifier_type": "register_base_ac_formula", "formula_id": "mage_armor"}
```

`GameState._create_spell_effect` calls a new helper that resolves the target creature (party or active enemy), looks the formula up by id, and installs it via the existing `Creature.register_base_ac_formula` + `active_base_ac_formula` API. `GameState` subscribes to `EventType.EFFECT_EXPIRED` to tear the registration down when the effect ends (time-based expiry, round-based expiry, and concentration break all already emit this event).

## Barkskin interpretation

SRD v5.2.1 wording (`docs/srd/spells/barkskin.md`): _"the target has an Armor Class of 17 if its AC is lower than that."_ This is a **floor**, not a replacement. The formula returns `max(creature._base_ac, 17)`, so a plate-armored fighter (AC 18) is unaffected, while an unarmored druid (AC 10) is raised to 17.

The floor is evaluated against `_base_ac` (the stored unarmored / armor-derived default), not against a base already inflated by other temporary spells — that matches the layered-modifier model: layered `AC_BONUS` effects stack on top of whichever base is active.

## Lint test

`tests/test_ac_seam_unification.py::TestACSetBaseLintData` walks `spells.json` and `items.json` and fails if any object carries `modifier_type: "ac_set_base"`. Prevents data regressions.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_attack_rolls.py -v` — 17 passed
- [x] `cd dnd-engine && uv run pytest -v -k "mage_armor or MageArmor or barkskin or Barkskin"` — 13 passed
- [x] `cd dnd-engine && uv run pytest tests/srd/ -x` — 432 passed, 257 skipped (unchanged)
- [x] `cd dnd-engine && uv run pytest tests/ -x` — **2734 passed**, 258 skipped
- [x] `TestArmorClass_OnlyOneBaseAC::test_only_one_base_ac_selection_is_enforced` continues to pass
- [x] End-to-end smoke: cast Mage Armor → AC 15, advance 9h → AC 10, formula cleared

## Files

- `dnd-engine/dnd_engine/rules/ac_formulas.py` (new) — formula registry
- `dnd-engine/dnd_engine/core/game_state.py` — seam wiring + effect-expiry subscriber
- `dnd-engine/dnd_engine/systems/time_manager.py` — `REGISTER_BASE_AC_FORMULA` enum
- `dnd-engine/dnd_engine/data/srd/spells.json` — Mage Armor migrated, Barkskin added
- `dnd-engine/dnd_engine/core/creature.py` — docstring updated
- `dnd-engine/tests/test_ac_seam_unification.py` (new) — 11 tests covering registry, cast/expiry, lint
- `dnd-engine/tests/test_spell_effect_modifiers.py` — 4 legacy AC_SET_BASE tests migrated

🤖 Generated with [Claude Code](https://claude.com/claude-code)