### PR TITLE
Add engine Map mirroring RoomLayout (#532b) — plan-03

### DIFF
--- a/dnd-engine/dnd_engine/core/map.py
+++ b/dnd-engine/dnd_engine/core/map.py
@@ -1,0 +1,142 @@
+# ABOUTME: Engine-side spatial Map mirroring the client's RoomLayout for tile/terrain queries.
+# ABOUTME: Read model only — client RoomLayout still drives rendering; no mutation API here.
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from dnd_engine.systems.action_economy import Terrain as TerrainType
+
+if TYPE_CHECKING:
+    from client_2d.integration.layout_schema import RoomLayout
+
+
+class TileType(str, Enum):
+    """
+    Engine-side tile kinds, mirroring the client's tile semantics.
+
+    Lowercase string values keep tiles JSON-friendly and consistent with the
+    plan-03 style used by ``Size``, ``MovementMode``, and ``Terrain``. The
+    client enum (``client_2d.integration.layout_schema.TileType``) is an
+    ``IntEnum``; ``Map.from_room_layout`` translates by enum *name*.
+    """
+
+    FLOOR = "floor"
+    WALL = "wall"
+    DOOR = "door"
+    WATER = "water"
+    PIT = "pit"
+
+
+# Walkability rules mirror RoomLayout.is_walkable (layout_schema.py): floors,
+# doors, and water are walkable; walls and pits block movement.
+_WALKABLE_TILES: frozenset[TileType] = frozenset(
+    {TileType.FLOOR, TileType.DOOR, TileType.WATER}
+)
+
+# SRD difficult-terrain rule: water counts as difficult terrain. The client
+# does not yet model difficult terrain; the engine adds it here.
+_DIFFICULT_TILES: frozenset[TileType] = frozenset({TileType.WATER})
+
+
+__all__ = ["Map", "TerrainType", "TileType"]
+
+
+class Map:
+    """
+    Engine read model of the spatial grid.
+
+    Stores tiles sparsely as ``dict[(x, y), TileType]``. Coordinates inside
+    ``(width, height)`` bounds but absent from the dict are treated as walls
+    (blocking, not walkable) — callers should populate every walkable cell
+    explicitly. Out-of-bounds coordinates are likewise treated as blocking.
+
+    The Map is immutable: there is no ``set_tile`` API. To update, construct
+    a new Map.
+    """
+
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        tiles: dict[tuple[int, int], TileType],
+    ) -> None:
+        self.width = width
+        self.height = height
+        # Defensive copy so external mutation of the source dict doesn't bleed in.
+        self._tiles: dict[tuple[int, int], TileType] = dict(tiles)
+
+    @classmethod
+    def from_room_layout(cls, layout: RoomLayout) -> Map:
+        """
+        Build an engine ``Map`` from a client ``RoomLayout``.
+
+        ``RoomLayout.tiles`` is a ``list[list[int]]`` indexed ``[y][x]``,
+        with values from the client's ``IntEnum`` ``TileType``. We translate
+        by enum *name* (FLOOR, WALL, DOOR, WATER, PIT) so the engine's
+        string-valued enum and the client's int-valued enum stay loosely
+        coupled.
+        """
+        # Lazy import keeps the engine package from depending on client_2d at
+        # import time. Tests using importorskip cover the real RoomLayout path.
+        from client_2d.integration.layout_schema import TileType as ClientTileType
+
+        tiles: dict[tuple[int, int], TileType] = {}
+        for y, row in enumerate(layout.tiles):
+            for x, raw in enumerate(row):
+                client_tile = ClientTileType(raw)
+                tiles[(x, y)] = TileType[client_tile.name]
+        return cls(width=layout.width, height=layout.height, tiles=tiles)
+
+    def _in_bounds(self, x: int, y: int) -> bool:
+        return 0 <= x < self.width and 0 <= y < self.height
+
+    def tile_at(self, x: int, y: int) -> TileType | None:
+        """Return the tile at ``(x, y)``, or ``None`` if out of bounds."""
+        if not self._in_bounds(x, y):
+            return None
+        return self._tiles.get((x, y))
+
+    def is_walkable(self, x: int, y: int) -> bool:
+        """
+        Return True if a creature can enter ``(x, y)`` by walking.
+
+        Floors, doors, and water are walkable. Walls and pits are not.
+        Out-of-bounds and missing tiles default to blocking (False).
+        """
+        if not self._in_bounds(x, y):
+            return False
+        tile = self._tiles.get((x, y))
+        if tile is None:
+            return False
+        return tile in _WALKABLE_TILES
+
+    def is_blocking(self, x: int, y: int) -> bool:
+        """
+        Return True if ``(x, y)`` blocks movement.
+
+        Walls and pits block. Out-of-bounds and missing tiles also block
+        (the engine treats unknown geometry as solid).
+        """
+        if not self._in_bounds(x, y):
+            return True
+        tile = self._tiles.get((x, y))
+        if tile is None:
+            return True
+        return tile not in _WALKABLE_TILES
+
+    def terrain_at(self, x: int, y: int) -> TerrainType:
+        """
+        Return the terrain category at ``(x, y)`` for movement-cost purposes.
+
+        Water is ``DIFFICULT`` per the SRD; everything else (including
+        out-of-bounds and unknown tiles) is ``NORMAL``. Callers should reject
+        the move via ``is_walkable`` before relying on terrain cost.
+        """
+        if not self._in_bounds(x, y):
+            return TerrainType.NORMAL
+        tile = self._tiles.get((x, y))
+        if tile in _DIFFICULT_TILES:
+            return TerrainType.DIFFICULT
+        return TerrainType.NORMAL

