### PR TITLE
Add ReactionDispatcher for trigger→reaction routing (plan-01 slice 2, closes #429)

### DIFF
--- a/dnd-engine/dnd_engine/systems/reactions.py
+++ b/dnd-engine/dnd_engine/systems/reactions.py
@@ -1,0 +1,185 @@
+# ABOUTME: Trigger->Reaction dispatcher for D&D 5E combat
+# ABOUTME: Routes named triggers to subscribed Reaction handlers in initiative order
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from dnd_engine.systems.action_economy import ActionType
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+    from dnd_engine.systems.initiative import InitiativeTracker
+
+
+class Trigger(str, Enum):
+    """Named triggers a creature can subscribe a Reaction to.
+
+    Each value is a free-standing event in combat that one or more
+    creatures may want to respond to with their once-per-round
+    Reaction. The SRD enumerates Reaction surfaces by example
+    (Shield, Counterspell, Opportunity Attack) rather than by a
+    fixed catalog, so this enum starts with the three the engine
+    needs first and is meant to grow as more Reaction-shaped
+    features land.
+    """
+
+    OPPORTUNITY_PROVOKED = "opportunity_provoked"
+    WOULD_BE_HIT = "would_be_hit"
+    SPELL_CAST_OBSERVED = "spell_cast_observed"
+
+
+@dataclass
+class TriggerContext:
+    """Payload passed to every eligible Reaction handler when a trigger fires.
+
+    Handlers read these fields to decide whether to react and what to
+    do. ``source`` is the creature that caused the trigger (e.g., the
+    attacker that hit you, the caster of the spell you saw). ``payload``
+    carries trigger-specific data (the attack roll, the spell level,
+    the destination tile) — the schema is owned by the publisher of
+    the trigger, not by the dispatcher.
+    """
+
+    trigger: Trigger
+    source: Creature | None = None
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ReactionOutcome:
+    """Result of a Reaction handler invocation.
+
+    Setting ``reacted=True`` tells the dispatcher to consume the
+    reactor's Reaction slot for this round. A handler that declines
+    (``reacted=False``) costs the reactor nothing and a later trigger
+    in the same round can still fire their Reaction.
+
+    ``description`` is a short human-readable summary for logs / the
+    event bus. ``data`` is a free-form bag the publisher and the
+    handler agree on (e.g., the +5 AC bonus Shield grants, the spell
+    that Counterspell stopped).
+    """
+
+    reacted: bool
+    description: str = ""
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+ReactionHandler = Callable[[TriggerContext], ReactionOutcome]
+
+
+@dataclass
+class _Subscription:
+    """Internal record: a creature's handler for one trigger."""
+
+    creature: Creature
+    trigger: Trigger
+    handler: ReactionHandler
+
+
+class ReactionDispatcher:
+    """Routes named triggers to subscribed Reaction handlers.
+
+    The dispatcher is the engine-side enforcement point for the SRD's
+    "you can't take another Reaction until the start of your next
+    turn" rule. Per-creature slots live on
+    ``InitiativeTracker.turn_states[creature].reaction_available``
+    and are reset by the existing ``InitiativeTracker.next_turn`` ->
+    ``TurnState.reset()`` path, so this dispatcher only has to *check
+    and consume* the slot, never reset it.
+
+    Reaction resolution order is initiative order (highest first) per
+    SRD's general timing convention for simultaneous fan-out. The SRD
+    also stipulates Reactions resolve "immediately after the trigger
+    unless the Reaction's description says otherwise" — this
+    dispatcher honors the default (synchronous, in-call resolution);
+    a future per-handler `timing` field can carve out the
+    "before-trigger" exceptions (e.g., Shield's AC bonus must apply to
+    the very attack that triggered it).
+    """
+
+    def __init__(self, tracker: InitiativeTracker):
+        self._tracker = tracker
+        self._subs: list[_Subscription] = []
+
+    def register(
+        self,
+        creature: Creature,
+        trigger: Trigger,
+        handler: ReactionHandler,
+    ) -> None:
+        """Subscribe ``creature``'s ``handler`` to ``trigger``.
+
+        Multiple subscriptions for the same (creature, trigger) pair
+        are allowed but only the most-recently-registered handler
+        fires — creatures generally have one Reaction option active
+        per trigger at a time, and "last wins" matches the way
+        features replace each other (e.g., upgrading Shield to a
+        higher-level variant). Unregister explicitly if a creature
+        needs to drop a subscription mid-combat.
+        """
+        self._subs.append(_Subscription(creature, trigger, handler))
+
+    def unregister(self, creature: Creature) -> None:
+        """Drop every subscription held by ``creature``.
+
+        Call when a combatant is removed from the initiative order so
+        their handlers don't accumulate across encounters.
+        """
+        self._subs = [s for s in self._subs if s.creature is not creature]
+
+    def publish(self, context: TriggerContext) -> list[ReactionOutcome]:
+        """Fire eligible Reactions for ``context.trigger`` in initiative order.
+
+        A reactor is eligible if all hold:
+
+        - they have a subscription for ``context.trigger``,
+        - they are alive (``creature.is_alive``),
+        - their ``TurnState.reaction_available`` is True.
+
+        Each eligible handler is invoked with ``context``. Handlers
+        that return ``ReactionOutcome(reacted=True)`` consume the
+        Reaction slot; ``reacted=False`` leaves the slot intact for a
+        later trigger in the same round.
+
+        Returns the outcomes from handlers that actually reacted, in
+        resolution order. An empty list means no one reacted (either
+        no subscribers or every subscriber declined / was ineligible).
+        """
+        outcomes: list[ReactionOutcome] = []
+        for creature, handler in self._eligible_in_initiative_order(context.trigger):
+            turn_state = self._tracker.turn_states.get(creature)
+            if turn_state is None or not turn_state.reaction_available:
+                continue
+            if not creature.is_alive:
+                continue
+            outcome = handler(context)
+            if outcome.reacted:
+                turn_state.consume_action(ActionType.REACTION)
+                outcomes.append(outcome)
+        return outcomes
+
+    def _eligible_in_initiative_order(
+        self, trigger: Trigger
+    ) -> list[tuple[Creature, ReactionHandler]]:
+        """Walk the tracker's initiative order, yielding subscribed reactors.
+
+        "Last subscription wins" for (creature, trigger) — see
+        ``register``. Creatures not in initiative are skipped (they
+        have no TurnState slot to consume).
+        """
+        per_creature: dict[Creature, ReactionHandler] = {}
+        for sub in self._subs:
+            if sub.trigger == trigger:
+                per_creature[sub.creature] = sub.handler
+
+        ordered: list[tuple[Creature, ReactionHandler]] = []
+        for entry in self._tracker.get_all_combatants():
+            handler = per_creature.get(entry.creature)
+            if handler is not None:
+                ordered.append((entry.creature, handler))
+        return ordered

--- a/dnd-engine/tests/srd/playing_the_game/test_reactions.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_reactions.py
@@ -82,31 +82,88 @@ class TestReaction_TriggerResponse:
     """
 
     def test_reaction_can_fire_outside_the_reactors_turn(self) -> None:
-        pytest.skip(
-            "GAP: The engine has no general 'trigger -> reaction' "
-            "dispatch. The only Reaction-shaped fan-out today is "
-            "`GameState.flee_combat()` "
-            "(dnd_engine/core/game_state.py:4194), which fires for "
-            "every living enemy when the *party* attempts to retreat. "
-            "There is no event-bus subscription model that lets a "
-            "creature register a reaction to fire on an arbitrary "
-            "trigger during another creature's turn (e.g., Shield in "
-            "response to being hit, Counterspell in response to a "
-            "cast). Tracked by issue #429 (depends on #412 reaction "
-            "economy); see also #413 for per-creature OAs on tactical "
-            "movement."
+        """A Reaction subscribed to a trigger fires regardless of whose turn it is.
+
+        Wizard is second in initiative. Goblin (whose turn it is)
+        provokes ``OPPORTUNITY_PROVOKED``; Wizard's handler fires
+        even though it is the Goblin's turn, and the Wizard's
+        Reaction slot is consumed. Closes #429.
+        """
+        from dnd_engine.core.creature import Abilities, Creature
+        from dnd_engine.core.dice import DiceRoller
+        from dnd_engine.systems.initiative import InitiativeTracker
+        from dnd_engine.systems.reactions import (
+            ReactionDispatcher,
+            ReactionOutcome,
+            Trigger,
+            TriggerContext,
         )
 
-    def test_reaction_can_fire_during_the_reactors_own_turn(self) -> None:
-        pytest.skip(
-            "GAP: same root cause as above — no trigger -> reaction "
-            "dispatch exists. The SRD explicitly carves out that a "
-            "Reaction may occur on the reactor's own turn (e.g., "
-            "Opportunity Attack provoked by another creature's "
-            "movement that happens to fall in your turn's window), "
-            "but with no reaction model at all this exception is "
-            "moot. Tracked by issue #429."
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        goblin = Creature("Goblin", max_hp=10, ac=15, abilities=abilities)
+        wizard = Creature("Wizard", max_hp=10, ac=15, abilities=abilities)
+        tracker = InitiativeTracker(DiceRoller(seed=1))
+        tracker.add_combatant(goblin)
+        tracker.add_combatant(wizard)
+        # Pin Goblin first in initiative deterministically.
+        for entry in tracker.combatants:
+            entry.initiative_roll = 20 if entry.creature is goblin else 10
+        tracker._sort_initiative()
+        tracker.current_turn_index = 0
+        # Sanity: the Goblin is the active turn, Wizard is the reactor.
+        assert tracker.get_current_combatant().creature is goblin
+
+        dispatcher = ReactionDispatcher(tracker)
+        dispatcher.register(
+            wizard,
+            Trigger.OPPORTUNITY_PROVOKED,
+            lambda ctx: ReactionOutcome(reacted=True, description="OA"),
         )
+
+        outcomes = dispatcher.publish(
+            TriggerContext(trigger=Trigger.OPPORTUNITY_PROVOKED, source=goblin)
+        )
+
+        assert len(outcomes) == 1
+        assert tracker.turn_states[wizard].reaction_available is False
+
+    def test_reaction_can_fire_during_the_reactors_own_turn(self) -> None:
+        """A reactor may consume its Reaction on its own turn.
+
+        The SRD explicitly allows this (e.g., an OA provoked during
+        your turn by another creature's forced movement). The
+        dispatcher gates only on ``reaction_available``, not on whose
+        turn it is. Closes #429.
+        """
+        from dnd_engine.core.creature import Abilities, Creature
+        from dnd_engine.core.dice import DiceRoller
+        from dnd_engine.systems.initiative import InitiativeTracker
+        from dnd_engine.systems.reactions import (
+            ReactionDispatcher,
+            ReactionOutcome,
+            Trigger,
+            TriggerContext,
+        )
+
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        fighter = Creature("Fighter", max_hp=10, ac=15, abilities=abilities)
+        tracker = InitiativeTracker(DiceRoller(seed=1))
+        tracker.add_combatant(fighter)
+        assert tracker.get_current_combatant().creature is fighter
+
+        dispatcher = ReactionDispatcher(tracker)
+        dispatcher.register(
+            fighter,
+            Trigger.OPPORTUNITY_PROVOKED,
+            lambda ctx: ReactionOutcome(reacted=True, description="OA"),
+        )
+
+        outcomes = dispatcher.publish(
+            TriggerContext(trigger=Trigger.OPPORTUNITY_PROVOKED)
+        )
+
+        assert len(outcomes) == 1
+        assert tracker.turn_states[fighter].reaction_available is False
 
 
 class TestReaction_OpportunityAttackIsMostCommon:
@@ -229,31 +286,52 @@ class TestReaction_TimingDefault:
     """
 
     def test_reaction_resolves_immediately_after_trigger_by_default(self) -> None:
-        pytest.skip(
-            "GAP: No trigger-bound Reaction dispatcher exists. The "
-            "engine has no concept of 'this Reaction is bound to "
-            "trigger X and fires immediately after X resolves'. "
-            "`flee_combat()` resolves its attack fan-out inline in "
-            "the same call (game_state.py:4238-4304), which is "
-            "incidentally 'immediately after' but is not gated on a "
-            "named trigger — every flee fires every enemy's "
-            "pseudo-OA regardless of any reaction state. A real "
-            "implementation needs (a) named triggers (movement-out-"
-            "of-reach, attacked, spell-cast-nearby, etc.) and (b) a "
-            "default resolve-immediately policy unless the Reaction "
-            "carves out 'before' / 'after' timing. Tracked by issue "
-            "#429 (depends on #412 reaction economy)."
+        """``ReactionDispatcher.publish`` resolves Reactions inline.
+
+        The default-timing rule is "Reactions resolve immediately
+        after their trigger." The dispatcher honors this by invoking
+        handlers synchronously inside ``publish`` — when control
+        returns to the caller, all eligible Reactions have already
+        run. Closes #429.
+        """
+        from dnd_engine.core.creature import Abilities, Creature
+        from dnd_engine.core.dice import DiceRoller
+        from dnd_engine.systems.initiative import InitiativeTracker
+        from dnd_engine.systems.reactions import (
+            ReactionDispatcher,
+            ReactionOutcome,
+            Trigger,
+            TriggerContext,
         )
+
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        reactor = Creature("Reactor", max_hp=10, ac=15, abilities=abilities)
+        tracker = InitiativeTracker(DiceRoller(seed=1))
+        tracker.add_combatant(reactor)
+        dispatcher = ReactionDispatcher(tracker)
+
+        call_order: list[str] = []
+
+        def handler(ctx: TriggerContext) -> ReactionOutcome:
+            call_order.append("handler")
+            return ReactionOutcome(reacted=True)
+
+        dispatcher.register(reactor, Trigger.WOULD_BE_HIT, handler)
+        call_order.append("before_publish")
+        dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+        call_order.append("after_publish")
+
+        assert call_order == ["before_publish", "handler", "after_publish"]
 
     def test_reaction_description_can_override_default_timing(self) -> None:
         pytest.skip(
-            "GAP: depends on the trigger/dispatch model in the test "
-            "above. The SRD's 'unless the Reaction's description says "
-            "otherwise' clause requires per-reaction timing metadata "
-            "(e.g., Shield resolves *before* the triggering hit is "
-            "applied so its AC bonus counts against that very "
-            "attack). spells.json carries `casting_time: '1 reaction'` "
-            "but no engine field encoding *which* trigger or *when* "
-            "relative to the trigger. Tracked under issue #429 as a "
-            "sub-clause of the dispatcher acceptance criteria."
+            "GAP: per-handler timing metadata (before / after trigger) "
+            "is not yet modeled. The dispatcher's default is "
+            "'immediately after trigger' (verified by the test above); "
+            "the SRD carve-out for handlers that resolve *before* the "
+            "trigger (e.g., Shield's AC bonus must apply to the very "
+            "attack that triggered it) requires either a `timing` "
+            "field on registration or a two-phase publish. Tracked "
+            "under issue #429 as a follow-up to the base dispatcher; "
+            "scheduled for the Shield implementation slice."
         )

--- a/dnd-engine/tests/test_reactions.py
+++ b/dnd-engine/tests/test_reactions.py
@@ -1,0 +1,311 @@
+# ABOUTME: Unit tests for the trigger->Reaction dispatcher
+# ABOUTME: Verifies per-creature consumption, initiative ordering, and trigger isolation
+
+from __future__ import annotations
+
+import pytest
+
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.systems.action_economy import ActionType
+from dnd_engine.systems.initiative import InitiativeTracker
+from dnd_engine.systems.reactions import (
+    ReactionDispatcher,
+    ReactionHandler,
+    ReactionOutcome,
+    Trigger,
+    TriggerContext,
+)
+
+
+def _make_creature(name: str, hp: int = 20, dex: int = 10) -> Creature:
+    abilities = Abilities(10, dex, 10, 10, 10, 10)
+    return Creature(name, max_hp=hp, ac=15, abilities=abilities)
+
+
+def _make_tracker(*creatures: Creature, initiatives: list[int] | None = None) -> InitiativeTracker:
+    """Build a tracker with deterministic initiative.
+
+    Adds each creature, then overwrites ``initiative_roll`` from the
+    ``initiatives`` list (high first matches list order) so tests can
+    assert ordering without flake.
+    """
+    tracker = InitiativeTracker(DiceRoller(seed=1))
+    for creature in creatures:
+        tracker.add_combatant(creature)
+    if initiatives is not None:
+        assert len(initiatives) == len(creatures)
+        for creature, roll in zip(creatures, initiatives, strict=True):
+            for entry in tracker.combatants:
+                if entry.creature is creature:
+                    entry.initiative_roll = roll
+        tracker._sort_initiative()
+        tracker.current_turn_index = 0
+    return tracker
+
+
+def _reacts_with(description: str, **data) -> ReactionHandler:
+    def handler(context: TriggerContext) -> ReactionOutcome:
+        return ReactionOutcome(reacted=True, description=description, data=data)
+
+    return handler
+
+
+def _declines(context: TriggerContext) -> ReactionOutcome:
+    return ReactionOutcome(reacted=False)
+
+
+class TestTriggerEnum:
+    def test_initial_triggers(self):
+        """The three triggers callers need first are all present."""
+        assert Trigger.OPPORTUNITY_PROVOKED.value == "opportunity_provoked"
+        assert Trigger.WOULD_BE_HIT.value == "would_be_hit"
+        assert Trigger.SPELL_CAST_OBSERVED.value == "spell_cast_observed"
+
+
+class TestSubscription:
+    def test_register_then_publish_invokes_handler(self):
+        reactor = _make_creature("Wizard")
+        attacker = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, attacker)
+        dispatcher = ReactionDispatcher(tracker)
+
+        dispatcher.register(reactor, Trigger.WOULD_BE_HIT, _reacts_with("Shield"))
+        outcomes = dispatcher.publish(
+            TriggerContext(trigger=Trigger.WOULD_BE_HIT, source=attacker)
+        )
+
+        assert len(outcomes) == 1
+        assert outcomes[0].description == "Shield"
+
+    def test_no_subscribers_returns_empty(self):
+        attacker = _make_creature("Goblin")
+        tracker = _make_tracker(attacker)
+        dispatcher = ReactionDispatcher(tracker)
+
+        outcomes = dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+
+        assert outcomes == []
+
+    def test_unregister_removes_creatures_subscriptions(self):
+        reactor = _make_creature("Wizard")
+        tracker = _make_tracker(reactor)
+        dispatcher = ReactionDispatcher(tracker)
+
+        dispatcher.register(reactor, Trigger.WOULD_BE_HIT, _reacts_with("Shield"))
+        dispatcher.unregister(reactor)
+        outcomes = dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+
+        assert outcomes == []
+
+    def test_last_subscription_wins_for_same_creature_and_trigger(self):
+        """Re-subscribing the same creature/trigger pair replaces the handler.
+
+        Matches how features upgrade: the new variant overrides the old.
+        """
+        reactor = _make_creature("Wizard")
+        tracker = _make_tracker(reactor)
+        dispatcher = ReactionDispatcher(tracker)
+
+        dispatcher.register(reactor, Trigger.WOULD_BE_HIT, _reacts_with("OldShield"))
+        dispatcher.register(reactor, Trigger.WOULD_BE_HIT, _reacts_with("NewShield"))
+        outcomes = dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+
+        assert len(outcomes) == 1
+        assert outcomes[0].description == "NewShield"
+
+
+class TestSlotConsumption:
+    def test_reacting_consumes_reaction_slot(self):
+        reactor = _make_creature("Wizard")
+        tracker = _make_tracker(reactor)
+        dispatcher = ReactionDispatcher(tracker)
+
+        dispatcher.register(reactor, Trigger.WOULD_BE_HIT, _reacts_with("Shield"))
+        dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+
+        assert tracker.turn_states[reactor].reaction_available is False
+
+    def test_second_publish_same_round_does_not_refire(self):
+        """SRD: 'you can't take another one until the start of your next turn'."""
+        reactor = _make_creature("Wizard")
+        tracker = _make_tracker(reactor)
+        dispatcher = ReactionDispatcher(tracker)
+
+        dispatcher.register(reactor, Trigger.WOULD_BE_HIT, _reacts_with("Shield"))
+        dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+        outcomes = dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+
+        assert outcomes == []
+
+    def test_declined_handler_does_not_consume_slot(self):
+        reactor = _make_creature("Wizard")
+        tracker = _make_tracker(reactor)
+        dispatcher = ReactionDispatcher(tracker)
+
+        dispatcher.register(reactor, Trigger.WOULD_BE_HIT, _declines)
+        outcomes = dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+
+        assert outcomes == []
+        assert tracker.turn_states[reactor].reaction_available is True
+
+    def test_slot_already_consumed_skips_handler(self):
+        """A handler must not be invoked when the slot is already spent.
+
+        Otherwise a declining handler called twice could cost CPU /
+        produce log noise without consuming anything. Eligibility is
+        gated *before* invocation.
+        """
+        reactor = _make_creature("Wizard")
+        tracker = _make_tracker(reactor)
+        dispatcher = ReactionDispatcher(tracker)
+        tracker.turn_states[reactor].consume_action(ActionType.REACTION)
+
+        invocations: list[TriggerContext] = []
+
+        def handler(context: TriggerContext) -> ReactionOutcome:
+            invocations.append(context)
+            return ReactionOutcome(reacted=False)
+
+        dispatcher.register(reactor, Trigger.WOULD_BE_HIT, handler)
+        dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+
+        assert invocations == []
+
+    def test_slot_resets_when_reactors_own_turn_comes_around(self):
+        """Integration with InitiativeTracker.next_turn: slot refills on own turn."""
+        reactor = _make_creature("Wizard")
+        other = _make_creature("Goblin")
+        # Reactor first in initiative so its first turn is already current.
+        tracker = _make_tracker(reactor, other, initiatives=[20, 10])
+        dispatcher = ReactionDispatcher(tracker)
+
+        dispatcher.register(reactor, Trigger.WOULD_BE_HIT, _reacts_with("Shield"))
+        dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+        assert tracker.turn_states[reactor].reaction_available is False
+
+        # Advance to other creature: reactor's slot must stay empty.
+        tracker.next_turn()
+        assert tracker.turn_states[reactor].reaction_available is False
+        outcomes_mid = dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+        assert outcomes_mid == []
+
+        # Advance back to reactor: TurnState.reset() refills the slot.
+        tracker.next_turn()
+        assert tracker.turn_states[reactor].reaction_available is True
+        outcomes_next = dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+        assert len(outcomes_next) == 1
+
+
+class TestEligibility:
+    def test_dead_reactor_is_skipped(self):
+        reactor = _make_creature("Wizard", hp=10)
+        tracker = _make_tracker(reactor)
+        dispatcher = ReactionDispatcher(tracker)
+        reactor.current_hp = 0
+
+        invocations: list[TriggerContext] = []
+
+        def handler(context: TriggerContext) -> ReactionOutcome:
+            invocations.append(context)
+            return ReactionOutcome(reacted=True)
+
+        dispatcher.register(reactor, Trigger.WOULD_BE_HIT, handler)
+        outcomes = dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+
+        assert invocations == []
+        assert outcomes == []
+
+    def test_creature_not_in_initiative_is_skipped(self):
+        """A creature without a TurnState slot can't react.
+
+        Reactions are an in-combat resource; non-combatants are not
+        eligible. The dispatcher tolerates stale subscriptions
+        (e.g., a creature was removed mid-encounter) by checking
+        turn_states membership.
+        """
+        outside_creature = _make_creature("Bystander")
+        tracker = _make_tracker()  # empty initiative
+        dispatcher = ReactionDispatcher(tracker)
+
+        dispatcher.register(outside_creature, Trigger.WOULD_BE_HIT, _reacts_with("Shield"))
+        outcomes = dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+
+        assert outcomes == []
+
+    def test_unrelated_trigger_does_not_fire_handler(self):
+        reactor = _make_creature("Wizard")
+        tracker = _make_tracker(reactor)
+        dispatcher = ReactionDispatcher(tracker)
+
+        dispatcher.register(reactor, Trigger.WOULD_BE_HIT, _reacts_with("Shield"))
+        outcomes = dispatcher.publish(
+            TriggerContext(trigger=Trigger.OPPORTUNITY_PROVOKED)
+        )
+
+        assert outcomes == []
+        assert tracker.turn_states[reactor].reaction_available is True
+
+
+class TestInitiativeOrder:
+    def test_outcomes_returned_in_initiative_order(self):
+        first = _make_creature("HighInit")
+        second = _make_creature("MidInit")
+        third = _make_creature("LowInit")
+        tracker = _make_tracker(first, second, third, initiatives=[20, 15, 5])
+        dispatcher = ReactionDispatcher(tracker)
+
+        dispatcher.register(third, Trigger.OPPORTUNITY_PROVOKED, _reacts_with("low"))
+        dispatcher.register(first, Trigger.OPPORTUNITY_PROVOKED, _reacts_with("high"))
+        dispatcher.register(second, Trigger.OPPORTUNITY_PROVOKED, _reacts_with("mid"))
+
+        outcomes = dispatcher.publish(
+            TriggerContext(trigger=Trigger.OPPORTUNITY_PROVOKED)
+        )
+
+        assert [o.description for o in outcomes] == ["high", "mid", "low"]
+
+    def test_all_eligible_reactors_consume_their_own_slots(self):
+        a = _make_creature("A")
+        b = _make_creature("B")
+        tracker = _make_tracker(a, b, initiatives=[20, 10])
+        dispatcher = ReactionDispatcher(tracker)
+
+        dispatcher.register(a, Trigger.OPPORTUNITY_PROVOKED, _reacts_with("a"))
+        dispatcher.register(b, Trigger.OPPORTUNITY_PROVOKED, _reacts_with("b"))
+
+        dispatcher.publish(TriggerContext(trigger=Trigger.OPPORTUNITY_PROVOKED))
+
+        assert tracker.turn_states[a].reaction_available is False
+        assert tracker.turn_states[b].reaction_available is False
+
+
+class TestTriggerContext:
+    def test_handler_observes_source_and_payload(self):
+        reactor = _make_creature("Wizard")
+        caster = _make_creature("EnemyCaster")
+        tracker = _make_tracker(reactor, caster)
+        dispatcher = ReactionDispatcher(tracker)
+
+        observed: list[TriggerContext] = []
+
+        def handler(context: TriggerContext) -> ReactionOutcome:
+            observed.append(context)
+            return ReactionOutcome(reacted=True)
+
+        dispatcher.register(reactor, Trigger.SPELL_CAST_OBSERVED, handler)
+        dispatcher.publish(
+            TriggerContext(
+                trigger=Trigger.SPELL_CAST_OBSERVED,
+                source=caster,
+                payload={"spell_id": "fireball", "level": 3},
+            )
+        )
+
+        assert len(observed) == 1
+        assert observed[0].source is caster
+        assert observed[0].payload == {"spell_id": "fireball", "level": 3}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Second slice of [plan-01: Action Economy & Reaction System](../tree/main/plans/01-action-economy-and-reaction-system.md). Adds the skeleton dispatcher that routes named triggers (OA, would-be-hit, spell-cast) to subscribed Reaction handlers, consuming the per-creature Reaction slot landed in [slice 1](https://github.com/JoeCotellese/rpggame/pull/586).

### New module: `dnd_engine/systems/reactions.py`

- **`Trigger`** enum — `OPPORTUNITY_PROVOKED`, `WOULD_BE_HIT`, `SPELL_CAST_OBSERVED`. Designed to grow as more Reaction-shaped features land.
- **`TriggerContext`** — trigger + source creature + free-form payload (publisher-owned schema).
- **`ReactionOutcome`** — `reacted` flag + description + data bag. `reacted=False` lets a handler decline without burning the slot.
- **`ReactionDispatcher`** — `register(creature, trigger, handler)` / `unregister(creature)` / `publish(context)`.
  - Eligibility gated on `is_alive`, `reaction_available`, and initiative-resident membership.
  - Resolution in **initiative order**, synchronous in-call (matches SRD default timing).
  - "Last subscription wins" for `(creature, trigger)` pairs (matches feature-upgrade semantics).

### SRD audit impact

Flips 3 previously-skipped rows in `tests/srd/playing_the_game/test_reactions.py` to real assertions:

- `test_reaction_can_fire_outside_the_reactors_turn`
- `test_reaction_can_fire_during_the_reactors_own_turn`
- `test_reaction_resolves_immediately_after_trigger_by_default`

2 skips remain in that file:
- `test_interrupted_turn_resumes_after_reaction_resolves` → slice 3 (#430)
- `test_reaction_description_can_override_default_timing` → Shield slice (per-handler `before`/`after` timing metadata)

Closes #429.

## Test plan

- [x] `uv run pytest tests/test_reactions.py` → 16 passed
- [x] `uv run pytest tests/srd/playing_the_game/test_reactions.py` → 7 passed, 2 skipped
- [x] Full engine suite: `uv run pytest --no-cov -q` → 2990 passed, 246 skipped, 0 failed
- [x] `uv run ruff check` clean
- [ ] Reviewer: confirm `_eligible_in_initiative_order`'s "last-wins" semantics match expectations; the alternative ("first-wins" / "all fire in registration order") is also defensible

## Plan-01 progress

| Slice | Status |
|---|---|
| 1. REACTION slot + ActionType | merged (#586) |
| 2. Trigger→Reaction dispatcher (#429) | **this PR** |
| 3. Mid-turn pause/resume (#430) | next |
| 4. Opportunity Attack as Reaction (#413) | blocked on 3 |
| 5. Dash/Dodge/Prone/StandUp (#435 #438 #439) | parallelizable now |
| 6. Disengage (#414) | blocked on 4 |
| 7. Help/Hide/Search/Study/Influence/Magic/Knockout | parallelizable now |
| 8. Bonus action gating (#434 #437 #440) | parallelizable now |
| 9. Free object slot + outside-combat enforcement | parallelizable now |

🤖 Generated with [Claude Code](https://claude.com/claude-code)