### PR TITLE
Wire Opportunity Attacks into tactical movement (closes #413) — plan-01 slice 4b

### DIFF
--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -25,6 +25,11 @@ from dnd_engine.systems.ai import EnemyAI
 from dnd_engine.systems.condition_manager import ConditionManager
 from dnd_engine.systems.initiative import InitiativeTracker
 from dnd_engine.systems.inventory import EquipmentSlot
+from dnd_engine.systems.opportunity_attacks import (
+    publish_movement_provoke,
+    register_default_opportunity_attack,
+)
+from dnd_engine.systems.reactions import ReactionDispatcher
 from dnd_engine.systems.spatial_index import SpatialIndex
 from dnd_engine.systems.time_manager import ActiveEffect, EffectType, TimeManager
 from dnd_engine.utils.events import Event, EventBus, EventType
@@ -630,6 +635,14 @@ class GameState:
         # Combat state
         self.in_combat = False
         self.initiative_tracker: InitiativeTracker | None = None
+        # Per-combat router for trigger → Reaction handlers. Lives only
+        # while combat is in progress; constructed in ``_start_combat``
+        # alongside the initiative tracker and torn down by
+        # ``_end_combat`` / ``flee_combat``. Opportunity Attack handlers
+        # are auto-registered for every combatant whose entity is placed
+        # on the spatial index at combat start; see
+        # ``_register_default_opportunity_attacks``.
+        self.reaction_dispatcher: ReactionDispatcher | None = None
         self.active_enemies: list[Creature] = []
         self.combat_engine = CombatEngine(self.dice_roller)
         self.combat_history: list[CombatEvent] = []
@@ -888,6 +901,7 @@ class GameState:
         dy: int,
         *,
         terrain: Terrain | None = None,
+        involuntary: bool = False,
     ) -> MoveResult:
         """Engine-owned single-tile combat move with validation.
 
@@ -922,6 +936,13 @@ class GameState:
                 terrain. When ``None`` (the default), the destination
                 terrain is read from ``Map.terrain_at`` so map geometry
                 drives cost.
+            involuntary: When ``True``, suppress the
+                ``OPPORTUNITY_PROVOKED`` publish at the end of a
+                successful step. Honors the SRD exception for movement
+                that doesn't use the mover's own action economy
+                (Teleport, Shoved, Hurled by Explosion). Callers
+                scripting forced movement pass ``True``; normal player
+                / AI step inputs leave the default.
 
         Returns:
             A :class:`MoveResult` describing the outcome. On failure the
@@ -1067,12 +1088,150 @@ class GameState:
                 f"(budget={budget}, cost={cost}, terrain={actual_terrain})"
             )
         self.move_creature(entity_id, dx, dy)
+
+        # Publish OPPORTUNITY_PROVOKED for the step we just committed.
+        # Order matters: the move has already been written to the
+        # spatial index, so the mover's tile reads ``destination``
+        # while the reactor's reach geometry is computed against the
+        # ``current`` / ``destination`` payload, not the live index.
+        # Involuntary movement (Teleport, Shoved, Hurled) skips the
+        # publish per the SRD exception.
+        if not involuntary:
+            self._publish_movement_opportunity(entity_id, current, destination)
+
         return MoveResult(
             ok=True,
             reason=None,
             position=destination,
             movement_remaining=turn_state.movement_remaining,
         )
+
+    def _publish_movement_opportunity(
+        self,
+        mover_entity_id: str,
+        from_position: Position,
+        to_position: Position,
+    ) -> None:
+        """Fire OPPORTUNITY_PROVOKED for a successful tactical step.
+
+        Resolves the mover's ``Creature`` from the entity_id, publishes
+        the trigger via the per-combat ``ReactionDispatcher``, then
+        for each handler that actually reacted, resolves the real
+        melee attack against the mover using the same monster-action
+        lookup that ``flee_combat`` uses for its OA fan-out.
+
+        Silent no-op when:
+            - ``reaction_dispatcher`` is None (no active combat),
+            - the entity_id doesn't resolve to a live Creature (unit
+              fixtures with synthetic ids), or
+            - the mover is no longer alive (rare; defensive).
+
+        Visibility:
+            Reactors that cannot see the mover at ``from_position`` do
+            not provoke. The check uses ``SpatialIndex.has_line_of_sight``
+            — a geometric (wall-blocking) check. Invisibility /
+            blinded / heavy obscurement gates land with plan-05's
+            perception primitives. Document the limitation here; do
+            not silently widen it.
+        """
+        if self.reaction_dispatcher is None or self.spatial is None:
+            return
+
+        mover = self._find_creature_by_id(mover_entity_id)
+        if mover is None or not mover.is_alive:
+            return
+
+        outcomes = publish_movement_provoke(
+            self.reaction_dispatcher,
+            mover,
+            from_position,
+            to_position,
+        )
+        for outcome in outcomes:
+            self._resolve_opportunity_attack_outcome(outcome, from_position)
+
+    def _resolve_opportunity_attack_outcome(
+        self,
+        outcome: Any,
+        mover_from_position: Position,
+    ) -> None:
+        """Resolve one OA ReactionOutcome into an actual melee attack.
+
+        The dispatcher has already consumed the reactor's Reaction
+        slot — this method is purely about turning the
+        ``{attacker, target, attack_kind}`` payload into a real
+        ``combat_engine.resolve_attack`` call and emitting the
+        corresponding ``DAMAGE_DEALT`` event so logs / UI can surface
+        the hit.
+
+        The SRD "creature you can see" clause is enforced upstream by
+        the ``can_see`` closure passed into
+        ``register_default_opportunity_attack``; an outcome here means
+        the handler already cleared visibility, reach, and slot
+        availability. ``mover_from_position`` is retained for any
+        future "the attack occurs right before it leaves your reach"
+        positional shenanigans but is not consulted today.
+
+        Currently only resolves outcomes whose attacker is in
+        ``active_enemies`` — PC-side OAs require active reaction-choice
+        UI (weapon select, etc.) and land in a later slice. PC reactor
+        outcomes are dropped silently with no damage applied; the slot
+        consumption alone matches the dispatcher contract.
+        """
+        del mover_from_position  # reserved for the SRD "right before" hook.
+        attacker = outcome.data.get("attacker")
+        target = outcome.data.get("target")
+        if attacker is None or target is None:
+            return
+        if not attacker.is_alive or not target.is_alive:
+            return
+
+        # PC-as-reactor is deferred to a later slice. Monster reactors
+        # have a well-defined "primary melee action" — the first action
+        # entry with an ``attack_bonus`` — so we use the same lookup as
+        # ``flee_combat``.
+        if attacker not in self.active_enemies:
+            return
+
+        monsters = self.data_loader.load_monsters()
+        monster_data = None
+        for _monster_id, mdata in monsters.items():
+            if mdata["name"] == attacker.name:
+                monster_data = mdata
+                break
+        if monster_data is None or not monster_data.get("actions"):
+            return
+
+        action = None
+        for act in monster_data["actions"]:
+            if "attack_bonus" in act:
+                action = act
+                break
+        if action is None:
+            return
+
+        result = self.combat_engine.resolve_attack(
+            attacker=attacker,
+            defender=target,
+            attack_bonus=action["attack_bonus"],
+            damage_dice=action["damage"],
+            apply_damage=True,
+            game_state=self,
+        )
+
+        if result.hit:
+            self.event_bus.emit(
+                Event(
+                    type=EventType.DAMAGE_DEALT,
+                    data={
+                        "attacker": attacker.name,
+                        "defender": target.name,
+                        "damage": result.damage,
+                        "opportunity_attack": True,
+                    },
+                )
+            )
+
 
     def start(self) -> None:
         """
