### PR TITLE
Massive-damage overflow + crit-at-0 (#448, #457) — plan-04

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -1175,14 +1175,17 @@ class Character(Creature):
         # Reconstruct the notation
         return f"{scaled_count}d{sides}{modifier_part}"
 
-    def take_damage(self, amount: int, event_bus=None) -> None:
+    def take_damage(self, amount: int, event_bus=None, critical_hit: bool = False) -> None:
         """
         Apply damage to the character.
 
         Handles D&D 5E death save mechanics:
         - If damage brings character to 0 HP, they fall unconscious
-        - If damage at 0 HP: add 1 death save failure
+        - If damage at 0 HP: add 1 death save failure (2 on a crit)
         - If damage >= max HP at 0 HP: instant death (massive damage)
+        - If damage from positive HP drops to 0 with remainder
+          (overflow) >= max HP: instant death (SRD massive-damage
+          overflow rule, #448)
 
         Falling Unconscious (SRD § Playing the Game › Dropping to 0
         Hit Points): when the character reaches 0 HP without dying
@@ -1193,15 +1196,22 @@ class Character(Creature):
         Args:
             amount: Amount of damage to apply
             event_bus: Optional EventBus for event emission
+            critical_hit: True when the damage source is a critical
+                hit. At 0 HP a crit adds 2 death-save failures
+                instead of 1 (SRD: "If the damage is from a Critical
+                Hit, you suffer two failures instead.").
         """
         from dnd_engine.utils.events import Event, EventType
 
         was_unconscious = self.is_unconscious
+        # Capture pre-damage HP so the positive-HP → 0 overflow path
+        # can compute the SRD remainder (amount - pre_hp).
+        pre_hp = self.current_hp
 
         # Apply damage (parent implementation)
         super().take_damage(amount)
 
-        # Handle damage while at 0 HP
+        # Handle damage while at 0 HP (already-unconscious entry)
         if was_unconscious:
             # Check for massive damage (damage >= max HP = instant death)
             if amount >= self.max_hp:
@@ -1216,8 +1226,10 @@ class Character(Creature):
                         )
                     )
             else:
-                # Taking damage at 0 HP = 1 automatic death save failure
-                self.add_death_save_failure(1)
+                # Taking damage at 0 HP = 1 automatic death save failure,
+                # 2 on a critical hit (SRD).
+                failures_added = 2 if critical_hit else 1
+                self.add_death_save_failure(failures_added)
 
                 if event_bus is not None:
                     event_bus.emit(
@@ -1227,6 +1239,31 @@ class Character(Creature):
                                 "character": self.name,
                                 "damage": amount,
                                 "failures": self.death_save_failures,
+                                "failures_added": failures_added,
+                                "critical_hit": critical_hit,
+                            },
+                        )
+                    )
+        elif pre_hp > 0 and self.current_hp == 0:
+            # Positive HP → 0 transition this call. Detect the SRD
+            # massive-damage overflow case: when the remainder of the
+            # incoming damage (after zeroing HP) meets or exceeds
+            # `max_hp`, the character dies outright rather than
+            # falling Unconscious. The "Unconscious" condition added
+            # by `_sync_dying_conditions` below will be replaced with
+            # "dead" because `death_save_failures` is forced to 3.
+            overflow = amount - pre_hp
+            if overflow >= self.max_hp:
+                self.death_save_failures = 3
+                if event_bus is not None:
+                    event_bus.emit(
+                        Event(
+                            type=EventType.MASSIVE_DAMAGE_DEATH,
+                            data={
+                                "character": self.name,
+                                "damage": amount,
+                                "max_hp": self.max_hp,
+                                "overflow": overflow,
                             },
                         )
                     )

--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -428,14 +428,20 @@ class CombatEngine:
             if apply_damage:
                 # Pass event_bus to take_damage for Character instances (death save handling)
                 if hasattr(defender, "take_damage") and hasattr(defender.__class__, "take_damage"):
-                    # Check if defender.take_damage accepts event_bus parameter
+                    # Inspect the defender's `take_damage` signature so
+                    # we surface the crit context only to callees that
+                    # accept it (Character does; the base Creature
+                    # does not). SRD § Death Saving Throws: a crit at
+                    # 0 HP yields 2 failures instead of 1.
                     import inspect
 
                     sig = inspect.signature(defender.take_damage)
+                    kwargs = {}
                     if "event_bus" in sig.parameters:
-                        defender.take_damage(total_post_modifier, event_bus=event_bus)
-                    else:
-                        defender.take_damage(total_post_modifier)
+                        kwargs["event_bus"] = event_bus
+                    if "critical_hit" in sig.parameters:
+                        kwargs["critical_hit"] = critical_hit
+                    defender.take_damage(total_post_modifier, **kwargs)
                 else:
                     defender.take_damage(total_post_modifier)
 

