### PR TITLE
Fix #569: stop double-advancing initiative after enemy turn

### DIFF
--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -543,11 +543,14 @@ class GameSession:
         self.entity_manager.sync_from_engine(self.engine)
         self.entity_manager.update_party_turn_status(self.engine)
 
-        turn_result = self.engine.advance_turn()
-
-        if turn_result.get("combat_ended"):
+        # The engine's process_enemy_turn already advances the initiative
+        # tracker on every non-party-wipe return path, so we must NOT call
+        # engine.advance_turn() again here — that double-advance silently
+        # skipped the next combatant and left their TurnState unrendered
+        # in MCP output (#569).
+        if not self.engine.in_combat:
             self._handle_combat_end()
-        elif not turn_result.get("is_player_turn"):
+        elif not self.engine.is_player_turn():
             self.enemy_turn_timer = ENEMY_TURN_DELAY
         else:
             if self.engine.is_current_combatant_unconscious():

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -1173,3 +1173,115 @@ class TestSessionSpawnMonsterOccupancy:
         ent = session.entity_manager.get_at_position(gx, gy)
         assert ent is not None
         assert ent.sub_type == "giant_rat"
+
+
+class TestSessionEnemyTurnSingleAdvance:
+    """Regression tests for #569.
+
+    Before the fix, ``_process_enemy_turn()`` called
+    ``engine.advance_turn()`` *after* ``engine.process_enemy_turn()``,
+    but the engine's ``process_enemy_turn`` already advances the
+    initiative tracker internally on every return path (party-wipe
+    branch aside). The result was a double-``next_turn()`` per enemy
+    turn — the next combatant was silently skipped and their
+    ``TurnState`` was never observed.
+
+    The symptom in playtest was a "Movement: N ft remaining" line that
+    appeared to carry over stale movement budget between combatant
+    turns: with the skipped combatant invisible to the MCP renderer,
+    each enemy drain pushed initiative forward by 2 slots and the
+    user couldn't see whose turn state was actually being rendered.
+    """
+
+    def test_process_enemy_turn_advances_initiative_by_one(self, session) -> None:
+        """One ``_process_enemy_turn()`` call must advance the initiative
+        index by exactly one slot — not two."""
+        # Add a second PC so we have ≥3 combatants and can detect a
+        # turn-skip (with 2 combatants the wrap masks the bug).
+        session.spawn_character("wizard", "human", ["dagger"], 4, 5, name="Bob")
+        tracker = session.engine.game_state.initiative_tracker
+        combatants = tracker.get_all_combatants()
+
+        # Force the goblin to be current so we exercise the non-PC path.
+        goblin_idx = next(
+            i for i, c in enumerate(combatants) if "goblin" in c.creature.name.lower()
+        )
+        tracker.current_turn_index = goblin_idx
+        # Reset goblin's turn state so the start condition is well-defined.
+        tracker.get_current_turn_state().reset(
+            speed=tracker.get_current_combatant().creature.speed
+        )
+
+        session.processing_enemy_turn = True
+        session._process_enemy_turn()
+
+        expected_idx = (goblin_idx + 1) % len(combatants)
+        expected_name = combatants[expected_idx].creature.name
+        actual_name = tracker.get_current_combatant().creature.name
+        assert actual_name == expected_name, (
+            f"_process_enemy_turn skipped a combatant: expected next = "
+            f"{expected_name} (idx {expected_idx}), got {actual_name} "
+            f"(idx {tracker.current_turn_index})"
+        )
+
+    def test_process_enemy_turn_calls_next_turn_once(self, session) -> None:
+        """The session's enemy-turn handler must not double-trigger
+        ``initiative_tracker.next_turn()`` — once via the engine's
+        ``process_enemy_turn`` (which already advances) and once via a
+        redundant session-side ``advance_turn`` call."""
+        session.spawn_character("wizard", "human", ["dagger"], 4, 5, name="Bob")
+        tracker = session.engine.game_state.initiative_tracker
+
+        # Force the goblin current.
+        combatants = tracker.get_all_combatants()
+        goblin_idx = next(
+            i for i, c in enumerate(combatants) if "goblin" in c.creature.name.lower()
+        )
+        tracker.current_turn_index = goblin_idx
+        tracker.get_current_turn_state().reset(
+            speed=tracker.get_current_combatant().creature.speed
+        )
+
+        # Count next_turn() calls.
+        original_next_turn = tracker.next_turn
+        call_count = {"n": 0}
+
+        def counting_next_turn() -> None:
+            call_count["n"] += 1
+            original_next_turn()
+
+        tracker.next_turn = counting_next_turn
+
+        session.processing_enemy_turn = True
+        session._process_enemy_turn()
+
+        assert call_count["n"] == 1, (
+            f"expected exactly one next_turn() per enemy turn, got {call_count['n']}"
+        )
+
+    def test_next_combatant_after_enemy_turn_has_full_movement(self, session) -> None:
+        """After a single enemy turn drain, the new current combatant's
+        ``movement_remaining`` must equal their full speed — proving the
+        engine's per-turn reset wasn't masked by a skipped slot."""
+        session.spawn_character("wizard", "human", ["dagger"], 4, 5, name="Bob")
+        tracker = session.engine.game_state.initiative_tracker
+        combatants = tracker.get_all_combatants()
+
+        goblin_idx = next(
+            i for i, c in enumerate(combatants) if "goblin" in c.creature.name.lower()
+        )
+        tracker.current_turn_index = goblin_idx
+        tracker.get_current_turn_state().reset(
+            speed=tracker.get_current_combatant().creature.speed
+        )
+
+        session.processing_enemy_turn = True
+        session._process_enemy_turn()
+
+        new_current = tracker.get_current_combatant()
+        new_turn_state = tracker.get_current_turn_state()
+        assert new_turn_state.movement_remaining == new_current.creature.speed, (
+            f"{new_current.creature.name} movement_remaining is "
+            f"{new_turn_state.movement_remaining}, expected "
+            f"{new_current.creature.speed}"
+        )