@@ -3670,6 +3829,7 @@ class GameState:
         """Initialize combat with current enemies, checking for surprise."""
         self.in_combat = True
         self.initiative_tracker = InitiativeTracker(self.dice_roller, self.time_manager)
+        self.reaction_dispatcher = ReactionDispatcher(self.initiative_tracker)
 
         # Check for surprise
         surprise_result = self._check_for_surprise()
@@ -3722,6 +3882,71 @@ class GameState:
                 },
             )
         )
+
+        # Auto-register the default 5-ft Opportunity Attack handler for
+        # every combatant that already has a spatial placement. Done
+        # after the COMBAT_START emit so any subscriber that needs to
+        # alter placements first runs against a quiescent dispatcher.
+        # Combats that never bootstrap ``spatial`` (legacy room-scoped
+        # encounters) simply skip OA wiring — ``attempt_combat_step``
+        # raises before any publish could occur, so the dispatcher
+        # stays empty and harmless.
+        self._register_default_opportunity_attacks()
+
+    def _register_default_opportunity_attacks(self) -> None:
+        """Subscribe every placed combatant to ``OPPORTUNITY_PROVOKED``.
+
+        Walks the spatial index for placed entities, resolves each back
+        to a live ``Creature`` via ``_find_creature_by_id``, and
+        registers the default 5-ft handler from
+        ``opportunity_attacks.register_default_opportunity_attack``. The
+        ``get_position`` closure captures the entity_id (not the
+        Creature) so subsequent moves are honored — handlers always
+        re-query the index when a trigger fires.
+
+        Skips silently when ``spatial``, ``initiative_tracker``, or
+        ``reaction_dispatcher`` is missing: a unit test that constructs
+        a minimal GameState without combat plumbing still gets a
+        no-op rather than a spurious AttributeError.
+        """
+        if (
+            self.spatial is None
+            or self.initiative_tracker is None
+            or self.reaction_dispatcher is None
+        ):
+            return
+
+        spatial = self.spatial
+        for entity_id in list(spatial.occupants().keys()):
+            creature = self._find_creature_by_id(entity_id)
+            if creature is None:
+                continue
+            # Bind ``entity_id`` via default arg to dodge Python's
+            # late-binding closure behavior — without this, every
+            # registered handler would re-query the index for the
+            # *last* entity_id seen in this loop.
+            def _position_lookup(
+                eid: str = entity_id,
+                _spatial: SpatialIndex = spatial,
+            ) -> Position | None:
+                return _spatial.position_of(eid)
+
+            def _can_see(
+                target: Position,
+                eid: str = entity_id,
+                _spatial: SpatialIndex = spatial,
+            ) -> bool:
+                origin = _spatial.position_of(eid)
+                if origin is None:
+                    return False
+                return _spatial.has_line_of_sight(origin, target)
+
+            register_default_opportunity_attack(
+                self.reaction_dispatcher,
+                creature,
+                get_position=_position_lookup,
+                can_see=_can_see,
+            )
 
     def _check_combat_end(self) -> None:
         """Check if combat should end and handle cleanup."""
