### PR TITLE
Fix #568: reject spawn_monster on occupied tiles

### DIFF
--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -1314,8 +1314,59 @@ class GameSession:
 
     # ========== Public dev/MCP API (gated upstream by dev_mode) ==========
 
+    def _reject_spawn_if_occupied(self, x: int, y: int) -> str | None:
+        """Return a rejection message if ``(x, y)`` is unsuitable for a
+        new creature spawn, else ``None``.
+
+        Consults four sources because each owns part of the truth during
+        the plan-03 transition:
+          * Room walls via ``room_layout.is_blocking`` — engine spatial
+            may not be bootstrapped yet for legacy room flows.
+          * ``entity_manager`` — owns the visible party + monster grid
+            positions before they're written into ``SpatialIndex``.
+          * Session ``player_x`` / ``player_y`` — the ``@`` marker is
+            tracked separately from party-member entities in some
+            scenarios (issue #568 repro).
+          * ``GameState.spatial.occupant_at`` — authoritative once
+            placements have been mirrored into it.
+        """
+        if self.room_layout is not None:
+            if not (0 <= x < self.room_layout.width and 0 <= y < self.room_layout.height):
+                return f"Cannot spawn at ({x},{y}): out of bounds."
+            if self.room_layout.is_blocking(x, y):
+                return f"Cannot spawn at ({x},{y}): tile is blocking (wall)."
+
+        if (x, y) == (self.player_x, self.player_y):
+            return f"Cannot spawn at ({x},{y}): tile is occupied by the player."
+
+        existing = self.entity_manager.get_at_position(x, y)
+        if existing is not None:
+            blocker_id = getattr(existing, "entity_id", "") or ""
+            name = self._resolve_blocker_name(blocker_id) if blocker_id else "an entity"
+            return f"Cannot spawn at ({x},{y}): tile is occupied by {name}."
+
+        game_state = self.engine.game_state
+        if game_state is not None and game_state.spatial is not None:
+            from dnd_engine.core.position import Position
+
+            occupant = game_state.spatial.occupant_at(Position(x, y))
+            if occupant is not None:
+                name = self._resolve_blocker_name(occupant) if occupant else "an entity"
+                return f"Cannot spawn at ({x},{y}): tile is occupied by {name}."
+        return None
+
     def spawn_monster(self, monster_id: str, x: int, y: int) -> str:
         """Spawn a monster via engine + visual entity manager."""
+        # Occupancy gate (#568): reject placements on the player marker,
+        # any entity-manager occupant, a wall, or a spatial-index
+        # occupant before the engine adds the creature to active_enemies
+        # / initiative. Without this gate the engine adapter writes to
+        # SpatialIndex (which would also reject) only AFTER appending to
+        # active_enemies, leaving a ghost monster with no spatial
+        # coordinate — visible in combat but invisible on the map.
+        rejection = self._reject_spawn_if_occupied(x, y)
+        if rejection is not None:
+            return rejection
         result = self.engine.spawn_monster(monster_id, x, y)
         enemy_index = len(self.engine.game_state.active_enemies) - 1
         creature_ref = self.engine.game_state.active_enemies[enemy_index]

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -1087,3 +1087,89 @@ class TestSessionSpawnMonsterDrainGate:
         session.spawn_monster("goblin", session.player_x + 5, session.player_y)
 
         assert session.processing_enemy_turn is False
