### PR TITLE
LevelUpHpPolicy: fixed vs roll (#404) — plan-04

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -40,6 +40,28 @@ class DyingState(str, Enum):
     DEAD = "dead"
 
 
+class LevelUpHpPolicy(str, Enum):
+    """HP-at-level-up policy.
+
+    SRD allows the player to either roll the class's hit die or take a
+    fixed value when leveling up. ROLL preserves the existing behavior;
+    FIXED uses ``SRD_FIXED_HP_PER_HIT_DIE``.
+    """
+
+    ROLL = "roll"
+    FIXED = "fixed"
+
+
+# SRD fixed HP-per-level values keyed by hit die.
+# 5e PHB p.15: take the average of the hit die rounded up (e.g., d10 -> 6).
+SRD_FIXED_HP_PER_HIT_DIE: dict[str, int] = {
+    "1d6": 4,
+    "1d8": 5,
+    "1d10": 6,
+    "1d12": 7,
+}
+
+
 class Character(Creature):
     """
     Player character class.
@@ -581,13 +603,20 @@ class Character(Creature):
 
         return removed
 
-    def check_for_level_up(self, data_loader, event_bus=None) -> bool:
+    def check_for_level_up(
+        self,
+        data_loader,
+        event_bus=None,
+        hp_policy: LevelUpHpPolicy = LevelUpHpPolicy.ROLL,
+    ) -> bool:
         """
         Check if character has enough XP to level up and execute level-up if so.
 
         Args:
             data_loader: DataLoader instance to access progression data
             event_bus: Optional EventBus to emit level-up events
+            hp_policy: How to determine HP gained at level-up. ROLL (default)
+                rolls the class hit die; FIXED uses the SRD fixed value.
 
         Returns:
             True if character leveled up, False otherwise
@@ -602,18 +631,25 @@ class Character(Creature):
         next_level_xp = int(progression["xp_by_level"].get(str(next_level), 999999))
 
         if self.xp >= next_level_xp:
-            self._level_up(data_loader, event_bus)
+            self._level_up(data_loader, event_bus, hp_policy=hp_policy)
             return True
 
         return False
 
-    def _level_up(self, data_loader, event_bus=None) -> None:
+    def _level_up(
+        self,
+        data_loader,
+        event_bus=None,
+        hp_policy: LevelUpHpPolicy = LevelUpHpPolicy.ROLL,
+    ) -> None:
         """
         Perform level-up: increase level, HP, and grant class features.
 
         Args:
             data_loader: DataLoader instance to access class data
             event_bus: Optional EventBus to emit events
+            hp_policy: How to determine HP gained at level-up. ROLL (default)
+                rolls the class hit die; FIXED uses the SRD fixed value.
         """
         old_level = self.level
         old_max_hp = self.max_hp
@@ -622,7 +658,7 @@ class Character(Creature):
         self.level += 1
 
         # Increase HP
-        self._increase_hp(data_loader)
+        self._increase_hp(data_loader, hp_policy=hp_policy)
 
         # Grant class features for new level
         self._grant_class_features(data_loader, event_bus)
@@ -639,16 +675,24 @@ class Character(Creature):
                         "old_level": old_level,
                         "new_level": self.level,
                         "hp_increase": self.max_hp - old_max_hp,
+                        "hp_policy": hp_policy.value,
                     },
                 )
             )
 
-    def _increase_hp(self, data_loader) -> None:
+    def _increase_hp(
+        self,
+        data_loader,
+        hp_policy: LevelUpHpPolicy = LevelUpHpPolicy.ROLL,
+    ) -> None:
         """
-        Increase max HP on level-up by rolling hit die + CON modifier.
+        Increase max HP on level-up by the class hit die (or SRD fixed value)
+        plus CON modifier.
 
         Args:
             data_loader: DataLoader instance to access class data
+            hp_policy: ROLL rolls the hit die; FIXED uses the SRD fixed value
+                (d6 -> 4, d8 -> 5, d10 -> 6, d12 -> 7).
         """
         # Get hit die from class data
         classes_data = data_loader.load_classes()
@@ -660,9 +704,15 @@ class Character(Creature):
         else:
             hit_die = class_data.get("hit_die", "1d8")
 
-        # Roll hit die and add CON modifier
         con_mod = self.abilities.con_mod
-        hp_increase = self._dice_roller.roll(hit_die).total + con_mod
+
+        if hp_policy == LevelUpHpPolicy.FIXED:
+            # SRD fixed value per hit die + CON modifier
+            fixed_value = SRD_FIXED_HP_PER_HIT_DIE.get(hit_die, 5)
+            hp_increase = fixed_value + con_mod
+        else:
+            # Roll hit die and add CON modifier
+            hp_increase = self._dice_roller.roll(hit_die).total + con_mod
 
         # Minimum 1 HP per level
         hp_increase = max(1, hp_increase)

