### PR TITLE
Bloodied state derived property (#488) — plan-04

### DIFF
--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -107,6 +107,25 @@ class Creature:
         return self.current_hp > 0
 
     @property
+    def is_bloodied(self) -> bool:
+        """Whether the creature is Bloodied (SRD § Playing the Game › Hit Points).
+
+        Per SRD: "If you have half your Hit Points or fewer, you're
+        Bloodied, which has no game effect on its own but which might
+        trigger other game effects."
+
+        Pure derived flag — no stored state, no condition registered,
+        no mechanical modifier attached. A creature at 0 HP is not
+        Bloodied (it's Dying/Dead/Stable instead); a creature at full
+        HP is not Bloodied. Threshold uses integer division, so a
+        creature with `max_hp=21` is Bloodied at `current_hp <= 10`.
+
+        Returns:
+            True iff `0 < current_hp <= max_hp // 2`.
+        """
+        return 0 < self.current_hp <= self.max_hp // 2
+
+    @property
     def initiative_modifier(self) -> int:
         """Initiative modifier (uses Dexterity)"""
         return self.abilities.dex_mod

--- a/dnd-engine/tests/srd/playing_the_game/test_hit_points.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_hit_points.py
@@ -232,23 +232,63 @@ class TestHitPoints_Bloodied:
     """
 
     def test_creature_at_half_hp_or_fewer_is_bloodied(self) -> None:
-        pytest.skip(
-            "GAP: there is no `is_bloodied` property on `Creature` "
-            "(dnd_engine/core/creature.py:57+) and no `bloodied` "
-            "condition in the catalog. The string 'bloodied' appears "
-            "only as flavor prose in campaign narrative data "
-            "(dnd_engine/data/content/campaigns/the_unquiet_dead/dungeons/"
-            "cult_hideout.json:265). Tracked by issue #488."
-        )
+        """`is_bloodied` is True iff `0 < current_hp <= max_hp // 2`.
+
+        Source: `dnd_engine/core/creature.py` `Creature.is_bloodied`.
+        A creature at full HP is not Bloodied; a creature at 0 HP is
+        Dying/Dead/Stable, not Bloodied.
+        """
+        # At exactly half HP -> Bloodied
+        creature = _make_creature(max_hp=20, current_hp=10)
+        assert creature.is_bloodied is True
+
+        # Below half -> Bloodied
+        creature = _make_creature(max_hp=20, current_hp=5)
+        assert creature.is_bloodied is True
+
+        # Down to 1 HP -> still Bloodied (still alive, still <= half)
+        creature = _make_creature(max_hp=20, current_hp=1)
+        assert creature.is_bloodied is True
+
+        # Just above half -> not Bloodied
+        creature = _make_creature(max_hp=20, current_hp=11)
+        assert creature.is_bloodied is False
+
+        # Full HP -> not Bloodied
+        creature = _make_creature(max_hp=20, current_hp=20)
+        assert creature.is_bloodied is False
+
+        # 0 HP -> not Bloodied (creature is Dying/Dead/Stable, not Bloodied)
+        creature = _make_creature(max_hp=20, current_hp=0)
+        assert creature.is_bloodied is False
 
     def test_bloodied_state_has_no_inherent_mechanical_effect(self) -> None:
-        pytest.skip(
-            "GAP: depends on Bloodied being implemented. The SRD calls "
-            "out that Bloodied has no game effect on its own — the "
-            "engine must surface the state as a flag (event / property) "
-            "without attaching capability-altering modifiers. Tracked "
-            "by issue #488."
-        )
+        """Becoming Bloodied is a flag only — no conditions, no capability shift.
+
+        The SRD spells out that Bloodied "has no game effect on its own
+        but which might trigger other game effects." This test pins the
+        engine to surface the state as a pure derived property without
+        attaching any modifier, condition, or action-economy change.
+        """
+        creature = _make_creature(max_hp=20, current_hp=20)
+
+        # Pre-state: not bloodied, no conditions, can act, not incapacitated.
+        assert creature.is_bloodied is False
+        conditions_before = dict(creature.active_conditions)
+        can_act_before = creature.can_take_actions()
+        incapacitated_before = creature.is_incapacitated()
+
+        # Drop below half HP -> becomes Bloodied.
+        creature.take_damage(15)
+        assert creature.current_hp == 5
+        assert creature.is_bloodied is True
+
+        # No conditions were added or removed by crossing the threshold.
+        assert creature.active_conditions == conditions_before
+
+        # Action-economy capabilities are unchanged.
+        assert creature.can_take_actions() == can_act_before
+        assert creature.is_incapacitated() == incapacitated_before
 
 
 class TestHitPoints_MaxHpField:

--- a/dnd-engine/tests/test_creature.py
+++ b/dnd-engine/tests/test_creature.py
@@ -134,6 +134,50 @@ class TestCreature:
         assert creature.current_hp == 0
         assert creature.is_alive is False
 
+    def test_is_bloodied_at_full_hp(self):
+        """A creature at full HP is not Bloodied."""
+        creature = Creature(name="Goblin", max_hp=20, ac=15, abilities=self.abilities)
+        assert creature.is_bloodied is False
+
+    def test_is_bloodied_at_exactly_half_hp(self):
+        """A creature at exactly half max HP is Bloodied (boundary: <= max_hp // 2)."""
+        creature = Creature(name="Goblin", max_hp=20, ac=15, abilities=self.abilities)
+        creature.take_damage(10)
+        assert creature.current_hp == 10
+        assert creature.is_bloodied is True
+
+    def test_is_bloodied_just_above_half_hp(self):
+        """A creature one HP above half is not Bloodied."""
+        creature = Creature(name="Goblin", max_hp=20, ac=15, abilities=self.abilities)
+        creature.take_damage(9)
+        assert creature.current_hp == 11
+        assert creature.is_bloodied is False
+
+    def test_is_bloodied_at_one_hp(self):
+        """A creature at 1 HP is Bloodied (still alive, still <= half)."""
+        creature = Creature(name="Goblin", max_hp=20, ac=15, abilities=self.abilities)
+        creature.take_damage(19)
+        assert creature.current_hp == 1
+        assert creature.is_bloodied is True
+
+    def test_is_bloodied_at_zero_hp(self):
+        """A creature at 0 HP is not Bloodied (it's Dying/Dead/Stable instead)."""
+        creature = Creature(name="Goblin", max_hp=20, ac=15, abilities=self.abilities)
+        creature.take_damage(20)
+        assert creature.current_hp == 0
+        assert creature.is_bloodied is False
+
+    def test_is_bloodied_uses_integer_half_for_odd_max_hp(self):
+        """Odd `max_hp` uses integer division: max_hp=21 -> bloodied at <= 10."""
+        creature = Creature(name="Goblin", max_hp=21, ac=15, abilities=self.abilities)
+        creature.take_damage(11)
+        assert creature.current_hp == 10
+        assert creature.is_bloodied is True
+
+        creature.heal(1)
+        assert creature.current_hp == 11
+        assert creature.is_bloodied is False
+
     def test_creature_conditions(self):
         """Test adding and removing conditions"""
         creature = Creature(name="Fighter", max_hp=20, ac=16, abilities=self.abilities)


### PR DESCRIPTION
## Summary
- Adds `Creature.is_bloodied` derived property per SRD § Playing the Game › Hit Points › Bloodied
- Pure data-surfacable flag; no inherent mechanical effect
- Un-skips both tests in `TestHitPoints_Bloodied`

## Slice scope (plan-04)
Slice 8 of [#533](../../issues/533). Closes #488.

## Test plan
- [x] `uv run pytest tests/srd/playing_the_game/test_hit_points.py::TestHitPoints_Bloodied -v`
- [x] `uv run pytest tests/srd/ -q` — no regressions
- [x] `uv run pytest tests/test_creature.py -q` — no regressions