### PR TITLE
Unconscious-on-0HP + DyingState foundation (#452, #334) — plan-04

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -20,6 +20,26 @@ class CharacterClass(Enum):
     CLERIC = "cleric"
 
 
+class DyingState(str, Enum):
+    """High-level dying-pipeline state for a Character.
+
+    Derived purely from `current_hp`, `death_save_failures`, and
+    `stabilized`. Foundation for SRD "Dropping to 0 Hit Points" logic
+    that needs a single read of where the character sits in the
+    unconscious / stable / dead pipeline.
+
+    - ALIVE:  current_hp > 0
+    - DYING:  current_hp == 0, failures < 3, not stabilized
+    - STABLE: current_hp == 0, stabilized (auto-recovers eventually)
+    - DEAD:   failures >= 3
+    """
+
+    ALIVE = "alive"
+    DYING = "dying"
+    STABLE = "stable"
+    DEAD = "dead"
+
+
 class Character(Creature):
     """
     Player character class.
@@ -1114,6 +1134,12 @@ class Character(Creature):
         - If damage at 0 HP: add 1 death save failure
         - If damage >= max HP at 0 HP: instant death (massive damage)
 
+        Falling Unconscious (SRD § Playing the Game › Dropping to 0
+        Hit Points): when the character reaches 0 HP without dying
+        outright, the Unconscious condition is added to
+        `active_conditions` so `is_incapacitated()` reflects it.
+        Death (3 failures) replaces `"unconscious"` with `"dead"`.
+
         Args:
             amount: Amount of damage to apply
             event_bus: Optional EventBus for event emission
@@ -1155,11 +1181,21 @@ class Character(Creature):
                         )
                     )
 
+        # Sync the SRD Unconscious / Dead condition flags with the
+        # derived HP / death-save state. Done after the damage and
+        # failure bookkeeping above so a single-blow kill ends in the
+        # correct terminal state.
+        self._sync_dying_conditions()
+
     def recover_hp(self, amount: int | None = None) -> int:
         """
         Recover hit points.
 
         If recovering from 0 HP, resets death saves.
+
+        SRD § Playing the Game › Falling Unconscious: the Unconscious
+        condition lasts "until you regain any Hit Points". Healing
+        past 0 HP removes the condition from `active_conditions`.
 
         Args:
             amount: Amount to heal (None = full heal)
@@ -1178,6 +1214,7 @@ class Character(Creature):
         # Reset death saves if regaining HP from unconscious
         if was_unconscious and self.current_hp > 0:
             self.reset_death_saves()
+            self.remove_condition("unconscious")
 
         return healed
 
@@ -1314,6 +1351,51 @@ class Character(Creature):
         """
         return self.death_save_failures >= 3
 
+    @property
+    def dying_state(self) -> DyingState:
+        """
+        High-level dying-pipeline state.
+
+        Derived purely from `current_hp`, `death_save_failures`, and
+        `stabilized`. See `DyingState` for the four values:
+        ALIVE / DYING / STABLE / DEAD. Pure read — no side effects.
+
+        Returns:
+            DyingState reflecting where the character sits in the SRD
+            "Dropping to 0 Hit Points" pipeline.
+        """
+        if self.death_save_failures >= 3:
+            return DyingState.DEAD
+        if self.current_hp > 0:
+            return DyingState.ALIVE
+        if self.stabilized:
+            return DyingState.STABLE
+        return DyingState.DYING
+
+    def _sync_dying_conditions(self) -> None:
+        """
+        Keep `active_conditions` in sync with the dying-state pipeline.
+
+        Writes the SRD Unconscious / Dead condition flags so that
+        `Creature.is_incapacitated()` (which checks
+        `active_conditions`) reflects the character's HP / death-save
+        state. Called from `take_damage` and `make_death_save` after
+        their bookkeeping completes.
+
+        - Dead (3+ failures): replace `"unconscious"` with `"dead"`.
+        - Unconscious (HP 0, failures < 3): add `"unconscious"`.
+        - Conscious (HP > 0): clear `"unconscious"`. The `"dead"`
+          flag is intentionally not cleared here — revival is its own
+          flow.
+        """
+        if self.death_save_failures >= 3:
+            self.remove_condition("unconscious")
+            self.add_condition("dead")
+        elif self.current_hp == 0:
+            self.add_condition("unconscious")
+        else:
+            self.remove_condition("unconscious")
+
     def make_death_save(self, event_bus=None) -> dict[str, Any]:
         """
         Roll a death saving throw.
@@ -1376,6 +1458,7 @@ class Character(Creature):
             # Natural 20: regain 1 HP and become conscious
             self.current_hp = 1
             self.reset_death_saves()
+            self.remove_condition("unconscious")
             conscious = True
         elif natural_1:
             # Natural 1: counts as 2 failures
@@ -1389,6 +1472,11 @@ class Character(Creature):
         else:
             # Failure
             self.death_save_failures += 1
+
+        # Sync the SRD Unconscious / Dead condition flags after the
+        # save resolves so 3-failure death paths replace 'unconscious'
+        # with 'dead' immediately.
+        self._sync_dying_conditions()
 
         # Build result
         result = {

--- a/dnd-engine/tests/srd/playing_the_game/test_dropping_to_0_hit_points.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_dropping_to_0_hit_points.py
@@ -230,25 +230,130 @@ class TestFallingUnconscious_ConditionApplied:
 
         `Creature.is_incapacitated()` (creature.py:320-340) checks
         membership of `"unconscious"` in `active_conditions`. Dropping
-        to 0 HP does NOT add the condition there — `take_damage`
-        (character.py:1100-1148) only updates death-save state. As a
-        result, an unconscious character is *not* flagged as
-        incapacitated by the SRD-glossary-aligned helper, so rules
-        that key off the Incapacitated condition (e.g. ranged-in-
-        close-combat advantage, OA visibility) won't see them.
+        to 0 HP adds the condition there so rules that key off the
+        Incapacitated condition (e.g. ranged-in-close-combat
+        advantage, OA visibility) see the downed character.
         """
-        pytest.skip(
-            "GAP: Dropping to 0 HP does not add the 'unconscious' "
-            "condition to `Creature.active_conditions`. `Character."
-            "take_damage` updates death-save state only "
-            "(dnd-engine/dnd_engine/core/character.py:1100-1148), so "
-            "`Creature.is_incapacitated()` "
-            "(dnd-engine/dnd_engine/core/creature.py:320-340), which "
-            "checks `active_conditions`, returns False for a "
-            "downed character. Rules that key off Incapacitated "
-            "(e.g. SRD ranged-attacks-in-close-combat exception) "
-            "won't fire. See issue #452."
-        )
+        character = _make_character(max_hp=12)
+
+        # Lethal-but-not-massive damage: brings positive-HP character
+        # to 0 without triggering the massive-damage instant-death
+        # branch (which requires already-at-0 entry today).
+        character.take_damage(12)
+
+        assert character.current_hp == 0
+        assert character.is_unconscious is True
+        assert "unconscious" in character.active_conditions
+        assert character.is_incapacitated() is True
+
+        # Healing past 0 HP should remove the Unconscious condition
+        # — SRD: "until you regain any Hit Points".
+        character.recover_hp(5)
+
+        assert character.current_hp == 5
+        assert "unconscious" not in character.active_conditions
+        assert character.is_incapacitated() is False
+
+
+class TestDyingState_DerivedProperty:
+    """Derived `Character.dying_state` reports Alive / Dying / Stable / Dead.
+
+    Foundation for plan-04 slices that need a single high-level read
+    of where a character sits in the dying pipeline. Pure function of
+    `current_hp`, `death_save_failures`, and `stabilized` — no setter,
+    no side effects.
+    """
+
+    def test_alive_when_hp_positive(self):
+        from dnd_engine.core.character import DyingState
+
+        character = _make_character(max_hp=12)
+
+        assert character.current_hp > 0
+        assert character.dying_state == DyingState.ALIVE
+
+    def test_dying_when_at_zero_hp_with_failures_below_three(self):
+        from dnd_engine.core.character import DyingState
+
+        character = _make_character(max_hp=12)
+        character.current_hp = 0
+
+        assert character.death_save_failures < 3
+        assert character.stabilized is False
+        assert character.dying_state == DyingState.DYING
+
+    def test_dying_with_partial_failures(self):
+        from dnd_engine.core.character import DyingState
+
+        character = _make_character(max_hp=12)
+        character.current_hp = 0
+        character.death_save_failures = 2
+
+        assert character.dying_state == DyingState.DYING
+
+    def test_stable_when_zero_hp_and_stabilized(self):
+        from dnd_engine.core.character import DyingState
+
+        character = _make_character(max_hp=12)
+        character.current_hp = 0
+        character.stabilized = True
+
+        assert character.dying_state == DyingState.STABLE
+
+    def test_dead_when_three_or_more_failures(self):
+        from dnd_engine.core.character import DyingState
+
+        character = _make_character(max_hp=12)
+        character.current_hp = 0
+        character.death_save_failures = 3
+
+        assert character.dying_state == DyingState.DEAD
+
+    def test_dying_state_is_read_only_property(self):
+        """`dying_state` is a derived property — no setter."""
+        character = _make_character(max_hp=12)
+
+        with pytest.raises(AttributeError):
+            character.dying_state = "alive"  # type: ignore[misc]
+
+
+class TestDyingState_DeathSaveLifecycle:
+    """Condition lifecycle around death-save outcomes."""
+
+    def test_natural_20_death_save_removes_unconscious_condition(self):
+        """Natural 20 brings the character to 1 HP and clears the
+        Unconscious condition from `active_conditions`."""
+        character = _make_character(max_hp=12)
+
+        character.take_damage(12)
+        assert "unconscious" in character.active_conditions
+
+        # Force a natural-20 death save by patching the dice roller
+        with patch.object(character._dice_roller, "roll") as mock_roll:
+            mock_roll.return_value = Mock(total=20)
+            result = character.make_death_save()
+
+        assert result["natural_20"] is True
+        assert character.current_hp == 1
+        assert "unconscious" not in character.active_conditions
+
+    def test_three_failures_replaces_unconscious_with_dead(self):
+        """When the character reaches 3 death save failures, the
+        Unconscious condition is replaced by a `"dead"` flag."""
+        character = _make_character(max_hp=12)
+
+        # Drop to 0 HP — adds 'unconscious'
+        character.take_damage(12)
+        assert "unconscious" in character.active_conditions
+
+        # Two more hits at 0 HP each add 1 death-save failure
+        character.take_damage(1)
+        character.take_damage(1)
+        character.take_damage(1)
+
+        assert character.is_dead is True
+        assert "unconscious" not in character.active_conditions
+        assert "dead" in character.active_conditions
 
 
 class TestDeathSavingThrows_TriggerOnStartOfTurn:


### PR DESCRIPTION
## Summary

Slice 1+2 of plan-04 ("0 HP, Death Saves & Hit-Point Model" — plan-master #533).

- When a `Character` drops to 0 HP, the SRD **Unconscious condition** is now written to `active_conditions`. `Creature.is_incapacitated()` (which checks `active_conditions`) now correctly returns `True` for downed characters, so SRD rules that key off the Incapacitated condition (ranged-in-close-combat advantage, OA visibility, etc.) finally fire.
- The condition is removed on any HP regain (heal, potion, nat-20 death save).
- Reaching 3 death-save failures replaces `"unconscious"` with `"dead"` in `active_conditions`.
- Adds a `DyingState` enum + `Character.dying_state` derived read-only property — pure function of `current_hp`, `death_save_failures`, and `stabilized` (`ALIVE` / `DYING` / `STABLE` / `DEAD`). Foundation for the rest of plan-04.

Closes #452. Closes #334. Refs plan-master #533.

### Files touched

- `dnd-engine/dnd_engine/core/character.py` — adds `DyingState`, `Character.dying_state`, `Character._sync_dying_conditions()`; `take_damage`, `recover_hp`, and `make_death_save` now call into the sync helper / `remove_condition("unconscious")` at the natural-20 branch. Massive-damage overflow branch and crit handling untouched (Slice 3+ owns those).
- `dnd-engine/tests/srd/playing_the_game/test_dropping_to_0_hit_points.py` — un-skipped `test_unconscious_condition_is_added_to_active_conditions`; added `TestDyingState_DerivedProperty` (6 tests) and `TestDyingState_DeathSaveLifecycle` (2 tests).

### Behavior change worth noting

Any rule that checks `Creature.is_incapacitated()` will now see a downed character as incapacitated (which is the SRD-correct behavior, but a real semantic change). No existing tests broke under the full suite.

## Test plan

- [x] `cd dnd-engine && uv run pytest tests/srd/playing_the_game/test_dropping_to_0_hit_points.py -v` — 35 passed, 9 skipped (1 fewer skip than baseline; 8 new tests added).
- [x] `cd dnd-engine && uv run pytest tests/test_death_saves_integration.py tests/test_death_saves.py tests/test_creature.py -v` — 91 passed, no regressions.
- [x] `cd dnd-engine && uv run pytest tests/srd/ -q` — 441 passed, 256 skipped.
- [x] `cd dnd-engine && uv run pytest -q` (full suite) — 2743 passed, 257 skipped (baseline: 2734/258).

🤖 Generated with [Claude Code](https://claude.com/claude-code)