@@ -3783,6 +4008,7 @@ class GameState:
         # Clear combat state
         self.in_combat = False
         self.initiative_tracker = None
+        self.reaction_dispatcher = None
 
         # Remove defeated enemies from room only on victory
         room = self.get_current_room()
@@ -4890,6 +5116,7 @@ class GameState:
         # Clear combat state (no XP awarded for fleeing)
         self.in_combat = False
         self.initiative_tracker = None
+        self.reaction_dispatcher = None
         self.clear_combat_history()
 
         # Enemies remain in room (can encounter them again)

--- a/dnd-engine/dnd_engine/systems/opportunity_attacks.py
+++ b/dnd-engine/dnd_engine/systems/opportunity_attacks.py
@@ -67,6 +67,7 @@ def register_default_opportunity_attack(
     reactor: Creature,
     get_position: Callable[[], Position | None],
     reach_feet: int = 5,
+    can_see: Callable[[Position], bool] | None = None,
 ) -> None:
     """Register the default OA reaction for ``reactor``.
 
@@ -75,7 +76,10 @@ def register_default_opportunity_attack(
           ``from_position``, AND
         - the mover is outside ``reach_feet`` at ``to_position``,
         - AND the reactor is itself placed on the grid,
-        - AND the mover is not the reactor (a creature can't OA itself).
+        - AND the mover is not the reactor (a creature can't OA itself),
+        - AND (if ``can_see`` is supplied) the reactor can see the
+          mover at ``from_position`` — i.e. the SRD's "creature that
+          you can see" clause.
 
     When all checks pass, the outcome carries attack metadata in
     ``data`` so a downstream slice can resolve the actual attack roll
@@ -100,6 +104,16 @@ def register_default_opportunity_attack(
             single square), matching the SRD default for an unarmed
             strike / non-reach weapon. Pass 10 (or larger) for reach
             weapons / large creatures.
+        can_see: Optional one-arg callable that returns whether the
+            reactor can see the given ``Position``. Called with the
+            mover's ``from_position`` (where the trigger was raised),
+            so a False return both suppresses the OA and leaves the
+            Reaction slot available for a later in-round trigger
+            (the SRD penalizes blindness with a missed OA, not with
+            a wasted Reaction). Production callers pass a closure
+            over ``SpatialIndex.has_line_of_sight``; leaving this
+            ``None`` is the test-helper default and matches the
+            pre-visibility semantics.
     """
 
     def handler(context: TriggerContext) -> ReactionOutcome:
