### PR TITLE
Add MovementMode enum + Creature.speeds dict (#432) — plan-03

### DIFF
--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -26,6 +26,26 @@ class Size(str, Enum):
     GARGANTUAN = "gargantuan"
 
 
+class MovementMode(str, Enum):
+    """
+    SRD movement modes (SRD § Playing the Game › Movement › Movement Modes).
+
+    The canonical string value matches the lowercase form that monsters.json
+    is expected to use for any future per-mode `speeds` dict, so values
+    round-trip cleanly through JSON. Drives per-mode movement-cost logic
+    later in plan-03; this enum is the data-model foundation those systems
+    read alongside `Creature.speeds`.
+    """
+
+    WALK = "walk"
+    CLIMB = "climb"
+    SWIM = "swim"
+    CRAWL = "crawl"
+    JUMP = "jump"
+    FLY = "fly"
+    BURROW = "burrow"
+
+
 @dataclass
 class Abilities:
     """
@@ -89,6 +109,7 @@ class Creature:
         current_hp: int | None = None,
         speed: int = 30,
         size: Size = Size.MEDIUM,
+        speeds: dict[MovementMode, int] | None = None,
     ):
         """
         Initialize a creature.
@@ -99,19 +120,43 @@ class Creature:
             ac: Armor class (target number for attacks)
             abilities: Ability scores (STR, DEX, CON, INT, WIS, CHA)
             current_hp: Starting HP (defaults to max_hp if not specified)
-            speed: Movement speed in feet per round (default 30 ft)
+            speed: Movement speed in feet per round (default 30 ft). The
+                legacy single-int `speed` kwarg is preserved so existing
+                callers and monsters.json (which carries a plain int)
+                keep working. When `speeds` is omitted, it is derived as
+                `{MovementMode.WALK: speed}` so per-mode consumers can
+                always read `creature.speeds[MovementMode.WALK]`.
             size: SRD size category (default Medium). Drives map footprint
                 and reach geometry in plan-03; defaulting to Medium keeps
                 Characters and any creature constructed without an explicit
                 size on the SRD baseline.
+            speeds: Optional per-mode speed map (Walk/Climb/Swim/etc.).
+                When provided, `self.speeds` is set to the supplied dict
+                verbatim — no WALK auto-injection. The legacy `self.speed`
+                attribute mirrors `speeds[MovementMode.WALK]` if present,
+                otherwise falls back to the `speed` kwarg (this matters
+                for fly-only creatures whose walk speed is 0).
         """
         self.name = name
         self.max_hp = max_hp
         self.current_hp = current_hp if current_hp is not None else max_hp
         self._base_ac = ac  # Store base AC (before modifiers from spells/effects)
         self.abilities = abilities
-        self.speed = speed  # Movement speed in feet (5 ft = 1 grid square)
         self.size = size
+        # Per-mode speeds (plan-03). When `speeds` is omitted, derive a
+        # single-entry {WALK: speed} dict so downstream cost-multiplier
+        # code (slices 3-4) can always index by MovementMode. When
+        # `speeds` is provided, honor it as-is — a fly-only creature can
+        # legitimately ship {FLY: 60} with no WALK entry.
+        if speeds is None:
+            self.speeds: dict[MovementMode, int] = {MovementMode.WALK: speed}
+            self.speed = speed  # Movement speed in feet (5 ft = 1 grid square)
+        else:
+            self.speeds = speeds
+            # Legacy `self.speed` mirrors WALK from the speeds dict when
+            # present so existing callers reading `creature.speed` keep
+            # working; otherwise fall back to the supplied `speed` kwarg.
+            self.speed = speeds.get(MovementMode.WALK, speed)
         # Condition tracking with metadata for duration and repeat saves
         # Maps condition name -> metadata dict
         self.active_conditions: dict[str, dict] = {}

--- a/dnd-engine/dnd_engine/rules/loader.py
+++ b/dnd-engine/dnd_engine/rules/loader.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from dnd_engine.core.creature import Abilities, Creature, Size
+from dnd_engine.core.creature import Abilities, Creature, MovementMode, Size
 from dnd_engine.core.dice import DiceRoller
 
 
@@ -85,7 +85,20 @@ class DataLoader:
         max_hp = max(1, hp_roll.total)  # Minimum 1 HP
 
         # Get speed (default 30 ft if not specified)
-        speed = data.get("speed", 30)
+        speed = int(data.get("speed", 30))
+
+        # Optional per-mode speeds dict (plan-03). monsters.json today
+        # only carries a plain int `speed`; future entries may add a
+        # `speeds: {walk: 30, swim: 30, ...}` map. When present, parse
+        # keys into MovementMode members and pass through so the
+        # Creature ships the full per-mode map. When absent, the
+        # Creature constructor derives {WALK: speed} from the int.
+        speeds_data = data.get("speeds")
+        speeds: dict[MovementMode, int] | None
+        if isinstance(speeds_data, dict):
+            speeds = {MovementMode(k): int(v) for k, v in speeds_data.items()}
+        else:
+            speeds = None
 
         # Get size (default Medium if not specified in the catalog). The
         # canonical lowercase string in monsters.json matches Size.value
@@ -101,6 +114,7 @@ class DataLoader:
             abilities=abilities,
             speed=speed,
             size=size,
+            speeds=speeds,
         )
 
         # Attach per-type damage modifier fields from the monster catalog.

--- a/dnd-engine/tests/test_movement_modes.py
+++ b/dnd-engine/tests/test_movement_modes.py
@@ -1,0 +1,165 @@
+# ABOUTME: Tests for MovementMode enum and Creature.speeds dict data shape
+# ABOUTME: Covers backward-compat with legacy `speed: int` and DataLoader wiring
+
+from unittest.mock import patch
+
+import pytest
+
+from dnd_engine.core.creature import Abilities, Creature, MovementMode
+from dnd_engine.rules.loader import DataLoader
+
+
+@pytest.fixture
+def abilities() -> Abilities:
+    """Baseline ability scores for a generic Medium humanoid."""
+    return Abilities(
+        strength=10,
+        dexterity=10,
+        constitution=10,
+        intelligence=10,
+        wisdom=10,
+        charisma=10,
+    )
+
+
+class TestMovementModeEnum:
+    """MovementMode enum shape — values, membership, JSON round-trip."""
+
+    def test_enum_has_all_seven_members(self):
+        """All seven SRD-relevant movement modes are present."""
+        expected = {"WALK", "CLIMB", "SWIM", "CRAWL", "JUMP", "FLY", "BURROW"}
+        actual = {member.name for member in MovementMode}
+        assert actual == expected
+
+    def test_enum_values_are_lowercase_strings(self):
+        """Values are lowercase strings for JSON-friendly serialization."""
+        assert MovementMode.WALK.value == "walk"
+        assert MovementMode.CLIMB.value == "climb"
+        assert MovementMode.SWIM.value == "swim"
+        assert MovementMode.CRAWL.value == "crawl"
+        assert MovementMode.JUMP.value == "jump"
+        assert MovementMode.FLY.value == "fly"
+        assert MovementMode.BURROW.value == "burrow"
+
+    def test_enum_round_trips_through_string_value(self):
+        """`MovementMode("swim")` resolves back to the same member identity."""
+        assert MovementMode("swim") is MovementMode.SWIM
+        assert MovementMode("fly") is MovementMode.FLY
+
+    def test_enum_is_string_subclass(self):
+        """Members compare equal to their string value (JSON friendliness)."""
+        assert MovementMode.WALK == "walk"
+
+
+class TestCreatureSpeedsDefault:
+    """Backward compat: passing only `speed=...` derives speeds = {WALK: speed}."""
+
+    def test_default_speed_populates_walk_in_speeds_dict(self, abilities):
+        """A creature built with legacy `speed=30` exposes both `speed` and `speeds`."""
+        creature = Creature(
+            name="Generic",
+            max_hp=10,
+            ac=10,
+            abilities=abilities,
+            speed=30,
+        )
+        assert creature.speed == 30
+        assert creature.speeds == {MovementMode.WALK: 30}
+
+    def test_speed_zero_still_populates_walk(self, abilities):
+        """A creature with speed=0 (e.g. statue) gets {WALK: 0}, not an empty dict."""
+        creature = Creature(
+            name="Statue",
+            max_hp=10,
+            ac=10,
+            abilities=abilities,
+            speed=0,
+        )
+        assert creature.speed == 0
+        assert creature.speeds == {MovementMode.WALK: 0}
+
+    def test_default_speed_when_kwarg_omitted(self, abilities):
+        """The default `speed=30` kwarg also flows into the speeds dict."""
+        creature = Creature(name="Default", max_hp=10, ac=10, abilities=abilities)
+        assert creature.speed == 30
+        assert creature.speeds == {MovementMode.WALK: 30}
+
+
+class TestCreatureSpeedsExplicit:
+    """When `speeds` is passed explicitly, it overrides the auto-derivation."""
+
+    def test_explicit_speeds_with_walk_sets_both_fields(self, abilities):
+        """speeds={WALK: 25, SWIM: 25} populates both `speeds` and legacy `speed`."""
+        creature = Creature(
+            name="Merfolk",
+            max_hp=10,
+            ac=10,
+            abilities=abilities,
+            speeds={MovementMode.WALK: 25, MovementMode.SWIM: 25},
+        )
+        assert creature.speed == 25
+        assert creature.speeds == {MovementMode.WALK: 25, MovementMode.SWIM: 25}
+
+    def test_explicit_speeds_without_walk_keeps_legacy_speed(self, abilities):
+        """speeds={FLY: 60} with speed=0 keeps speed=0 — no WALK auto-injection."""
+        creature = Creature(
+            name="Flying Snake",
+            max_hp=10,
+            ac=10,
+            abilities=abilities,
+            speed=0,
+            speeds={MovementMode.FLY: 60},
+        )
+        assert creature.speed == 0
+        assert creature.speeds == {MovementMode.FLY: 60}
+        assert MovementMode.WALK not in creature.speeds
+
+    def test_explicit_speeds_with_walk_overrides_speed_kwarg(self, abilities):
+        """When speeds includes WALK, the legacy `speed` attribute mirrors it."""
+        creature = Creature(
+            name="OverriddenWalker",
+            max_hp=10,
+            ac=10,
+            abilities=abilities,
+            speed=30,
+            speeds={MovementMode.WALK: 40, MovementMode.CLIMB: 20},
+        )
+        assert creature.speed == 40
+        assert creature.speeds == {MovementMode.WALK: 40, MovementMode.CLIMB: 20}
+
+
+class TestDataLoaderSpeeds:
+    """DataLoader.create_monster wires `speed` / `speeds` into the Creature."""
+
+    def test_goblin_has_walk_speed_only(self):
+        """Goblin in monsters.json has `speed: 30` and no `speeds` dict."""
+        loader = DataLoader()
+        goblin = loader.create_monster("goblin")
+        assert goblin.speed == 30
+        assert goblin.speeds == {MovementMode.WALK: 30}
+
+    def test_loader_parses_speeds_dict_when_present(self):
+        """When a monster entry carries a `speeds` dict, the loader parses it."""
+        loader = DataLoader()
+        fake_monster_catalog = {
+            "merfolk": {
+                "name": "Merfolk",
+                "abilities": {
+                    "str": 10,
+                    "dex": 13,
+                    "con": 12,
+                    "int": 11,
+                    "wis": 11,
+                    "cha": 12,
+                },
+                "hp": "2d8",
+                "ac": 11,
+                "speed": 10,
+                "speeds": {"walk": 10, "swim": 40},
+            }
+        }
+        with patch.object(loader, "load_monsters", return_value=fake_monster_catalog):
+            merfolk = loader.create_monster("merfolk")
+        assert merfolk.speeds == {MovementMode.WALK: 10, MovementMode.SWIM: 40}
+        # Legacy `speed` attribute mirrors WALK from the speeds dict.
+        assert merfolk.speed == 10


### PR DESCRIPTION
## Summary

Wave 1 / Slice 2 of plan-03 (Movement, Terrain & Positioning, plan-master #532). Lands the data-shape foundation for per-mode movement; the cost-multiplier and enforcement logic come in slices 3-4.

- Adds `MovementMode(str, Enum)` with seven members: Walk / Climb / Swim / Crawl / Jump / Fly / Burrow. Lowercase string values for JSON friendliness.
- Adds `Creature.speeds: dict[MovementMode, int]` field. When the legacy `speed: int` kwarg is provided alone, `speeds` defaults to `{MovementMode.WALK: speed}` so all existing callers and `monsters.json` (plain ints today) keep working.
- `Creature.speed` remains a plain `int` attribute on the instance, kept in lockstep with `speeds[WALK]`. Not converted to a `@property` — downstream code can keep mutating it (Slow spell, future mount state).
- `DataLoader.create_monster` now optionally parses `data["speeds"]` as a `dict[str, int]` if present (future-proofing). monsters.json is **not** modified — a follow-up enrichment PR can backfill climb/swim/fly speeds once the consumer logic (slice 3-4) lands.

## Explicitly out of scope

- `EventType.OPPORTUNITY_PROVOKED` — moved to slice 6 (#413) where it belongs.
- Per-mode cost multipliers, `TurnState.consume_movement` changes, difficult-terrain enforcement.
- monsters.json content updates.
- Any "needs Swim speed to swim at full cost" gating.

## Files touched

- `dnd-engine/dnd_engine/core/creature.py` — `MovementMode` enum + `speeds` kwarg/field on `Creature` (+50/-1).
- `dnd-engine/dnd_engine/rules/loader.py` — optional `data["speeds"]` parse path (+18/-2).
- `dnd-engine/tests/test_movement_modes.py` — new, 12 tests covering enum membership, round-trip, default-from-speed, explicit speeds, fly-only edge case, loader plain-int + dict paths (+165).

## Test plan

- [x] `tests/test_movement_modes.py`: 12 passed
- [x] Non-SRD suite: 2333 passed, 1 skipped (no regressions vs branch base)
- [x] SRD suite: 454 passed, 249 skipped (skip count unchanged)
- [x] `ruff check` clean on all touched files

## Coordination with #556

Branched off `main`, parallel to PR #556 (`Add Creature.size data field`). Both PRs touch `Creature.__init__` signature; whichever lands second will need a trivial rebase to append both kwargs. Recommend merging #556 first since it's smaller; this PR will auto-rebase or take a one-line conflict resolution.

## Follow-ups (not in this PR)

- File a separate issue: backfill monsters.json with per-mode `speeds` dicts where SRD prescribes Climb/Fly/Swim/Burrow (giant_rat, giant_spider, etc.). Gated behind slice 3-4 so we don't ship unused data.
- Loader's `MovementMode(k)` is strict: a typo like `"flyy"` raises `ValueError` from `create_monster`. Preferable for catching bad content early; flagged for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)