--- a/dnd-engine/tests/srd/playing_the_game/test_engine_map.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_engine_map.py
@@ -1,0 +1,232 @@
+# ABOUTME: Tests for engine-side Map (plan-03 P2): tile/terrain queries, walkability.
+# ABOUTME: Covers TileType enum, TerrainType re-export, Map construction, RoomLayout import.
+
+from __future__ import annotations
+
+import pytest
+
+from dnd_engine.core.map import Map, TerrainType, TileType
+from dnd_engine.systems.action_economy import Terrain
+
+
+class TestTileTypeEnum:
+    """TileType enum mirrors client tile semantics with lowercase JSON-friendly values."""
+
+    def test_all_five_members_present(self) -> None:
+        assert TileType.FLOOR.value == "floor"
+        assert TileType.WALL.value == "wall"
+        assert TileType.DOOR.value == "door"
+        assert TileType.WATER.value == "water"
+        assert TileType.PIT.value == "pit"
+
+    def test_round_trip_from_string(self) -> None:
+        assert TileType("floor") is TileType.FLOOR
+        assert TileType("wall") is TileType.WALL
+        assert TileType("door") is TileType.DOOR
+        assert TileType("water") is TileType.WATER
+        assert TileType("pit") is TileType.PIT
+
+
+class TestTerrainTypeReExport:
+    """TerrainType is re-exported from action_economy — one source of truth."""
+
+    def test_terrain_type_is_action_economy_terrain(self) -> None:
+        # Identity check: confirms re-export, not a duplicate enum.
+        assert TerrainType is Terrain
+
+    def test_members(self) -> None:
+        assert TerrainType.NORMAL.value == "normal"
+        assert TerrainType.DIFFICULT.value == "difficult"
+
+
+@pytest.fixture
+def basic_map() -> Map:
+    """3x3 map with one floor, one wall, one water tile; other coords default to wall."""
+    return Map(
+        width=3,
+        height=3,
+        tiles={
+            (0, 0): TileType.FLOOR,
+            (1, 1): TileType.WALL,
+            (2, 2): TileType.WATER,
+        },
+    )
+
+
+class TestMapWalkability:
+    """Walkable rules mirror client RoomLayout: FLOOR/DOOR/WATER walkable; WALL/PIT blocking."""
+
+    def test_floor_is_walkable(self, basic_map: Map) -> None:
+        assert basic_map.is_walkable(0, 0) is True
+
+    def test_wall_is_not_walkable(self, basic_map: Map) -> None:
+        assert basic_map.is_walkable(1, 1) is False
+
+    def test_water_is_walkable(self, basic_map: Map) -> None:
+        assert basic_map.is_walkable(2, 2) is True
+
+    def test_out_of_bounds_high_is_not_walkable(self, basic_map: Map) -> None:
+        assert basic_map.is_walkable(0, 5) is False
+
+    def test_out_of_bounds_negative_is_not_walkable(self, basic_map: Map) -> None:
+        assert basic_map.is_walkable(-1, 0) is False
+
+    @pytest.mark.parametrize(
+        "tile_type,expected_walkable",
+        [
+            (TileType.FLOOR, True),
+            (TileType.DOOR, True),
+            (TileType.WATER, True),
+            (TileType.WALL, False),
+            (TileType.PIT, False),
+        ],
+    )
+    def test_walkable_by_tile_type(
+        self, tile_type: TileType, expected_walkable: bool
+    ) -> None:
+        m = Map(width=1, height=1, tiles={(0, 0): tile_type})
+        assert m.is_walkable(0, 0) is expected_walkable
+
+
+class TestMapBlocking:
+    """is_blocking is the dual of is_walkable for known tiles; out-of-bounds also blocks."""
+
+    def test_wall_is_blocking(self, basic_map: Map) -> None:
+        assert basic_map.is_blocking(1, 1) is True
+
+    def test_floor_is_not_blocking(self, basic_map: Map) -> None:
+        assert basic_map.is_blocking(0, 0) is False
+
+    def test_out_of_bounds_is_blocking(self, basic_map: Map) -> None:
+        assert basic_map.is_blocking(0, 5) is True
+
+    @pytest.mark.parametrize(
+        "tile_type,expected_blocking",
+        [
+            (TileType.WALL, True),
+            (TileType.PIT, True),
+            (TileType.FLOOR, False),
+            (TileType.DOOR, False),
+            (TileType.WATER, False),
+        ],
+    )
+    def test_blocking_by_tile_type(
+        self, tile_type: TileType, expected_blocking: bool
+    ) -> None:
+        m = Map(width=1, height=1, tiles={(0, 0): tile_type})
+        assert m.is_blocking(0, 0) is expected_blocking
+
+
+class TestMapTerrain:
+    """WATER maps to DIFFICULT terrain; everything else to NORMAL."""
+
+    def test_floor_is_normal_terrain(self, basic_map: Map) -> None:
+        assert basic_map.terrain_at(0, 0) == TerrainType.NORMAL
+
+    def test_water_is_difficult_terrain(self, basic_map: Map) -> None:
+        assert basic_map.terrain_at(2, 2) == TerrainType.DIFFICULT
+
+    def test_out_of_bounds_defaults_to_normal(self, basic_map: Map) -> None:
+        # Out-of-bounds doesn't crash; engine spatial code rejects via is_walkable first.
+        assert basic_map.terrain_at(0, 5) == TerrainType.NORMAL
+
+    @pytest.mark.parametrize(
+        "tile_type,expected_terrain",
+        [
+            (TileType.FLOOR, TerrainType.NORMAL),
+            (TileType.DOOR, TerrainType.NORMAL),
+            (TileType.WALL, TerrainType.NORMAL),
+            (TileType.PIT, TerrainType.NORMAL),
+            (TileType.WATER, TerrainType.DIFFICULT),
+        ],
+    )
+    def test_terrain_by_tile_type(
+        self, tile_type: TileType, expected_terrain: TerrainType
+    ) -> None:
+        m = Map(width=1, height=1, tiles={(0, 0): tile_type})
+        assert m.terrain_at(0, 0) == expected_terrain
+
+
+class TestMapTileAt:
+    """tile_at returns the stored TileType, or None for out-of-bounds."""
+
+    def test_in_bounds_returns_tile(self, basic_map: Map) -> None:
+        assert basic_map.tile_at(0, 0) is TileType.FLOOR
+        assert basic_map.tile_at(1, 1) is TileType.WALL
+        assert basic_map.tile_at(2, 2) is TileType.WATER
+
+    def test_out_of_bounds_returns_none(self, basic_map: Map) -> None:
+        assert basic_map.tile_at(0, 5) is None
+        assert basic_map.tile_at(-1, 0) is None
+
+
+class TestMapMissingTileDefaultsToWall:
+    """Coords inside bounds but absent from the tiles dict are treated as walls (blocking)."""
+
+    def test_missing_tile_is_not_walkable(self) -> None:
+        m = Map(width=3, height=3, tiles={})
+        assert m.is_walkable(1, 1) is False
+
+    def test_missing_tile_is_blocking(self) -> None:
+        m = Map(width=3, height=3, tiles={})
+        assert m.is_blocking(1, 1) is True
+
+
+class TestMapFromRoomLayout:
+    """Integration: build engine Map from a client RoomLayout (skip if client-2d absent)."""
+
+    def test_from_room_layout_preserves_tiles(self) -> None:
+        layout_schema = pytest.importorskip("client_2d.integration.layout_schema")
+        ClientTileType = layout_schema.TileType
+        RoomLayout = layout_schema.RoomLayout
+
+        # 3x3 grid containing one of each tile type (PIT in last cell to fill).
+        # Layout rows are list[list[int]], indexed [y][x].
+        layout = RoomLayout(
+            width=3,
+            height=3,
+            tiles=[
+                [ClientTileType.FLOOR, ClientTileType.WALL, ClientTileType.DOOR],
+                [ClientTileType.WATER, ClientTileType.PIT, ClientTileType.FLOOR],
+                [ClientTileType.FLOOR, ClientTileType.FLOOR, ClientTileType.FLOOR],
+            ],
+            spawn_points={"player": (0, 0)},
+        )
+
+        m = Map.from_room_layout(layout)
+
+        # Tile-by-tile correspondence (engine tiles indexed [x, y]; client [y][x]).
+        expected = {
+            (0, 0): TileType.FLOOR,
+            (1, 0): TileType.WALL,
+            (2, 0): TileType.DOOR,
+            (0, 1): TileType.WATER,
+            (1, 1): TileType.PIT,
+            (2, 1): TileType.FLOOR,
+            (0, 2): TileType.FLOOR,
+            (1, 2): TileType.FLOOR,
+            (2, 2): TileType.FLOOR,
+        }
+        for (x, y), expected_tile in expected.items():
+            assert m.tile_at(x, y) is expected_tile, (
+                f"mismatch at ({x},{y}): got {m.tile_at(x, y)!r}, expected {expected_tile!r}"
+            )
+
+    def test_from_room_layout_preserves_dimensions(self) -> None:
+        layout_schema = pytest.importorskip("client_2d.integration.layout_schema")
+        ClientTileType = layout_schema.TileType
+        RoomLayout = layout_schema.RoomLayout
+
+        layout = RoomLayout(
+            width=2,
+            height=2,
+            tiles=[
+                [ClientTileType.FLOOR, ClientTileType.FLOOR],
+                [ClientTileType.FLOOR, ClientTileType.FLOOR],
+            ],
+            spawn_points={"player": (0, 0)},
+        )
+        m = Map.from_room_layout(layout)
+        assert m.is_walkable(0, 0) is True
+        assert m.is_walkable(1, 1) is True
+        assert m.is_walkable(2, 0) is False  # out of bounds


