### PR TITLE
Add Creature.size data field (#442) — plan-03

### DIFF
--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -5,6 +5,25 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import Enum
+
+
+class Size(str, Enum):
+    """
+    SRD creature size categories (SRD § Creature Statistics › Size).
+
+    The canonical string value matches the lowercase form used in
+    `monsters.json` so values round-trip cleanly through JSON. Size
+    drives map footprint and reach geometry in plan-03; this enum is
+    the data-model foundation those systems read.
+    """
+
+    TINY = "tiny"
+    SMALL = "small"
+    MEDIUM = "medium"
+    LARGE = "large"
+    HUGE = "huge"
+    GARGANTUAN = "gargantuan"
 
 
 @dataclass
@@ -69,6 +88,7 @@ class Creature:
         abilities: Abilities,
         current_hp: int | None = None,
         speed: int = 30,
+        size: Size = Size.MEDIUM,
     ):
         """
         Initialize a creature.
@@ -80,6 +100,10 @@ class Creature:
             abilities: Ability scores (STR, DEX, CON, INT, WIS, CHA)
             current_hp: Starting HP (defaults to max_hp if not specified)
             speed: Movement speed in feet per round (default 30 ft)
+            size: SRD size category (default Medium). Drives map footprint
+                and reach geometry in plan-03; defaulting to Medium keeps
+                Characters and any creature constructed without an explicit
+                size on the SRD baseline.
         """
         self.name = name
         self.max_hp = max_hp
@@ -87,6 +111,7 @@ class Creature:
         self._base_ac = ac  # Store base AC (before modifiers from spells/effects)
         self.abilities = abilities
         self.speed = speed  # Movement speed in feet (5 ft = 1 grid square)
+        self.size = size
         # Condition tracking with metadata for duration and repeat saves
         # Maps condition name -> metadata dict
         self.active_conditions: dict[str, dict] = {}

--- a/dnd-engine/dnd_engine/rules/loader.py
+++ b/dnd-engine/dnd_engine/rules/loader.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.creature import Abilities, Creature, Size
 from dnd_engine.core.dice import DiceRoller
 
 
@@ -87,6 +87,12 @@ class DataLoader:
         # Get speed (default 30 ft if not specified)
         speed = data.get("speed", 30)
 
+        # Get size (default Medium if not specified in the catalog). The
+        # canonical lowercase string in monsters.json matches Size.value
+        # directly; .lower() lets the loader tolerate stray casing without
+        # forcing a JSON rewrite.
+        size = Size(data.get("size", "medium").lower())
+
         # Create the creature
         creature = Creature(
             name=data["name"],
@@ -94,6 +100,7 @@ class DataLoader:
             ac=data["ac"],
             abilities=abilities,
             speed=speed,
+            size=size,
         )
 
         # Attach per-type damage modifier fields from the monster catalog.

--- a/dnd-engine/tests/srd/playing_the_game/test_mounted_combat.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_mounted_combat.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 import pytest
 
