### PR TITLE
Fix #576: route spread_party_for_combat around occupied tiles

### DIFF
--- a/client-2d/src/client_2d/entities/entity_manager.py
+++ b/client-2d/src/client_2d/entities/entity_manager.py
@@ -197,6 +197,45 @@ class EntityManager:
 
         return removed
 
+    def _find_free_tile_near(
+        self,
+        target_x: int,
+        target_y: int,
+        layout: RoomLayout,
+        max_radius: int = 5,
+    ) -> tuple[int, int] | None:
+        """Return the nearest in-bounds, non-blocking, unoccupied tile to
+        ``(target_x, target_y)`` via a Chebyshev-distance spiral search.
+
+        Returns ``None`` if no candidate is free inside ``max_radius`` —
+        callers should fall back to a safe default (typically the
+        formation center) in that case.
+
+        "Occupied" is read from the entity-manager's combined entity
+        collection so monsters, items, and party members already placed
+        in the current spread iteration all count as blockers.
+        """
+
+        def _is_free(x: int, y: int) -> bool:
+            if not (0 <= x < layout.width and 0 <= y < layout.height):
+                return False
+            if layout.is_blocking(x, y):
+                return False
+            return self.get_at_position(x, y) is None
+
+        if _is_free(target_x, target_y):
+            return (target_x, target_y)
+
+        for radius in range(1, max_radius + 1):
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    if max(abs(dx), abs(dy)) != radius:
+                        continue
+                    cx, cy = target_x + dx, target_y + dy
+                    if _is_free(cx, cy):
+                        return (cx, cy)
+        return None
+
     def spread_party_for_combat(
         self,
         engine: EngineAdapter,
@@ -255,9 +294,18 @@ class EntityManager:
             px = max(1, min(px, layout.width - 2))
             py = max(1, min(py, layout.height - 2))
 
-            # If blocked, try the center position
-            if layout.is_blocking(px, py):
-                px, py = center_x, center_y
+            # Pick a tile that is neither a wall nor already occupied by
+            # another entity (monster, item, prior party member). Without
+            # this, a spawn_monster() that triggers the combat-start
+            # spread will overlay the front-left fighter onto the new
+            # monster, hiding it from the ASCII map (#576).
+            chosen = self._find_free_tile_near(px, py, layout)
+            if chosen is None:
+                # Last-resort fallback preserves the legacy behavior of
+                # stacking onto the center tile when no free tile can be
+                # found inside the spiral search radius.
+                chosen = (center_x, center_y)
+            px, py = chosen
 
             positions.append((px, py))
 

--- a/client-2d/tests/test_entity_integration.py
+++ b/client-2d/tests/test_entity_integration.py
@@ -363,6 +363,76 @@ class TestEntityManagerEngineIntegration:
             assert pm._creature_ref is not None
             assert pm.character_class != ""
 
+    def test_spread_party_avoids_existing_monster_tile(
+        self, engine_adapter, layout_loader
+    ):
+        """Regression for #576: ``spread_party_for_combat`` must skip tiles
+        already held by a monster instead of overlaying party members on
+        them.
+
+        Without this guarantee, ``session.spawn_monster`` followed by the
+        automatic spread-into-combat step lands the front-left fighter
+        on the just-spawned monster, hiding the monster on the ASCII map
+        and breaking the occupancy invariant the #574 gate was added to
+        protect.
+        """
+        from client_2d.entities.entity import MonsterEntity
+
+        manager = EntityManager()
+
+        layout = layout_loader.load_room_with_fallback(
+            dungeon_name="cellar",
+            room_id="cellar.storage",
+            campaign_id="poisoned_laboratory",
+            default_width=20,
+            default_height=15,
+            exits={"south": "cellar.stairs"},
+        )
+
+        # Start from an empty manager (no room monsters) so we can pin a
+        # single monster onto the front-left formation tile and assert
+        # that the spread step routes around it.
+        manager.clear()
+
+        center_x, center_y = 10, 7
+        front_left = (center_x - 1, center_y)
+
+        blocker = MonsterEntity(
+            entity_id="monster_blocker",
+            grid_x=front_left[0],
+            grid_y=front_left[1],
+            entity_type=EntityType.MONSTER,
+            sub_type="goblin",
+        )
+        manager._add_entity(blocker)
+
+        positions = manager.spread_party_for_combat(
+            engine=engine_adapter,
+            center_x=center_x,
+            center_y=center_y,
+            layout=layout,
+            character_textures={},
+        )
+
+        # The blocking monster's tile must not appear in the formation
+        # positions, and no party member should be sitting on it.
+        assert front_left not in positions, (
+            f"spread_party_for_combat placed a party member onto the "
+            f"monster's tile {front_left}; positions={positions}"
+        )
+        for pm in manager.get_party_members():
+            assert (pm.grid_x, pm.grid_y) != front_left, (
+                f"party member {pm.entity_id} landed on monster tile "
+                f"{front_left}"
+            )
+
+        # The blocker itself must remain at its tile, untouched.
+        still_there = manager.get_at_position(*front_left)
+        assert still_there is blocker, (
+            f"blocker monster was displaced or evicted by the spread step; "
+            f"get_at_position({front_left}) -> {still_there}"
+        )
+
     def test_collapse_party_removes_party_entities(
         self, engine_adapter, layout_loader
     ):


### PR DESCRIPTION
## Summary
- Closes #576.
- `EntityManager.spread_party_for_combat` now skips tiles already held by monsters, items, or prior party members instead of only checking `layout.is_blocking`.
- Spiral search via the new `_find_free_tile_near` helper picks the closest free tile to each formation offset (Chebyshev distance, up to radius 5). Legacy center-stack fallback retained for the never-observed "every nearby tile occupied" case.

## Background
PR #574 added an occupancy gate to `session.spawn_monster`, but in the headless MCP startup path party members aren't in `entity_manager` yet — `load_from_room` only populates monsters + items. The first `spawn_monster` call is what flips the session into COMBAT mode, which then triggers `_spread_party_for_combat()`. That step placed the front-left fighter at `(center_x - 1, center_y)` regardless of who was already there, dropping the fighter onto the just-spawned monster. The map rendered the fighter on top, and Visible Entities only reported one occupant per tile — so the monster was invisible to the player even though it acted normally in combat.

The PR #574 unit tests passed because their `session` fixture pre-populates the party via a different path; the regression only surfaces from the headless MCP startup.

## Test plan
- [x] New regression test `TestEntityManagerEngineIntegration.test_spread_party_avoids_existing_monster_tile` pins a goblin onto the front-left formation tile and asserts the spread step routes the fighter elsewhere while leaving the goblin in place.
- [x] Full `tests/test_entity_integration.py` + `tests/test_game_session.py` runs green (65 passed, 1 skipped).
- [x] Live MCP verification: `uv run dnd-2d --headless --dev --mcp`, `set_seed(42)`, `spawn_monster("goblin", 9, 7)`. Goblin renders as `C` at (9, 7); fighter routes to (8, 6); both appear in Visible Entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)