### PR TITLE
Add Dash, Disengage, Drop Prone, Stand Up (closes #414, #435, #439) — plan-01 slice 5a

### DIFF
--- a/dnd-engine/dnd_engine/systems/action_economy.py
+++ b/dnd-engine/dnd_engine/systems/action_economy.py
@@ -81,6 +81,14 @@ class TurnState:
     reaction_available: bool = True
     free_object_interaction_used: bool = False
     movement_remaining: int = 30  # Movement in feet (5 ft = 1 grid square)
+    speed: int = 30  # Cached effective Speed for this turn (feet). Used by
+    # actions that scale to Speed: Dash adds it to the movement pool,
+    # Stand Up costs half of it, Drop Prone is forbidden when it is 0.
+    disengaged_this_turn: bool = False  # Set by the Disengage action;
+    # consulted by the Opportunity Attack handler to suppress reactions
+    # the actor's movement would otherwise provoke. Cleared by reset()
+    # at the start of the actor's next turn — the SRD's "rest of the
+    # turn" window naturally ends there.
 
     def consume_action(self, action_type: ActionType) -> bool:
         """
@@ -200,6 +208,8 @@ class TurnState:
         self.reaction_available = True
         self.free_object_interaction_used = False
         self.movement_remaining = speed
+        self.speed = speed
+        self.disengaged_this_turn = False
 
     def has_any_action(self) -> bool:
         """

--- a/dnd-engine/dnd_engine/systems/actions.py
+++ b/dnd-engine/dnd_engine/systems/actions.py
@@ -1,0 +1,109 @@
+# ABOUTME: Core action handlers for the SRD's missing combat-turn actions
+# ABOUTME: Dash, Disengage, Drop Prone, Stand Up — slice 5a of plan-01
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from dnd_engine.systems.action_economy import ActionType, TurnState
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+
+
+ActionResult = tuple[bool, str | None]
+
+
+def dash(turn_state: TurnState) -> ActionResult:
+    """Take the Dash action.
+
+    SRD § Actions › Dash: "For the rest of the turn, give yourself
+    extra movement equal to your Speed." Additive on top of any
+    remaining movement (the actor may have already moved before
+    Dashing).
+
+    Args:
+        turn_state: The acting creature's TurnState. Must have its
+            ``speed`` set (typically via ``reset(speed)`` at the start
+            of the turn).
+
+    Returns:
+        ``(True, None)`` on success. ``(False, reason)`` when the
+        actor's Action slot is already consumed.
+    """
+    if not turn_state.consume_action(ActionType.ACTION):
+        return False, "no action available"
+    turn_state.movement_remaining += turn_state.speed
+    return True, None
+
+
+def disengage(turn_state: TurnState) -> ActionResult:
+    """Take the Disengage action.
+
+    SRD § Actions › Disengage: "Your movement doesn't provoke
+    Opportunity Attacks for the rest of the turn." Sets a flag the
+    Opportunity Attack handler in ``opportunity_attacks.py`` consults
+    before reacting. The flag is cleared by ``TurnState.reset`` at the
+    actor's next turn — naturally ending the "rest of the turn" window.
+
+    Args:
+        turn_state: The acting creature's TurnState.
+
+    Returns:
+        ``(True, None)`` on success. ``(False, reason)`` when the
+        actor's Action slot is already consumed.
+    """
+    if not turn_state.consume_action(ActionType.ACTION):
+        return False, "no action available"
+    turn_state.disengaged_this_turn = True
+    return True, None
+
+
+def drop_prone(creature: Creature, turn_state: TurnState) -> ActionResult:
+    """Voluntarily drop prone on the actor's own turn.
+
+    SRD § Movement › Dropping Prone: "On your turn, you can give
+    yourself the Prone condition without using an action or any of
+    your Speed, but you can't do so if your Speed is 0."
+
+    Args:
+        creature: The actor dropping prone.
+        turn_state: The actor's TurnState. ``speed`` is consulted for
+            the Speed-zero carve-out.
+
+    Returns:
+        ``(True, None)`` on success. ``(False, "speed is 0")`` when
+        the actor's effective Speed is 0.
+    """
+    if turn_state.speed == 0:
+        return False, "speed is 0"
+    creature.add_condition("prone")
+    return True, None
+
+
+def stand_up(creature: Creature, turn_state: TurnState) -> ActionResult:
+    """Stand up from prone, consuming half the actor's Speed.
+
+    Rules Glossary › Prone: "Standing up from prone costs half the
+    creature's Speed." Implemented as a ``consume_movement`` deduction
+    of ``speed // 2``. Refuses to clear Prone if the actor isn't
+    currently prone, or if the actor lacks the movement budget.
+
+    Args:
+        creature: The actor standing up.
+        turn_state: The actor's TurnState. ``speed`` determines the
+            cost; ``movement_remaining`` is the budget consulted.
+
+    Returns:
+        ``(True, None)`` on success. ``(False, "not prone")`` when the
+        actor isn't prone. ``(False, "insufficient movement")`` when
+        the actor cannot afford the half-Speed cost. On failure neither
+        the condition nor the movement pool is modified.
+    """
+    if not creature.has_condition("prone"):
+        return False, "not prone"
+    cost = turn_state.speed // 2
+    if not turn_state.consume_movement(cost):
+        return False, "insufficient movement"
+    creature.remove_condition("prone")
+    return True, None

--- a/dnd-engine/dnd_engine/systems/opportunity_attacks.py
+++ b/dnd-engine/dnd_engine/systems/opportunity_attacks.py
@@ -48,8 +48,15 @@ def publish_movement_provoke(
     Returns:
         The list of ReactionOutcomes from handlers that actually
         reacted, in initiative order. Empty when no eligible reactor
-        threatened the mover at ``from_position``.
+        threatened the mover at ``from_position`` or when the mover
+        has taken the Disengage action this turn (SRD: "Your movement
+        doesn't provoke Opportunity Attacks for the rest of the
+        turn"). Suppression at the publish boundary preserves the
+        reactor's Reaction slot — no handler runs, no slot consumed.
     """
+    mover_turn = dispatcher.tracker.turn_states.get(mover)
+    if mover_turn is not None and mover_turn.disengaged_this_turn:
+        return []
     return dispatcher.publish(
         TriggerContext(
             trigger=Trigger.OPPORTUNITY_PROVOKED,

--- a/dnd-engine/dnd_engine/systems/reactions.py
+++ b/dnd-engine/dnd_engine/systems/reactions.py
@@ -106,6 +106,17 @@ class ReactionDispatcher:
         self._tracker = tracker
         self._subs: list[_Subscription] = []
 
+    @property
+    def tracker(self) -> InitiativeTracker:
+        """The initiative tracker this dispatcher is bound to.
+
+        Exposed read-only so trigger publishers (e.g.,
+        ``publish_movement_provoke``) and integration code can consult
+        per-actor turn state without reaching into the private
+        ``_tracker`` field.
+        """
+        return self._tracker
+
     def register(
         self,
         creature: Creature,

--- a/dnd-engine/tests/srd/playing_the_game/test_actions.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_actions.py
@@ -137,18 +137,19 @@ class TestAction_Dash:
     """
 
     def test_dash_action_doubles_movement_for_the_turn(self) -> None:
-        pytest.skip(
-            "GAP: Dash is not a playable action. The string 'Dash' "
-            "appears only as flavor text in "
-            "dnd_engine/data/srd/classes.json (rogue Cunning Action: "
-            "'You can take a bonus action to Dash, Disengage, or Hide.') "
-            "and dnd_engine/data/srd/monsters.json (spy bonus action). "
-            "There is no action handler, no `TurnState` method that "
-            "grants extra movement equal to Speed, and the scenario "
-            "script executor (dnd_engine/scenarios/script_executor.py:"
-            "200-224) only dispatches 'wait', 'attack', and "
-            "'monster_attack'. Tracked by issue #435."
-        )
+        """Dash consumes the Action and adds the actor's Speed to the
+        remaining movement pool for the rest of the turn (SRD: 'For
+        the rest of the turn, give yourself extra movement equal to
+        your Speed')."""
+        from dnd_engine.systems.actions import dash
+
+        turn = TurnState()
+        turn.reset(speed=30)
+        ok, _ = dash(turn)
+
+        assert ok is True
+        assert turn.action_available is False
+        assert turn.movement_remaining == 60  # 30 base + 30 from Dash
 
 
 class TestAction_Disengage:
@@ -159,15 +160,43 @@ class TestAction_Disengage:
     """
 
     def test_disengage_action_suppresses_opportunity_attacks_this_turn(self) -> None:
-        pytest.skip(
-            "GAP: Disengage is not a playable action. 'Disengage' "
-            "appears only as flavor text in "
-            "dnd_engine/data/srd/classes.json (rogue cunning action) "
-            "and dnd_engine/data/srd/monsters.json (goblin Nimble "
-            "Escape, spy). No action handler, dispatcher entry, or "
-            "movement flag is wired up. Tracked by issue #414 (depends "
-            "on #413 per-creature OAs)."
+        """Disengage consumes the Action and sets the per-turn flag
+        the OA publish path consults; while the flag is set, the
+        actor's movement does not provoke Opportunity Attacks (SRD:
+        'Your movement doesn't provoke Opportunity Attacks for the
+        rest of the turn')."""
+        from dnd_engine.core.position import Position
+        from dnd_engine.systems.actions import disengage
+        from dnd_engine.systems.initiative import InitiativeTracker
+        from dnd_engine.systems.opportunity_attacks import (
+            publish_movement_provoke,
+            register_default_opportunity_attack,
         )
+        from dnd_engine.systems.reactions import ReactionDispatcher
+
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        reactor = Creature("Fighter", max_hp=20, ac=15, abilities=abilities)
+        mover = Creature("Goblin", max_hp=20, ac=15, abilities=abilities)
+        tracker = InitiativeTracker(DiceRoller(seed=1))
+        tracker.add_combatant(reactor)
+        tracker.add_combatant(mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: Position(5, 5)
+        )
+
+        ok, _ = disengage(tracker.turn_states[mover])
+        assert ok is True
+
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(6, 5),
+            to_position=Position(8, 5),
+        )
+
+        assert outcomes == []
+        assert tracker.turn_states[reactor].reaction_available is True
 
 
 class TestAction_Dodge:

--- a/dnd-engine/tests/srd/playing_the_game/test_movement_and_position.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_movement_and_position.py
@@ -350,34 +350,48 @@ class TestDroppingProne_FreeOnYourTurn:
     """
 
     def test_drop_prone_action_exists(self) -> None:
-        pytest.skip(
-            "GAP: no `drop_prone` action handler. `Creature.add_condition('prone')` "
-            "(dnd_engine/core/creature.py:242) is the only way to apply "
-            "the Prone condition, and it's used by spell/trap effects "
-            "(e.g., the `caltrops` item rolls a DC 10 DEX save to "
-            "knock the target prone). There is no scenario script "
-            "action, MCP tool, or client UI for a creature to "
-            "voluntarily drop prone on its own turn. Tracked by "
-            "issue #439."
-        )
+        """A voluntary drop-prone handler exists and applies the Prone
+        condition to the actor."""
+        from dnd_engine.systems.actions import drop_prone
+
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        actor = Creature("Hero", max_hp=20, ac=15, abilities=abilities, speed=30)
+        turn = TurnState()
+        turn.reset(speed=30)
+
+        ok, _ = drop_prone(actor, turn)
+
+        assert ok is True
+        assert actor.has_condition("prone") is True
 
     def test_drop_prone_does_not_consume_action_or_movement(self) -> None:
-        pytest.skip(
-            "GAP: dependent on a drop-prone action existing (#439). "
-            "Per SRD it must not consume the actor's action, bonus "
-            "action, or any of its Speed pool. Once the action handler "
-            "lands, it must call neither `consume_action` nor "
-            "`consume_movement`."
-        )
+        """SRD: 'without using an action or any of your Speed'."""
+        from dnd_engine.systems.actions import drop_prone
+
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        actor = Creature("Hero", max_hp=20, ac=15, abilities=abilities, speed=30)
+        turn = TurnState()
+        turn.reset(speed=30)
+
+        drop_prone(actor, turn)
+
+        assert turn.action_available is True
+        assert turn.bonus_action_available is True
+        assert turn.movement_remaining == 30
 
     def test_drop_prone_forbidden_when_speed_is_zero(self) -> None:
-        pytest.skip(
-            "GAP: dependent on a drop-prone action existing (#439). "
-            "SRD carve-out: a creature with Speed 0 (e.g., grappled, "
-            "restrained, or zero-Speed condition) cannot voluntarily "
-            "drop prone. The handler must read the creature's current "
-            "effective Speed before allowing the transition."
-        )
+        """SRD carve-out: cannot voluntarily drop prone when Speed is 0."""
+        from dnd_engine.systems.actions import drop_prone
+
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        actor = Creature("Hero", max_hp=20, ac=15, abilities=abilities, speed=0)
+        turn = TurnState()
+        turn.reset(speed=0)
+
+        ok, _ = drop_prone(actor, turn)
+
+        assert ok is False
+        assert actor.has_condition("prone") is False
 
 
 class TestStandingUpFromProne_HalfSpeedCost:
@@ -390,12 +404,21 @@ class TestStandingUpFromProne_HalfSpeedCost:
     """
 
     def test_stand_up_from_prone_costs_half_speed(self) -> None:
-        pytest.skip(
-            "GAP: no `stand_up` action handler. Per Rules Glossary "
-            "(Prone): standing up costs half the creature's Speed. No "
-            "engine code consumes half of `TurnState.movement_remaining` "
-            "to clear the Prone condition. Tracked by issue #439."
-        )
+        """Rules Glossary (Prone): standing up costs half the
+        creature's Speed."""
+        from dnd_engine.systems.actions import stand_up
+
+        abilities = Abilities(10, 10, 10, 10, 10, 10)
+        actor = Creature("Hero", max_hp=20, ac=15, abilities=abilities, speed=30)
+        actor.add_condition("prone")
+        turn = TurnState()
+        turn.reset(speed=30)
+
+        ok, _ = stand_up(actor, turn)
+
+        assert ok is True
+        assert actor.has_condition("prone") is False
+        assert turn.movement_remaining == 15  # 30 - (30 // 2)
 
 
 class TestCreatureSize_SpaceFromSizeCategory:

--- a/dnd-engine/tests/test_action_economy.py
+++ b/dnd-engine/tests/test_action_economy.py
@@ -143,6 +143,22 @@ class TestTurnState:
         assert turn.reaction_available is True
         assert turn.free_object_interaction_used is False
 
+    def test_initial_speed_and_disengaged_defaults(self):
+        """New TurnState carries speed=30 and is not disengaged."""
+        turn = TurnState()
+        assert turn.speed == 30
+        assert turn.disengaged_this_turn is False
+
+    def test_reset_caches_speed_and_clears_disengaged(self):
+        """reset(speed) updates the cached speed and clears the
+        per-turn Disengage flag (the SRD's 'rest of the turn' window
+        ends with the actor's turn)."""
+        turn = TurnState()
+        turn.disengaged_this_turn = True
+        turn.reset(speed=25)  # Dwarf
+        assert turn.speed == 25
+        assert turn.disengaged_this_turn is False
+
     def test_has_any_action(self):
         """Test checking if any actions remain"""
         turn = TurnState()

--- a/dnd-engine/tests/test_actions.py
+++ b/dnd-engine/tests/test_actions.py
@@ -1,0 +1,171 @@
+# ABOUTME: Unit tests for slice-5a core actions (Dash, Disengage, Drop Prone, Stand Up)
+# ABOUTME: Plan-01 step 4 — handlers for the SRD's missing core actions
+
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.systems.action_economy import ActionType, TurnState
+from dnd_engine.systems.actions import dash, disengage, drop_prone, stand_up
+
+
+def _make_creature(name: str = "Hero", speed: int = 30) -> Creature:
+    return Creature(
+        name=name,
+        max_hp=20,
+        ac=15,
+        abilities=Abilities(10, 10, 10, 10, 10, 10),
+        speed=speed,
+    )
+
+
+class TestDash:
+    """SRD § Actions › Dash:
+    'For the rest of the turn, give yourself extra movement equal to
+    your Speed.'
+    """
+
+    def test_dash_consumes_action_and_adds_speed_to_movement_pool(self):
+        turn = TurnState()
+        turn.reset(speed=30)
+        ok, reason = dash(turn)
+        assert ok is True
+        assert reason is None
+        assert turn.action_available is False
+        assert turn.movement_remaining == 60  # 30 base + 30 from Dash
+
+    def test_dash_fails_when_no_action_available(self):
+        turn = TurnState()
+        turn.reset(speed=30)
+        turn.consume_action(ActionType.ACTION)
+        ok, reason = dash(turn)
+        assert ok is False
+        assert reason == "no action available"
+        assert turn.movement_remaining == 30  # unchanged
+
+    def test_dash_applies_to_remaining_movement_not_a_set_value(self):
+        """A creature that already moved 10 ft (pool=20) then Dashes
+        ends up with 50 ft remaining, not 60. SRD says 'extra
+        movement equal to your Speed', i.e. additive."""
+        turn = TurnState()
+        turn.reset(speed=30)
+        turn.consume_movement(10)
+        assert turn.movement_remaining == 20
+        ok, _ = dash(turn)
+        assert ok is True
+        assert turn.movement_remaining == 50
+
+    def test_dash_uses_cached_speed_for_dwarf(self):
+        turn = TurnState()
+        turn.reset(speed=25)  # Dwarf
+        ok, _ = dash(turn)
+        assert ok is True
+        assert turn.movement_remaining == 50
+
+
+class TestDisengage:
+    """SRD § Actions › Disengage:
+    'Your movement doesn't provoke Opportunity Attacks for the rest
+    of the turn.'
+    """
+
+    def test_disengage_consumes_action_and_sets_flag(self):
+        turn = TurnState()
+        turn.reset(speed=30)
+        ok, reason = disengage(turn)
+        assert ok is True
+        assert reason is None
+        assert turn.action_available is False
+        assert turn.disengaged_this_turn is True
+
+    def test_disengage_fails_when_no_action_available(self):
+        turn = TurnState()
+        turn.reset(speed=30)
+        turn.consume_action(ActionType.ACTION)
+        ok, reason = disengage(turn)
+        assert ok is False
+        assert reason == "no action available"
+        assert turn.disengaged_this_turn is False
+
+    def test_disengage_flag_resets_on_next_turn(self):
+        turn = TurnState()
+        turn.reset(speed=30)
+        disengage(turn)
+        assert turn.disengaged_this_turn is True
+        turn.reset(speed=30)
+        assert turn.disengaged_this_turn is False
+
+
+class TestDropProne:
+    """SRD § Movement › Dropping Prone:
+    'On your turn, you can give yourself the Prone condition without
+    using an action or any of your Speed, but you can't do so if your
+    Speed is 0.'
+    """
+
+    def test_drop_prone_adds_condition_without_consuming(self):
+        actor = _make_creature()
+        turn = TurnState()
+        turn.reset(speed=30)
+        ok, reason = drop_prone(actor, turn)
+        assert ok is True
+        assert reason is None
+        assert actor.has_condition("prone") is True
+        # No action, no bonus action, no movement consumed.
+        assert turn.action_available is True
+        assert turn.bonus_action_available is True
+        assert turn.movement_remaining == 30
+
+    def test_drop_prone_forbidden_when_speed_is_zero(self):
+        actor = _make_creature()
+        turn = TurnState()
+        turn.reset(speed=0)
+        ok, reason = drop_prone(actor, turn)
+        assert ok is False
+        assert reason == "speed is 0"
+        assert actor.has_condition("prone") is False
+
+
+class TestStandUp:
+    """Rules Glossary › Prone:
+    'Standing up from prone costs half the creature's Speed.'
+    """
+
+    def test_stand_up_costs_half_speed_and_clears_prone(self):
+        actor = _make_creature()
+        actor.add_condition("prone")
+        turn = TurnState()
+        turn.reset(speed=30)
+        ok, reason = stand_up(actor, turn)
+        assert ok is True
+        assert reason is None
+        assert actor.has_condition("prone") is False
+        assert turn.movement_remaining == 15  # 30 - 15 (half of 30)
+
+    def test_stand_up_fails_when_not_prone(self):
+        actor = _make_creature()
+        turn = TurnState()
+        turn.reset(speed=30)
+        ok, reason = stand_up(actor, turn)
+        assert ok is False
+        assert reason == "not prone"
+        assert turn.movement_remaining == 30
+
+    def test_stand_up_fails_when_insufficient_movement(self):
+        actor = _make_creature()
+        actor.add_condition("prone")
+        turn = TurnState()
+        turn.reset(speed=30)
+        turn.consume_movement(20)  # 10 ft left, need 15
+        ok, reason = stand_up(actor, turn)
+        assert ok is False
+        assert reason == "insufficient movement"
+        assert actor.has_condition("prone") is True  # still prone
+        assert turn.movement_remaining == 10  # unchanged
+
+    def test_stand_up_dwarf_costs_half_of_25_speed(self):
+        actor = _make_creature(speed=25)
+        actor.add_condition("prone")
+        turn = TurnState()
+        turn.reset(speed=25)
+        ok, _ = stand_up(actor, turn)
+        assert ok is True
+        # 25 // 2 = 12, leaving 13
+        assert turn.movement_remaining == 13

--- a/dnd-engine/tests/test_disengage_oa_integration.py
+++ b/dnd-engine/tests/test_disengage_oa_integration.py
@@ -1,0 +1,113 @@
+# ABOUTME: Integration test for Disengage suppressing Opportunity Attacks
+# ABOUTME: Disengage action sets a turn-state flag the OA publish path consults
+
+from __future__ import annotations
+
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.position import Position
+from dnd_engine.systems.actions import disengage
+from dnd_engine.systems.initiative import InitiativeTracker
+from dnd_engine.systems.opportunity_attacks import (
+    publish_movement_provoke,
+    register_default_opportunity_attack,
+)
+from dnd_engine.systems.reactions import ReactionDispatcher
+
+
+def _make_creature(name: str) -> Creature:
+    abilities = Abilities(10, 10, 10, 10, 10, 10)
+    return Creature(name, max_hp=20, ac=15, abilities=abilities)
+
+
+def _make_tracker(*creatures: Creature) -> InitiativeTracker:
+    tracker = InitiativeTracker(DiceRoller(seed=1))
+    for creature in creatures:
+        tracker.add_combatant(creature)
+    return tracker
+
+
+class TestDisengageSuppressesOpportunityAttacks:
+    def test_disengaged_mover_does_not_provoke_oa(self):
+        """SRD: After Disengage, the actor's movement doesn't provoke
+        Opportunity Attacks for the rest of the turn."""
+        reactor = _make_creature("Fighter")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: Position(5, 5)
+        )
+
+        # Goblin takes Disengage on their turn.
+        mover_turn = tracker.turn_states[mover]
+        ok, _ = disengage(mover_turn)
+        assert ok is True
+        assert mover_turn.disengaged_this_turn is True
+
+        # Goblin moves out of Fighter's reach — would normally provoke.
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(6, 5),
+            to_position=Position(8, 5),
+        )
+
+        assert outcomes == []
+        # Reaction slot is intact — no OA fired.
+        assert tracker.turn_states[reactor].reaction_available is True
+
+    def test_non_disengaged_mover_still_provokes_oa(self):
+        """Sanity check: without Disengage, the same movement provokes
+        (so the suppression is the difference, not a coincidence)."""
+        reactor = _make_creature("Fighter")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: Position(5, 5)
+        )
+
+        # Mover does NOT disengage.
+        outcomes = publish_movement_provoke(
+            dispatcher,
+            mover=mover,
+            from_position=Position(6, 5),
+            to_position=Position(8, 5),
+        )
+
+        assert len(outcomes) == 1
+        assert outcomes[0].reacted is True
+
+    def test_disengage_flag_only_suppresses_for_one_turn(self):
+        """Disengage applies for the rest of the actor's turn. When
+        TurnState.reset is called for the actor's next turn, the flag
+        clears and subsequent moves provoke again."""
+        reactor = _make_creature("Fighter")
+        mover = _make_creature("Goblin")
+        tracker = _make_tracker(reactor, mover)
+        dispatcher = ReactionDispatcher(tracker)
+        register_default_opportunity_attack(
+            dispatcher, reactor, get_position=lambda: Position(5, 5)
+        )
+
+        # Disengage this turn — provoking move is suppressed.
+        mover_turn = tracker.turn_states[mover]
+        disengage(mover_turn)
+        outcomes_now = publish_movement_provoke(
+            dispatcher, mover=mover,
+            from_position=Position(6, 5), to_position=Position(8, 5),
+        )
+        assert outcomes_now == []
+
+        # Mover's next turn begins — flag clears.
+        mover_turn.reset(speed=mover.speed)
+        assert mover_turn.disengaged_this_turn is False
+
+        # Same provoking move now triggers the OA.
+        outcomes_next = publish_movement_provoke(
+            dispatcher, mover=mover,
+            from_position=Position(6, 5), to_position=Position(8, 5),
+        )
+        assert len(outcomes_next) == 1
+        assert outcomes_next[0].reacted is True