### PR DESCRIPTION
## Summary
- Drop the redundant `engine.advance_turn()` in `session._process_enemy_turn()` so each enemy turn advances the initiative tracker exactly once (the engine's `process_enemy_turn` already calls `next_turn()` internally on every non-party-wipe return path).
- Switch the post-turn branching to read engine predicates directly (`in_combat`, `is_player_turn`, `is_current_combatant_unconscious`) instead of relying on the now-removed `advance_turn` result dict.
- Add three regression tests in `TestSessionEnemyTurnSingleAdvance` that pin the single-advance contract.
- Closes #569.

## Why
The session's enemy-turn handler was calling `next_turn()` twice per enemy turn — once via `engine.process_enemy_turn()` (the engine internally advances), once via the explicit `engine.advance_turn()` that followed. This silently skipped the next combatant in initiative, so their `TurnState` was never observed and the "Movement: N ft remaining" line displayed in MCP output looked frozen / stale between turns.

Repro before the fix (3-combatant party + goblin, goblin forced current):
```
next_turn() #1: Goblin → Bob       ← from engine.process_enemy_turn
next_turn() #2: Bob → Archy        ← from session.engine.advance_turn (the bug)
```
Bob's turn was effectively erased from the MCP view of combat.

## Test plan
- [x] `uv run pytest tests/test_game_session.py::TestSessionEnemyTurnSingleAdvance` — 3 / 3 new tests pass.
- [x] `uv run pytest tests/` (client-2d) — 459 / 460 pass (1 pre-existing skip).
- [x] `cd dnd-engine && uv run pytest tests/` — 2953 / 3203 pass (250 pre-existing skips).
- [ ] Manual: `uv run dnd-2d --headless --dev --mcp` + `spawn_monster("goblin", 13, 7)` with a 3-combatant party → confirm each combatant's turn surfaces sequentially in `game_state` output with their full base speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)