### PR TITLE
Implement difficult-terrain cost multiplier (#436) — plan-03

### DIFF
--- a/dnd-engine/dnd_engine/systems/action_economy.py
+++ b/dnd-engine/dnd_engine/systems/action_economy.py
@@ -22,6 +22,37 @@ class ActionType(Enum):
     NO_ACTION = "no_action"
 
 
+class Terrain(str, Enum):
+    """
+    Kinds of terrain a creature may move through, for movement-cost purposes.
+
+    SRD: "Each foot of movement in difficult terrain costs 1 extra foot."
+    So a 5-foot step through difficult terrain costs 10 feet of movement.
+    """
+
+    NORMAL = "normal"
+    DIFFICULT = "difficult"
+
+
+def cost_for(feet: int, terrain: Terrain) -> int:
+    """
+    Compute the movement-pool cost for traveling ``feet`` through ``terrain``.
+
+    Difficult terrain costs 1 extra foot per foot moved (effectively 2x).
+    Normal terrain costs exactly ``feet``.
+
+    Args:
+        feet: Distance the creature wants to travel, in feet.
+        terrain: Terrain kind being traversed.
+
+    Returns:
+        The number of feet to deduct from the movement pool.
+    """
+    if terrain == Terrain.DIFFICULT:
+        return feet * 2
+    return feet
+
+
 @dataclass
 class TurnState:
     """
@@ -80,15 +111,22 @@ class TurnState:
 
         return False
 
-    def consume_movement(self, feet: int = 5) -> bool:
+    def consume_movement(
+        self, feet: int = 5, terrain: Terrain = Terrain.NORMAL
+    ) -> bool:
         """
         Consume movement from remaining movement pool.
 
         Args:
             feet: Amount of movement to consume (default 5 ft = 1 grid square)
+            terrain: Terrain kind being traversed. Difficult terrain doubles
+                the cost per foot (SRD: each foot in difficult terrain costs
+                1 extra foot). Defaults to NORMAL so existing callers are
+                unaffected.
 
         Returns:
-            True if movement was available and consumed, False if insufficient
+            True if movement was available and consumed, False if insufficient.
+            On insufficient movement, ``movement_remaining`` is NOT changed.
 
         Example:
             >>> turn = TurnState(movement_remaining=30)
@@ -96,9 +134,14 @@ class TurnState:
             True
             >>> turn.movement_remaining
             25
+            >>> turn.consume_movement(5, terrain=Terrain.DIFFICULT)
+            True
+            >>> turn.movement_remaining
+            15
         """
-        if self.movement_remaining >= feet:
-            self.movement_remaining -= feet
+        cost = cost_for(feet, terrain)
+        if self.movement_remaining >= cost:
+            self.movement_remaining -= cost
             return True
         return False
 

--- a/dnd-engine/tests/test_difficult_terrain.py
+++ b/dnd-engine/tests/test_difficult_terrain.py
@@ -1,0 +1,102 @@
+# ABOUTME: Tests for difficult-terrain movement cost multiplier (issue #436)
+# ABOUTME: Verifies Terrain enum, cost_for helper, and TurnState.consume_movement(terrain=...)
+
+import pytest
+
+from dnd_engine.systems.action_economy import Terrain, TurnState, cost_for
+
+
+class TestTerrainEnum:
+    """Terrain enum exposes the SRD-relevant terrain kinds."""
+
+    def test_normal_value(self):
+        assert Terrain.NORMAL.value == "normal"
+
+    def test_difficult_value(self):
+        assert Terrain.DIFFICULT.value == "difficult"
+
+    def test_terrain_is_str_enum(self):
+        # Terrain(str, Enum) matches the pattern used by ActionType-style enums
+        # elsewhere in the codebase and allows JSON-friendly serialization.
+        assert isinstance(Terrain.NORMAL.value, str)
+        assert isinstance(Terrain.DIFFICULT.value, str)
+
+
+class TestCostFor:
+    """cost_for centralizes the per-foot multiplier for a terrain kind."""
+
+    def test_normal_terrain_is_one_to_one(self):
+        assert cost_for(5, Terrain.NORMAL) == 5
+
+    def test_difficult_terrain_doubles_cost(self):
+        # SRD: "Each foot of movement in difficult terrain costs 1 extra foot."
+        assert cost_for(5, Terrain.DIFFICULT) == 10
+
+    def test_zero_feet_normal_is_zero(self):
+        assert cost_for(0, Terrain.NORMAL) == 0
+
+    def test_zero_feet_difficult_is_zero(self):
+        assert cost_for(0, Terrain.DIFFICULT) == 0
+
+    def test_fifteen_feet_difficult(self):
+        assert cost_for(15, Terrain.DIFFICULT) == 30
+
+    @pytest.mark.parametrize(
+        "feet,terrain,expected_cost",
+        [
+            (5, Terrain.NORMAL, 5),
+            (5, Terrain.DIFFICULT, 10),
+            (10, Terrain.NORMAL, 10),
+            (10, Terrain.DIFFICULT, 20),
+            (1, Terrain.DIFFICULT, 2),
+        ],
+    )
+    def test_cost_table(self, feet, terrain, expected_cost):
+        assert cost_for(feet, terrain) == expected_cost
+
+
+class TestConsumeMovementBackwardCompat:
+    """Existing callers (no terrain kwarg) continue to behave exactly as before."""
+
+    def test_default_terrain_normal_deducts_feet_unchanged(self):
+        turn = TurnState(movement_remaining=30)
+        result = turn.consume_movement(feet=5)
+        assert result is True
+        assert turn.movement_remaining == 25
+
+    def test_default_call_with_no_args_still_deducts_five(self):
+        turn = TurnState(movement_remaining=30)
+        result = turn.consume_movement()
+        assert result is True
+        assert turn.movement_remaining == 25
+
+
+class TestConsumeMovementDifficultTerrain:
+    """Difficult terrain doubles the cost deducted from movement_remaining."""
+
+    def test_difficult_terrain_deducts_double(self):
+        turn = TurnState(movement_remaining=30)
+        result = turn.consume_movement(feet=5, terrain=Terrain.DIFFICULT)
+        assert result is True
+        assert turn.movement_remaining == 20
+
+    def test_difficult_terrain_explicit_normal_matches_default(self):
+        turn = TurnState(movement_remaining=30)
+        result = turn.consume_movement(feet=5, terrain=Terrain.NORMAL)
+        assert result is True
+        assert turn.movement_remaining == 25
+
+    def test_insufficient_movement_in_difficult_terrain_does_not_deduct(self):
+        # consume_movement's existing contract: check bounds, return False
+        # without deducting if insufficient. Difficult terrain must respect
+        # the same contract.
+        turn = TurnState(movement_remaining=5)
+        result = turn.consume_movement(feet=5, terrain=Terrain.DIFFICULT)
+        assert result is False
+        assert turn.movement_remaining == 5
+
+    def test_exactly_enough_movement_in_difficult_terrain(self):
+        turn = TurnState(movement_remaining=10)
+        result = turn.consume_movement(feet=5, terrain=Terrain.DIFFICULT)
+        assert result is True
+        assert turn.movement_remaining == 0


### PR DESCRIPTION
## Summary

Wave 1 / Slice 3 of plan-03 (Movement, Terrain & Positioning, plan-master #532). Engine-side capability for SRD difficult terrain: each foot of movement costs 1 extra foot.

- Adds `Terrain(str, Enum)` with `NORMAL = "normal"` and `DIFFICULT = "difficult"`.
- Adds module-level helper `cost_for(feet, terrain) -> int` so the rule lives in one place (slice 4 will extend it for per-mode multipliers).
- `TurnState.consume_movement` accepts an optional `terrain: Terrain = Terrain.NORMAL` kwarg. Normal terrain behaves exactly as today; `DIFFICULT` doubles the cost.
- Preserves the existing insufficient-movement contract: if the (terrain-adjusted) cost exceeds `movement_remaining`, returns `False` and does not deduct.

## Explicitly out of scope

- Per-mode movement costs (slice 4, #433) — `cost_for` is designed to fold in cleanly when that lands.
- Threading per-tile terrain data from `layout_schema.RoomLayout` through `client-2d` and `script_executor` into `consume_movement` calls. Engine has the capability; callers default to `Terrain.NORMAL` and behave unchanged until later slices wire them up.
- Any `MovementMode` work.
- Modifying scenarios or the 2D client.

## Files touched

- `dnd-engine/dnd_engine/systems/action_economy.py` — `Terrain` enum, `cost_for` helper, `consume_movement` terrain kwarg (+47/-4).
- `dnd-engine/tests/test_difficult_terrain.py` — new, 19 tests across 4 classes covering enum values, `cost_for` table (parametrized), backward-compat default, double-cost, insufficient-movement on difficult, exact-boundary (+102).

## Test plan

- [x] `tests/test_difficult_terrain.py`: 19 passed
- [x] Non-SRD suite: 2340 passed, 1 skipped (= 2321 baseline + 19 new; no regressions)
- [x] SRD suite: 454 passed, 249 skipped (skip count unchanged)
- [x] `ruff check` clean on touched files

## Coordination

Branched off `main`, independent of PR #556 (Creature.size) and PR #557 (speeds dict). No merge conflicts expected — this slice only touches `action_economy.py` and a new test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)