--- a/dnd-engine/tests/srd/playing_the_game/test_hit_points.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_hit_points.py
@@ -323,3 +323,45 @@ class TestHitPoints_MaxHpField:
         creature = _make_creature(max_hp=10, current_hp=8)
         creature.heal(100)
         assert creature.current_hp == 10
+
+
+class TestHitPoints_LevelUpHpPolicy:
+    """SRD § Playing the Game › Hit Points › HP at level-up.
+
+    > Each time you gain a level, your Hit Point maximum increases. To
+    > determine the increase, take your class's Hit Die roll (or use the
+    > fixed value listed for your class) and add your Constitution
+    > modifier. The fixed values are 4 for d6, 5 for d8, 6 for d10, and
+    > 7 for d12.
+    """
+
+    def test_fixed_hp_per_hit_die_matches_srd(self) -> None:
+        """`SRD_FIXED_HP_PER_HIT_DIE` matches the SRD-listed fixed values.
+
+        Source: `dnd_engine/core/character.py` —
+        `SRD_FIXED_HP_PER_HIT_DIE` maps each hit die to its SRD fixed
+        value (d6 -> 4, d8 -> 5, d10 -> 6, d12 -> 7).
+        """
+        from dnd_engine.core.character import SRD_FIXED_HP_PER_HIT_DIE
+
+        assert SRD_FIXED_HP_PER_HIT_DIE["1d6"] == 4
+        assert SRD_FIXED_HP_PER_HIT_DIE["1d8"] == 5
+        assert SRD_FIXED_HP_PER_HIT_DIE["1d10"] == 6
+        assert SRD_FIXED_HP_PER_HIT_DIE["1d12"] == 7
+
+    def test_level_up_fixed_policy_uses_srd_value(self) -> None:
+        """FIXED policy applies the SRD fixed value plus CON modifier.
+
+        Source: `dnd_engine/core/character.py` — `_increase_hp` branches
+        on `hp_policy`: FIXED looks up `SRD_FIXED_HP_PER_HIT_DIE` and
+        adds the CON modifier (clamped to a minimum of 1).
+        """
+        from dnd_engine.core.character import LevelUpHpPolicy
+        from dnd_engine.rules.loader import DataLoader
+
+        character = _make_character(max_hp=12)
+        initial_hp = character.max_hp
+        character.gain_xp(300)
+        character.check_for_level_up(DataLoader(), hp_policy=LevelUpHpPolicy.FIXED)
+        # Fighter d10 fixed = 6; CON 13 -> +1. Increase = 7.
+        assert character.max_hp - initial_hp == 7

--- a/dnd-engine/tests/test_leveling_system.py
+++ b/dnd-engine/tests/test_leveling_system.py
@@ -1,7 +1,12 @@
 # ABOUTME: Unit tests for character leveling system
 # ABOUTME: Tests XP thresholds, level-up mechanics, HP increases, and feature granting
 
-from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.character import (
+    SRD_FIXED_HP_PER_HIT_DIE,
+    Character,
+    CharacterClass,
+    LevelUpHpPolicy,
+)
 from dnd_engine.core.creature import Abilities
 from dnd_engine.rules.loader import DataLoader
 from dnd_engine.utils.events import Event, EventBus, EventType
@@ -293,3 +298,127 @@ class TestLevelingSystem:
 
         assert not leveled_up
         assert self.character.level == 1
