### PR TITLE
Bootstrap spatial at combat start (#532g) — plan-03

### DIFF
--- a/client-2d/src/client_2d/integration/engine_adapter.py
+++ b/client-2d/src/client_2d/integration/engine_adapter.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from client_2d.integration.layout_schema import RoomLayout
     from dnd_engine.core.character import Character
 
 # Default party size cap. When no explicit character_ids are passed to
@@ -241,6 +242,43 @@ class EngineAdapter:
         return {
             "in_combat": self._game_state.in_combat,
             "enemies": [e.name for e in self._game_state.active_enemies],
+        }
+
+    def bootstrap_spatial_from_layout(
+        self, room_layout: RoomLayout
+    ) -> dict[str, Any]:
+        """Build an engine ``Map`` from the visual ``RoomLayout`` and
+        bootstrap ``GameState.spatial``.
+
+        Single seam the session calls at combat start so the engine-owned
+        movement validation path (``GameState.attempt_combat_step``) has a
+        Map + SpatialIndex to operate against. Idempotent in spirit: if a
+        SpatialIndex is already installed, this replaces it
+        (``replace=True``) so a new encounter or room transition gets a
+        fresh, accurate Map.
+
+        Args:
+            room_layout: The session's current visual layout. Translated
+                tile-by-tile via ``Map.from_room_layout``.
+
+        Returns:
+            ``{"status": "bootstrapped", "width": int, "height": int}`` so
+            callers (and any future MCP/script consumer) can confirm the
+            wire.
+
+        Raises:
+            ValueError: If ``initialize_game()`` has not been called yet.
+        """
+        if self._game_state is None:
+            raise ValueError("Must call initialize_game() first")
+        from dnd_engine.core.map import Map
+
+        engine_map = Map.from_room_layout(room_layout)
+        self._game_state.bootstrap_spatial(engine_map, replace=True)
+        return {
+            "status": "bootstrapped",
+            "width": engine_map.width,
+            "height": engine_map.height,
         }
 
     @property

--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -184,6 +184,7 @@ class GameSession:
             print(f"  Combat started! Enemies: {', '.join(start_info['enemies'])}")
             self.current_mode = GameMode.COMBAT
             self._spread_party_for_combat()
+            self._bootstrap_spatial_for_combat()
             self._add_combat_log(f"Combat begins! {len(start_info['enemies'])} enemies!")
             current = self.engine.get_current_combatant()
             if current:
@@ -295,6 +296,46 @@ class GameSession:
         self.lighting.update_party_lights(light_positions, "torch")
         lit_tiles = self.lighting.calculate_lighting()
         self.fog.apply_lighting(lit_tiles)
+
+    def _bootstrap_spatial_for_combat(self) -> int:
+        """Wire ``GameState.spatial`` for an encounter starting now.
+
+        Builds an engine ``Map`` from the current ``RoomLayout`` via the
+        engine adapter, then walks every ``EntityManager`` entity that
+        has an entity_id and pushes its visual ``(grid_x, grid_y)`` into
+        the SpatialIndex via ``engine.set_position``. Entities the engine
+        rejects (blocking tile or already occupied) are silently skipped
+        — the visual layer remains authoritative for them until the next
+        successful placement.
+
+        Called from every combat-start path (initial start, room
+        transition, dev spawn, scenario load) so the first turn's call
+        to ``GameState.attempt_combat_step`` sees an accurate spatial
+        model.
+
+        Returns:
+            Count of entities successfully placed in the SpatialIndex.
+            Caller can compare against ``EntityManager`` totals to spot
+            divergences during debugging.
+        """
+        if self.engine.game_state is None or self.room_layout is None:
+            return 0
+
+        self.engine.bootstrap_spatial_from_layout(self.room_layout)
+
+        placed = 0
+        for entity in self.entity_manager.get_all():
+            entity_id = getattr(entity, "entity_id", None)
+            if not entity_id:
+                continue
+            if entity.grid_x is None or entity.grid_y is None:
+                continue
+            result = self.engine.set_position(
+                entity_id, entity.grid_x, entity.grid_y
+            )
+            if "error" not in result:
+                placed += 1
+        return placed
 
     def _spread_party_for_combat(self) -> None:
         """Spread party into formation around current position."""
@@ -453,6 +494,7 @@ class GameSession:
                 enemies = [e.name for e in game_state.active_enemies]
                 self.current_mode = GameMode.COMBAT
                 self._spread_party_for_combat()
+                self._bootstrap_spatial_for_combat()
                 self._add_combat_log(f"Combat! {len(enemies)} enemies: {', '.join(enemies)}")
                 current = self.engine.get_current_combatant()
                 if current:
@@ -1269,6 +1311,9 @@ class GameSession:
             # placed PCs via spawn_character / load_scenario.
             if not self.entity_manager.get_party_members():
                 self._spread_party_for_combat()
+            # Combat-start hook: wire spatial so engine-owned movement
+            # validation has a Map + populated SpatialIndex from turn 1.
+            self._bootstrap_spatial_for_combat()
 
         return (
             f"Spawned {result['name']} at ({x},{y}) as {result['entity_id']}. " + self.get_state()
@@ -1440,6 +1485,9 @@ class GameSession:
 
         if game_state.in_combat:
             self.current_mode = GameMode.COMBAT
+            # Combat-start hook: wire spatial so engine-owned movement
+            # validation has a Map + populated SpatialIndex from turn 1.
+            self._bootstrap_spatial_for_combat()
         else:
             self.current_mode = GameMode.EXPLORATION
 

--- a/client-2d/tests/test_engine_adapter_spatial.py
+++ b/client-2d/tests/test_engine_adapter_spatial.py
@@ -230,3 +230,60 @@ class TestRemoveCreaturePositionAdapter:
 
         with pytest.raises(ValueError, match="initialize_game"):
             EngineAdapter().remove_creature_position("goblin_0")
+
+
+class TestBootstrapSpatialFromLayout:
+    """Plan-03 P7 — adapter-side hook that turns a visual RoomLayout into
+    an engine Map and installs a SpatialIndex on GameState. This is the
+    single seam combat-start uses to wire up engine-owned movement."""
+
+    def _make_room_layout(self, width: int = 6, height: int = 5):
+        """A small all-floor RoomLayout suitable for Map.from_room_layout."""
+        from client_2d.integration.layout_schema import (
+            RoomLayout,
+            SpawnPoints,
+            TileType,
+        )
+
+        tiles = [[int(TileType.FLOOR) for _ in range(width)] for _ in range(height)]
+        return RoomLayout(
+            width=width,
+            height=height,
+            tiles=tiles,
+            spawn_points=SpawnPoints(player=(1, 1)),
+        )
+
+    def test_bootstrap_spatial_from_layout_returns_status_dict(
+        self, initialized_adapter
+    ) -> None:
+        """Returns a status dict carrying the new Map's dimensions."""
+        layout = self._make_room_layout(width=7, height=4)
+
+        result = initialized_adapter.bootstrap_spatial_from_layout(layout)
+
+        assert result == {"status": "bootstrapped", "width": 7, "height": 4}
+        assert initialized_adapter.game_state.spatial is not None
+
+    def test_bootstrap_spatial_from_layout_replaces_existing(
+        self, adapter_with_spatial
+    ) -> None:
+        """A second call replaces the existing SpatialIndex (replace=True)."""
+        # First bootstrap was via the fixture's 20x20 map.
+        assert adapter_with_spatial.game_state.spatial is not None
+        original_index = adapter_with_spatial.game_state.spatial
+
+        layout = self._make_room_layout(width=8, height=6)
+        result = adapter_with_spatial.bootstrap_spatial_from_layout(layout)
+
+        assert result == {"status": "bootstrapped", "width": 8, "height": 6}
+        # New SpatialIndex object — the old one was discarded.
+        assert adapter_with_spatial.game_state.spatial is not original_index
+
+    def test_bootstrap_spatial_from_layout_raises_without_game_state(self) -> None:
+        """Init guard mirrors the other adapter primitives."""
+        from client_2d.integration.engine_adapter import EngineAdapter
+
+        with pytest.raises(ValueError, match="initialize_game"):
+            EngineAdapter().bootstrap_spatial_from_layout(
+                self._make_room_layout(),
+            )

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -459,7 +459,7 @@ class TestSessionCombatMoveSpatialDelegation:
         # Use the session's existing RoomLayout to seed the engine Map.
         game_state = session.engine.game_state
         engine_map = Map.from_room_layout(session.room_layout)
-        game_state.bootstrap_spatial(engine_map)
+        game_state.bootstrap_spatial(engine_map, replace=True)
 
         # Place the current PC at the session's player tile.
         current = session.engine.get_current_combatant()
@@ -533,7 +533,7 @@ class TestSessionCombatMoveSpatialDelegation:
         }
         engine_map = Map(width=3, height=3, tiles=tiles)
         game_state = session.engine.game_state
-        game_state.bootstrap_spatial(engine_map)
+        game_state.bootstrap_spatial(engine_map, replace=True)
         pc = session.engine.party.characters[0]
         entity_id = f"pc_{pc.name.lower().replace(' ', '_')}"
         game_state.set_position(entity_id, target_x, target_y)
@@ -566,7 +566,7 @@ class TestSessionCombatMoveSpatialDelegation:
         # Bootstrap spatial but DO NOT call set_position for the PC.
         game_state = session.engine.game_state
         engine_map = Map.from_room_layout(session.room_layout)
-        game_state.bootstrap_spatial(engine_map)
+        game_state.bootstrap_spatial(engine_map, replace=True)
         current = session.engine.get_current_combatant()
         entity_id = f"pc_{current['creature'].name.lower().replace(' ', '_')}"
         assert game_state.spatial.position_of(entity_id) is None
@@ -621,7 +621,7 @@ class TestSessionCombatMoveSpatialDelegation:
         # the new goblin).
         game_state = session.engine.game_state
         engine_map = Map.from_room_layout(session.room_layout)
-        game_state.bootstrap_spatial(engine_map)
+        game_state.bootstrap_spatial(engine_map, replace=True)
         pc = session.engine.party.characters[0]
         entity_id = f"pc_{pc.name.lower().replace(' ', '_')}"
         game_state.set_position(entity_id, target_x, target_y)
@@ -658,7 +658,7 @@ class TestSessionCombatMoveSpatialDelegation:
 
         game_state = session.engine.game_state
         engine_map = Map.from_room_layout(session.room_layout)
-        game_state.bootstrap_spatial(engine_map)
+        game_state.bootstrap_spatial(engine_map, replace=True)
         current = session.engine.get_current_combatant()
         entity_id = f"pc_{current['creature'].name.lower().replace(' ', '_')}"
         game_state.set_position(entity_id, target_x, target_y)
@@ -682,3 +682,146 @@ class TestSessionCombatMoveSpatialDelegation:
         assert result == "Cannot move: prone"
         # PC must not have moved on the unknown rejection.
         assert (session.player_x, session.player_y) == (target_x, target_y)
+
+
+class TestSessionBootstrapForCombat:
+    """Plan-03 P7 — session-side wiring that activates the engine combat
+    path in production. ``_bootstrap_spatial_for_combat`` builds an
+    engine ``Map`` from the visual ``RoomLayout`` and seeds the
+    SpatialIndex with every EntityManager entity so the first turn has
+    accurate spatial truth."""
+
+    def test_bootstrap_places_party_members(self, session) -> None:
+        """Every PartyMemberEntity with grid coords lands in spatial."""
+        from dnd_engine.core.position import Position
+
+        # Sanity: fixture loaded a party member.
+        party = session.entity_manager.get_party_members()
+        assert party, "scenario fixture must populate at least one PC"
+        pc_entity = party[0]
+
+        placed = session._bootstrap_spatial_for_combat()
+
+        # PC ended up in spatial at its EntityManager coords.
+        spatial = session.engine.game_state.spatial
+        assert spatial is not None
+        assert (
+            spatial.occupant_at(Position(pc_entity.grid_x, pc_entity.grid_y))
+            == pc_entity.entity_id
+        )
+        assert placed >= 1
+
+    def test_bootstrap_places_monsters(self, session) -> None:
+        """Every MonsterEntity with grid coords lands in spatial."""
+        from dnd_engine.core.position import Position
+
+        monsters = session.entity_manager.get_monsters()
+        assert monsters, "scenario fixture must populate at least one monster"
+        monster = monsters[0]
+
+        session._bootstrap_spatial_for_combat()
+
+        spatial = session.engine.game_state.spatial
+        assert (
+            spatial.occupant_at(Position(monster.grid_x, monster.grid_y))
+            == monster.entity_id
+        )
+
+    def test_bootstrap_silently_skips_blocking_entities(self, session) -> None:
+        """An entity sitting on what the engine Map treats as a wall must
+        not crash the bootstrap — it is silently skipped while the rest
+        of the placements succeed."""
+        from dnd_engine.core.position import Position
+
+        # Find a wall tile in the room layout — any blocking position
+        # works as the engine Map mirrors RoomLayout walkability.
+        wall_xy = None
+        for y in range(session.room_layout.height):
+            for x in range(session.room_layout.width):
+                if session.room_layout.is_blocking(x, y):
+                    wall_xy = (x, y)
+                    break
+            if wall_xy is not None:
+                break
+        assert wall_xy is not None, "room layout must have at least one wall"
+
+        # Park a monster on the wall (entity_manager allows any coord;
+        # spatial bootstrap must tolerate the divergence).
+        monsters = session.entity_manager.get_monsters()
+        assert monsters
+        monster = monsters[0]
+        monster.grid_x, monster.grid_y = wall_xy
+
+        # No crash; monster simply absent from spatial afterward.
+        placed = session._bootstrap_spatial_for_combat()
+
+        spatial = session.engine.game_state.spatial
+        assert spatial.occupant_at(Position(*wall_xy)) is None
+        # Returned count reflects only successfully placed entities.
+        assert placed >= 0
+
+    def test_bootstrap_returns_count_of_placements(self, session) -> None:
+        """Count == number of entities successfully placed in spatial."""
+        placed = session._bootstrap_spatial_for_combat()
+
+        spatial = session.engine.game_state.spatial
+        assert placed == len(spatial.occupants())
+
+    def test_combat_move_uses_engine_path_after_bootstrap(self, session) -> None:
+        """End-to-end: after ``_bootstrap_spatial_for_combat`` the next
+        ``combat_move`` runs through the engine (``attempt_combat_step``)
+        and surfaces the same wire format the engine-path tests pin."""
+        _force_player_turn(session)
+
+        # Move the PC to a tile with empty space around for a clean step.
+        target_x, target_y = 5, 5
+        session.player_x = target_x
+        session.player_y = target_y
+        for ent in session.entity_manager.get_party_members():
+            ent.grid_x = target_x
+            ent.grid_y = target_y
+
+        # Wire spatial via the session helper — production seam.
+        session._bootstrap_spatial_for_combat()
+        starting_movement = session.engine.get_current_turn_state().movement_remaining
+
+        result = session.combat_move("north")
+
+        expected_first_line = (
+            f"Moved north. Movement remaining: {starting_movement - 5} ft."
+        )
+        assert result.startswith(expected_first_line + "\n"), (
+            f"engine wire format not surfaced: got {result.splitlines()[0]!r}"
+        )
+
+    def test_load_scenario_bootstraps_spatial(self, session) -> None:
+        """Combat-start via ``load_scenario`` (the scenario fixture's
+        path) must leave spatial populated so the next combat_move runs
+        through the engine path with no additional setup."""
+        from dnd_engine.core.position import Position
+
+        # The session fixture loads ranged_attack_basic via load_scenario,
+        # which is a combat-start path; spatial should already be wired.
+        spatial = session.engine.game_state.spatial
+        assert spatial is not None, "load_scenario must bootstrap spatial"
+
+        # At least one party member is present in spatial at its
+        # EntityManager-recorded tile.
+        party = session.entity_manager.get_party_members()
+        assert party
+        pc = party[0]
+        assert spatial.occupant_at(Position(pc.grid_x, pc.grid_y)) == pc.entity_id
+
+    def test_spawn_monster_from_exploration_bootstraps_spatial(self, session) -> None:
+        """Dev-mode ``spawn_monster`` flipping EXPLORATION -> COMBAT is a
+        combat-start path; spatial must be wired afterward so the move
+        validation surface is ready for the first turn."""
+        from client_2d.core.constants import GameMode
+
+        session.clear_enemies()
+        assert session.current_mode == GameMode.EXPLORATION
+
+        session.spawn_monster("goblin", 12, 5)
+
+        assert session.engine.game_state.spatial is not None
+        assert session.current_mode == GameMode.COMBAT


### PR DESCRIPTION
## Summary

The activation slice for plan-03's engine spatial-model migration (master #532). Until this PR, `GameState.attempt_combat_step` (P5 #565) was dormant in production because nothing called `GameState.bootstrap_spatial(...)`. This PR wires it into every combat-start hook in the session.

**After this lands, every real combat encounter exercises the engine path.** The legacy `RoomLayout`-driven path is retained as the exploration-mode movement code and as the safety net inside `_combat_move_via_engine` for unhandled cases (per the P5 fix-forward).

## API

- **`EngineAdapter.bootstrap_spatial_from_layout(room_layout) -> dict`** (internal — not exposed via MCP). Builds an engine `Map` from the visual `RoomLayout`, calls `GameState.bootstrap_spatial(map, replace=True)`, returns `{"status": "bootstrapped", "width": ..., "height": ...}`. Idempotent via `replace=True` so room transitions and mid-game reboots build fresh maps.
- **`GameSession._bootstrap_spatial_for_combat()`** — private session helper. Bootstraps spatial, then iterates `entity_manager.get_all()` and calls `engine.set_position(...)` for each entity. Silently skips entities the engine rejects (blocking/occupied — `_adapter_spatial_ids` tracks the successful placements).

## Combat-start hooks (all client-side; engine has no RoomLayout)

| Hook | File | Trigger |
|---|---|---|
| `initialize()` line 188 | `session.py` | Initial game start when `start_game()` reports combat |
| `_transition_room()` line 458 | `session.py` | Room transition into a room with monsters |
| `spawn_monster()` line 1318 | `session.py` | Dev-mode spawn flips EXPLORATION → COMBAT |
| `load_scenario()` line 1449 | `session.py` | YAML scenario loaded already in combat |

All hooks sit AFTER EntityManager population and BEFORE the first combatant turn.

## Files touched

- `client-2d/src/client_2d/integration/engine_adapter.py` — `bootstrap_spatial_from_layout` (+38).
- `client-2d/src/client_2d/session.py` — `_bootstrap_spatial_for_combat` + 4 combat-start call sites (+48).
- `client-2d/tests/test_engine_adapter_spatial.py` — 3 new adapter tests (+57).
- `client-2d/tests/test_game_session.py` — 7 new session tests; 5 pre-existing `TestSessionCombatMoveSpatialDelegation` tests updated to use `bootstrap_spatial(map, replace=True)` (production now bootstraps via the session fixture, so the manual test bootstrap needs the replace flag) (+148/-5).

## Test plan

- [x] Non-SRD engine: 2408 passed, 1 skipped, 1 failed (the failure is `test_party_defeats_enemy`, pre-existing on main — unrelated)
- [x] SRD engine: 544 passed, 249 skipped (unchanged)
- [x] Scenario tests: 40 passed (the production bootstrap path is exercised on every scenario load)
- [x] client-2d full suite: 437 passed (= 427 baseline + 10 new), 1 pre-existing port-bind flake, 12 pre-existing env errors
- [x] `ruff check` clean on all touched files

## Coordination

The 5 P5 tests in `TestSessionCombatMoveSpatialDelegation` needed `replace=True` because production now bootstraps via the `load_scenario` fixture before those tests can. This is the canonical signal the migration plan called out: "If anything starts depending on the engine path that used to depend on the legacy path, you'll see it here." Not a regression — those tests were probing an unwired contract that no longer exists in production.

## Next slices unblocked

- **P6 (#532f, #401)** — engine-owned range check now has populated spatial state to read from.
- **P8 (#413)** — OA provocation event can subscribe to CREATURE_MOVED knowing the events actually fire in real combat.
- **Post-spine** Cover (#473), footprint (#442), Prone (#445) — all can read SpatialIndex with confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)