### PR TITLE
Add Opportunity Attack scaffolding on ReactionDispatcher (plan-01 slice 4, partial #413)

### DIFF
--- a/dnd-engine/dnd_engine/systems/opportunity_attacks.py
+++ b/dnd-engine/dnd_engine/systems/opportunity_attacks.py
@@ -1,0 +1,138 @@
+# ABOUTME: Opportunity Attack scaffolding on top of ReactionDispatcher
+# ABOUTME: Default OA handler reacts when a mover leaves the reactor's reach
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from dnd_engine.core.distance import distance_in_feet
+from dnd_engine.systems.reactions import (
+    ReactionOutcome,
+    Trigger,
+    TriggerContext,
+)
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+    from dnd_engine.core.position import Position
+    from dnd_engine.systems.reactions import ReactionDispatcher
+
+
+# Canonical payload keys for OPPORTUNITY_PROVOKED triggers. Published
+# by movement code and consumed by registered OA handlers. Centralized
+# here so callers don't drift on the schema.
+PAYLOAD_FROM_POSITION = "from_position"
+PAYLOAD_TO_POSITION = "to_position"
+
+
+def publish_movement_provoke(
+    dispatcher: ReactionDispatcher,
+    mover: Creature,
+    from_position: Position,
+    to_position: Position,
+) -> list[ReactionOutcome]:
+    """Publish an ``OPPORTUNITY_PROVOKED`` trigger for a single tactical move.
+
+    Convenience wrapper around ``dispatcher.publish`` that pins the
+    payload schema used by ``register_default_opportunity_attack``.
+    Movement code calls this after a successful step; handlers decide
+    individually whether the mover left *their* reach.
+
+    Args:
+        dispatcher: The shared ReactionDispatcher for this combat.
+        mover: The creature that just moved (becomes ``ctx.source``).
+        from_position: Where the mover was before the step.
+        to_position: Where the mover is now.
+
+    Returns:
+        The list of ReactionOutcomes from handlers that actually
+        reacted, in initiative order. Empty when no eligible reactor
+        threatened the mover at ``from_position``.
+    """
+    return dispatcher.publish(
+        TriggerContext(
+            trigger=Trigger.OPPORTUNITY_PROVOKED,
+            source=mover,
+            payload={
+                PAYLOAD_FROM_POSITION: from_position,
+                PAYLOAD_TO_POSITION: to_position,
+            },
+        )
+    )
+
+
+def register_default_opportunity_attack(
+    dispatcher: ReactionDispatcher,
+    reactor: Creature,
+    get_position: Callable[[], Position | None],
+    reach_feet: int = 5,
+) -> None:
+    """Register the default OA reaction for ``reactor``.
+
+    The handler fires (consuming the Reaction slot) iff:
+        - the mover was within ``reach_feet`` of the reactor at
+          ``from_position``, AND
+        - the mover is outside ``reach_feet`` at ``to_position``,
+        - AND the reactor is itself placed on the grid,
+        - AND the mover is not the reactor (a creature can't OA itself).
+
+    When all checks pass, the outcome carries attack metadata in
+    ``data`` so a downstream slice can resolve the actual attack roll
+    without redoing the geometry:
+
+        ``{"attacker": reactor, "target": mover, "attack_kind":
+        "melee_opportunity", "reach_feet": reach_feet}``
+
+    ``get_position`` is injected (rather than taking a SpatialIndex
+    directly) so the helper doesn't pull in GameState plumbing — tests
+    can pass a plain lambda and production code can curry in
+    ``SpatialIndex.position_of`` lookups.
+
+    Args:
+        dispatcher: The shared ReactionDispatcher for this combat.
+        reactor: The creature whose Reaction may fire.
+        get_position: Zero-arg callable that returns ``reactor``'s
+            current Position (or ``None`` if unplaced). Called once
+            per trigger so the reach check uses fresh coordinates
+            even when the reactor moved.
+        reach_feet: The reactor's melee reach. Defaults to 5 ft (a
+            single square), matching the SRD default for an unarmed
+            strike / non-reach weapon. Pass 10 (or larger) for reach
+            weapons / large creatures.
+    """
+
+    def handler(context: TriggerContext) -> ReactionOutcome:
+        mover = context.source
+        if mover is None or mover is reactor:
+            return ReactionOutcome(reacted=False)
+
+        from_pos = context.payload.get(PAYLOAD_FROM_POSITION)
+        to_pos = context.payload.get(PAYLOAD_TO_POSITION)
+        reactor_pos = get_position()
+        if from_pos is None or to_pos is None or reactor_pos is None:
+            return ReactionOutcome(reacted=False)
+
+        was_in_reach = (
+            distance_in_feet(reactor_pos.x, reactor_pos.y, from_pos.x, from_pos.y)
+            <= reach_feet
+        )
+        still_in_reach = (
+            distance_in_feet(reactor_pos.x, reactor_pos.y, to_pos.x, to_pos.y)
+            <= reach_feet
+        )
+        if not (was_in_reach and not still_in_reach):
+            return ReactionOutcome(reacted=False)
+
+        return ReactionOutcome(
+            reacted=True,
+            description=f"{reactor.name} takes an opportunity attack on {mover.name}",
+            data={
+                "attacker": reactor,
+                "target": mover,
+                "attack_kind": "melee_opportunity",
+                "reach_feet": reach_feet,
+            },
+        )
+
+    dispatcher.register(reactor, Trigger.OPPORTUNITY_PROVOKED, handler)

--- a/dnd-engine/tests/test_opportunity_attacks.py
+++ b/dnd-engine/tests/test_opportunity_attacks.py
@@ -1,0 +1,309 @@
+# ABOUTME: Unit tests for Opportunity Attack scaffolding on the ReactionDispatcher
+# ABOUTME: Verifies reach-check geometry, slot consumption, and per-reactor eligibility
+
+from __future__ import annotations
+
+import pytest
+
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.position import Position
+from dnd_engine.systems.action_economy import ActionType
+from dnd_engine.systems.initiative import InitiativeTracker
+from dnd_engine.systems.opportunity_attacks import (
+    publish_movement_provoke,
+    register_default_opportunity_attack,
+)
+from dnd_engine.systems.reactions import ReactionDispatcher
+
+
+def _make_creature(name: str) -> Creature:
+    abilities = Abilities(10, 10, 10, 10, 10, 10)
+    return Creature(name, max_hp=20, ac=15, abilities=abilities)
+
+
+def _make_tracker(*creatures: Creature) -> InitiativeTracker:
+    tracker = InitiativeTracker(DiceRoller(seed=1))
+    for creature in creatures:
+        tracker.add_combatant(creature)
+    return tracker
+
+
+class TestRegisterDefaultOpportunityAttack:
+    def test_mover_leaving_reach_provokes_reaction(self):
+        reactor = _make_creature("Fighter")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: Position(5, 5)
+        )
+
+        # Goblin starts adjacent to Fighter, then steps to a non-adjacent tile.
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(6, 5),
+            to_position=Position(8, 5),
+        )
+
+        assert len(outcomes) == 1
+        outcome = outcomes[0]
+        assert outcome.reacted is True
+        assert outcome.data["attacker"] is reactor
+        assert outcome.data["target"] is mover
+        assert outcome.data["attack_kind"] == "melee_opportunity"
+        assert outcome.data["reach_feet"] == 5
+
+    def test_lateral_move_keeping_adjacency_does_not_provoke(self):
+        reactor = _make_creature("Fighter")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: Position(5, 5)
+        )
+
+        # Goblin slides around the Fighter but stays within 5 ft.
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(6, 5),
+            to_position=Position(6, 6),
+        )
+
+        assert outcomes == []
+        assert tracker.turn_states[reactor].reaction_available is True
+
+    def test_move_starting_out_of_reach_does_not_provoke(self):
+        """Entering reach (or moving while already out of reach) is not an OA.
+
+        SRD: "an OA fires when a creature you can see *leaves* your
+        reach." Approaching is not a provoke; the trigger has to be a
+        reach-to-no-reach transition.
+        """
+        reactor = _make_creature("Fighter")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: Position(5, 5)
+        )
+
+        # Goblin was already non-adjacent and stays non-adjacent.
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(10, 10),
+            to_position=Position(11, 10),
+        )
+
+        assert outcomes == []
+
+    def test_move_entering_reach_does_not_provoke(self):
+        reactor = _make_creature("Fighter")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: Position(5, 5)
+        )
+
+        # Goblin steps from non-adjacent into adjacency.
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(7, 5),
+            to_position=Position(6, 5),
+        )
+
+        assert outcomes == []
+        assert tracker.turn_states[reactor].reaction_available is True
+
+    def test_reactor_does_not_oa_itself(self):
+        """A creature moving itself cannot trigger its own OA."""
+        reactor = _make_creature("Fighter")
+        tracker = _make_tracker(reactor)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: Position(5, 5)
+        )
+
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=reactor,
+            from_position=Position(6, 5),
+            to_position=Position(8, 5),
+        )
+
+        assert outcomes == []
+        assert tracker.turn_states[reactor].reaction_available is True
+
+    def test_unplaced_reactor_does_not_react(self):
+        """When get_position returns None, the reactor has no reach to defend."""
+        reactor = _make_creature("Fighter")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: None
+        )
+
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(6, 5),
+            to_position=Position(8, 5),
+        )
+
+        assert outcomes == []
+        assert tracker.turn_states[reactor].reaction_available is True
+
+    def test_reach_weapon_provokes_at_extended_range(self):
+        """A 10 ft reach weapon threatens 2 squares, not 1."""
+        reactor = _make_creature("Fighter")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher,
+            reactor,
+            get_position=lambda: Position(5, 5),
+            reach_feet=10,
+        )
+
+        # Goblin was 10 ft away (2 squares); steps to 15 ft (3 squares).
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(7, 5),
+            to_position=Position(8, 5),
+        )
+
+        assert len(outcomes) == 1
+        assert outcomes[0].data["reach_feet"] == 10
+
+
+class TestSlotConsumption:
+    def test_provoking_oa_consumes_reactors_reaction_slot(self):
+        reactor = _make_creature("Fighter")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: Position(5, 5)
+        )
+
+        publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(6, 5),
+            to_position=Position(8, 5),
+        )
+
+        assert tracker.turn_states[reactor].reaction_available is False
+
+    def test_second_provoke_same_round_does_not_fire_oa(self):
+        """SRD once-per-round: a reactor can't OA twice between their turns."""
+        reactor = _make_creature("Fighter")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: Position(5, 5)
+        )
+
+        publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(6, 5),
+            to_position=Position(8, 5),
+        )
+        # Mover wanders back and leaves again in the same round.
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(6, 5),
+            to_position=Position(9, 5),
+        )
+
+        assert outcomes == []
+
+    def test_oa_slot_already_consumed_blocks_handler(self):
+        reactor = _make_creature("Fighter")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: Position(5, 5)
+        )
+        tracker.turn_states[reactor].consume_action(ActionType.REACTION)
+
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(6, 5),
+            to_position=Position(8, 5),
+        )
+
+        assert outcomes == []
+
+
+class TestMultipleReactors:
+    def test_only_threatening_reactors_react(self):
+        """Two enemies, only one in reach — only that one reacts."""
+        threat = _make_creature("Threat")
+        bystander = _make_creature("Bystander")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(threat, bystander, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, threat, get_position=lambda: Position(5, 5)
+        )
+        register_default_opportunity_attack(
+            dispatcher, bystander, get_position=lambda: Position(20, 20)
+        )
+
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(6, 5),
+            to_position=Position(8, 5),
+        )
+
+        assert len(outcomes) == 1
+        assert outcomes[0].data["attacker"] is threat
+        assert tracker.turn_states[threat].reaction_available is False
+        assert tracker.turn_states[bystander].reaction_available is True
+
+    def test_two_threatening_reactors_both_oa(self):
+        """A mover surrounded by two attackers provokes from both."""
+        north = _make_creature("North")
+        south = _make_creature("South")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(north, south, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, north, get_position=lambda: Position(5, 4)
+        )
+        register_default_opportunity_attack(
+            dispatcher, south, get_position=lambda: Position(5, 6)
+        )
+
+        # Mover starts at (5,5) — adjacent to both — and bolts east to (8,5).
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(5, 5),
+            to_position=Position(8, 5),
+        )
+
+        assert len(outcomes) == 2
+        attackers = {o.data["attacker"] for o in outcomes}
+        assert attackers == {north, south}
+        assert tracker.turn_states[north].reaction_available is False
+        assert tracker.turn_states[south].reaction_available is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