@@ -122,6 +136,11 @@ def register_default_opportunity_attack(
             <= reach_feet
         )
         if not (was_in_reach and not still_in_reach):
+            return ReactionOutcome(reacted=False)
+
+        # Visibility check *after* reach: we don't want to spend cycles
+        # on LOS when the mover never threatened the reactor.
+        if can_see is not None and not can_see(from_pos):
             return ReactionOutcome(reacted=False)
 
         return ReactionOutcome(

--- a/dnd-engine/tests/srd/playing_the_game/test_melee_attacks.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_melee_attacks.py
@@ -18,15 +18,26 @@ from pathlib import Path
 
 import pytest
 
+from dnd_engine.core.character import Character, CharacterClass
 from dnd_engine.core.combat import CombatEngine
 from dnd_engine.core.creature import Abilities, Creature
 from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.entity_ids import pc_entity_id
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.map import Map, TileType
+from dnd_engine.core.party import Party
+from dnd_engine.core.position import Position
+from dnd_engine.rules.loader import DataLoader
 from dnd_engine.scenarios.loader import ScenarioLoader
 from dnd_engine.scenarios.script_executor import (
     ScriptExecutor,
     _attack_range_for,
     _attack_reach_for,
 )
+from dnd_engine.systems.opportunity_attacks import (
+    register_default_opportunity_attack,
+)
+from dnd_engine.utils.events import Event, EventBus, EventType
 
 pytestmark = pytest.mark.srd(
     "playing-the-game/melee-attacks.md",
@@ -259,6 +270,155 @@ enemies:
         )
 
 
+def _build_oa_fixture() -> tuple[GameState, str, Creature, Character]:
+    """Construct a minimal combat with a fighter adjacent to a goblin.
+
+    Returns ``(game_state, pc_entity_id, goblin, fighter)``. The fighter
+    sits at ``(1, 1)`` and the goblin at ``(2, 1)`` — 5 ft apart, in
+    each other's default reach. The map is otherwise open floor on a
+    5x3 grid so the fighter has room to step away in any direction.
+    """
+    tiles: dict[tuple[int, int], TileType] = {}
+    for y in range(3):
+        for x in range(5):
+            tiles[(x, y)] = TileType.FLOOR
+    grid_map = Map(width=5, height=3, tiles=tiles)
+
+    fighter = Character(
+        name="Brick",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=Abilities(
+            strength=16, dexterity=14, constitution=15,
+            intelligence=10, wisdom=12, charisma=8,
+        ),
+        max_hp=20,
+        ac=16,
+        xp=0,
+    )
+    party = Party(characters=[fighter])
+
+    game_state = GameState(
+        party=party,
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+        dice_roller=DiceRoller(seed=42),
+    )
+    game_state.bootstrap_spatial(grid_map)
+
+    goblin = game_state.data_loader.create_monster("goblin")
+    game_state.active_enemies.append(goblin)
+
+    pc_id = pc_entity_id(fighter.name)
+    goblin_id = "goblin_0"
+    game_state.set_position(pc_id, 1, 1)
+    game_state.set_position(goblin_id, 2, 1)
+
+    # Start combat AFTER placements so OA handlers register against the
+    # already-placed entities. Force the PC to be the active combatant
+    # so attempt_combat_step queries the PC's TurnState.
+    game_state._start_combat()
+    tracker = game_state.initiative_tracker
+    assert tracker is not None
+    for idx, entry in enumerate(tracker.combatants):
+        if entry.creature is fighter:
+            tracker.current_turn_index = idx
+            break
+    tracker.turn_states[fighter].reset(speed=fighter.speed)
+
+    return game_state, pc_id, goblin, fighter
+
+
+def _build_oa_fixture_no_los() -> tuple[GameState, str, Creature, Character]:
+    """OA fixture where a wall blocks LOS between the goblin and the PC.
+
+    Adjacent-tile LOS is always clear on a tile grid (no half-walls),
+    so to exercise visibility specifically the goblin gets a 10-ft
+    reach override and the wall sits in the 2-tile gap between them:
+
+        Fighter at (1, 1)  ── WALL ──  Goblin at (3, 1)   reach=10
+
+    Reach gate passes (was 10 ft, now 15 ft); LOS gate fails (wall
+    blocks the raycast). With the SRD visibility clause enforced,
+    the goblin's Reaction stays available and no OA is resolved.
+    """
+    tiles: dict[tuple[int, int], TileType] = {}
+    for y in range(3):
+        for x in range(5):
+            tiles[(x, y)] = TileType.FLOOR
+    tiles[(2, 1)] = TileType.WALL  # blocks LOS between (1, 1) and (3, 1)
+    grid_map = Map(width=5, height=3, tiles=tiles)
+
+    fighter = Character(
+        name="Brick",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=Abilities(
+            strength=16, dexterity=14, constitution=15,
+            intelligence=10, wisdom=12, charisma=8,
+        ),
+        max_hp=20,
+        ac=16,
+        xp=0,
+    )
+    party = Party(characters=[fighter])
+
+    game_state = GameState(
+        party=party,
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+        dice_roller=DiceRoller(seed=42),
+    )
+    game_state.bootstrap_spatial(grid_map)
+
+    goblin = game_state.data_loader.create_monster("goblin")
+    game_state.active_enemies.append(goblin)
+
+    pc_id = pc_entity_id(fighter.name)
+    goblin_id = "goblin_0"
+    game_state.set_position(pc_id, 1, 1)
+    game_state.set_position(goblin_id, 3, 1)
+
+    game_state._start_combat()
+    # Re-register the goblin with 10-ft reach so the wall-blocked LOS
+    # gate is what suppresses the OA, not the reach gate. The default
+    # 5-ft handler registered by _register_default_opportunity_attacks
+    # stays subscribed too, but the dispatcher's "last wins" rule
+    # means the new registration takes precedence.
+    spatial = game_state.spatial
+    assert spatial is not None
+    assert game_state.reaction_dispatcher is not None
+
+    def _gob_pos() -> Position | None:
+        return spatial.position_of(goblin_id)
+
+    def _gob_can_see(target: Position) -> bool:
+        origin = spatial.position_of(goblin_id)
+        if origin is None:
+            return False
+        return spatial.has_line_of_sight(origin, target)
+
+    register_default_opportunity_attack(
+        game_state.reaction_dispatcher,
+        goblin,
+        get_position=_gob_pos,
+        reach_feet=10,
+        can_see=_gob_can_see,
+    )
+
+    tracker = game_state.initiative_tracker
+    assert tracker is not None
+    for idx, entry in enumerate(tracker.combatants):
+        if entry.creature is fighter:
+            tracker.current_turn_index = idx
+            break
+    tracker.turn_states[fighter].reset(speed=fighter.speed)
+
+    return game_state, pc_id, goblin, fighter
+
+
 class TestOpportunityAttacks_Triggering:
     """SRD § Playing the Game › Melee Attacks › Opportunity Attacks (trigger).
 
@@ -298,17 +458,61 @@ class TestOpportunityAttacks_Triggering:
         )
 
     def test_tactical_movement_out_of_reach_provokes_opportunity_attack(self):
-        pytest.skip(
-            "GAP: OAs do not fire on normal tactical movement during "
-            "combat. The engine's only OA path is "
-            "dnd_engine/core/game_state.py:4190 `flee_combat()`, which "
-            "fires when the *party as a whole* attempts to retreat to "
-            "the previous room. There is no per-creature position "
-            "model on the engine side during combat (room-scoped), so "
-            "a creature moving out of an adjacent enemy's reach during "
-            "its own turn does not provoke. Tracked by issue #413 "
-            "(depends on #412 Reaction economy)."
+        """Stepping out of an adjacent enemy's reach consumes their Reaction.
+
+        Fighter at (1, 1), goblin at (2, 1) — 5 ft apart. The fighter
+        steps to (0, 1), 10 ft from the goblin and outside its default
+        reach. The dispatcher publishes ``OPPORTUNITY_PROVOKED`` and the
+        goblin's handler fires: its ``reaction_available`` slot flips
+        to ``False`` and a ``DAMAGE_DEALT`` event with
+        ``opportunity_attack=True`` rides the bus (when the attack
+        hits) — verifying the publish + resolve hooks land an actual
+        attack roll, not just a slot consumption.
+        """
+        game_state, pc_id, goblin, fighter = _build_oa_fixture()
+
+        # Pre-check: dispatcher exists, goblin's Reaction is live.
+        assert game_state.reaction_dispatcher is not None
+        tracker = game_state.initiative_tracker
+        assert tracker is not None
+        assert tracker.turn_states[goblin].reaction_available is True
+
+        damage_events: list[Event] = []
+        game_state.event_bus.subscribe(
+            EventType.DAMAGE_DEALT, damage_events.append
         )
+
+        # PC steps west, away from the goblin.
+        result = game_state.attempt_combat_step(pc_id, dx=-1, dy=0)
+        assert result.ok, f"step failed unexpectedly: {result.reason}"
+        assert result.position == Position(0, 1)
+
+        # The goblin's Reaction slot was consumed: SRD § Reactions
+        # contract met.
+        assert tracker.turn_states[goblin].reaction_available is False, (
+            "OA handler fired but did not consume the reactor's "
+            "Reaction slot — the dispatcher / handler contract is broken."
+        )
+
+        # Exactly one damage event corresponding to the OA. The
+        # deterministic seed (42) gives the goblin's scimitar attack a
+        # consistent roll for this fixture, but we don't assert on
+        # specific hit/damage values — only on the *resolution shape*
+        # (event emitted iff the roll hit, marked as OA).
+        oa_events = [
+            e for e in damage_events
+            if e.data.get("opportunity_attack") is True
+        ]
+        # Either the attack hit (>=1 oa event) or missed (0 events).
+        # Both branches are SRD-compliant — the contract is that the
+        # OA was attempted, evidenced by slot consumption above. The
+        # event-count assertion below pins the resolution-side shape.
+        assert len(oa_events) <= 1, (
+            f"expected at most one OA damage event, got {len(oa_events)}"
+        )
+        for e in oa_events:
+            assert e.data["attacker"] == goblin.name
+            assert e.data["defender"] == fighter.name
 
 
 class TestOpportunityAttacks_Avoidance:
@@ -333,13 +537,42 @@ class TestOpportunityAttacks_Avoidance:
         )
 
     def test_involuntary_movement_does_not_provoke(self):
-        pytest.skip(
-            "GAP: dependent on per-creature OA system existing first. "
-            "SRD carves out exceptions for Teleport and movement "
-            "that doesn't use the creature's own action economy "
-            "(e.g., shoved, hurled by an explosion). The engine has "
-            "no OA system on tactical movement, so the exception is "
-            "moot until that's built. Tracked under issue #413."
+        """Forced movement (Teleport/Shoved/Hurled) skips OA publishing.
+
+        Same fixture as the triggering test, but the step is marked
+        ``involuntary=True``. The OA dispatcher is never invoked, so
+        the goblin keeps its Reaction for any later in-round trigger
+        and no damage event fires. The SRD calls this out explicitly:
+
+            > You also don't provoke an Opportunity Attack when you
+            > Teleport or when you are moved without using your
+            > movement, action, Bonus Action, or Reaction.
+        """
+        game_state, pc_id, goblin, _fighter = _build_oa_fixture()
+        tracker = game_state.initiative_tracker
+        assert tracker is not None
+
+        damage_events: list[Event] = []
+        game_state.event_bus.subscribe(
+            EventType.DAMAGE_DEALT, damage_events.append
+        )
+
+        result = game_state.attempt_combat_step(
+            pc_id, dx=-1, dy=0, involuntary=True
+        )
+        assert result.ok
+        assert result.position == Position(0, 1)
+
+        assert tracker.turn_states[goblin].reaction_available is True, (
+            "involuntary movement consumed the goblin's Reaction — "
+            "the publish hook should have been suppressed."
+        )
+        oa_events = [
+            e for e in damage_events
+            if e.data.get("opportunity_attack") is True
+        ]
+        assert oa_events == [], (
+            f"involuntary movement produced OA damage events: {oa_events}"
         )
 
 
@@ -366,12 +599,51 @@ class TestOpportunityAttacks_Mechanics:
         )
 
     def test_opportunity_attack_requires_seeing_the_provoker(self):
-        pytest.skip(
-            "GAP: visibility is not consulted by `flee_combat()`. The "
-            "SRD requires that the OA-maker can see the creature "
-            "leaving reach (e.g., an invisible creature provokes no "
-            "OA from a sighted-only enemy). Engine-side combat has "
-            "no visibility/perception query exposed to attack "
-            "resolution. Tracked under issue #413 (per-creature OA "
-            "system is the prerequisite)."
+        """A wall between reactor and mover suppresses the OA.
+
+        The SRD says you can only make an OA against a creature you
+        can see. Slice 4b uses geometric line-of-sight as the proxy
+        for "can see" — full invisibility / blinded / heavy
+        obscurement gates land with plan-05's perception primitives.
+
+        Fixture: fighter at (1, 1) with a 10-ft-reach goblin at
+        (3, 1); a wall at (2, 1) breaks LOS between them. The fighter
+        steps to (0, 1) — outside even the 10-ft reach — so the reach
+        gate alone would normally fire the OA. The visibility gate
+        keeps the goblin's Reaction available and emits no damage.
+        """
+        game_state, pc_id, goblin, _fighter = _build_oa_fixture_no_los()
+        tracker = game_state.initiative_tracker
+        assert tracker is not None
+        assert tracker.turn_states[goblin].reaction_available is True
+
+        # Sanity: confirm LOS really is blocked by the wall fixture.
+        spatial = game_state.spatial
+        assert spatial is not None
+        assert not spatial.has_line_of_sight(
+            Position(3, 1), Position(1, 1)
+        ), (
+            "fixture setup error: expected LOS between (3, 1) and "
+            "(1, 1) to be blocked by the wall at (2, 1)."
+        )
+
+        damage_events: list[Event] = []
+        game_state.event_bus.subscribe(
+            EventType.DAMAGE_DEALT, damage_events.append
+        )
+
+        result = game_state.attempt_combat_step(pc_id, dx=-1, dy=0)
+        assert result.ok
+        assert result.position == Position(0, 1)
+
+        assert tracker.turn_states[goblin].reaction_available is True, (
+            "wall-blocked LOS still let the OA fire — visibility gate "
+            "in register_default_opportunity_attack is not honored."
+        )
+        oa_events = [
+            e for e in damage_events
+            if e.data.get("opportunity_attack") is True
+        ]
+        assert oa_events == [], (
+            f"unseen mover produced OA damage events: {oa_events}"
         )


### PR DESCRIPTION
## Summary

Second half of [#413](https://github.com/JoeCotellese/rpggame/issues/413), building on the [slice-4 scaffolding](https://github.com/JoeCotellese/rpggame/pull/589). Wires the per-combat `ReactionDispatcher` and the default OA handler into `GameState.attempt_combat_step` so tactical movement on a creature's own turn provokes Opportunity Attacks per the SRD.

### Dispatcher lifecycle (`game_state.py`)

- `GameState.reaction_dispatcher: ReactionDispatcher | None` constructed in `_start_combat` alongside the existing `InitiativeTracker`; torn down in `_end_combat` and `flee_combat`.
- `_register_default_opportunity_attacks()` walks the spatial index after combat starts, resolves each placed entity_id back to its live `Creature` via `_find_creature_by_id`, and calls `register_default_opportunity_attack` with closures that re-query the spatial index each trigger (handlers stay correct even as combatants move).
- `flee_combat` is unchanged — it doesn't go through `attempt_combat_step` and still owns its own retreat-time OA fan-out.

### Publish hook (`attempt_combat_step`)

After a successful step, `_publish_movement_opportunity` fires `OPPORTUNITY_PROVOKED` and resolves any reacting outcome via `combat_engine.resolve_attack`, emitting `DAMAGE_DEALT` with `opportunity_attack=True` on hit.

New keyword-only arg: **`involuntary: bool = False`**. When `True`, the publish is suppressed entirely — honors the SRD's Teleport / Shoved / Hurled exception. Existing callers are unaffected (default keeps current behavior).

### Visibility gate (`opportunity_attacks.py`)

`register_default_opportunity_attack` now accepts an optional `can_see: Callable[[Position], bool]`. When provided, it's called with the mover's `from_position` *after* the reach gate; a `False` return suppresses the OA without consuming the Reaction slot — matching the SRD's "creature you can see" clause penalty (missed OA, not wasted Reaction).

GameState curries `SpatialIndex.has_line_of_sight` as the production proxy. Full invisibility / blinded / heavy obscurement land with plan-05's perception primitives — documented at the call site, not silently widened.

### SRD tests flipped

Three previously-`pytest.skip` cases in `tests/srd/playing_the_game/test_melee_attacks.py` now exercise the real flow:

| Test | Verifies |
|---|---|
| `test_tactical_movement_out_of_reach_provokes_opportunity_attack` | Reaction slot consumed; OA-tagged `DAMAGE_DEALT` event shape |
| `test_involuntary_movement_does_not_provoke` | `involuntary=True` keeps reactor's Reaction available, no damage event |
| `test_opportunity_attack_requires_seeing_the_provoker` | Wall between reactor and mover suppresses OA; slot stays available |

Remaining `pytest.skip` in the file:
- `test_disengage_action_prevents_opportunity_attack` — gated on **#414** (slice 6).
- `test_opportunity_attack_consumes_attackers_reaction` — gated on flee-combat refactor through the dispatcher; **#412** Reaction economy itself is now done.

## Test plan

- [x] `uv run pytest tests/test_opportunity_attacks.py tests/test_reactions.py tests/test_gamestate_attempt_combat_step.py tests/srd/playing_the_game/test_melee_attacks.py tests/srd/playing_the_game/test_reactions.py --no-cov` → 71 passed, 3 skipped
- [x] Full engine suite: `uv run pytest --no-cov -q` → 3019 passed, 242 skipped, 0 failed (up from 3016/245 — three SRD tests flipped)
- [x] `uv run ruff check` clean
- [ ] Reviewer: confirm the `can_see` placement (handler-level, not GameState-level) — moves the slot-consumption gate to where the SRD penalty actually applies (decline before consuming) instead of dropping the outcome post-consume

## Plan-01 progress

| Slice | Status |
|---|---|
| 1. REACTION slot + ActionType (#412) | merged (#586) |
| 2. Trigger→Reaction dispatcher (#429) | merged (#587) |
| 3. Mid-turn pause/resume (#430) | merged (#588) |
| 4. OA scaffolding (partial #413) | merged (#589) |
| **4b. OA GameState wiring (closes #413)** | **this PR** |
| 5. Dash/Dodge/Prone/StandUp (#435 #438 #439) | parallelizable now |
| 6. Disengage (#414) | unblocked by this PR |
| 7. Help/Hide/Search/Study/Influence/Magic/Knockout | parallelizable now |
| 8. Bonus action gating (#434 #437 #440) | parallelizable now |
| 9. Free object slot + outside-combat enforcement | parallelizable now |

Closes #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)