### PR DESCRIPTION
## Summary

Phase 2 of the engine spatial-model migration for plan-03 (master #532). Parallel read model — the client's `RoomLayout` keeps driving rendering; the engine grows its own `Map` for spatial queries. Zero client/script behavior change.

- New `dnd_engine/core/map.py` exporting:
  - `TileType(str, Enum)` with `FLOOR / WALL / DOOR / WATER / PIT` — lowercase string values matching the prior plan-03 style (`Size`, `MovementMode`, `Terrain`).
  - `TerrainType` re-exported from `systems/action_economy.Terrain` (slice 3, #436). One source of truth for the difficult-terrain enum, no competing duplicate.
  - `Map(width, height, tiles)` with `is_walkable`, `is_blocking`, `terrain_at`, `tile_at`, plus `Map.from_room_layout(layout)` for the engine↔client bridge.
- Walkable rules mirror `client-2d` `RoomLayout.is_walkable`: `FLOOR`, `DOOR`, `WATER` walkable; `WALL`, `PIT`, OOB, and unspecified tiles blocking.
- Terrain rule: `WATER → DIFFICULT`, everything else → `NORMAL` (engine adds the SRD rule the client doesn't yet model).

## Bridge details

Client `TileType` is an `IntEnum` (values 0-4); engine `TileType` is a `str` enum for JSON friendliness. `from_room_layout` bridges by **member name** (`TileType[client_tile.name]`), which is robust to either side renumbering values. Real-client integration tests use `pytest.importorskip("client_2d.integration.layout_schema")` so the engine suite stays green in environments without `client-2d` installed.

## Explicitly out of scope

- `Position` value object, `Creature.position` field, `SpatialIndex` — those are P1 (#559) and P3.
- Any `GameState` or `client-2d` modification.
- Pathfinding, LoS, or geometry queries beyond the four `Map` methods.
- Mutation API (no `set_tile`) — `Map` is immutable; updates rebuild.

## Files touched

- `dnd-engine/dnd_engine/core/map.py` — new, 142 LOC.
- `dnd-engine/tests/srd/playing_the_game/test_engine_map.py` — new, 232 LOC.

## Test plan

- [x] `test_engine_map.py`: 34 passed, 2 skipped (the 2 skips are real-client integration paths gated by `importorskip`)
- [x] Non-SRD suite: 2367 passed, 1 skipped (unchanged)
- [x] SRD suite: 488 passed, 251 skipped (= 454 baseline + 34 new passing; skip delta +2 is the gated integration cases)
- [x] `ruff check` clean on new files

## Coordination

Branched off `main`, independent of PR #559 (P1 `Position`). No file overlap — clean parallel merge expected.

## Next

P3 builds `SpatialIndex` on top of this `Map` and `Position` (#559), adding placement, distance, LoS, and tiles-in-range. P4 wires it into `GameState`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)