### PR TITLE
Fix #579: register co-located entity symbol so @ overlay doesn't hide it

### DIFF
--- a/client-2d/src/client_2d/testing/state_renderer.py
+++ b/client-2d/src/client_2d/testing/state_renderer.py
@@ -128,6 +128,11 @@ class StateRenderer:
         """Get the character to display at a given tile position."""
         # Player always visible at their position
         if x == player_x and y == player_y:
+            # Register any co-located entity so it appears in the legend
+            # and Visible Entities even though @ overlays the glyph.
+            entity = entity_at.get((x, y))
+            if entity:
+                self._get_entity_symbol(entity)
             return self.PLAYER_CHAR
 
         # Check visibility

--- a/client-2d/tests/test_state_renderer.py
+++ b/client-2d/tests/test_state_renderer.py
@@ -453,3 +453,70 @@ class TestStateRendererDirections:
         renderer = StateRenderer(width=5, height=5)
         direction = renderer._get_direction(0, 0)
         assert direction == "here"
+
+
+class TestStateRendererPlayerTileOverlay:
+    """Regression tests for issue #579.
+
+    When the @ cursor occupies the same tile as another entity, the entity
+    must still appear in the legend and Visible Entities, even though @
+    overlays the entity glyph on the ASCII map.
+    """
+
+    @pytest.fixture
+    def bright_room(self) -> tuple[list[list[int]], FogOfWarSystem]:
+        """Create a 5x5 open room with all tiles bright."""
+        room = [[0] * 5 for _ in range(5)]
+        fog = FogOfWarSystem(width=5, height=5)
+        for y in range(5):
+            for x in range(5):
+                fog.set_visibility(x, y, LightingState.BRIGHT)
+        return room, fog
+
+    def test_ascii_map_shows_player_when_entity_on_same_tile(
+        self, bright_room: tuple[list[list[int]], FogOfWarSystem]
+    ):
+        """@ overlay is preserved when an entity shares the player's tile."""
+        room, fog = bright_room
+        renderer = StateRenderer(width=5, height=5)
+        entities = [Entity(x=2, y=2, entity_type="party", entity_id="wizard_1")]
+
+        ascii_map = renderer.render_ascii_map(
+            room=room, player_x=2, player_y=2, entities=entities, fog=fog
+        )
+
+        lines = ascii_map.split("\n")
+        assert lines[2][2] == "@"
+
+    def test_legend_includes_entity_on_player_tile(
+        self, bright_room: tuple[list[list[int]], FogOfWarSystem]
+    ):
+        """Legend lists entities co-located with the player."""
+        room, fog = bright_room
+        renderer = StateRenderer(width=5, height=5)
+        entities = [Entity(x=2, y=2, entity_type="party", entity_id="wizard_1")]
+
+        state = renderer.render_state(
+            room=room, player_x=2, player_y=2, entities=entities, fog=fog
+        )
+
+        assert "party:wizard_1" in state["legend"].values()
+
+    def test_visible_entities_includes_entity_on_player_tile(
+        self, bright_room: tuple[list[list[int]], FogOfWarSystem]
+    ):
+        """Visible Entities reports co-located entities with distance 0/'here'."""
+        room, fog = bright_room
+        renderer = StateRenderer(width=5, height=5)
+        entities = [Entity(x=2, y=2, entity_type="party", entity_id="wizard_1")]
+
+        state = renderer.render_state(
+            room=room, player_x=2, player_y=2, entities=entities, fog=fog
+        )
+
+        assert "wizard_1" in state["visible_entities"]
+        wizard = state["visible_entities"]["wizard_1"]
+        assert wizard["distance"] == 0
+        assert wizard["direction"] == "here"
+        assert wizard["position"] == [2, 2]
+        assert wizard["type"] == "party"


### PR DESCRIPTION
## Summary
- Fixes #579 — when the `@` cursor occupies the same tile as another entity, the entity now still appears in the legend and `visible_entities` (with `distance: 0`, `direction: "here"`).
- Preserves the `@` overlay on the ASCII map, which the issue explicitly endorses.

## Root cause
`StateRenderer._get_tile_char` short-circuited at the player tile and returned `PLAYER_CHAR` before calling `_get_entity_symbol`. Symbol assignment is lazy — entries are only added to `self._entity_symbols` when `_get_entity_symbol` runs. Downstream, `build_legend` and `render_state`'s `visible_entities` both gate on `self._entity_symbols`, so the co-located entity was silently dropped from both views.

## Changes
- **`client-2d/src/client_2d/testing/state_renderer.py`** (5 lines): in `_get_tile_char`, register any entity at the player's tile before returning `PLAYER_CHAR`. Map glyph behavior unchanged.
- **`client-2d/tests/test_state_renderer.py`** (67 lines): new `TestStateRendererPlayerTileOverlay` regression class with three tests:
  - `test_ascii_map_shows_player_when_entity_on_same_tile` — guards the overlay behavior.
  - `test_legend_includes_entity_on_player_tile` — legend lists co-located entity.
  - `test_visible_entities_includes_entity_on_player_tile` — `distance: 0`, `direction: "here"`, `position: [x, y]`.

## Test plan
- [x] TDD red→green: two new tests fail before the fix, all three pass after.
- [x] Full client-2d suite: 472 passed.
- [x] Ruff lint: clean. (Format check flags pre-existing drift only — tracked by #396.)
- [x] Manual MCP repro from the issue:
  - Spawn goblin, `set_position party_1 10 7` to overlap `@`.
  - `game_state()` confirms `D party:wizard_1 at [10, 7] (0 squares here)` now appears in Visible Entities, `D = party:wizard_1` in legend, map still shows `@` overlay.
  - Move wizard off the tile → `D` reappears at its own glyph (no regression in normal rendering).

## Related issues
Fixes #579. Possibly mitigates a contributing factor to #576 (already shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)