### PR TITLE
Fix #577: stop tick from racing MCP commands and skipping PC turns

### DIFF
--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -268,6 +268,15 @@ class GameSession:
             return
 
         if self.processing_enemy_turn:
+            # When MCP is driving, wait()/attack()/spawn_monster() drain
+            # enemy turns synchronously via _drain_enemy_turns(). Letting
+            # the tick loop also auto-drain races against user commands:
+            # after ENEMY_TURN_DELAY seconds of think-time the ticker
+            # silently advances one enemy turn and lands on the next PC,
+            # so the user's next wait() burns that PC's turn instead of
+            # resolving the enemy's (#577). Hand pacing to the bridge.
+            if self._mcp_bridge is not None:
+                return
             self.enemy_turn_timer -= delta_time
             if self.enemy_turn_timer <= 0:
                 if self.engine.is_current_combatant_unconscious():
@@ -684,12 +693,16 @@ class GameSession:
     # ========== MCP command processing ==========
 
     def _process_mcp_commands(self) -> None:
-        """Drain one pending command from the MCP bridge, if any."""
-        if self._mcp_bridge is None:
-            return
+        """Drain one pending command from the MCP bridge, if any.
 
-        # Skip if enemy turn is being processed (avoid inconsistent state)
-        if self.processing_enemy_turn:
+        Once ``tick`` hands enemy-turn pacing to the bridge (#577), the
+        ``processing_enemy_turn`` flag stays raised between MCP calls
+        until ``wait()``/``attack()`` drains it. Polling commands while
+        that flag is set is therefore the normal MCP-driven flow, not a
+        race — those handlers drain synchronously, leaving the flag in
+        a consistent state before they return.
+        """
+        if self._mcp_bridge is None:
             return
 
         request = self._mcp_bridge.poll_commands()

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -225,6 +225,89 @@ class TestSessionTick:
         assert session.processing_enemy_turn in (False, True)
         session.tick(0.016)
 
+    def test_tick_polls_mcp_commands_while_enemy_turn_pending(self) -> None:
+        """Regression for #577 follow-on: with the ticker no longer
+        auto-draining, ``_process_mcp_commands`` must still poll user
+        commands while ``processing_enemy_turn`` is True. Otherwise the
+        user's ``game_wait()`` deadlocks waiting for a tick that never
+        services the queue, because spawn_monster leaves the flag
+        raised until the next user-initiated drain.
+        """
+        from client_2d.mcp_bridge import CommandRequest, CommandType, MCPBridge
+        from client_2d.session import GameSession
+
+        s = GameSession(enable_mcp=False, dev_mode=True)
+        bridge = MCPBridge()
+        s._mcp_bridge = bridge
+
+        # Simulate the post-spawn state: an enemy is queued up and the
+        # drain gate is raised, exactly as spawn_monster leaves things.
+        s.processing_enemy_turn = True
+
+        # Enqueue a no-op GET_STATE command and verify tick drains it.
+        request = CommandRequest(command_type=CommandType.GET_STATE)
+        bridge._command_queue.put(request)
+
+        s.tick(0.016)
+
+        assert request.response_future.done(), (
+            "MCP command starved while processing_enemy_turn was True; "
+            "wait()/attack() would deadlock waiting for tick to service it"
+        )
+
+    def test_tick_does_not_auto_drain_enemy_turns_when_mcp_active(self) -> None:
+        """Regression for #577: with MCP driving the session, tick must NOT
+        auto-process an enemy turn after ENEMY_TURN_DELAY elapses.
+
+        The MCP code path drains enemy turns synchronously inside
+        ``wait()``/``attack()``/``spawn_monster()`` via
+        ``_drain_enemy_turns``. If ``tick`` also auto-drains in the
+        background it races against the user's commands and silently
+        consumes a PC's turn: tick advances Goblin -> Abe between
+        spawn_monster and the user's first wait(); the user's wait then
+        operates on Abe, advancing Abe -> Bob and burning Abe's turn.
+        """
+        import random
+
+        from client_2d.mcp_bridge import MCPBridge
+        from client_2d.session import GameSession
+
+        s = GameSession(enable_mcp=False, dev_mode=True)
+        # Match the live MCP wiring without starting the HTTP thread:
+        # an attached _mcp_bridge is what signals "MCP is driving."
+        s.initialize()
+        s._mcp_bridge = MCPBridge()
+        # Deterministic seed used in the #577 repro.
+        s.engine.game_state.dice_roller.random = random.Random(42)
+
+        s.spawn_monster("goblin", 9, 7)
+        tracker = s.engine.game_state.initiative_tracker
+        assert tracker is not None
+
+        # After spawn the goblin should be the current combatant and the
+        # drain gate should be raised so the user's next wait() resolves it.
+        current_before = tracker.get_current_combatant()
+        assert current_before is not None
+        assert current_before.creature.name == "Goblin"
+        assert s.processing_enemy_turn is True
+        idx_before = tracker.current_turn_index
+
+        # Simulate the user thinking about their move for several seconds.
+        # Each tick is one frame; together they exceed ENEMY_TURN_DELAY (1.5s).
+        for _ in range(120):
+            s.tick(0.05)
+
+        # The ticker must NOT have advanced past the goblin while MCP
+        # is the driver. The goblin's turn is the user's to resolve.
+        current_after = tracker.get_current_combatant()
+        assert current_after is not None, "tick must not corrupt initiative state"
+        assert tracker.current_turn_index == idx_before, (
+            f"tick silently advanced initiative under MCP: idx "
+            f"{idx_before} -> {tracker.current_turn_index}, "
+            f"current now {current_after.creature.name}"
+        )
+        assert current_after.creature.name == "Goblin"
+
 
 class TestMCPServerWiring:
     def test_enable_mcp_creates_bridge_and_server(self) -> None:


### PR DESCRIPTION
## Summary
- Disable the session tick loop's auto-drain of enemy turns when MCP is driving (`_mcp_bridge is not None`); MCP `wait()`/`attack()`/`spawn_monster()` already drain synchronously via `_drain_enemy_turns`.
- Drop the `processing_enemy_turn` early-return in `_process_mcp_commands` — with the ticker no longer clearing that flag in the background, the guard would deadlock subsequent MCP commands.
- Add two regression tests in `TestSessionTick`.

Closes #577.

## Root cause
`session.tick` ran at ~30 Hz and, after `ENEMY_TURN_DELAY = 1.5s`, auto-processed one enemy turn. Under MCP playtest with >1.5s of think-time between commands, the ticker silently advanced `Goblin → Abe` between `spawn_monster` and the user's first `game_wait`. The user's `wait()` then operated on Abe (passing him), so the next state showed `Current Turn: Bob` with Abe's turn silently consumed — looking like Abe was never in initiative.

Headless inspection confirmed Abe IS in initiative with seed 42: `[Goblin(11), Abe(7), Bob(3)]`. The bug is a wall-clock race, not an initiative-construction defect.

## Test plan
- [x] `pytest tests/test_game_session.py` — 56 passed.
- [x] Live MCP repro: `set_seed(42)` → `spawn_monster(goblin, 9, 7)` → `game_wait()` now shows `Current Turn: Abe` (was `Bob`); subsequent waits cycle Goblin → Abe → Bob → wrap correctly.
- [ ] Windowed mode unaffected (`_mcp_bridge is None`, ticker still paces enemy turns for animation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)