### PR TITLE
Add REACTION slot to TurnState and ActionType (plan-01 slice 1, closes #412)

### DIFF
--- a/dnd-engine/dnd_engine/systems/action_economy.py
+++ b/dnd-engine/dnd_engine/systems/action_economy.py
@@ -12,12 +12,16 @@ class ActionType(Enum):
     Each turn, a character can take:
     - One ACTION (attack, cast spell, use item, etc.)
     - One BONUS_ACTION (if they have an ability that uses it)
+    - One REACTION (Shield, Counterspell, Opportunity Attack, etc.) —
+      fired in response to a trigger; one per round, resets at the
+      start of the reactor's next turn
     - One FREE_OBJECT interaction (draw weapon, open door, etc.)
     - Any number of NO_ACTION activities (dropping items, speaking, etc.)
     """
 
     ACTION = "action"
     BONUS_ACTION = "bonus_action"
+    REACTION = "reaction"
     FREE_OBJECT = "free_object"
     NO_ACTION = "no_action"
 
@@ -59,14 +63,22 @@ class TurnState:
     Tracks available actions for a single combat turn.
 
     D&D 5E action economy rules:
-    - Each turn gets: 1 action, 1 bonus action, 1 free object interaction
+    - Each turn gets: 1 action, 1 bonus action, 1 reaction, 1 free
+      object interaction
     - Actions are consumed when used
-    - All actions reset at the start of the next turn
+    - The Reaction slot is per-round, not per-turn: it resets only
+      when the reactor's own turn comes around again (SRD: "you can't
+      take another one until the start of your next turn"). Because
+      TurnState.reset() is invoked by InitiativeTracker.next_turn at
+      the start of each creature's own turn, resetting the reaction
+      slot there honors the once-per-round rule.
+    - All other actions reset at the start of the next turn
     - Movement is tracked per turn (typically 30 ft, varies by creature speed)
     """
 
     action_available: bool = True
     bonus_action_available: bool = True
+    reaction_available: bool = True
     free_object_interaction_used: bool = False
     movement_remaining: int = 30  # Movement in feet (5 ft = 1 grid square)
 
@@ -96,6 +108,12 @@ class TurnState:
         elif action_type == ActionType.BONUS_ACTION:
             if self.bonus_action_available:
                 self.bonus_action_available = False
+                return True
+            return False
+
+        elif action_type == ActionType.REACTION:
+            if self.reaction_available:
+                self.reaction_available = False
                 return True
             return False
 
@@ -159,6 +177,8 @@ class TurnState:
             return self.action_available
         elif action_type == ActionType.BONUS_ACTION:
             return self.bonus_action_available
+        elif action_type == ActionType.REACTION:
+            return self.reaction_available
         elif action_type == ActionType.FREE_OBJECT:
             return not self.free_object_interaction_used
         elif action_type == ActionType.NO_ACTION:
@@ -177,6 +197,7 @@ class TurnState:
         """
         self.action_available = True
         self.bonus_action_available = True
+        self.reaction_available = True
         self.free_object_interaction_used = False
         self.movement_remaining = speed
 
@@ -196,6 +217,8 @@ class TurnState:
             parts.append("Action")
         if self.bonus_action_available:
             parts.append("Bonus Action")
+        if self.reaction_available:
+            parts.append("Reaction")
         if not self.free_object_interaction_used:
             parts.append("Free Object")
 

--- a/dnd-engine/tests/srd/playing_the_game/test_reactions.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_reactions.py
@@ -60,16 +60,18 @@ class TestReaction_Definition:
         )
 
     def test_reaction_action_type_is_modeled_in_action_economy(self) -> None:
-        pytest.skip(
-            "GAP: `ActionType` in dnd_engine/systems/action_economy.py "
-            "enumerates ACTION, BONUS_ACTION, FREE_OBJECT, NO_ACTION but "
-            "not REACTION. The TurnState dataclass tracks "
-            "action_available / bonus_action_available / "
-            "free_object_interaction_used / movement_remaining with no "
-            "reaction-equivalent field. The SRD's 'special action called "
-            "a Reaction' has no first-class model on the engine side. "
-            "Tracked by issue #412 (Reaction economy)."
-        )
+        """ActionType enumerates REACTION; TurnState tracks reaction_available.
+
+        SRD requires the "special action called a Reaction" to be a
+        first-class member of the action economy. Closes the original
+        gap captured under issue #412.
+        """
+        from dnd_engine.systems.action_economy import ActionType
+
+        assert ActionType.REACTION.value == "reaction"
+        turn = TurnState()
+        assert hasattr(turn, "reaction_available")
+        assert turn.reaction_available is True
 
 
 class TestReaction_TriggerResponse:
@@ -145,55 +147,54 @@ class TestReaction_OncePerRound:
     > start of your next turn.
     """
 
-    def test_turn_state_has_no_reaction_slot(self) -> None:
-        """Source-level guard: `TurnState` does not track a reaction.
+    def test_turn_state_tracks_reaction_slot(self) -> None:
+        """`TurnState` exposes a `reaction_available` field.
 
-        The SRD's "you can't take another one until the start of your
-        next turn" requires per-creature state that records 'did this
-        creature already use its Reaction this round?'. `TurnState`
-        currently exposes only `action_available`,
-        `bonus_action_available`, `free_object_interaction_used`, and
-        `movement_remaining`. This test pins the absence so that the
-        moment a `reaction_available` field is added, the test will
-        flip to xfail/fail and prompt removing the skip on
-        `test_reaction_consumed_blocks_a_second_reaction_same_round`
-        below.
+        SRD requires per-creature state that records "did this
+        creature already use its Reaction this round?". `TurnState`
+        now carries `reaction_available` alongside the existing
+        action / bonus_action / free-object / movement slots.
 
-        Closing this gap is issue #412.
+        Closes the original gap captured under issue #412.
         """
         turn = TurnState()
-        assert not hasattr(turn, "reaction_available"), (
-            "TurnState now has a `reaction_available` field — the "
-            "Reaction economy gap (#412) appears to be closing. Flip "
-            "this audit test to a real assertion that the field is "
-            "consumed on Reaction-use and reset on `TurnState.reset()`."
-        )
+        assert hasattr(turn, "reaction_available")
+        assert turn.reaction_available is True
 
     def test_reaction_consumed_blocks_a_second_reaction_same_round(self) -> None:
-        pytest.skip(
-            "GAP: Reaction economy is not modeled. With no "
-            "`reaction_available` flag on TurnState and no "
-            "Reaction-consuming code path, two Reactions in the same "
-            "round cannot be detected, let alone rejected. "
-            "`flee_combat()` (dnd_engine/core/game_state.py:4194) "
-            "fans out one attack per living enemy on every flee with "
-            "no per-creature once-per-round guard. Tracked by issue "
-            "#412."
-        )
+        """Consuming the Reaction slot blocks a second Reaction this round.
+
+        SRD: "When you take a Reaction, you can't take another one
+        until the start of your next turn." A second
+        ``consume_action(REACTION)`` in the same turn must return
+        ``False``.
+        """
+        from dnd_engine.systems.action_economy import ActionType
+
+        turn = TurnState()
+        assert turn.consume_action(ActionType.REACTION) is True
+        assert turn.reaction_available is False
+        assert turn.consume_action(ActionType.REACTION) is False
+        assert turn.is_action_available(ActionType.REACTION) is False
 
     def test_reaction_resets_at_start_of_next_turn(self) -> None:
-        pytest.skip(
-            "GAP: `TurnState.reset()` (action_economy.py:125) resets "
-            "`action_available`, `bonus_action_available`, "
-            "`free_object_interaction_used`, and `movement_remaining` "
-            "but has no reaction slot to reset. The SRD's 'until the "
-            "start of your next turn' phrasing requires a reaction "
-            "flag that is cleared by the same path that resets the "
-            "rest of the action economy. `InitiativeTracker.next_turn` "
-            "(systems/initiative.py:199-202) invokes `.reset()` on "
-            "the incoming combatant; the reaction flag must be reset "
-            "there once it exists. Tracked by issue #412."
-        )
+        """`TurnState.reset()` restores the Reaction slot.
+
+        SRD's "until the start of your next turn" phrasing requires a
+        reaction flag that is cleared by the same path that resets
+        the rest of the action economy. ``InitiativeTracker.next_turn``
+        invokes ``.reset()`` on the incoming combatant, so resetting
+        the reaction flag there enforces the once-per-round rule.
+        """
+        from dnd_engine.systems.action_economy import ActionType
+
+        turn = TurnState()
+        turn.consume_action(ActionType.REACTION)
+        assert turn.reaction_available is False
+
+        turn.reset()
+        assert turn.reaction_available is True
+        assert turn.is_action_available(ActionType.REACTION) is True
 
 
 class TestReaction_InterruptedTurnContinuation:

--- a/dnd-engine/tests/test_action_economy.py
+++ b/dnd-engine/tests/test_action_economy.py
@@ -15,6 +15,7 @@ class TestActionType:
         """Test that all required action types are defined"""
         assert ActionType.ACTION
         assert ActionType.BONUS_ACTION
+        assert ActionType.REACTION
         assert ActionType.FREE_OBJECT
         assert ActionType.NO_ACTION
 
@@ -22,6 +23,7 @@ class TestActionType:
         """Test that action types have correct string values"""
         assert ActionType.ACTION.value == "action"
         assert ActionType.BONUS_ACTION.value == "bonus_action"
+        assert ActionType.REACTION.value == "reaction"
         assert ActionType.FREE_OBJECT.value == "free_object"
         assert ActionType.NO_ACTION.value == "no_action"
 
@@ -35,6 +37,7 @@ class TestTurnState:
 
         assert turn.action_available is True
         assert turn.bonus_action_available is True
+        assert turn.reaction_available is True
         assert turn.free_object_interaction_used is False
 
     def test_consume_action(self):
@@ -61,6 +64,19 @@ class TestTurnState:
 
         # Second consumption should fail
         result = turn.consume_action(ActionType.BONUS_ACTION)
+        assert result is False
+
+    def test_consume_reaction(self):
+        """Test consuming the reaction slot"""
+        turn = TurnState()
+
+        # First consumption should succeed
+        result = turn.consume_action(ActionType.REACTION)
+        assert result is True
+        assert turn.reaction_available is False
+
+        # Second consumption should fail (one Reaction per round)
+        result = turn.consume_action(ActionType.REACTION)
         assert result is False
 
     def test_consume_free_object(self):
@@ -92,6 +108,7 @@ class TestTurnState:
         # All actions available initially
         assert turn.is_action_available(ActionType.ACTION) is True
         assert turn.is_action_available(ActionType.BONUS_ACTION) is True
+        assert turn.is_action_available(ActionType.REACTION) is True
         assert turn.is_action_available(ActionType.FREE_OBJECT) is True
         assert turn.is_action_available(ActionType.NO_ACTION) is True
 
@@ -99,6 +116,7 @@ class TestTurnState:
         turn.consume_action(ActionType.ACTION)
         assert turn.is_action_available(ActionType.ACTION) is False
         assert turn.is_action_available(ActionType.BONUS_ACTION) is True  # Still available
+        assert turn.is_action_available(ActionType.REACTION) is True  # Still available
 
     def test_reset(self):
         """Test resetting all actions"""
@@ -107,11 +125,13 @@ class TestTurnState:
         # Consume all actions
         turn.consume_action(ActionType.ACTION)
         turn.consume_action(ActionType.BONUS_ACTION)
+        turn.consume_action(ActionType.REACTION)
         turn.consume_action(ActionType.FREE_OBJECT)
 
         # Verify all consumed
         assert turn.action_available is False
         assert turn.bonus_action_available is False
+        assert turn.reaction_available is False
         assert turn.free_object_interaction_used is True
 
         # Reset
@@ -120,6 +140,7 @@ class TestTurnState:
         # Verify all available again
         assert turn.action_available is True
         assert turn.bonus_action_available is True
+        assert turn.reaction_available is True
         assert turn.free_object_interaction_used is False
 
     def test_has_any_action(self):
@@ -160,11 +181,13 @@ class TestTurnState:
         str_repr = str(turn)
         assert "Action" in str_repr
         assert "Bonus Action" in str_repr
+        assert "Reaction" in str_repr
         assert "Free Object" in str_repr
 
         # After consuming everything
         turn.consume_action(ActionType.ACTION)
         turn.consume_action(ActionType.BONUS_ACTION)
+        turn.consume_action(ActionType.REACTION)
         turn.consume_action(ActionType.FREE_OBJECT)
 
         str_repr = str(turn)
@@ -304,6 +327,32 @@ class TestInitiativeTrackerActions:
 
         turn_state = tracker.get_current_turn_state()
         assert turn_state is None
+
+    def test_reaction_resets_when_creatures_turn_comes_around(self):
+        """Reaction slot resets on the reactor's own next turn (SRD)."""
+        tracker = InitiativeTracker()
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+
+        hero = Creature("Hero", max_hp=20, ac=15, abilities=abilities)
+        enemy = Creature("Goblin", max_hp=7, ac=15, abilities=abilities)
+
+        tracker.add_combatant(hero)
+        tracker.add_combatant(enemy)
+
+        # Consume reaction on whichever creature is up first.
+        first_state = tracker.get_current_turn_state()
+        assert first_state.consume_action(ActionType.REACTION) is True
+        assert first_state.reaction_available is False
+
+        # Advancing to the *other* creature must not refill our slot.
+        tracker.next_turn()
+        # The reference to first_state is the same instance held in
+        # tracker.turn_states[first_creature]; it must still be empty.
+        assert first_state.reaction_available is False
+
+        # Round-trip back to the original creature; reset must refill it.
+        tracker.next_turn()
+        assert first_state.reaction_available is True
 
 
 class TestMovementTracking:


### PR DESCRIPTION
## Summary

First slice of [plan-01: Action Economy & Reaction System](../tree/main/plans/01-action-economy-and-reaction-system.md). Makes Reaction a first-class member of the action economy so later slices (trigger dispatcher, Opportunity Attacks, Shield/Counterspell) have state to consume.

- `ActionType.REACTION = "reaction"` — fifth member of the action-type enum.
- `TurnState.reaction_available: bool = True` — wired through `consume_action`, `is_action_available`, `reset`, `__str__`.
- Once-per-round rule ("until the start of your next turn") is enforced through the existing `InitiativeTracker.next_turn` → `TurnState.reset()` path; no initiative-loop changes were needed in this slice.

## SRD audit impact

Flips 3 previously-skipped rows in `tests/srd/playing_the_game/test_reactions.py` to real assertions:

- `test_reaction_action_type_is_modeled_in_action_economy`
- `test_turn_state_tracks_reaction_slot` (renamed from `test_turn_state_has_no_reaction_slot`)
- `test_reaction_consumed_blocks_a_second_reaction_same_round`
- `test_reaction_resets_at_start_of_next_turn`

The 5 remaining skips in that file depend on the Reaction dispatcher (slice 2) and interrupted-turn pause/resume (slice 3).

Closes #412.

## Test plan

- [x] `uv run pytest tests/test_action_economy.py tests/srd/playing_the_game/test_reactions.py` → 35 passed, 5 skipped
- [x] Full engine suite: `uv run pytest --no-cov -q` → 2971 passed, 249 skipped, 0 failed
- [ ] Reviewer: confirm `__str__` change doesn't break any human-facing UI that scrapes the string (no callers found, but worth a fresh look)

## Plan-01 progress

| Slice | Status |
|---|---|
| 1. REACTION slot + ActionType | **this PR** |
| 2. Trigger→Reaction dispatcher (#429) | next |
| 3. Mid-turn pause/resume (#430) | blocked on 2 |
| 4. Opportunity Attack as Reaction (#413) | blocked on 2 |
| 5. Dash/Dodge/Prone/StandUp (#435 #438 #439) | parallelizable after this |
| 6. Disengage (#414) | blocked on 4 |
| 7. Help/Hide/Search/Study/Influence/Magic/Knockout (#441 #443 #449 #451 #444 #446 #485) | parallelizable after this |
| 8. Bonus action gating (#434 #437 #440) | parallelizable after this |
| 9. Free object slot + outside-combat enforcement (#472 #519 #56 #455) | parallelizable after this |

🤖 Generated with [Claude Code](https://claude.com/claude-code)