### PR TITLE
Stable transitions (#454, #458, #460) — plan-04

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -1148,6 +1148,13 @@ class Character(Creature):
 
         was_unconscious = self.is_unconscious
 
+        # SRD § Stabilizing a Character › Stable state: "If the
+        # creature takes damage, it stops being Stable and starts
+        # making Death Saving Throws again." Clear before damage is
+        # applied so the downstream at-0-HP failure rule kicks in.
+        if self.stabilized:
+            self.stabilized = False
+
         # Apply damage (parent implementation)
         super().take_damage(amount)
 
@@ -1252,6 +1259,10 @@ class Character(Creature):
         - Recover resources with recovery_type="short_rest" (living characters only)
         - Clear conditions with duration <= 60 minutes
         - Can spend Hit Dice to heal (not implemented in MVP)
+        - SRD § Stabilizing a Character › Stable state: a Stable
+          character that has rested for 1d4 hours regains 1 HP. A
+          short rest is exactly 1 hour, so the roll may or may not
+          meet the threshold (25% chance: a roll of 1).
 
         Returns:
             Dictionary containing:
@@ -1266,6 +1277,10 @@ class Character(Creature):
             resources_recovered = []
             conditions_removed = []
         else:
+            # SRD: Stable creatures regain 1 HP after 1d4 hours. Run
+            # this before resource recovery so the result is reflected
+            # in dying-state queries for the rest of the rest flow.
+            self.process_stable_recovery(hours_elapsed=1.0)
             resources_recovered = self.recover_resources("short_rest")
             # Clear conditions that would expire within 1 hour (60 minutes)
             conditions_removed = self.clear_conditions_by_max_duration(max_minutes=60)
@@ -1305,6 +1320,14 @@ class Character(Creature):
             resources_recovered = []
             conditions_removed = []
         else:
+            # SRD § Stabilizing a Character › Stable state: a Stable
+            # creature regains 1 HP after 1d4 hours. An 8-hour long
+            # rest always exceeds that threshold, but
+            # `process_stable_recovery` still rolls the 1d4 for
+            # consistency and event emission. Run before
+            # `recover_hp` so the Stable→1HP transition completes
+            # before standard healing fills HP to full.
+            self.process_stable_recovery(hours_elapsed=8.0)
             hp_recovered = self.recover_hp()
             resources_recovered = self.recover_resources("long_rest")
             # Clear all non-permanent conditions (8 hours exceeds any timed condition)
@@ -1466,8 +1489,15 @@ class Character(Creature):
         elif success:
             # Success
             self.death_save_successes += 1
-            # Check for stabilization (3 successes)
+            # Check for stabilization (3 successes). Per SRD § Death
+            # Saving Throws: "The number of both is reset to zero
+            # when you ... become Stable." Zero the counters first,
+            # then flip `stabilized = True` (don't call
+            # `reset_death_saves()`, which would also clear the
+            # stabilized flag we're about to set).
             if self.death_save_successes >= 3:
+                self.death_save_successes = 0
+                self.death_save_failures = 0
                 self.stabilized = True
         else:
             # Failure
@@ -1544,9 +1574,69 @@ class Character(Creature):
         Used when:
         - Ally uses Medicine check (DC 10) successfully
         - Character gets 3 death save successes
+
+        Per SRD § Death Saving Throws: "The number of both is reset
+        to zero when you ... become Stable." Both counters zero out
+        as the character transitions into the Stable state.
         """
         if self.current_hp == 0:
+            self.death_save_successes = 0
+            self.death_save_failures = 0
             self.stabilized = True
+
+    def process_stable_recovery(
+        self, hours_elapsed: float, event_bus=None
+    ) -> bool:
+        """
+        Apply the SRD natural-healing rule for Stable creatures.
+
+        SRD § Stabilizing a Character › Stable state: "A Stable
+        creature that isn't healed regains 1 Hit Point after 1d4
+        hours."
+
+        Rolls 1d4 to determine the threshold in hours. If the
+        elapsed rest time meets or exceeds that threshold, the
+        character regains 1 HP, exits the Stable state, and clears
+        the Unconscious condition. Otherwise this is a no-op.
+
+        Args:
+            hours_elapsed: Hours of rest the character has had since
+                becoming Stable (or since the last recovery check).
+            event_bus: Optional EventBus for `STABLE_RECOVERY` emission.
+
+        Returns:
+            True if recovery occurred this call, False otherwise.
+        """
+        from dnd_engine.utils.events import Event, EventType
+
+        # Recovery only applies to Stable creatures still at 0 HP.
+        if not self.stabilized or self.current_hp > 0:
+            return False
+
+        threshold_hours = self._dice_roller.roll("1d4").total
+        if hours_elapsed < threshold_hours:
+            return False
+
+        # SRD: regain 1 HP. Healing past 0 implicitly exits the
+        # Dying/Stable pipeline, so reset death-save state and drop
+        # the Unconscious condition (mirrors `recover_hp`).
+        self.current_hp = 1
+        self.reset_death_saves()
+        self.remove_condition("unconscious")
+
+        if event_bus is not None:
+            event_bus.emit(
+                Event(
+                    type=EventType.STABLE_RECOVERY,
+                    data={
+                        "character": self.name,
+                        "hours_elapsed": hours_elapsed,
+                        "threshold_hours": threshold_hours,
+                    },
+                )
+            )
+
+        return True
 
     def can_cast_spell(self, spell: Spell) -> bool:
         """

--- a/dnd-engine/dnd_engine/utils/events.py
+++ b/dnd-engine/dnd_engine/utils/events.py
@@ -37,6 +37,7 @@ class EventType(Enum):
     DAMAGE_AT_ZERO_HP = "damage_at_zero_hp"
     MASSIVE_DAMAGE_DEATH = "massive_damage_death"
     CHARACTER_STABILIZED = "character_stabilized"
+    STABLE_RECOVERY = "stable_recovery"
 
     # Exploration events
     ROOM_ENTER = "room_enter"

--- a/dnd-engine/tests/srd/playing_the_game/test_dropping_to_0_hit_points.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_dropping_to_0_hit_points.py
@@ -490,20 +490,38 @@ class TestDeathSavingThrows_ThreeSuccessesOrFailures:
 
         Tracks both counters independently; the SRD wording "don't
         need to be consecutive" maps to the engine using separate
-        increment paths for each branch (character.py:1376-1383).
+        increment paths for each branch. Per SRD, both counters
+        reset to zero upon becoming Stable, so after the third
+        success they are both 0 even though the run mixed S and F.
         """
         character = _make_character()
         character.current_hp = 0
 
-        rolls = [15, 5, 15, 5, 15]  # S, F, S, F, S
+        # Capture counters after the second success (pre-stable) so
+        # we still demonstrate the non-consecutive tracking before
+        # the SRD's reset-on-Stable rule zeroes both counters.
         with patch.object(character._dice_roller, "roll") as mock_roll:
-            mock_roll.side_effect = [Mock(total=r) for r in rolls]
-            for _ in rolls:
+            mock_roll.side_effect = [
+                Mock(total=15),  # S
+                Mock(total=5),  # F
+                Mock(total=15),  # S
+                Mock(total=5),  # F
+            ]
+            for _ in range(4):
                 character.make_death_save()
 
-        assert character.death_save_successes == 3
+        assert character.death_save_successes == 2
         assert character.death_save_failures == 2
+        assert character.stabilized is False
+
+        # Third success: stabilizes and resets per SRD.
+        with patch.object(character._dice_roller, "roll") as mock_roll:
+            mock_roll.return_value = Mock(total=15)
+            character.make_death_save()
+
         assert character.stabilized is True
+        assert character.death_save_successes == 0
+        assert character.death_save_failures == 0
 
     def test_regaining_any_hit_points_resets_both_counters(self):
         """Healing 1 HP from 0 zeroes successes and failures.
@@ -525,25 +543,36 @@ class TestDeathSavingThrows_ThreeSuccessesOrFailures:
     def test_becoming_stable_resets_both_counters(self):
         """SRD: counts reset to zero on Stable.
 
-        Engine sets `stabilized = True` on the 3rd success but does
-        NOT reset `death_save_successes` to 0 (character.py:1376-1380).
-        After 3 successes the character still has
-        `death_save_successes == 3`, so the SRD wording "is reset to
-        zero when you ... become Stable" is not honored. Tracked by
-        a new gap issue.
+        On the third success in `make_death_save`, both counters
+        must zero out as the character transitions to Stable. Same
+        rule for the Medicine-check path via `stabilize_character`.
+        See issue #454.
         """
-        pytest.skip(
-            "GAP: Becoming Stable (3 successes) does not reset "
-            "`death_save_successes`/`death_save_failures` to zero. "
-            "`Character.make_death_save` "
-            "(dnd-engine/dnd_engine/core/character.py:1376-1380) sets "
-            "`stabilized = True` on the third success but leaves the "
-            "counters at their current values. The SRD says 'The "
-            "number of both is reset to zero when you regain any Hit "
-            "Points or become Stable.' Same gap applies to "
-            "`stabilize_character()` via Medicine check. See issue "
-            "#454."
-        )
+        # Path 1: third success via make_death_save
+        character = _make_character()
+        character.current_hp = 0
+        character.death_save_successes = 2
+        character.death_save_failures = 1
+
+        with patch.object(character._dice_roller, "roll") as mock_roll:
+            mock_roll.return_value = Mock(total=15)
+            character.make_death_save()
+
+        assert character.stabilized is True
+        assert character.death_save_successes == 0
+        assert character.death_save_failures == 0
+
+        # Path 2: Medicine-check stabilization via stabilize_character
+        character2 = _make_character()
+        character2.current_hp = 0
+        character2.death_save_successes = 1
+        character2.death_save_failures = 1
+
+        character2.stabilize_character()
+
+        assert character2.stabilized is True
+        assert character2.death_save_successes == 0
+        assert character2.death_save_failures == 0
 
 
 class TestDeathSavingThrows_Rolling20Or1:
@@ -782,38 +811,62 @@ class TestStabilizingACharacter_StableState:
         """Damage to a stable, 0-HP character must clear `stabilized`.
 
         Per SRD: "If the creature takes damage, it stops being Stable
-        and starts making Death Saving Throws again."
-        `Character.take_damage` (character.py:1100-1148) adds the
-        damage-at-0-HP failure but does NOT flip
-        `self.stabilized = False`. The character would still be
-        skipped by `process_unconscious_turn`'s
-        `if character.stabilized:` short-circuit (game_state.py:4157)
-        and continue not making rolls.
+        and starts making Death Saving Throws again." After taking
+        damage, the character is no longer Stable and the damage-at-
+        0-HP rule adds a death-save failure. See issue #458.
         """
-        pytest.skip(
-            "GAP: Damage to a stable creature does not clear "
-            "`stabilized`. `Character.take_damage` "
-            "(dnd-engine/dnd_engine/core/character.py:1100-1148) "
-            "increments death-save failures but never sets "
-            "`self.stabilized = False`. As a result, "
-            "`process_unconscious_turn` "
-            "(dnd-engine/dnd_engine/core/game_state.py:4156-4168) "
-            "continues to short-circuit on `character.stabilized` and "
-            "the SRD's 'stops being Stable and starts making Death "
-            "Saving Throws again' clause is unenforced. See issue "
-            "#458."
-        )
+        character = _make_character()
+        character.current_hp = 0
+        character.stabilize_character()
+        assert character.stabilized is True
+
+        character.take_damage(3)
+
+        assert character.stabilized is False
+        assert character.death_save_failures == 1
 
     def test_stable_creature_regains_one_hit_point_after_1d4_hours(self):
-        pytest.skip(
-            "GAP: No long-rest / hours-elapsed tick is modeled for "
-            "stable creatures. `rg 'stable.*1d4\\|stable.*hour\\|"
-            "stable.*1 hp' dnd-engine/dnd_engine/` is empty. "
-            "`test_death_saves_integration.py::test_stabilized_"
-            "character_heals_naturally_over_time` documents the gap "
-            "in a comment ('After 1d4 hours, would heal to 1 HP — "
-            "not implemented in MVP'). See issue #460."
-        )
+        """SRD: a Stable creature that isn't healed regains 1 HP after
+        1d4 hours of rest.
+
+        `Character.process_stable_recovery(hours_elapsed)` rolls 1d4
+        and converts Stable -> 1 HP if the elapsed time meets or
+        exceeds the rolled threshold. Below threshold: no change.
+        See issue #460.
+        """
+        # Above-threshold case: 1d4 rolls 2, 2.0 hours elapsed >= 2.
+        # Drive through take_damage so the Unconscious condition is
+        # applied by `_sync_dying_conditions`, matching the live flow.
+        character = _make_character()
+        character.take_damage(character.max_hp)
+        character.stabilize_character()
+        assert character.stabilized is True
+        assert "unconscious" in character.active_conditions
+
+        with patch.object(character._dice_roller, "roll") as mock_roll:
+            mock_roll.return_value = Mock(total=2)
+            recovered = character.process_stable_recovery(hours_elapsed=2.0)
+
+        assert recovered is True
+        assert character.current_hp == 1
+        assert character.stabilized is False
+        assert character.death_save_failures == 0
+        assert character.death_save_successes == 0
+        assert "unconscious" not in character.active_conditions
+
+        # Below-threshold case: 1d4 rolls 3, only 1.0 hour elapsed.
+        character2 = _make_character()
+        character2.take_damage(character2.max_hp)
+        character2.stabilize_character()
+
+        with patch.object(character2._dice_roller, "roll") as mock_roll:
+            mock_roll.return_value = Mock(total=3)
+            recovered = character2.process_stable_recovery(hours_elapsed=1.0)
+
+        assert recovered is False
+        assert character2.current_hp == 0
+        assert character2.stabilized is True
+        assert "unconscious" in character2.active_conditions
 
 
 class TestEventEmission_DeathSaveEventsAreSurfaced:

--- a/dnd-engine/tests/test_death_saves.py
+++ b/dnd-engine/tests/test_death_saves.py
@@ -154,7 +154,13 @@ class TestDeathSaveRolls:
         assert character.death_save_failures == 2
 
     def test_three_successes_stabilizes(self, character, event_bus):
-        """Three successes should stabilize the character."""
+        """Three successes should stabilize the character.
+
+        Per SRD § Death Saving Throws: "The number of both is reset
+        to zero when you ... become Stable." After the third success,
+        the success counter zeroes out as the character transitions
+        into the Stable state.
+        """
         character.current_hp = 0
         character.death_save_successes = 2
 
@@ -164,7 +170,8 @@ class TestDeathSaveRolls:
 
         assert result["stabilized"]
         assert character.stabilized
-        assert character.death_save_successes == 3
+        assert character.death_save_successes == 0
+        assert character.death_save_failures == 0
 
     def test_three_failures_means_death(self, character, event_bus):
         """Three failures should kill the character."""
@@ -386,3 +393,93 @@ class TestDeathSaveEdgeCases:
         assert character.death_save_successes == 0
         assert character.death_save_failures == 0
         assert not character.stabilized
+
+
+class TestProcessStableRecovery:
+    """SRD § Stabilizing a Character › Stable state:
+    "A Stable creature that isn't healed regains 1 Hit Point after
+    1d4 hours."
+    """
+
+    def test_recovery_happens_when_elapsed_meets_threshold(self, character):
+        """Elapsed >= rolled 1d4 threshold: heal to 1 HP, clear state."""
+        character.current_hp = 0
+        character.stabilize_character()
+
+        with patch.object(character._dice_roller, "roll") as mock_roll:
+            mock_roll.return_value = Mock(total=2)
+            recovered = character.process_stable_recovery(hours_elapsed=2.0)
+
+        assert recovered is True
+        assert character.current_hp == 1
+        assert character.stabilized is False
+        assert character.death_save_failures == 0
+        assert character.death_save_successes == 0
+        assert "unconscious" not in character.active_conditions
+
+    def test_recovery_skips_when_elapsed_below_threshold(self, character):
+        """Elapsed < rolled 1d4 threshold: no recovery."""
+        character.current_hp = 0
+        character.stabilize_character()
+
+        with patch.object(character._dice_roller, "roll") as mock_roll:
+            mock_roll.return_value = Mock(total=4)
+            recovered = character.process_stable_recovery(hours_elapsed=1.0)
+
+        assert recovered is False
+        assert character.current_hp == 0
+        assert character.stabilized is True
+
+    def test_recovery_no_op_when_not_stabilized(self, character):
+        """Non-stable creature is unaffected by `process_stable_recovery`."""
+        character.current_hp = 0
+        # Not stabilized
+        recovered = character.process_stable_recovery(hours_elapsed=8.0)
+
+        assert recovered is False
+        assert character.current_hp == 0
+        assert character.stabilized is False
+
+    def test_recovery_no_op_when_already_healed(self, character):
+        """Recovery skips creatures who already have HP."""
+        character.current_hp = 5
+        character.stabilized = True  # Inconsistent but defensive
+
+        recovered = character.process_stable_recovery(hours_elapsed=8.0)
+
+        assert recovered is False
+        assert character.current_hp == 5
+
+    def test_recovery_emits_event(self, character, event_bus):
+        """`process_stable_recovery` emits `STABLE_RECOVERY` event."""
+        character.current_hp = 0
+        character.stabilize_character()
+        events = []
+        event_bus.subscribe(EventType.STABLE_RECOVERY, lambda e: events.append(e))
+
+        with patch.object(character._dice_roller, "roll") as mock_roll:
+            mock_roll.return_value = Mock(total=1)
+            character.process_stable_recovery(hours_elapsed=4.0, event_bus=event_bus)
+
+        assert len(events) == 1
+        assert events[0].data["character"] == "TestHero"
+
+    def test_long_rest_revives_stable_character(self, character):
+        """An 8-hour long rest always exceeds 1d4 hours, so a Stable
+        character should wake at >=1 HP and then continue with the
+        standard long-rest healing.
+        """
+        character.current_hp = 0
+        character.stabilize_character()
+
+        # 1d4 mocked to any value 1-4: 8h always exceeds
+        with patch.object(character._dice_roller, "roll") as mock_roll:
+            mock_roll.return_value = Mock(total=4)
+            character.take_long_rest()
+
+        # After long rest the character should be at full HP via the
+        # standard recover_hp() path (stable recovery brought to 1
+        # first, then recovery fills the rest).
+        assert character.current_hp == character.max_hp
+        assert character.stabilized is False
+        assert "unconscious" not in character.active_conditions

--- a/dnd-engine/tests/test_death_saves_integration.py
+++ b/dnd-engine/tests/test_death_saves_integration.py
@@ -259,11 +259,13 @@ class TestDeathSaveProgression:
         assert result2["successes"] == 2
         assert not result2["stabilized"]
 
-        # Third success - stabilizes
+        # Third success - stabilizes. Per SRD § Death Saving Throws,
+        # both counters reset to zero on Stable, so the result reports
+        # 0 successes (the character is now in the Stable state).
         with patch.object(fighter._dice_roller, "roll") as mock_roll:
             mock_roll.return_value = Mock(total=18)
             result3 = fighter.make_death_save(event_bus)
-        assert result3["successes"] == 3
+        assert result3["successes"] == 0
         assert result3["stabilized"]
 
     def test_multiple_failed_death_saves(self, fighter, event_bus):


### PR DESCRIPTION
## Summary

Wave 2-B / Slice 4 of plan-04 ("0 HP, Death Saves & Hit-Point Model", plan-master #533). Closes the three "Stable state" transitions left as gaps in the SRD audit.

- **#454** — Becoming Stable now resets both `death_save_successes` and `death_save_failures` to zero per SRD "The number of both is reset to zero when you ... become Stable." Applied in both transition paths: third success in `make_death_save`, and Medicine-check in `stabilize_character`.
- **#458** — Damage to a Stable creature now clears `stabilized` at the entry of `Character.take_damage` (single if-block, no other behavior changes). The downstream damage-at-0-HP rule then adds a death-save failure as the SRD requires.
- **#460** — Adds `Character.process_stable_recovery(hours_elapsed, event_bus=None)`. Rolls 1d4 to determine the threshold; if `hours_elapsed >= threshold`, the character returns to 1 HP, resets death-save state, drops the Unconscious condition, and emits a new `EventType.STABLE_RECOVERY`. Wired into `take_short_rest(1h)` and `take_long_rest(8h)` so Stable characters wake naturally during rest.

## Files touched

- `dnd-engine/dnd_engine/core/character.py` — `make_death_save`, `stabilize_character`, `take_damage` (single-line add), `take_short_rest`, `take_long_rest`, new `process_stable_recovery`.
- `dnd-engine/dnd_engine/utils/events.py` — new `EventType.STABLE_RECOVERY`.
- Tests: 3 SRD tests un-skipped with real assertions; 6 new unit tests for `process_stable_recovery`; 2 pre-existing tests updated to match SRD reset-on-Stable.

## Test plan

- [x] Three previously-skipped SRD tests in `tests/srd/playing_the_game/test_dropping_to_0_hit_points.py` now run and pass
- [x] New `TestProcessStableRecovery` class in `tests/test_death_saves.py` covers above-threshold, below-threshold, no-op (non-stable / already-healed), event emission, and long-rest revival
- [x] Full SRD sweep: 446 passed, 251 skipped (0 regressions)
- [x] Full project sweep: 2760 passed, 252 skipped
- [x] `take_damage` edit is a single if-block addition (minimal merge-conflict surface with Wave 2-A's crit-handling changes on the same function)

## Notes on Wave 2-A coordination

Wave 2-A is being implemented in parallel and also touches `Character.take_damage`. This PR keeps the `take_damage` edit to one if-block placed at function entry (immediately after capturing `was_unconscious`) so it should merge cleanly regardless of which wave lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)