+
+
+class TestSessionSpawnMonsterOccupancy:
+    """Regression tests for #568.
+
+    ``spawn_monster()`` previously placed a monster on any tile,
+    including tiles already occupied by the player marker ``@``, a
+    party member, an existing monster, or a wall. The fix rejects the
+    spawn with a clear error and leaves engine + entity manager + the
+    SpatialIndex untouched so the dev can retry at a free tile.
+    """
+
+    def test_spawn_monster_on_player_marker_tile_rejected(self, session) -> None:
+        """Spawning on the ``@`` marker's tile must fail without mutating
+        state. This is the literal reproducer from #568 — goblin was
+        invisible because it was placed under ``@``."""
+        before_enemies = list(session.engine.game_state.active_enemies)
+        before_monsters = {
+            e.entity_id: (e.grid_x, e.grid_y) for e in session.entity_manager.get_monsters()
+        }
+
+        result = session.spawn_monster("goblin", session.player_x, session.player_y)
+
+        assert "occupied" in result.lower() or "blocked" in result.lower(), (
+            f"expected occupancy rejection, got: {result!r}"
+        )
+        # Engine state untouched: no new enemy entry.
+        assert session.engine.game_state.active_enemies == before_enemies
+        # Entity manager untouched: no new monster entity.
+        after_monsters = {
+            e.entity_id: (e.grid_x, e.grid_y) for e in session.entity_manager.get_monsters()
+        }
+        assert after_monsters == before_monsters
+
+    def test_spawn_monster_on_party_member_tile_rejected(self, session) -> None:
+        """Spawning on a party member's tile must fail with no state
+        mutation, regardless of whether ``@`` happens to share that tile."""
+        party = session.entity_manager.get_party_members()
+        assert party, "fixture should populate at least one party member"
+        pm = party[0]
+        before_enemies = list(session.engine.game_state.active_enemies)
+        before_monsters = {
+            e.entity_id: (e.grid_x, e.grid_y) for e in session.entity_manager.get_monsters()
+        }
+
+        result = session.spawn_monster("goblin", pm.grid_x, pm.grid_y)
+
+        assert "occupied" in result.lower() or "blocked" in result.lower(), (
+            f"expected occupancy rejection, got: {result!r}"
+        )
+        assert session.engine.game_state.active_enemies == before_enemies
+        after_monsters = {
+            e.entity_id: (e.grid_x, e.grid_y) for e in session.entity_manager.get_monsters()
+        }
+        assert after_monsters == before_monsters
+
+    def test_spawn_monster_on_existing_monster_tile_rejected(self, session) -> None:
+        """A second spawn on a tile already holding a monster must fail."""
+        monsters = session.entity_manager.get_monsters()
+        assert monsters, "fixture should populate at least one monster"
+        m = monsters[0]
+        before_enemies = list(session.engine.game_state.active_enemies)
+
+        result = session.spawn_monster("goblin", m.grid_x, m.grid_y)
+
+        assert "occupied" in result.lower() or "blocked" in result.lower(), (
+            f"expected occupancy rejection, got: {result!r}"
+        )
+        assert session.engine.game_state.active_enemies == before_enemies
+
+    def test_spawn_monster_on_free_tile_still_succeeds(self, session) -> None:
+        """Sanity check — the occupancy gate must not block legitimate
+        spawns on empty tiles."""
+        gx, gy = session.player_x + 3, session.player_y
+        # Confirm the target tile is genuinely free in this fixture.
+        assert session.entity_manager.get_at_position(gx, gy) is None
+        assert (gx, gy) != (session.player_x, session.player_y)
+
+        result = session.spawn_monster("giant_rat", gx, gy)
+
+        assert "occupied" not in result.lower()
+        assert "blocked" not in result.lower()
+        # Monster reached the entity manager at the requested tile.
+        ent = session.entity_manager.get_at_position(gx, gy)
+        assert ent is not None
+        assert ent.sub_type == "giant_rat"


### PR DESCRIPTION
## Summary
- Add occupancy gate to `session.spawn_monster()` that consults room walls, the `@` marker, entity manager, and `SpatialIndex` before placing a monster.
- Rejected spawns return a clear `Cannot spawn at (x,y): ...` message with no engine / entity-manager / spatial-index mutation.
- Closes #568.

## Why
The engine adapter's `spawn_monster()` appends the creature to `active_enemies` and joins initiative **before** writing to `SpatialIndex`. When the SpatialIndex rejected the placement the response carried an `"error"` key, but `session.spawn_monster()` ignored it — leaving a ghost monster with no spatial coordinate, visible in combat but invisible on the ASCII map (the `@` rendered on top hid the conflict).

The cleanest, smallest-scope fix is a pre-flight occupancy check at the session layer. It consults all four sources because each owns part of the truth during the plan-03 transition:
- `room_layout.is_blocking` — walls / OOB (engine spatial isn't always bootstrapped yet for legacy rooms).
- `session.player_x` / `player_y` — the `@` marker is tracked separately from party-member entities in some scenarios (the #568 repro).
- `entity_manager.get_at_position` — owns visible party + monster grid positions.
- `GameState.spatial.occupant_at` — authoritative once placements have been mirrored.

## Test plan
- [x] Four new tests in `TestSessionSpawnMonsterOccupancy` cover the `@` marker tile, party-member tile, existing-monster tile, and the happy-path free tile.
- [x] `uv run pytest tests/test_game_session.py` — 51 / 51 pass (47 prior + 4 new).
- [x] `uv run pytest tests/` — 460 / 461 pass (1 pre-existing skip).
- [ ] Manual: `uv run dnd-2d --headless --dev --mcp` + `spawn_monster("goblin", 10, 7)` on player tile → confirm rejection string surfaces in MCP reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)