### PR TITLE
Fix #578: anchor @ cursor to active combatant before move math

### DIFF
--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -952,6 +952,19 @@ class GameSession:
             speed = current["creature"].speed if current else 30
             return f"No movement remaining (0/{speed} ft). Use game_attack() or game_wait()."
 
+        # Anchor the `@` cursor to the active combatant's TRUE tile
+        # before computing the move. ``spread_party_for_combat`` puts
+        # each PC on its own tile around `@`, but `self.player_x/y` is
+        # never re-synced when turns advance — so a non-leader PC's
+        # ``combat_move`` would otherwise compute ``new_x = player_x +
+        # dx`` from the stale leader tile and then ``update_current_turn
+        # _position(new_x, new_y)`` would slam the PC's entity grid to
+        # that wrong destination (either a silent no-op when it lands
+        # on the PC's existing tile, or a teleport). See #578.
+        combatant_pos = self.entity_manager.get_current_turn_position(self.engine)
+        if combatant_pos is not None:
+            self.player_x, self.player_y = combatant_pos
+
         dx, dy = {
             "north": (0, -1),
             "south": (0, 1),

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -492,6 +492,89 @@ class TestSessionCombatMoveBlockedByMonster:
         assert "Giant Rat" in result
 
 
+class TestSessionCombatMoveAnchorsToActiveCombatant:
+    """Regression tests for #578.
+
+    The ``@`` cursor (``session.player_x/y``) is set during the
+    room-entry party-spread to the party-leader tile and is never
+    re-anchored to the active PC when their turn begins. Before this
+    fix, ``combat_move`` computed the destination as
+    ``self.player_x + dx`` — so a non-leader PC's move went from the
+    cursor's tile rather than the PC's true tile. The downstream
+    ``update_current_turn_position(new_x, new_y)`` call then slammed
+    the PC's entity grid to that wrong destination, either silently
+    no-op-ing (when the destination equalled the PC's existing tile)
+    or teleporting the PC. Both flavors consumed 5 ft of budget per
+    press without doing what the player asked.
+    """
+
+    def test_move_anchors_north_when_cursor_lags_south(self, session) -> None:
+        """When ``@`` is one tile south of the active PC, pressing
+        north must move the PC one tile north of its TRUE tile — not
+        leave the PC in place after the cursor's would-be destination
+        collides with the PC's current tile."""
+        _force_player_turn(session)
+
+        # Scenario seeds Archy at (3, 5) and `@` follows. Decouple
+        # them: leave `@` at (3, 5) but lift the PC's entity grid one
+        # tile north to (3, 4). This mimics the issue #578 repro where
+        # spread_party_for_combat puts non-leader PCs on tiles other
+        # than `@`.
+        party = session.entity_manager.get_party_members()
+        assert len(party) == 1
+        pc_entity = party[0]
+        pc_entity.grid_x = 3
+        pc_entity.grid_y = 4
+        assert (session.player_x, session.player_y) == (3, 5)
+
+        starting_movement = session.engine.get_current_turn_state().movement_remaining
+
+        session.combat_move("north")
+
+        # The PC must move from its TRUE tile (3, 4) → (3, 3). Under
+        # the bug, ``new_y = self.player_y + dy = 5 - 1 = 4`` and
+        # ``update_current_turn_position(3, 4)`` re-set the PC's grid
+        # back to (3, 4) — a silent no-op despite the budget spend.
+        assert (pc_entity.grid_x, pc_entity.grid_y) == (3, 3)
+        # Cursor coupled to the PC after the move.
+        assert (session.player_x, session.player_y) == (3, 3)
+        # Exactly one 5-ft step on normal terrain.
+        assert (
+            session.engine.get_current_turn_state().movement_remaining
+            == starting_movement - 5
+        )
+
+    def test_repeated_moves_anchor_each_time(self, session) -> None:
+        """Two consecutive presses from a desynced cursor must each
+        advance the PC by one tile. The pre-fix behaviour was that the
+        first press wasted budget while snapping `@` onto the PC; only
+        the second press moved the PC. This pins both presses to a
+        real advance so a regression that re-introduces the snap-then-
+        move pattern fails immediately."""
+        _force_player_turn(session)
+
+        party = session.entity_manager.get_party_members()
+        assert len(party) == 1
+        pc_entity = party[0]
+        # PC at (3, 4); `@` lags at (3, 5).
+        pc_entity.grid_x = 3
+        pc_entity.grid_y = 4
+        assert (session.player_x, session.player_y) == (3, 5)
+
+        starting_movement = session.engine.get_current_turn_state().movement_remaining
+
+        session.combat_move("north")
+        session.combat_move("north")
+
+        # PC advances two tiles north of its true starting tile.
+        assert (pc_entity.grid_x, pc_entity.grid_y) == (3, 2)
+        assert (session.player_x, session.player_y) == (3, 2)
+        assert (
+            session.engine.get_current_turn_state().movement_remaining
+            == starting_movement - 10
+        )
+
+
 class TestSessionResetGameMCPDispatch:
     """Tests for the MCP bridge dispatch path of reset_game (#373).
 


### PR DESCRIPTION
## Summary
- Re-anchor `self.player_x/y` to the active combatant's true tile (via `entity_manager.get_current_turn_position`) at the top of `combat_move`, before any move arithmetic.
- Both the legacy and plan-03 spatial paths use the cursor as their basis, so the single sync point covers both.
- After a successful move the cursor stays coupled to the PC, matching the player's mental model.

## Root cause
`combat_move` computed the destination as `self.player_x + dx`, but `self.player_x/y` (the `@` cursor) is set during room-entry party spread to the party-leader tile and is never re-synced when turns advance. For a non-leader PC the move went from the cursor's tile rather than the PC's true tile — and the downstream `update_current_turn_position(new_x, new_y)` then slammed the PC's entity grid to that wrong destination, producing either a silent no-op (when the destination equalled the PC's existing tile, matching the issue repro) or a teleport. Either way the 5-ft budget was consumed without doing what the player asked.

## Regression tests (`TestSessionCombatMoveAnchorsToActiveCombatant`)
- `test_move_anchors_north_when_cursor_lags_south` — pins the silent-no-op flavor: `@` one tile south of PC, press north, PC must advance one tile (was: PC unchanged, budget consumed).
- `test_repeated_moves_anchor_each_time` — pins two consecutive presses so a regression that re-introduces the snap-then-move pattern fails on the first press.

## Test plan
- [x] `uv run pytest tests/test_game_session.py` — all 58 pass.
- [ ] Live MCP repro from the issue: `set_seed(42)` → `spawn_monster("goblin", 9, 7)` → `game_wait()` → `game_move("east")` → confirm Bob actually moves east and the budget drops by 5 ft.

Closes #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)