--- a/dnd-engine/tests/srd/playing_the_game/test_dropping_to_0_hit_points.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_dropping_to_0_hit_points.py
@@ -184,24 +184,58 @@ class TestInstantDeath_MassiveDamage:
         """SRD example: HP 6, max 12, take 18 → drops to 0, remainder
         of 12 (== max) → instant death.
 
-        The engine's `take_damage` only checks the massive-damage
-        threshold when `was_unconscious` was already True at entry
-        (character.py:1115-1133). The classic SRD overflow case where
-        a single blow brings the character from positive HP to 0 with
-        remainder >= max_hp is NOT modeled — the character merely
-        falls unconscious instead of dying outright. Tracked by the
-        new gap issue filed alongside this audit.
+        `Character.take_damage` captures the pre-damage HP and, after
+        applying damage via the parent, detects the positive-HP →
+        overflow path: if the remainder (`amount - pre_hp`) meets or
+        exceeds `max_hp`, `death_save_failures` is set to 3 and the
+        `MASSIVE_DAMAGE_DEATH` event is emitted, mirroring the
+        already-at-0 instant-death branch.
         """
-        pytest.skip(
-            "GAP: Massive damage overflow from positive HP is not "
-            "modeled. `Character.take_damage` "
-            "(dnd-engine/dnd_engine/core/character.py:1115-1133) only "
-            "checks the massive-damage threshold when the character "
-            "was *already* unconscious at entry. A single attack that "
-            "deals 18 damage to a max-12 character at 6 HP should "
-            "kill outright per SRD; today it leaves the character "
-            "unconscious with 0 failures. See issue #448."
-        )
+        character = _make_character(max_hp=12)
+        character.current_hp = 6
+
+        character.take_damage(18)
+
+        assert character.current_hp == 0
+        assert character.death_save_failures == 3
+        assert character.is_dead is True
+
+    def test_overflow_below_max_hp_falls_unconscious_not_dead(self):
+        """Overflow strictly less than `max_hp` is the standard
+        positive-HP → 0 transition: Unconscious, not instant death.
+
+        SRD edge: HP 6, max 12, take 17 → overflow 11 < max 12 →
+        character falls Unconscious with 0 failures. Regression guard
+        ensuring the new instant-death branch only fires when the
+        remainder meets or exceeds the max-HP threshold.
+        """
+        character = _make_character(max_hp=12)
+        character.current_hp = 6
+
+        character.take_damage(17)
+
+        assert character.current_hp == 0
+        assert character.is_dead is False
+        assert character.is_unconscious is True
+        assert character.death_save_failures == 0
+
+    def test_massive_damage_overflow_emits_massive_damage_death_event(self):
+        """The overflow-from-positive-HP instant-death path emits
+        `MASSIVE_DAMAGE_DEATH` so listeners see the same SRD outcome
+        as the already-at-0 branch.
+        """
+        character = _make_character(max_hp=12)
+        character.current_hp = 6
+        bus = EventBus()
+        events = []
+        bus.subscribe(EventType.MASSIVE_DAMAGE_DEATH, lambda e: events.append(e))
+
+        character.take_damage(18, event_bus=bus)
+
+        assert len(events) == 1
+        assert events[0].data["character"] == character.name
+        assert events[0].data["damage"] == 18
+        assert events[0].data["max_hp"] == 12
 
 
 class TestFallingUnconscious_ConditionApplied:
@@ -618,25 +652,49 @@ class TestDamageAtZeroHP_AutoFailure:
     def test_critical_hit_damage_at_zero_hp_adds_two_failures(self):
         """A critical hit at 0 HP must add 2 failures, not 1.
 
-        `Character.take_damage(amount, event_bus=None)` does not
-        accept a `critical_hit` flag (character.py:1100), and the
-        combat resolver does not surface crit context through the
-        damage application path (combat.py:188-200 calls
-        `defender.take_damage(damage + sneak_attack_damage)` with no
-        crit signal). As a result, a critical at 0 HP currently only
-        increments failures by 1. The SRD requires 2.
+        `Character.take_damage` now accepts a `critical_hit` keyword
+        flag (character.py). When the character is at 0 HP and the
+        incoming damage is non-massive, the failure increment is
+        doubled (2 instead of 1) per SRD. `CombatEngine.resolve_attack`
+        propagates the crit flag through the damage-application call,
+        but unit-level coverage here exercises `take_damage` directly.
         """