+
+
+class TestLevelUpHpPolicy:
+    """Test the LevelUpHpPolicy enum (ROLL vs FIXED) for HP at level-up.
+
+    SRD allows the player to take a fixed HP value at level-up instead of
+    rolling: d6 -> 4, d8 -> 5, d10 -> 6, d12 -> 7. Default is ROLL to
+    preserve current behavior.
+    """
+
+    def setup_method(self):
+        """Set up test fixtures"""
+        self.data_loader = DataLoader()
+        self.event_bus = EventBus()
+        self.events_received = []
+        self.event_bus.subscribe(EventType.LEVEL_UP, self._capture_event)
+
+    def _capture_event(self, event: Event):
+        self.events_received.append(event)
+
+    def _make_fighter(self, *, con_score: int = 14) -> Character:
+        abilities = Abilities(
+            strength=16,
+            dexterity=14,
+            constitution=con_score,
+            intelligence=10,
+            wisdom=12,
+            charisma=8,
+        )
+        return Character(
+            name="Test Fighter",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=abilities,
+            max_hp=12,
+            ac=16,
+            xp=0,
+        )
+
+    def test_level_up_roll_policy_preserves_current_behavior(self):
+        """Default ROLL policy keeps existing rolled-HP behavior."""
+        fighter = self._make_fighter(con_score=14)  # CON +2, d10 hit die
+        initial_hp = fighter.max_hp
+        fighter.gain_xp(300)
+
+        leveled_up = fighter.check_for_level_up(
+            self.data_loader, self.event_bus, hp_policy=LevelUpHpPolicy.ROLL
+        )
+
+        assert leveled_up
+        hp_increase = fighter.max_hp - initial_hp
+        # d10 (1..10) + CON +2 -> range [3, 12]
+        assert 3 <= hp_increase <= 12
+
+    def test_level_up_fixed_policy_uses_srd_value(self):
+        """FIXED policy uses SRD fixed value (6 for d10) plus CON modifier."""
+        fighter = self._make_fighter(con_score=14)  # CON +2, d10 hit die
+        initial_hp = fighter.max_hp
+        fighter.gain_xp(300)
+
+        leveled_up = fighter.check_for_level_up(
+            self.data_loader, self.event_bus, hp_policy=LevelUpHpPolicy.FIXED
+        )
+
+        assert leveled_up
+        # Fighter d10 fixed = 6, plus CON +2 = 8
+        assert fighter.max_hp - initial_hp == SRD_FIXED_HP_PER_HIT_DIE["1d10"] + 2
+        assert fighter.max_hp - initial_hp == 8
+
+    def test_level_up_fixed_policy_clamps_minimum_to_1(self):
+        """FIXED policy still honors the SRD minimum-1-HP-per-level clamp."""
+        # Build a wizard (1d6 hit die) with very low CON (-5 modifier).
+        # Fixed d6 = 4, +(-5) = -1 -> clamped to 1.
+        abilities = Abilities(
+            strength=10,
+            dexterity=10,
+            constitution=1,  # CON 1 -> -5 modifier
+            intelligence=16,
+            wisdom=12,
+            charisma=8,
+        )
+        wizard = Character(
+            name="Frail Wizard",
+            character_class=CharacterClass.WIZARD,
+            level=1,
+            abilities=abilities,
+            max_hp=6,
+            ac=10,
+            xp=0,
+        )
+        initial_hp = wizard.max_hp
+        wizard.gain_xp(300)
+
+        leveled_up = wizard.check_for_level_up(
+            self.data_loader, self.event_bus, hp_policy=LevelUpHpPolicy.FIXED
+        )
+
+        assert leveled_up
+        # 4 (d6 fixed) + (-5 CON) = -1, clamped to 1
+        assert wizard.max_hp - initial_hp == 1
+
+    def test_level_up_event_records_hp_policy(self):
+        """LEVEL_UP event payload includes the hp_policy used."""
+        fighter = self._make_fighter()
+        fighter.gain_xp(300)
+
+        fighter.check_for_level_up(
+            self.data_loader, self.event_bus, hp_policy=LevelUpHpPolicy.FIXED
+        )
+
+        level_up_events = [e for e in self.events_received if e.type == EventType.LEVEL_UP]
+        assert len(level_up_events) == 1
+        assert level_up_events[0].data["hp_policy"] == "fixed"
+
+        # And again with ROLL — same field, different value.
+        self.events_received.clear()
+        fighter2 = self._make_fighter()
+        fighter2.gain_xp(300)
+        fighter2.check_for_level_up(
+            self.data_loader, self.event_bus, hp_policy=LevelUpHpPolicy.ROLL
+        )
+        level_up_events = [e for e in self.events_received if e.type == EventType.LEVEL_UP]
+        assert len(level_up_events) == 1
+        assert level_up_events[0].data["hp_policy"] == "roll"


### PR DESCRIPTION
## Summary
- Adds `LevelUpHpPolicy` enum (`ROLL` | `FIXED`) and `SRD_FIXED_HP_PER_HIT_DIE` constant
- Plumbs `hp_policy` through `Character.check_for_level_up` and `_level_up`
- Default `ROLL` — backwards compatible
- Level-up event payload records the policy used

## Slice scope (plan-04)
Slice 9 of [#533](../../issues/533). Closes #404.

## Test plan
- [x] `uv run pytest tests/test_leveling_system.py -q`
- [x] `uv run pytest tests/test_character.py tests/test_character_campaign_prep.py -q`
- [x] `uv run pytest tests/srd/ -q` — no regressions