### PR TITLE
Fix #572: drain enemy turns on game_wait() instead of skipping them

### DIFF
--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -1293,7 +1293,16 @@ class GameSession:
         if not self.engine.in_combat:
             return "Not in combat! Use game_move() to explore."
 
-        self.pass_turn()
+        if self.engine.is_player_turn():
+            # Standard semantic: the PC chooses to pass. advance off them
+            # so the drain can run subsequent enemies.
+            self.pass_turn()
+        else:
+            # Non-PC turn (e.g. just after spawn_monster() left an enemy
+            # first in initiative, #572). Don't burn the enemy's slot via
+            # pass_turn(); raise the drain gate so _drain_enemy_turns()
+            # runs the enemy AI instead of silently advancing past it.
+            self.processing_enemy_turn = True
 
         self._drain_enemy_turns()
 
@@ -1331,6 +1340,18 @@ class GameSession:
             # placed PCs via spawn_character / load_scenario.
             if not self.entity_manager.get_party_members():
                 self._spread_party_for_combat()
+
+        # Mirror initialize()'s drain-gate pattern: if the spawn left a
+        # non-PC (or unconscious PC) as the current combatant, raise
+        # processing_enemy_turn so the next wait() / attack() drains the
+        # owed turn instead of silently advancing past it (#572).
+        if self.engine.in_combat:
+            if not self.engine.is_player_turn():
+                self.processing_enemy_turn = True
+                self.enemy_turn_timer = ENEMY_TURN_DELAY
+            elif self.engine.is_current_combatant_unconscious():
+                self.processing_enemy_turn = True
+                self.enemy_turn_timer = ENEMY_TURN_DELAY
 
         return (
             f"Spawned {result['name']} at ({x},{y}) as {result['entity_id']}. " + self.get_state()

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -951,3 +951,139 @@ class TestSessionMCPResponseSurfacesCombatEvents:
         assert session._pending_combat_events == ["Goblin hits Archy for 5 damage!"]
         assert "Recent Combat:" not in state
         assert "Goblin hits Archy for 5 damage!" not in state
+
+
+class TestSessionWaitOnEnemyTurn:
+    """Regression tests for #572.
+
+    Calling ``wait()`` while a non-PC is the current combatant must
+    drain enemy turns rather than burn the enemy's slot via
+    ``pass_turn()``. The bug was that ``wait()`` unconditionally called
+    ``pass_turn()`` (which logs ``"X waits..."`` and advances initiative
+    past whoever is current — including an enemy), so the enemy's AI
+    never ran and the response was silent.
+    """
+
+    HEADER = "Between turns:"
+
+    def test_wait_on_enemy_turn_drains_instead_of_skipping(self, session) -> None:
+        """When ``wait()`` is invoked on an enemy's turn, the enemy AI
+        runs and surfaces in the response under the ``Between turns:``
+        header — instead of being silently skipped."""
+        adjacent_x = session.player_x + 1
+        adjacent_y = session.player_y
+        session.spawn_monster("goblin", adjacent_x, adjacent_y)
+
+        # Pin the goblin as the current combatant so wait() is invoked on
+        # its turn. Lower the drain gate to simulate the pre-#572-fix
+        # state for spawn_monster (also covered by separate tests below).
+        goblin = session.engine.game_state.active_enemies[-1]
+        _force_combatant_turn(session, goblin)
+        session.processing_enemy_turn = False
+        session.set_seed(42)
+
+        response = session.wait()
+
+        # Goblin's per-turn handler must have produced an action line.
+        verbs = ("hits", "misses", "takes no action")
+        assert any(v in response for v in verbs), (
+            f"no enemy-action verb in wait() reply "
+            f"(goblin turn was skipped):\n{response}"
+        )
+        assert self.HEADER in response, (
+            f"missing {self.HEADER!r} header in wait() reply:\n{response}"
+        )
+
+    def test_wait_on_enemy_turn_does_not_log_pc_waits(self, session) -> None:
+        """``wait()`` on an enemy's turn must not call ``pass_turn()`` —
+        which would write a ``"Goblin waits..."`` line and advance off
+        the goblin without running its AI.
+
+        The leaked line lives in ``session.combat_log`` rather than the
+        response string (``pass_turn`` appends *before* the drain so the
+        line is not captured into ``_pending_combat_events``), so we
+        assert against the log directly.
+        """
+        adjacent_x = session.player_x + 1
+        adjacent_y = session.player_y
+        session.spawn_monster("goblin", adjacent_x, adjacent_y)
+
+        goblin = session.engine.game_state.active_enemies[-1]
+        _force_combatant_turn(session, goblin)
+        session.processing_enemy_turn = False
+        session.set_seed(42)
+
+        log_before = list(session.combat_log)
+        session.wait()
+        new_lines = session.combat_log[len(log_before):]
+
+        assert not any("Goblin waits" in line for line in new_lines), (
+            f"goblin turn was burned via pass_turn (wait line leaked):\n"
+            f"{new_lines}"
+        )
+
+
+class TestSessionSpawnMonsterDrainGate:
+    """Regression tests for #572 companion bug.
+
+    ``spawn_monster()`` previously never set ``processing_enemy_turn``
+    even when the spawn left a non-PC as the current combatant. The
+    initial-combat path in ``initialize()`` does this correctly; the fix
+    mirrors that pattern in ``spawn_monster()`` so subsequent
+    ``wait()`` / ``attack()`` calls find the drain gate raised.
+    """
+
+    def test_spawn_monster_raises_drain_gate_when_enemy_is_current(
+        self, session, monkeypatch
+    ) -> None:
+        """When the engine reports a non-PC as current combatant after a
+        spawn, ``processing_enemy_turn`` must be ``True`` so the next
+        ``wait()`` / ``attack()`` drains the enemy AI."""
+        session.processing_enemy_turn = False
+
+        # Patch the engine's turn predicates so this test pins the fix's
+        # gate-raise behavior without coupling to engine RNG or
+        # initiative internals. Matches the "goblin lands first in
+        # initiative" outcome described in #572.
+        monkeypatch.setattr(session.engine, "is_player_turn", lambda: False)
+        monkeypatch.setattr(
+            session.engine, "is_current_combatant_unconscious", lambda: False
+        )
+
+        session.spawn_monster("goblin", session.player_x + 5, session.player_y)
+
+        assert session.processing_enemy_turn is True
+
+    def test_spawn_monster_raises_drain_gate_when_pc_unconscious(
+        self, session, monkeypatch
+    ) -> None:
+        """Mirror the ``initialize()`` branch that handles a current PC
+        who is unconscious — the drain loop owns death-save processing,
+        so the gate must be raised in that case too."""
+        session.processing_enemy_turn = False
+
+        monkeypatch.setattr(session.engine, "is_player_turn", lambda: True)
+        monkeypatch.setattr(
+            session.engine, "is_current_combatant_unconscious", lambda: True
+        )
+
+        session.spawn_monster("goblin", session.player_x + 5, session.player_y)
+
+        assert session.processing_enemy_turn is True
+
+    def test_spawn_monster_leaves_gate_lowered_when_pc_is_current(
+        self, session, monkeypatch
+    ) -> None:
+        """When the engine reports a conscious PC as current combatant
+        after a spawn, ``processing_enemy_turn`` must remain ``False`` —
+        the PC owes the next action and the drain must not run."""
+        session.processing_enemy_turn = False
+
+        monkeypatch.setattr(session.engine, "is_player_turn", lambda: True)
+        monkeypatch.setattr(
+            session.engine, "is_current_combatant_unconscious", lambda: False
+        )
+
+        session.spawn_monster("goblin", session.player_x + 5, session.player_y)
+
+        assert session.processing_enemy_turn is False


### PR DESCRIPTION
## Summary

Closes #572 — the second of the four MCP playtest stabilization bugs (after #570 which shipped in PR #571).

- `game_wait()` no longer skips an enemy's turn when called on a non-PC slot — it now drains the enemy AI so the action surfaces under `Between turns:`.
- `spawn_monster()` now raises the drain gate when the spawn leaves a non-PC (or unconscious PC) as the current combatant, mirroring `initialize()`'s pattern.

## Root cause

- `wait()` (`session.py:1291`) unconditionally called `self.pass_turn()`, which logs `"{name} waits..."` and `advance_turn()`s past whoever is current — including an enemy. The goblin's AI never ran. With #570 merged the symptom became more visible: the `Between turns:` block stayed empty because nothing actually drained.
- `spawn_monster()` (`session.py:1308`) never set `processing_enemy_turn`, so even after the spawn left an enemy first in initiative the drain loop's gate stayed lowered — making the `wait()` bug above deterministically reproducible right after a spawn.

## Changes

- **`client-2d/src/client_2d/session.py`** — two small edits, both mirroring patterns already present in the file:
  - `wait()`: gate the `pass_turn()` call behind `engine.is_player_turn()`; otherwise raise `processing_enemy_turn` so `_drain_enemy_turns()` runs the enemy AI.
  - `spawn_monster()`: after the mode-to-COMBAT switch, mirror `initialize()`'s `lines 198-203` pattern — raise the drain gate when the spawn leaves a non-PC (or unconscious PC) as the current combatant.
- **`client-2d/tests/test_game_session.py`** — two new test classes (5 tests total):
  - `TestSessionWaitOnEnemyTurn` — pins the `wait()` semantic via a deterministic `spawn_monster` + `_force_combatant_turn` + `set_seed` setup; asserts both the enemy-action surfacing and the absence of a leaked `"Goblin waits..."` line.
  - `TestSessionSpawnMonsterDrainGate` — uses `monkeypatch` on the engine's turn predicates to pin the gate-raise behavior without coupling to RNG/initiative internals. Covers all three branches (enemy current, unconscious PC current, conscious PC current).

## Testing

- [x] `uv run pytest tests/test_game_session.py -v` — 47/47 pass (5 new + 42 existing). No regressions on `TestSessionDrainEnemyTurns` or `TestSessionMCPResponseSurfacesCombatEvents`.
- [x] python-code-reviewer skill — no critical/quality issues. (Note: ruff format flagged pre-existing drift from PRs #565/#571 in code I did not touch; left for a separate cleanup PR per CLAUDE.md "no unrelated changes" rule.)
- [x] End-to-end MCP repro (per #572 steps):
  ```
  > set_seed(42)
  > spawn_monster("goblin", 11, 7)   # Current Turn: Goblin
  > game_wait()
  → Between turns:
      Goblin hits Bob for 4 damage!
    Current Turn: Bob
  ```
  Bob's HP correctly drops 8/8 → 4/8; party 17/17 → 13/17.

## Related

- Closes #572
- Builds on #570 / PR #571 (MCP combat observability) — without that fix the `Between turns:` block has nowhere to surface the drained turns
- Companion bugs still open from the same playtest: #568 (spawn_monster occupancy bypass), #569 (movement-budget display reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)