First half of [#413](https://github.com/JoeCotellese/rpggame/issues/413). Reusable OA helper layer on top of the [slice-2 dispatcher](https://github.com/JoeCotellese/rpggame/pull/587), so a future slice can wire `GameState.attempt_combat_step` to publish `OPPORTUNITY_PROVOKED` without re-litigating design.

### New module: `dnd_engine/systems/opportunity_attacks.py`

- **`PAYLOAD_FROM_POSITION` / `PAYLOAD_TO_POSITION`** — canonical payload keys, so publishers and handlers don't drift on schema.
- **`publish_movement_provoke(dispatcher, mover, from, to)`** — convenience wrapper that pins the payload schema.
- **`register_default_opportunity_attack(dispatcher, reactor, get_position, reach_feet=5)`** — registers a handler that reacts iff the mover transitions reach → no-reach.
  - Skips self-OA, unplaced reactors, no-reach-throughout moves, reach-entry moves.
  - Outcome `data` carries `{attacker, target, attack_kind: "melee_opportunity", reach_feet}` so a downstream slice can resolve the actual attack roll without redoing the geometry.
  - `get_position` is injected (not a SpatialIndex dep) so tests can pass plain lambdas and production code can curry in `spatial.position_of` lookups.

### Tests: `tests/test_opportunity_attacks.py` — 12 cases

| Category | Cases |
|---|---|
| Reach geometry | leave-reach provokes, lateral-adjacent doesn't, never-in-reach doesn't, enter-reach doesn't |
| Eligibility | self-OA blocked, unplaced reactor blocked, 10 ft reach weapon threatens 2 squares |
| Slot consumption | provokes consume slot, second provoke same round no-op, pre-consumed slot blocks handler |
| Multi-reactor | only threatening enemies react, surrounded mover provokes from both |

### Out of scope (deferred)

- **GameState integration** — `attempt_combat_step` does not yet publish `OPPORTUNITY_PROVOKED`. Wiring is a follow-up that needs to decide:
  - where OA handlers auto-register on combatant add,
  - how to pull the spatial-index position lookup into the `get_position` lambda.
- **Attack damage resolution** — handlers signal "would attack" via `outcome.data`; no `combat_engine.resolve_attack` call yet.
- **`flee_combat` refactor** — stays as-is; current behavior preserved.
- **Disengage suppression** (#414, slice 6).
- **Visibility check** (plan-05): no "creature you can see" gate yet.

Partial #413 — the closing follow-up will land the GameState publish hook and flip the skipped `test_tactical_movement_out_of_reach_provokes_opportunity_attack` SRD test.

## Test plan

- [x] `uv run pytest tests/test_opportunity_attacks.py` → 12 passed
- [x] Full engine suite: `uv run pytest --no-cov -q` → 3016 passed, 245 skipped, 0 failed
- [x] `uv run ruff check` clean
- [ ] Reviewer: confirm the `get_position` injection design vs. accepting a `SpatialIndex` directly; injection wins on testability but adds a small caller burden when wiring real combats

## Plan-01 progress

| Slice | Status |
|---|---|
| 1. REACTION slot + ActionType (#412) | merged (#586) |
| 2. Trigger→Reaction dispatcher (#429) | merged (#587) |
| 3. Mid-turn pause/resume (#430) | merged (#588) |
| 4. OA scaffolding (partial #413) | **this PR** |
| 4b. OA GameState wiring (closes #413) | follow-up |
| 5. Dash/Dodge/Prone/StandUp (#435 #438 #439) | parallelizable now |
| 6. Disengage (#414) | blocked on 4b |
| 7. Help/Hide/Search/Study/Influence/Magic/Knockout | parallelizable now |
| 8. Bonus action gating (#434 #437 #440) | parallelizable now |
| 9. Free object slot + outside-combat enforcement | parallelizable now |

🤖 Generated with [Claude Code](https://claude.com/claude-code)