-        pytest.skip(
-            "GAP: Critical-hit damage at 0 HP does not double the "
-            "death-save failure. `Character.take_damage` "
-            "(dnd-engine/dnd_engine/core/character.py:1100-1148) "
-            "accepts only `(amount, event_bus)` — no `critical_hit` "
-            "flag — and `CombatEngine.resolve_attack` "
-            "(dnd-engine/dnd_engine/core/combat.py:188-200) calls "
-            "`take_damage` without surfacing crit context. A crit "
-            "while at 0 HP today registers as 1 failure, not 2. "
-            "See issue #457."
-        )
+        character = _make_character()
+        character.current_hp = 0
+
+        character.take_damage(3, critical_hit=True)
+
+        assert character.death_save_failures == 2
+        assert character.is_dead is False  # 2 < 3
+
+    def test_non_critical_damage_at_zero_hp_still_adds_one_failure(self):
+        """Regression guard: a normal (non-crit) hit at 0 HP keeps
+        the 1-failure increment. The crit branch only fires when
+        `critical_hit=True` is passed explicitly.
+        """
+        character = _make_character()
+        character.current_hp = 0
+
+        character.take_damage(3, critical_hit=False)
+
+        assert character.death_save_failures == 1
+
+    def test_critical_hit_damage_at_zero_hp_emits_event_with_crit_metadata(self):
+        """The `DAMAGE_AT_ZERO_HP` event payload surfaces the
+        `critical_hit` flag and `failures_added` so observers can
+        distinguish crit hits from normal hits at 0 HP.
+        """
+        character = _make_character()
+        character.current_hp = 0
+        bus = EventBus()
+        events = []
+        bus.subscribe(EventType.DAMAGE_AT_ZERO_HP, lambda e: events.append(e))
+
+        character.take_damage(3, event_bus=bus, critical_hit=True)
+
+        assert len(events) == 1
+        assert events[0].data["critical_hit"] is True
+        assert events[0].data["failures_added"] == 2
 
     def test_damage_equal_to_max_hp_at_zero_hp_causes_instant_death(self):
         """Already covered by `TestInstantDeath_MassiveDamage` above —

--- a/dnd-engine/tests/test_death_saves_integration.py
+++ b/dnd-engine/tests/test_death_saves_integration.py
@@ -151,6 +151,100 @@ class TestCombatDamageWithDeathSaves:
             assert fighter.death_save_failures >= 3
             assert len(events) == 1
 
+    def test_critical_hit_at_zero_hp_via_combat_engine_adds_two_failures(
+        self, fighter, goblin, combat_engine, event_bus
+    ):
+        """A critical hit (natural 20) resolved through `CombatEngine`
+        against a 0-HP defender adds 2 death-save failures, exercising
+        the full crit-flag plumbing from `resolve_attack` into
+        `Character.take_damage`.
+        """
+        fighter.current_hp = 0
+        events = []
+        event_bus.subscribe(EventType.DAMAGE_AT_ZERO_HP, lambda e: events.append(e))
+
+        # Force a natural-20 attack roll → critical_hit=True; the
+        # damage roll deliberately stays below max_hp so the crit-at-0
+        # branch fires (not the massive-damage branch).
+        with patch.object(combat_engine.dice_roller, "roll") as mock_roll:
+            mock_roll.side_effect = [
+                Mock(total=20, rolls=[20]),  # Natural 20 attack → crit
+                Mock(total=3, rolls=[1, 2]),  # Low damage roll
+            ]
+            result = combat_engine.resolve_attack(
+                attacker=goblin,
+                defender=fighter,
+                attack_bonus=4,
+                damage_dice="1d6",
+                apply_damage=True,
+                event_bus=event_bus,
+            )
+
+        assert result.critical_hit is True
+        assert fighter.death_save_failures == 2
+        assert len(events) == 1
+        assert events[0].data["critical_hit"] is True
+        assert events[0].data["failures_added"] == 2
+
+    def test_non_critical_hit_at_zero_hp_via_combat_engine_adds_one_failure(
+        self, fighter, goblin, combat_engine, event_bus
+    ):
+        """Regression guard: a non-crit hit at 0 HP via the combat
+        engine still adds exactly 1 failure (no crit upgrade leakage).
+        """
+        fighter.current_hp = 0
+
+        # Attack roll of 15 (hit but not crit) and a small damage roll.
+        with patch.object(combat_engine.dice_roller, "roll") as mock_roll:
+            mock_roll.side_effect = [
+                Mock(total=15, rolls=[15]),  # Normal hit (not nat-20)
+                Mock(total=3, rolls=[3]),  # Low damage roll
+            ]
+            result = combat_engine.resolve_attack(
+                attacker=goblin,
+                defender=fighter,
+                attack_bonus=4,
+                damage_dice="1d6",
+                apply_damage=True,
+                event_bus=event_bus,
+            )
+
+        assert result.critical_hit is False
+        assert result.hit is True
+        assert fighter.death_save_failures == 1
+
+    def test_massive_damage_overflow_from_positive_hp_via_combat_engine(
+        self, fighter, goblin, combat_engine, event_bus
+    ):
+        """A single combat-engine attack that drops a positive-HP
+        character to 0 with damage overflow >= max_hp kills outright.
+
+        SRD overflow: HP 6/12, take 18 → remainder 12 == max → dead.
+        """
+        fighter.current_hp = 6
+        events = []
+        event_bus.subscribe(EventType.MASSIVE_DAMAGE_DEATH, lambda e: events.append(e))
+
+        with patch.object(combat_engine.dice_roller, "roll") as mock_roll:
+            mock_roll.side_effect = [
+                Mock(total=15, rolls=[15]),  # Normal hit (not crit)
+                Mock(total=18, rolls=[6, 6, 6]),  # Overflow >= max_hp
+            ]
+            result = combat_engine.resolve_attack(
+                attacker=goblin,
+                defender=fighter,
+                attack_bonus=4,
+                damage_dice="3d6",
+                apply_damage=True,
+                event_bus=event_bus,
+            )
+
+        assert result.hit is True
+        assert fighter.current_hp == 0
+        assert fighter.is_dead is True
+        assert fighter.death_save_failures == 3
+        assert len(events) == 1
+
 
 class TestPartyWipeMechanics:
     """Test party wipe conditions with death saves."""


### PR DESCRIPTION
## Summary

Wave 2-A of plan-04 (plan-master #533). Combines two SRD-conformance slices that both rewrite the damage-at-0 / overflow path in `Character.take_damage`:

- **Slice 3 (#448) — Massive-damage overflow from positive HP.** Per SRD: "When damage reduces a character to 0 Hit Points and damage remains, the character dies if the remainder equals or exceeds their Hit Point maximum." `Character.take_damage` now captures `pre_hp` and, on the positive-HP → 0 transition, checks `overflow = amount - pre_hp >= max_hp`. If so, `death_save_failures = 3` and a `MASSIVE_DAMAGE_DEATH` event fires. `_sync_dying_conditions()` then promotes Unconscious → Dead.
- **Slice 5 (#457) — Critical-hit damage at 0 HP adds 2 failures.** Per SRD: "If the damage is from a Critical Hit, you suffer two failures instead." `Character.take_damage` accepts a new `critical_hit: bool = False` keyword. At 0 HP the failure increment becomes `2 if critical_hit else 1`. `CombatEngine.resolve_attack` propagates the existing `critical_hit` local through to `defender.take_damage` via a signature-aware kwargs build (only sends `critical_hit` to callees whose signature accepts it, so the base `Creature.take_damage` is unaffected).
- `DAMAGE_AT_ZERO_HP` event payload now includes `critical_hit: bool` and `failures_added: int` for observability.
- `MASSIVE_DAMAGE_DEATH` payload from the new overflow path adds the `overflow` field so listeners can distinguish overflow-from-positive-HP from already-at-0 massive damage.
- No changes to the stable-transition pipeline (Slice 4 territory) — `was_unconscious` / `_sync_dying_conditions` flow preserved.

Closes #448. Closes #457. Refs plan-master #533.

## Test plan

- [x] `tests/srd/playing_the_game/test_dropping_to_0_hit_points.py` — both previously-skipped SRD tests un-skipped and passing:
  - `test_massive_damage_overflow_from_positive_hp_causes_instant_death`
  - `test_critical_hit_damage_at_zero_hp_adds_two_failures`
- [x] New SRD coverage (5 tests):
  - `test_overflow_below_max_hp_falls_unconscious_not_dead` (boundary: 17 dmg, max 12, HP 6 → unconscious, not dead)
  - `test_massive_damage_overflow_emits_massive_damage_death_event`
  - `test_non_critical_damage_at_zero_hp_still_adds_one_failure` (regression guard)
  - `test_critical_hit_damage_at_zero_hp_emits_event_with_crit_metadata`
- [x] New integration tests in `tests/test_death_saves_integration.py` exercising live `CombatEngine`:
  - `test_critical_hit_at_zero_hp_via_combat_engine_adds_two_failures`
  - `test_non_critical_hit_at_zero_hp_via_combat_engine_adds_one_failure`
  - `test_massive_damage_overflow_from_positive_hp_via_combat_engine`
- [x] Existing death-save and combat tests still pass:
  - `tests/test_death_saves.py` — 29 passed
  - `tests/test_death_saves_integration.py` — 20 passed
  - `tests/test_combat.py` — 66 passed
  - `tests/test_creature.py` — 51 passed
  - `tests/srd/` (broad sweep) — 451 passed, 252 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)