### PR DESCRIPTION
## Summary

Slice 5a of plan-01 — first four of step 4's missing core actions on the SRD action surface. Pairs naturally with the OA system shipped in slices 4 / 4b.

- **Dash** (#435) — consumes the Action, adds `Speed` to the remaining movement pool.
- **Disengage** (#414) — consumes the Action, sets `TurnState.disengaged_this_turn`; the OA publish path consults this flag and short-circuits, so no reactor's Reaction slot is consumed.
- **Drop Prone** (#439) — free action; refused when effective Speed is 0 per SRD.
- **Stand Up** (#439) — costs `Speed // 2` of movement; refused if not prone or budget insufficient.

## Changes

- **`dnd_engine/systems/actions.py`** (new) — standalone handlers, each `(creature, turn_state) → (success, reason)`. Decoupled from any one orchestrator (script_executor, GameState, future MCP all call in equally).
- **`dnd_engine/systems/action_economy.py`** — `TurnState` gains `speed` (cached effective Speed for the turn) and `disengaged_this_turn`. Both reset in `reset(speed)`.
- **`dnd_engine/systems/reactions.py`** — `ReactionDispatcher` exposes a public read-only `tracker` property so trigger publishers can consult per-actor turn state without reaching into `_tracker`.
- **`dnd_engine/systems/opportunity_attacks.py`** — `publish_movement_provoke` short-circuits when the mover has `disengaged_this_turn` set. Preserves the reactor's Reaction slot (no handler runs, no consumption).

## Tests

Six SRD gating tests flipped from `pytest.skip` to real assertions:

- `test_dash_action_doubles_movement_for_the_turn`
- `test_disengage_action_suppresses_opportunity_attacks_this_turn`
- `test_drop_prone_action_exists`
- `test_drop_prone_does_not_consume_action_or_movement`
- `test_drop_prone_forbidden_when_speed_is_zero`
- `test_stand_up_from_prone_costs_half_speed`

Plus:

- **13 unit tests** in `tests/test_actions.py` covering success + each failure mode for all four actions.
- **3 integration tests** in `tests/test_disengage_oa_integration.py`: suppression fires, sanity check that the same move provokes without Disengage, and flag clears on the next turn.
- **2 new unit tests** in `tests/test_action_economy.py` verifying the new `speed` / `disengaged_this_turn` defaults and reset behavior.

Slice-impacted suite: **113 passed, 29 skipped** (unrelated SRD gaps), 0 failed. Ruff clean on touched files.

## Test plan

- [x] Unit tests pass (`uv run pytest tests/test_actions.py tests/test_action_economy.py tests/test_disengage_oa_integration.py`)
- [x] Integration tests pass
- [x] SRD gating tests pass (`tests/srd/playing_the_game/test_actions.py::TestAction_Dash`, `TestAction_Disengage`, `test_movement_and_position.py::TestDroppingProne_FreeOnYourTurn`, `TestStandingUpFromProne_HalfSpeedCost`)
- [x] No regressions in slice 4b OA tests (`tests/test_opportunity_attacks.py`)
- [x] Ruff clean

## Out of scope for this slice (intentional)

- Downstream effects of `prone` (movement halving, attack disadvantage, ranged disadvantage) — separate movement/combat-modifier work.
- AI choosing Dash / Disengage / Drop Prone — separate AI integration.
- MCP exposure (`game_dash`, etc.) — follow-up if needed.
- Cunning Action / Nimble Escape routing these as bonus actions — belongs to bonus-action gating (slice 8 / #434).

## Related

- Plan-01 master: #530
- Closes #414 (Disengage), #435 (Dash), #439 (Drop Prone / Stand Up)
- Next slice: 5b (Dodge, Help) — adds the Dodging + Helping conditions.
- Bookkeeping (separate from this PR, already landed on `main` via direct GH ops): #443 re-homed to plan-05, #444 re-homed to plan-07, #591 opened for the class-feature registry that blocks #446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)