### PR TITLE
Add mid-turn pause/resume for interrupted Reactions (plan-01 slice 3, closes #430)

### DIFF
--- a/dnd-engine/dnd_engine/systems/initiative.py
+++ b/dnd-engine/dnd_engine/systems/initiative.py
@@ -73,6 +73,11 @@ class InitiativeTracker:
         self.turn_states: dict[
             Creature, TurnState
         ] = {}  # Maps creature instance to their turn state
+        # LIFO stack of suspended turn indices. Pushed by
+        # pause_for_reaction so that a Reaction firing mid-turn can
+        # treat the reactor as the current combatant for the duration
+        # of its handler, then resume the interrupted turn.
+        self._pause_stack: list[int] = []
 
     def add_combatant(self, creature: Creature) -> InitiativeEntry:
         """
@@ -200,6 +205,60 @@ class InitiativeTracker:
         current = self.get_current_combatant()
         if current and current.creature in self.turn_states:
             self.turn_states[current.creature].reset(speed=current.creature.speed)
+
+    def pause_for_reaction(self, reactor: Creature) -> None:
+        """
+        Suspend the current turn so a Reaction can resolve as ``reactor``.
+
+        Pushes ``current_turn_index`` onto the pause stack and points
+        the tracker at ``reactor``'s entry. Unlike ``next_turn``, this
+        does NOT call ``TurnState.reset()`` — the SRD guarantees the
+        reactor consumes only their Reaction slot, not a fresh turn,
+        and the interrupted creature must resume on the same
+        ``TurnState`` they had before the pause.
+
+        Args:
+            reactor: The creature whose Reaction is firing. Must be
+                in the initiative order.
+
+        Raises:
+            ValueError: ``reactor`` is not a registered combatant.
+        """
+        reactor_index = next(
+            (i for i, e in enumerate(self.combatants) if e.creature is reactor),
+            None,
+        )
+        if reactor_index is None:
+            raise ValueError(
+                f"Cannot pause for reaction: {reactor.name!r} is not in initiative."
+            )
+
+        self._pause_stack.append(self.current_turn_index)
+        self.current_turn_index = reactor_index
+
+    def resume_paused_turn(self) -> None:
+        """
+        Restore the turn that was suspended by ``pause_for_reaction``.
+
+        Pops the pause stack and restores ``current_turn_index``. Does
+        not touch the resumed creature's ``TurnState`` — they pick
+        back up wherever the Reaction interrupted them.
+
+        Raises:
+            RuntimeError: ``resume_paused_turn`` was called without a
+                matching ``pause_for_reaction``.
+        """
+        if not self._pause_stack:
+            raise RuntimeError(
+                "resume_paused_turn called without a matching "
+                "pause_for_reaction (pause stack is empty)."
+            )
+        self.current_turn_index = self._pause_stack.pop()
+
+    @property
+    def is_paused_for_reaction(self) -> bool:
+        """True while at least one turn is suspended for a Reaction."""
+        return bool(self._pause_stack)
 
     def get_all_combatants(self) -> list[InitiativeEntry]:
         """

--- a/dnd-engine/dnd_engine/systems/reactions.py
+++ b/dnd-engine/dnd_engine/systems/reactions.py
@@ -146,6 +146,15 @@ class ReactionDispatcher:
         Reaction slot; ``reacted=False`` leaves the slot intact for a
         later trigger in the same round.
 
+        When the reactor is not the currently-active combatant, the
+        tracker is paused (``InitiativeTracker.pause_for_reaction``)
+        for the duration of the handler call so that downstream code
+        reading ``get_current_combatant()`` sees the reactor, not the
+        interrupted creature. The pause is released before the next
+        handler runs, so reactor ordering remains pure initiative
+        order and the interrupted creature's ``TurnState`` is never
+        touched.
+
         Returns the outcomes from handlers that actually reacted, in
         resolution order. An empty list means no one reacted (either
         no subscribers or every subscriber declined / was ineligible).
@@ -157,7 +166,17 @@ class ReactionDispatcher:
                 continue
             if not creature.is_alive:
                 continue
-            outcome = handler(context)
+
+            current = self._tracker.get_current_combatant()
+            interrupts_another_turn = current is not None and current.creature is not creature
+            if interrupts_another_turn:
+                self._tracker.pause_for_reaction(creature)
+            try:
+                outcome = handler(context)
+            finally:
+                if interrupts_another_turn:
+                    self._tracker.resume_paused_turn()
+
             if outcome.reacted:
                 turn_state.consume_action(ActionType.REACTION)
                 outcomes.append(outcome)

--- a/dnd-engine/tests/srd/playing_the_game/test_reactions.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_reactions.py
@@ -262,20 +262,62 @@ class TestReaction_InterruptedTurnContinuation:
     """
 
     def test_interrupted_turn_resumes_after_reaction_resolves(self) -> None:
-        pytest.skip(
-            "GAP: There is no interruption model in the turn loop. "
-            "`InitiativeTracker.next_turn` "
-            "(dnd_engine/systems/initiative.py:173) advances the "
-            "turn index monotonically; nothing pauses the active "
-            "turn to resolve a Reaction triggered mid-action and "
-            "then resume the original turn. Because no Reactions "
-            "fire mid-turn today (see TestReaction_TriggerResponse), "
-            "this rule has nothing to enforce, but the SRD's "
-            "continuation guarantee will need a mid-turn pause/"
-            "resume mechanism once Reactions are wired up. Tracked "
-            "by issue #430 (depends on #412 reaction economy and "
-            "#429 trigger->reaction dispatcher)."
+        """The interrupted creature resumes on the same TurnState.
+
+        Goblin is mid-turn: their Action has been spent, their
+        Movement is half-consumed. A WOULD_BE_HIT trigger fires the
+        Wizard's Shield reaction. After the dispatcher returns:
+
+        - the Wizard's Reaction slot is consumed,
+        - the Goblin remains the current combatant,
+        - the Goblin's TurnState (action + movement) is unchanged,
+        - the pause stack is empty.
+
+        Closes #430.
+        """
+        from dnd_engine.core.creature import Abilities, Creature
+        from dnd_engine.core.dice import DiceRoller
+        from dnd_engine.systems.action_economy import ActionType
+        from dnd_engine.systems.initiative import InitiativeTracker
+        from dnd_engine.systems.reactions import (
+            ReactionDispatcher,
+            ReactionOutcome,
+            Trigger,
+            TriggerContext,
         )
+
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        goblin = Creature("Goblin", max_hp=10, ac=15, abilities=abilities)
+        wizard = Creature("Wizard", max_hp=10, ac=15, abilities=abilities)
+        tracker = InitiativeTracker(DiceRoller(seed=1))
+        tracker.add_combatant(goblin)
+        tracker.add_combatant(wizard)
+        for entry in tracker.combatants:
+            entry.initiative_roll = 20 if entry.creature is goblin else 10
+        tracker._sort_initiative()
+        tracker.current_turn_index = 0
+        # Goblin is mid-turn: action spent, half movement spent.
+        tracker.turn_states[goblin].consume_action(ActionType.ACTION)
+        tracker.turn_states[goblin].consume_movement(15)
+
+        dispatcher = ReactionDispatcher(tracker)
+        observed_current: list[str] = []
+
+        def shield(ctx: TriggerContext) -> ReactionOutcome:
+            observed_current.append(tracker.get_current_combatant().creature.name)
+            return ReactionOutcome(reacted=True, description="Shield")
+
+        dispatcher.register(wizard, Trigger.WOULD_BE_HIT, shield)
+        dispatcher.publish(
+            TriggerContext(trigger=Trigger.WOULD_BE_HIT, source=goblin)
+        )
+
+        assert observed_current == ["Wizard"]
+        assert tracker.get_current_combatant().creature is goblin
+        assert tracker.is_paused_for_reaction is False
+        assert tracker.turn_states[goblin].action_available is False
+        assert tracker.turn_states[goblin].movement_remaining == 15
+        assert tracker.turn_states[wizard].reaction_available is False
 
 
 class TestReaction_TimingDefault:

--- a/dnd-engine/tests/test_initiative.py
+++ b/dnd-engine/tests/test_initiative.py
@@ -1,6 +1,8 @@
 # ABOUTME: Unit tests for the initiative system
 # ABOUTME: Tests turn order tracking, round management, and combatant removal
 
+import pytest
+
 from dnd_engine.core.creature import Abilities, Creature
 from dnd_engine.core.dice import DiceRoller
 from dnd_engine.systems.initiative import InitiativeEntry, InitiativeTracker
@@ -327,6 +329,103 @@ class TestInitiativeTracker:
         assert goblin1 not in self.tracker.turn_states
         assert goblin2 in self.tracker.turn_states
         assert self.tracker.combatants[0].creature == goblin2
+
+
+class TestReactionPauseResume:
+    """Test pause_for_reaction / resume_paused_turn used by Reactions."""
+
+    def setup_method(self):
+        self.tracker = InitiativeTracker(DiceRoller(seed=42))
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        self.goblin = Creature("Goblin", 7, 15, abilities)
+        self.wizard = Creature("Wizard", 12, 12, abilities)
+        self.tracker.add_combatant(self.goblin)
+        self.tracker.add_combatant(self.wizard)
+        # Pin Goblin first deterministically.
+        for entry in self.tracker.combatants:
+            entry.initiative_roll = 20 if entry.creature is self.goblin else 10
+        self.tracker._sort_initiative()
+        self.tracker.current_turn_index = 0
+
+    def test_pause_swaps_current_combatant_to_reactor(self):
+        assert self.tracker.get_current_combatant().creature is self.goblin
+        self.tracker.pause_for_reaction(self.wizard)
+        assert self.tracker.get_current_combatant().creature is self.wizard
+
+    def test_pause_does_not_reset_reactor_turn_state(self):
+        """Pausing for a Reaction must not refresh the reactor's TurnState.
+
+        The reactor consumes only their Reaction slot, not a fresh
+        turn — any partially-spent movement / bonus action must
+        survive the pause.
+        """
+        self.tracker.turn_states[self.wizard].action_available = False
+        self.tracker.turn_states[self.wizard].movement_remaining = 5
+
+        self.tracker.pause_for_reaction(self.wizard)
+
+        assert self.tracker.turn_states[self.wizard].action_available is False
+        assert self.tracker.turn_states[self.wizard].movement_remaining == 5
+
+    def test_pause_does_not_reset_interrupted_turn_state(self):
+        """The interrupted creature's TurnState is untouched by pause/resume."""
+        self.tracker.turn_states[self.goblin].action_available = False
+        self.tracker.turn_states[self.goblin].movement_remaining = 10
+
+        self.tracker.pause_for_reaction(self.wizard)
+        self.tracker.resume_paused_turn()
+
+        assert self.tracker.turn_states[self.goblin].action_available is False
+        assert self.tracker.turn_states[self.goblin].movement_remaining == 10
+
+    def test_resume_restores_prior_current_combatant(self):
+        self.tracker.pause_for_reaction(self.wizard)
+        self.tracker.resume_paused_turn()
+        assert self.tracker.get_current_combatant().creature is self.goblin
+
+    def test_is_paused_flag_tracks_stack_state(self):
+        assert self.tracker.is_paused_for_reaction is False
+        self.tracker.pause_for_reaction(self.wizard)
+        assert self.tracker.is_paused_for_reaction is True
+        self.tracker.resume_paused_turn()
+        assert self.tracker.is_paused_for_reaction is False
+
+    def test_nested_pauses_unwind_lifo(self):
+        """A pause stack lets reactions trigger further reactions cleanly.
+
+        Slice 2's dispatcher doesn't nest, but the stack design must
+        not preclude it — if a Reaction handler itself publishes a
+        trigger that fires another Reaction, the inner pause must
+        unwind before the outer one.
+        """
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        cleric = Creature("Cleric", 10, 14, abilities)
+        self.tracker.add_combatant(cleric)
+        # Re-pin so order is Goblin, Wizard, Cleric.
+        order = {self.goblin: 20, self.wizard: 15, cleric: 10}
+        for entry in self.tracker.combatants:
+            entry.initiative_roll = order[entry.creature]
+        self.tracker._sort_initiative()
+        self.tracker.current_turn_index = 0
+
+        self.tracker.pause_for_reaction(self.wizard)
+        self.tracker.pause_for_reaction(cleric)
+        assert self.tracker.get_current_combatant().creature is cleric
+        self.tracker.resume_paused_turn()
+        assert self.tracker.get_current_combatant().creature is self.wizard
+        self.tracker.resume_paused_turn()
+        assert self.tracker.get_current_combatant().creature is self.goblin
+        assert self.tracker.is_paused_for_reaction is False
+
+    def test_resume_without_pause_raises(self):
+        with pytest.raises(RuntimeError, match="pause stack is empty"):
+            self.tracker.resume_paused_turn()
+
+    def test_pause_for_non_combatant_raises(self):
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        bystander = Creature("Bystander", 10, 10, abilities)
+        with pytest.raises(ValueError, match="not in initiative"):
+            self.tracker.pause_for_reaction(bystander)
 
 
 class TestInitiativeEntry:

--- a/dnd-engine/tests/test_reactions.py
+++ b/dnd-engine/tests/test_reactions.py
@@ -307,5 +307,110 @@ class TestTriggerContext:
         assert observed[0].payload == {"spell_id": "fireball", "level": 3}
 
 
+class TestMidTurnPauseAndResume:
+    """Reactions firing on someone else's turn pause the active turn.
+
+    SRD § Reactions › Interrupted-turn continuation:
+    > If the reaction interrupts another creature's turn, that
+    > creature can continue its turn right after the Reaction.
+    """
+
+    def test_handler_observes_reactor_as_current_combatant(self):
+        goblin = _make_creature("Goblin")
+        wizard = _make_creature("Wizard")
+        # Goblin first in initiative — its turn is current.
+        tracker = _make_tracker(goblin, wizard, initiatives=[20, 10])
+        dispatcher = ReactionDispatcher(tracker)
+        assert tracker.get_current_combatant().creature is goblin
+
+        observed: list[Creature] = []
+
+        def handler(ctx: TriggerContext) -> ReactionOutcome:
+            observed.append(tracker.get_current_combatant().creature)
+            return ReactionOutcome(reacted=True)
+
+        dispatcher.register(wizard, Trigger.WOULD_BE_HIT, handler)
+        dispatcher.publish(
+            TriggerContext(trigger=Trigger.WOULD_BE_HIT, source=goblin)
+        )
+
+        assert observed == [wizard]
+
+    def test_current_combatant_restored_after_publish(self):
+        goblin = _make_creature("Goblin")
+        wizard = _make_creature("Wizard")
+        tracker = _make_tracker(goblin, wizard, initiatives=[20, 10])
+        dispatcher = ReactionDispatcher(tracker)
+
+        dispatcher.register(wizard, Trigger.WOULD_BE_HIT, _reacts_with("Shield"))
+        dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+
+        assert tracker.get_current_combatant().creature is goblin
+        assert tracker.is_paused_for_reaction is False
+
+    def test_interrupted_creature_turn_state_unchanged(self):
+        """The interrupted creature must resume on the same TurnState."""
+        goblin = _make_creature("Goblin")
+        wizard = _make_creature("Wizard")
+        tracker = _make_tracker(goblin, wizard, initiatives=[20, 10])
+        dispatcher = ReactionDispatcher(tracker)
+        # Goblin mid-turn: action spent, half movement spent.
+        tracker.turn_states[goblin].consume_action(ActionType.ACTION)
+        tracker.turn_states[goblin].consume_movement(15)
+
+        dispatcher.register(wizard, Trigger.WOULD_BE_HIT, _reacts_with("Shield"))
+        dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+
+        assert tracker.turn_states[goblin].action_available is False
+        assert tracker.turn_states[goblin].movement_remaining == 15
+
+    def test_no_pause_when_reactor_is_current_combatant(self):
+        """A reactor on their own turn doesn't trigger a pause swap.
+
+        Slice spec: pause only when reactor != current actor. Without
+        this guard the dispatcher would self-pause and the stack would
+        grow even for own-turn reactions.
+        """
+        fighter = _make_creature("Fighter")
+        tracker = _make_tracker(fighter)
+        dispatcher = ReactionDispatcher(tracker)
+        assert tracker.get_current_combatant().creature is fighter
+
+        observed_paused: list[bool] = []
+
+        def handler(ctx: TriggerContext) -> ReactionOutcome:
+            observed_paused.append(tracker.is_paused_for_reaction)
+            return ReactionOutcome(reacted=True)
+
+        dispatcher.register(fighter, Trigger.OPPORTUNITY_PROVOKED, handler)
+        dispatcher.publish(TriggerContext(trigger=Trigger.OPPORTUNITY_PROVOKED))
+
+        assert observed_paused == [False]
+        assert tracker.is_paused_for_reaction is False
+
+    def test_pause_released_even_when_handler_raises(self):
+        """Pause stack must unwind even when a handler errors out.
+
+        Without try/finally, a buggy reactor would strand the tracker
+        in a paused state, corrupting all subsequent
+        get_current_combatant calls.
+        """
+        goblin = _make_creature("Goblin")
+        wizard = _make_creature("Wizard")
+        tracker = _make_tracker(goblin, wizard, initiatives=[20, 10])
+        dispatcher = ReactionDispatcher(tracker)
+
+        def boom(ctx: TriggerContext) -> ReactionOutcome:
+            raise RuntimeError("handler exploded")
+
+        dispatcher.register(wizard, Trigger.WOULD_BE_HIT, boom)
+
+        with pytest.raises(RuntimeError, match="handler exploded"):
+            dispatcher.publish(TriggerContext(trigger=Trigger.WOULD_BE_HIT))
+
+        assert tracker.is_paused_for_reaction is False
+        assert tracker.get_current_combatant().creature is goblin
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Third slice of [plan-01: Action Economy & Reaction System](../tree/main/plans/01-action-economy-and-reaction-system.md). Lets a Reaction firing during another creature's turn temporarily own the "current combatant" pointer, then resume the interrupted turn on its original `TurnState`. Builds on [slice 1](https://github.com/JoeCotellese/rpggame/pull/586) (Reaction slot) and [slice 2](https://github.com/JoeCotellese/rpggame/pull/587) (dispatcher).

### `InitiativeTracker` changes

- `_pause_stack: list[int]` — LIFO stack of suspended turn indices.
- `pause_for_reaction(reactor)` — push current index, point tracker at reactor. Raises `ValueError` if reactor isn't in initiative.
- `resume_paused_turn()` — pop, restore. Raises `RuntimeError` if stack is empty.
- `is_paused_for_reaction` property for observability.
- **Crucially, neither method calls `TurnState.reset()`** — the interrupted creature picks back up on the same partially-spent state (action consumed, half movement gone).

### `ReactionDispatcher` changes

- `publish` wraps each handler invocation in pause/resume when reactor ≠ current combatant.
- Uses `try/finally` so a buggy handler can't strand the tracker paused.
- Reactors on their own turn skip the swap (no-op pause guard).

### SRD audit impact

Flips the last remaining `TestReaction_InterruptedTurnContinuation` skip in `tests/srd/playing_the_game/test_reactions.py` to a real assertion. The Goblin-mid-turn → Wizard-Shield → Goblin-resumes scenario now runs end-to-end.

The one remaining skip in that file is `test_reaction_description_can_override_default_timing` — that needs per-handler `before`/`after` timing metadata and is scheduled for the Shield implementation slice.

Closes #430.

## Test plan

- [x] `uv run pytest tests/test_initiative.py` → 30 passed
- [x] `uv run pytest tests/test_reactions.py` → 21 passed
- [x] `uv run pytest tests/srd/playing_the_game/test_reactions.py` → 8 passed, 1 skipped
- [x] Full engine suite: `uv run pytest --no-cov -q` → 3004 passed, 245 skipped, 0 failed
- [x] `uv run ruff check` clean
- [ ] Reviewer: confirm `pause_for_reaction` raising on non-combatant matches your preference (vs. silent no-op); I picked raise because the dispatcher already gates by `turn_states` membership, so reaching the raise path means a real bug

## Plan-01 progress

| Slice | Status |
|---|---|
| 1. REACTION slot + ActionType (#412) | merged (#586) |
| 2. Trigger→Reaction dispatcher (#429) | merged (#587) |
| 3. Mid-turn pause/resume (#430) | **this PR** |
| 4. Opportunity Attack as Reaction (#413) | next — can now flee_combat refactor land cleanly |
| 5. Dash/Dodge/Prone/StandUp (#435 #438 #439) | parallelizable now |
| 6. Disengage (#414) | blocked on 4 |
| 7. Help/Hide/Search/Study/Influence/Magic/Knockout | parallelizable now |
| 8. Bonus action gating (#434 #437 #440) | parallelizable now |
| 9. Free object slot + outside-combat enforcement | parallelizable now |

The reaction *foundation* is complete after this slice — everything downstream is feature work on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)