-from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.creature import Abilities, Creature, Size
 from dnd_engine.systems.action_economy import TurnState
 
 pytestmark = pytest.mark.srd(
@@ -66,26 +66,24 @@ class TestMountedCombat_SizeAndWillingnessGate:
     > the following rules.
     """
 
-    def test_creature_class_has_no_size_attribute(self) -> None:
-        """Source-level guard: `Creature` does not carry a `size` field.
+    def test_creature_class_carries_size_field(self) -> None:
+        """Data-model check: `Creature` carries a `size` field (#442).
 
         The SRD's "at least one size larger than a rider" gate requires
         each creature to declare a size category (Tiny / Small /
         Medium / Large / Huge / Gargantuan). `monsters.json` records
-        `size` per stat block (e.g., goblin = "small") but
-        `Creature` (`dnd_engine/core/creature.py:61`) carries only
-        `name`, `max_hp`, `ac`, `abilities`, `speed`, and
-        `active_conditions` — no `size` attribute exists. The mount
-        gate therefore has nothing to check. Tracked by issue #442
-        (creature size categories).
+        `size` per stat block (e.g., goblin = "small") and
+        `Creature` (`dnd_engine/core/creature.py`) carries a `size`
+        attribute typed as `Size`, defaulting to `Size.MEDIUM`. This is
+        the data-model foundation issue #442 lands; the mount
+        eligibility comparison itself still depends on a mount-action
+        handler (tracked by issue #526) and is asserted in
+        `test_mount_must_be_one_size_larger_than_rider` below.
         """
         creature = _make_creature()
-        assert not hasattr(creature, "size"), (
-            "Creature now has a `size` attribute — the engine-side "
-            "creature-size gap (#442) appears to be closing. Flip "
-            "`test_mount_must_be_one_size_larger_than_rider` to a "
-            "real assertion."
-        )
+        assert hasattr(creature, "size"), "Creature must carry a `size` field per #442"
+        assert isinstance(creature.size, Size), "Creature.size must be a Size enum member"
+        assert creature.size is Size.MEDIUM, "Default creature size should be Medium"
 
     def test_monsters_json_carries_size_per_stat_block(self) -> None:
         """Data-parity check: `monsters.json` records a `size` per monster.

--- a/dnd-engine/tests/test_creature_size.py
+++ b/dnd-engine/tests/test_creature_size.py
@@ -1,0 +1,141 @@
+# ABOUTME: Unit tests for Creature size data field and Size enum
+# ABOUTME: Covers SRD size categories, defaulting behavior, and monster catalog loading
+
+from unittest.mock import patch
+
+import pytest
+
+from dnd_engine.core.creature import Abilities, Creature, Size
+from dnd_engine.rules.loader import DataLoader
+
+
+class TestSizeEnum:
+    """Test the Size enum covers all SRD creature sizes."""
+
+    def test_all_srd_sizes_present(self):
+        """Size enum should cover the six SRD creature sizes."""
+        expected = {"tiny", "small", "medium", "large", "huge", "gargantuan"}
+        actual = {member.value for member in Size}
+        assert actual == expected
+
+    def test_values_are_lowercase_strings(self):
+        """Each Size member's .value should be the lowercase canonical string."""
+        assert Size.TINY.value == "tiny"
+        assert Size.SMALL.value == "small"
+        assert Size.MEDIUM.value == "medium"
+        assert Size.LARGE.value == "large"
+        assert Size.HUGE.value == "huge"
+        assert Size.GARGANTUAN.value == "gargantuan"
+
+    def test_size_roundtrips_from_string(self):
+        """Constructing Size from its canonical string should recover the member."""
+        assert Size("tiny") is Size.TINY
+        assert Size("small") is Size.SMALL
+        assert Size("medium") is Size.MEDIUM
+        assert Size("large").value == "large"
+        assert Size("huge") is Size.HUGE
+        assert Size("gargantuan") is Size.GARGANTUAN
+
+
+class TestCreatureSizeField:
+    """Test that the Creature class carries a size field defaulting to Medium."""
+
+    def _abilities(self) -> Abilities:
+        return Abilities(
+            strength=10, dexterity=10, constitution=10, intelligence=10, wisdom=10, charisma=10
+        )
+
+    def test_creature_defaults_to_medium(self):
+        """A bare Creature(...) should default to Size.MEDIUM."""
+        creature = Creature(name="Tester", max_hp=10, ac=10, abilities=self._abilities())
+        assert creature.size is Size.MEDIUM
+
+    def test_creature_accepts_explicit_size(self):
+        """Creature(...) should honor an explicit size argument."""
+        creature = Creature(
+            name="Big Tester",
+            max_hp=10,
+            ac=10,
+            abilities=self._abilities(),
+            size=Size.LARGE,
+        )
+        assert creature.size is Size.LARGE
+
+    @pytest.mark.parametrize(
+        "size",
+        [Size.TINY, Size.SMALL, Size.MEDIUM, Size.LARGE, Size.HUGE, Size.GARGANTUAN],
+    )
+    def test_creature_size_round_trips(self, size: Size):
+        """Every Size value should survive a Creature construction round-trip."""
+        creature = Creature(
+            name="Tester",
+            max_hp=10,
+            ac=10,
+            abilities=self._abilities(),
+            size=size,
+        )
+        assert creature.size is size
+
+
+class TestDataLoaderMonsterSize:
+    """Test that DataLoader.create_monster reads the size field from monsters.json."""
+
+    def test_goblin_loads_as_small(self):
+        """The SRD goblin entry is 'small' — loader should surface Size.SMALL."""
+        loader = DataLoader()
+        goblin = loader.create_monster("goblin")
+        assert goblin.size is Size.SMALL
+
+    def test_wolf_loads_as_medium(self):
+        """The SRD wolf entry is 'medium' — loader should surface Size.MEDIUM."""
+        loader = DataLoader()
+        wolf = loader.create_monster("wolf")
+        assert wolf.size is Size.MEDIUM
+
+    def test_missing_size_defaults_to_medium(self):
+        """A monster catalog entry without a size key should default to Medium."""
+        # Stub monsters.json with one entry that omits "size" — exercises the
+        # loader's .get(..., "medium") default branch without modifying real
+        # catalog data.
+        stub_monsters = {
+            "sizeless_test_monster": {
+                "name": "Sizeless Test Monster",
+                "hp": "1d4",
+                "ac": 10,
+                "abilities": {
+                    "str": 10,
+                    "dex": 10,
+                    "con": 10,
+                    "int": 10,
+                    "wis": 10,
+                    "cha": 10,
+                },
+            }
+        }
+        loader = DataLoader()
+        with patch.object(loader, "load_monsters", return_value=stub_monsters):
+            creature = loader.create_monster("sizeless_test_monster")
+        assert creature.size is Size.MEDIUM
+
+    def test_size_string_is_case_insensitive(self):
+        """An uppercase size string in the catalog should still load cleanly."""
+        stub_monsters = {
+            "shouting_giant": {
+                "name": "Shouting Giant",
+                "hp": "1d4",
+                "ac": 10,
+                "size": "HUGE",
+                "abilities": {
+                    "str": 10,
+                    "dex": 10,
+                    "con": 10,
+                    "int": 10,
+                    "wis": 10,
+                    "cha": 10,
+                },
+            }
+        }
+        loader = DataLoader()
+        with patch.object(loader, "load_monsters", return_value=stub_monsters):
+            creature = loader.create_monster("shouting_giant")
+        assert creature.size is Size.HUGE


### PR DESCRIPTION
## Summary

Wave 1 / Slice 1 of plan-03 (Movement, Terrain & Positioning, plan-master #532). Lands the data-model foundation that downstream slices (#473 Cover, footprint logic, future geometry work) will read from.

- Adds `Size(str, Enum)` covering all six SRD sizes (Tiny..Gargantuan) with canonical lowercase string values so JSON round-trips cleanly.
- Adds `size: Size = Size.MEDIUM` kwarg on `Creature.__init__` (default Medium so existing callers and characters work unchanged).
- `DataLoader.create_monster` now reads `monsters.json["size"]` parallel to `speed`; tolerates missing key by defaulting to Medium.

**Explicitly out of scope:** multi-tile footprint, pathing changes, cover, any size-driven mechanics. Those come in later plan-03 slices once the engine has a first-class spatial model.

## Files touched

- `dnd-engine/dnd_engine/core/creature.py` — `Size` enum + `size` field.
- `dnd-engine/dnd_engine/rules/loader.py` — wire `size` from monsters.json (one-line addition parallel to existing `speed` load).
- `dnd-engine/tests/test_creature_size.py` — new (15 tests: enum membership, round-trip, default, loader wiring, missing-key default).
- `dnd-engine/tests/srd/playing_the_game/test_mounted_combat.py` — flipped the existing gap-tracking guard `test_creature_class_has_no_size_attribute` (which the test's own docstring instructed to flip when #442 closed) into `test_creature_class_carries_size_field`. Sister mount-eligibility tests remain skipped — those are #526 territory.

## Test plan

- [x] `tests/test_creature_size.py`: 15 passed
- [x] Non-SRD suite: 2336 passed, 1 skipped (no regressions)
- [x] SRD suite: 454 passed, 249 skipped (skip count unchanged; the mounted-combat guard converted from "passing as gap-open" to "passing as gap-closed")
- [x] `ruff check` clean on all touched files
- [x] `monsters.json` untouched — all 15 SRD monsters already carry `size` (verified via `jq`)

## Notes for downstream slices

`Creature` is a plain class with `__init__`, not a dataclass (despite the plan's wording). `size` is added as a kwarg at the end of the signature; all 50+ existing `Creature(...)` call sites use keyword args, so no positional-breakage risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)