### PR TITLE
Add #591: class-feature registry for Magic action dispatch

### DIFF
--- a/dnd-engine/dnd_engine/data/srd/classes.json
+++ b/dnd-engine/dnd_engine/data/srd/classes.json
@@ -42,6 +42,7 @@
         },
         {
           "name": "Second Wind",
+          "feature_id": "fighter.second_wind",
           "description": "You have a limited well of stamina. Once per short rest, you can use a bonus action to regain 1d10 + fighter level HP.",
           "resource": {
             "pool": "second_wind",
@@ -53,6 +54,7 @@
       "2": [
         {
           "name": "Action Surge",
+          "feature_id": "fighter.action_surge",
           "description": "You can push yourself beyond your normal limits. Once per short rest, you can take one additional action on your turn.",
           "resource": {
             "pool": "action_surge",
@@ -202,6 +204,7 @@
         },
         {
           "name": "Arcane Recovery",
+          "feature_id": "wizard.arcane_recovery",
           "description": "You can regain some of your magical energy by studying your spellbook. Once per day when you finish a short rest, you can choose expended spell slots to recover.",
           "resource": {
             "pool": "arcane_recovery",

--- a/dnd-engine/dnd_engine/systems/class_features.py
+++ b/dnd-engine/dnd_engine/systems/class_features.py
@@ -1,0 +1,259 @@
+# ABOUTME: Registry of class features (Second Wind, Action Surge, etc.) as callable, action-costed handlers
+# ABOUTME: Prerequisite for the Magic action (#446); catalogs features so they can be dispatched on a turn
+
+"""Class-feature registry for the SRD "use a magical feature" surface.
+
+Class features used to live as descriptive strings in
+``dnd_engine/data/srd/classes.json`` with no callable surface. This
+module turns each into a :class:`ClassFeature`: a stable id, the action
+it costs, the resource pool it spends, and a handler that applies the
+effect and returns a structured :class:`FeatureResult`.
+
+The Magic action dispatcher (#446) consumes this registry; the
+:func:`use_feature` dispatcher here owns the action-economy and
+resource gating so callers do not repeat it.
+
+How to add a class feature
+---------------------------
+1. Add a stable ``"feature_id"`` to the feature's entry in
+   ``classes.json`` ``features_by_level`` (e.g. ``"fighter.second_wind"``).
+   If the feature spends a per-rest resource, keep its existing
+   ``"resource"`` block — pools are granted at level-up by
+   ``Character._grant_class_features``.
+2. Register a handler here keyed by that same ``feature_id`` using the
+   :func:`register` decorator, declaring the action cost and (for
+   dispatcher-managed spend) the resource pool name.
+
+``tests/test_class_features.py`` walks ``classes.json`` and fails CI if a
+declared ``feature_id`` has no handler here — so a forgotten handler is
+caught and points right back at this module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.systems.action_economy import ActionType, TurnState
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+
+
+@dataclass
+class FeatureResult:
+    """Structured outcome of attempting to use a class feature.
+
+    Attributes:
+        success: Whether the feature was used.
+        message: Short human-readable reason or label (failure reason on
+            ``success=False``; the feature name on success).
+        data: Feature-specific payload (e.g. ``{"healed": 7}``).
+    """
+
+    success: bool
+    message: str | None = None
+    data: dict = field(default_factory=dict)
+
+
+# A handler applies the feature's effect. Action-economy and resource
+# spend are already settled by use_feature() before it is called.
+FeatureHandler = Callable[["Creature", TurnState, Any, Any], FeatureResult]
+
+
+@dataclass
+class ClassFeature:
+    """A class feature catalogued for combat-turn dispatch.
+
+    Attributes:
+        feature_id: Stable id, e.g. ``"fighter.second_wind"``.
+        name: Display name.
+        action_cost: The action economy slot the feature costs
+            (``ActionType.NO_ACTION`` for features that cost nothing).
+        resource_pool: Name of the :class:`ResourcePool` the dispatcher
+            spends, or ``None`` when the handler manages its own
+            resource accounting (e.g. Arcane Recovery).
+        handler: Callable applying the effect.
+        uses: Resource units spent per activation (default 1).
+    """
+
+    feature_id: str
+    name: str
+    action_cost: ActionType
+    resource_pool: str | None
+    handler: FeatureHandler
+    uses: int = 1
+
+
+# The one place every dispatchable class feature is registered.
+FEATURE_REGISTRY: dict[str, ClassFeature] = {}
+
+
+def register(
+    feature_id: str,
+    name: str,
+    action_cost: ActionType,
+    resource_pool: str | None,
+    uses: int = 1,
+    registry: dict[str, ClassFeature] | None = None,
+) -> Callable[[FeatureHandler], FeatureHandler]:
+    """Decorator that registers a handler as a :class:`ClassFeature`.
+
+    Args:
+        feature_id: Stable id keying the registry.
+        name: Display name.
+        action_cost: Action-economy slot the feature costs.
+        resource_pool: Dispatcher-managed pool name, or ``None`` for
+            handler-managed accounting.
+        uses: Resource units per activation.
+        registry: Target registry (defaults to the global
+            ``FEATURE_REGISTRY``; overridable for test isolation).
+
+    Returns:
+        The handler unchanged, after registering it.
+    """
+    target = FEATURE_REGISTRY if registry is None else registry
+
+    def decorator(handler: FeatureHandler) -> FeatureHandler:
+        target[feature_id] = ClassFeature(
+            feature_id=feature_id,
+            name=name,
+            action_cost=action_cost,
+            resource_pool=resource_pool,
+            handler=handler,
+            uses=uses,
+        )
+        return handler
+
+    return decorator
+
+
+def get_feature(
+    feature_id: str, registry: dict[str, ClassFeature] | None = None
+) -> ClassFeature | None:
+    """Return the registered feature, or ``None`` if unknown."""
+    target = FEATURE_REGISTRY if registry is None else registry
+    return target.get(feature_id)
+
+
+def list_features(
+    registry: dict[str, ClassFeature] | None = None,
+) -> list[ClassFeature]:
+    """Return all registered features."""
+    target = FEATURE_REGISTRY if registry is None else registry
+    return list(target.values())
+
+
+def use_feature(
+    actor: Creature,
+    turn_state: TurnState,
+    feature_id: str,
+    *,
+    target: Any = None,
+    payload: Any = None,
+    registry: dict[str, ClassFeature] | None = None,
+) -> FeatureResult:
+    """Dispatch a class feature, settling action economy and resources.
+
+    Gating runs *before* any consumption: if either the action slot or
+    the resource pool is unavailable, nothing is consumed and a failure
+    result is returned. Only when both gates pass are the action slot
+    and (for dispatcher-managed features) the resource spent, and the
+    handler invoked.
+
+    Args:
+        actor: The creature using the feature.
+        turn_state: The actor's :class:`TurnState`.
+        feature_id: Id of the feature to use.
+        target: Optional target creature/object for the handler.
+        payload: Optional feature-specific input for the handler
+            (e.g. ``{"spell_slot_levels": {1: 1}}`` for Arcane Recovery,
+            or ``{"dice_roller": DiceRoller(seed=...)}`` for determinism).
+        registry: Registry to dispatch against (defaults to the global).
+
+    Returns:
+        The handler's :class:`FeatureResult`, or a failure result when
+        the feature is unknown or a gate refuses.
+    """
+    feature = get_feature(feature_id, registry=registry)
+    if feature is None:
+        return FeatureResult(False, f"unknown feature: {feature_id}")
+
+    if not turn_state.is_action_available(feature.action_cost):
+        return FeatureResult(False, "action unavailable")
+
+    if feature.resource_pool is not None:
+        get_pool = getattr(actor, "get_resource_pool", None)
+        pool = get_pool(feature.resource_pool) if get_pool else None
+        if pool is None or not pool.is_available(feature.uses):
+            return FeatureResult(False, "resource unavailable")
+
+    turn_state.consume_action(feature.action_cost)
+    if feature.resource_pool is not None:
+        actor.use_resource(feature.resource_pool, feature.uses)
+
+    return feature.handler(actor, turn_state, target, payload)
+
+
+# --------------------------------------------------------------------------
+# Cohort handlers — existing-class proof of concept (Fighter, Wizard).
+# Each id below mirrors a "feature_id" in classes.json (see guardrail test).
+# --------------------------------------------------------------------------
+
+
+@register(
+    "fighter.second_wind",
+    "Second Wind",
+    ActionType.BONUS_ACTION,
+    "second_wind",
+)
+def _second_wind(
+    actor: Creature, turn_state: TurnState, target: Any, payload: Any
+) -> FeatureResult:
+    """Regain 1d10 + fighter level HP as a Bonus Action (once per short rest)."""
+    payload = payload or {}
+    roller = payload.get("dice_roller") or DiceRoller()
+    roll = roller.roll(f"1d10+{actor.level}")
+    healed = actor.recover_hp(roll.total)
+    return FeatureResult(True, "Second Wind", {"healed": healed, "roll": roll.total})
+
+
+@register(
+    "fighter.action_surge",
+    "Action Surge",
+    ActionType.NO_ACTION,
+    "action_surge",
+)
+def _action_surge(
+    actor: Creature, turn_state: TurnState, target: Any, payload: Any
+) -> FeatureResult:
+    """Take one additional action this turn (once per short rest)."""
+    turn_state.action_available = True
+    return FeatureResult(True, "Action Surge", {"extra_action": True})
+
+
+@register(
+    "wizard.arcane_recovery",
+    "Arcane Recovery",
+    ActionType.NO_ACTION,
+    # resource_pool=None: Character.use_arcane_recovery consumes the
+    # "arcane_recovery" pool itself, so the dispatcher must not also
+    # spend it (that would double-consume).
+    None,
+)
+def _arcane_recovery(
+    actor: Creature, turn_state: TurnState, target: Any, payload: Any
+) -> FeatureResult:
+    """Recover spell slots (once per long rest); delegates to the Character.
+
+    The slots to recover are passed via ``payload["spell_slot_levels"]``
+    (e.g. ``{1: 1}`` for one 1st-level slot).
+    """
+    payload = payload or {}
+    slot_levels = payload.get("spell_slot_levels", {})
+    recovered = actor.use_arcane_recovery(slot_levels)
+    if not recovered:
+        return FeatureResult(False, "arcane recovery unavailable")
+    return FeatureResult(True, "Arcane Recovery", {"recovered": slot_levels})

--- a/dnd-engine/tests/test_class_features.py
+++ b/dnd-engine/tests/test_class_features.py
@@ -1,0 +1,270 @@
+# ABOUTME: Tests for the class-feature registry (#591) — catalog, dispatcher, cohort
+# ABOUTME: Unit (registry mechanics), integration (real Character + pools + rest), data-parity guardrail
+
+import json
+from pathlib import Path
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.systems.action_economy import ActionType, TurnState
+from dnd_engine.systems.class_features import (
+    ClassFeature,
+    FeatureResult,
+    get_feature,
+    list_features,
+    register,
+    use_feature,
+)
+from dnd_engine.systems.resources import ResourcePool
+
+CLASSES_JSON = Path(__file__).resolve().parents[1] / "dnd_engine" / "data" / "srd" / "classes.json"
+
+
+def _fighter(level: int = 1, max_hp: int = 20) -> Character:
+    return Character(
+        name="Test Fighter",
+        character_class=CharacterClass.FIGHTER,
+        level=level,
+        abilities=Abilities(16, 14, 14, 10, 12, 8),
+        max_hp=max_hp,
+        ac=16,
+    )
+
+
+def _wizard(level: int = 2, max_hp: int = 14) -> Character:
+    return Character(
+        name="Test Wizard",
+        character_class=CharacterClass.WIZARD,
+        level=level,
+        abilities=Abilities(8, 14, 12, 16, 12, 10),
+        max_hp=max_hp,
+        ac=12,
+    )
+
+
+class TestRegistryMechanics:
+    """Unit: register / get / list and the use_feature gate logic.
+
+    These exercise the dispatcher in isolation against an isolated
+    registry dict so they neither depend on nor pollute the global
+    FEATURE_REGISTRY.
+    """
+
+    def test_register_get_list_roundtrip(self):
+        reg: dict[str, ClassFeature] = {}
+
+        @register(
+            "test.noop",
+            "No-Op",
+            ActionType.ACTION,
+            None,
+            registry=reg,
+        )
+        def _noop(actor, turn_state, target, payload):
+            return FeatureResult(True, "noop")
+
+        feature = get_feature("test.noop", registry=reg)
+        assert feature is not None
+        assert feature.feature_id == "test.noop"
+        assert feature.name == "No-Op"
+        assert feature.action_cost is ActionType.ACTION
+        assert feature.resource_pool is None
+        assert feature in list_features(registry=reg)
+
+    def test_use_feature_unknown_id_returns_failure(self):
+        actor = _fighter()
+        turn = TurnState()
+        turn.reset()
+        result = use_feature(actor, turn, "does.not.exist", registry={})
+        assert result.success is False
+        assert "unknown feature" in (result.message or "")
+
+    def test_use_feature_result_shape_on_success(self):
+        reg: dict[str, ClassFeature] = {}
+
+        @register("test.ok", "Ok", ActionType.NO_ACTION, None, registry=reg)
+        def _ok(actor, turn_state, target, payload):
+            return FeatureResult(True, "done", {"k": "v"})
+
+        result = use_feature(_fighter(), TurnState(), "test.ok", registry=reg)
+        assert isinstance(result, FeatureResult)
+        assert result.success is True
+        assert result.message == "done"
+        assert result.data == {"k": "v"}
+
+    def test_gate_fails_when_action_slot_unavailable_resource_untouched(self):
+        reg: dict[str, ClassFeature] = {}
+
+        @register("test.bonus", "B", ActionType.BONUS_ACTION, "pool", registry=reg)
+        def _b(actor, turn_state, target, payload):
+            return FeatureResult(True)
+
+        actor = _fighter()
+        actor.add_resource_pool(ResourcePool("pool", 1, 1, "short_rest"))
+        turn = TurnState()
+        turn.reset()
+        turn.consume_action(ActionType.BONUS_ACTION)  # spend the bonus action
+
+        result = use_feature(actor, turn, "test.bonus", registry=reg)
+
+        assert result.success is False
+        assert "action" in (result.message or "")
+        # gate ran before consume: the resource pool is untouched
+        assert actor.get_resource_pool("pool").current == 1
+
+    def test_gate_fails_when_resource_empty_action_untouched(self):
+        reg: dict[str, ClassFeature] = {}
+
+        @register("test.bonus2", "B2", ActionType.BONUS_ACTION, "pool", registry=reg)
+        def _b2(actor, turn_state, target, payload):
+            return FeatureResult(True)
+
+        actor = _fighter()
+        actor.add_resource_pool(ResourcePool("pool", 0, 1, "short_rest"))  # empty
+        turn = TurnState()
+        turn.reset()
+
+        result = use_feature(actor, turn, "test.bonus2", registry=reg)
+
+        assert result.success is False
+        assert "resource" in (result.message or "")
+        # gate ran before consume: the bonus action is still available
+        assert turn.bonus_action_available is True
+
+
+class TestSecondWind:
+    """Integration: Fighter Second Wind — bonus action, short-rest pool, heals."""
+
+    def test_second_wind_heals_consumes_bonus_action_and_pool(self):
+        char = _fighter(level=1, max_hp=20)
+        char.add_resource_pool(ResourcePool("second_wind", 1, 1, "short_rest"))
+        char.current_hp = 2
+        turn = TurnState()
+        turn.reset(speed=30)
+
+        expected = DiceRoller(seed=42).roll("1d10+1").total
+        result = use_feature(
+            char,
+            turn,
+            "fighter.second_wind",
+            payload={"dice_roller": DiceRoller(seed=42)},
+        )
+
+        assert result.success is True
+        assert char.current_hp == 2 + expected
+        assert char.get_resource_pool("second_wind").current == 0
+        assert turn.bonus_action_available is False
+
+    def test_second_wind_unavailable_when_pool_empty_then_recovers_on_short_rest(self):
+        char = _fighter(level=1, max_hp=20)
+        char.add_resource_pool(ResourcePool("second_wind", 1, 1, "short_rest"))
+        char.current_hp = 2
+
+        first_turn = TurnState()
+        first_turn.reset()
+        assert use_feature(char, first_turn, "fighter.second_wind").success is True
+
+        # Fresh turn — pool is now empty, so the resource gate refuses and
+        # leaves the bonus action available (gate-before-consume).
+        next_turn = TurnState()
+        next_turn.reset()
+        denied = use_feature(char, next_turn, "fighter.second_wind")
+        assert denied.success is False
+        assert next_turn.bonus_action_available is True
+
+        char.take_short_rest()
+        assert char.get_resource_pool("second_wind").current == 1
+        rested_turn = TurnState()
+        rested_turn.reset()
+        assert use_feature(char, rested_turn, "fighter.second_wind").success is True
+
+
+class TestActionSurge:
+    """Integration: Fighter Action Surge — no action cost, grants an extra action."""
+
+    def test_action_surge_grants_extra_action_and_consumes_pool(self):
+        char = _fighter(level=2)
+        char.add_resource_pool(ResourcePool("action_surge", 1, 1, "short_rest"))
+        turn = TurnState()
+        turn.reset()
+        turn.consume_action(ActionType.ACTION)  # main action already spent
+        assert turn.action_available is False
+
+        result = use_feature(char, turn, "fighter.action_surge")
+
+        assert result.success is True
+        assert turn.action_available is True  # extra action granted
+        assert char.get_resource_pool("action_surge").current == 0
+
+
+class TestArcaneRecovery:
+    """Integration: Wizard Arcane Recovery — long-rest pool, handler-managed accounting.
+
+    Its pool is consumed by Character.use_arcane_recovery itself, so the
+    registry entry declares resource_pool=None to avoid double-consume.
+    """
+
+    def test_arcane_recovery_restores_slots_and_consumes_its_own_pool(self):
+        wiz = _wizard(level=2)
+        wiz.add_resource_pool(ResourcePool("arcane_recovery", 1, 1, "long_rest"))
+        wiz.add_resource_pool(ResourcePool("1st level slots", 0, 2, "long_rest"))
+        turn = TurnState()
+        turn.reset()
+
+        result = use_feature(
+            wiz,
+            turn,
+            "wizard.arcane_recovery",
+            payload={"spell_slot_levels": {1: 1}},
+        )
+
+        assert result.success is True
+        assert wiz.get_resource_pool("1st level slots").current == 1
+        assert wiz.get_resource_pool("arcane_recovery").current == 0
+
+
+class TestDataRegistryParity:
+    """Guardrail: every feature_id declared in classes.json has a handler.
+
+    This is the safety net for future class authors: declaring a class
+    feature in data with a `feature_id` but forgetting to register a
+    handler fails CI here and names the registry module.
+    """
+
+    def _declared_features(self):
+        data = json.loads(CLASSES_JSON.read_text())
+        declared = []
+        for class_data in data.values():
+            for feats in (class_data.get("features_by_level") or {}).values():
+                for feat in feats:
+                    if "feature_id" in feat:
+                        declared.append(feat)
+        return declared
+
+    def test_classes_json_declares_the_cohort(self):
+        ids = {f["feature_id"] for f in self._declared_features()}
+        assert {
+            "fighter.second_wind",
+            "fighter.action_surge",
+            "wizard.arcane_recovery",
+        } <= ids
+
+    def test_every_declared_feature_id_is_registered(self):
+        for feat in self._declared_features():
+            fid = feat["feature_id"]
+            registered = get_feature(fid)
+            assert registered is not None, (
+                f"classes.json declares feature_id '{fid}' with no handler "
+                f"registered in dnd_engine/systems/class_features.py"
+            )
+
+    def test_dispatcher_managed_pool_matches_data(self):
+        """When the registry declares a dispatcher-managed pool, it must
+        match the data's resource.pool. Handler-managed features
+        (resource_pool=None, e.g. Arcane Recovery) are exempt."""
+        for feat in self._declared_features():
+            registered = get_feature(feat["feature_id"])
+            if registered.resource_pool is None:
+                continue
+            assert registered.resource_pool == feat["resource"]["pool"]


### PR DESCRIPTION
## Summary
- Adds a **class-feature registry** — the prerequisite infrastructure that unblocks the Magic action (#446) and closes out **plan-01** (last of 19 children).
- Catalogs class features with a stable id, action cost, resource pool, and a handler returning a structured `FeatureResult`; `use_feature()` dispatcher settles action-economy + resource gating (gate-before-consume) so callers don't repeat it.
- Wires a proof-of-concept cohort against classes that **already exist** (Fighter, Wizard) — genuinely end-to-end, no new class scaffolding.

## Changes
- **`dnd_engine/systems/class_features.py`** (new): `FeatureResult`, `ClassFeature`, `FEATURE_REGISTRY`, `register` decorator, `get_feature`/`list_features`, and the `use_feature()` dispatcher. Module docstring documents the two-step recipe for adding future features.
- **`dnd_engine/data/srd/classes.json`**: additive `feature_id` keys linking Second Wind, Action Surge, and Arcane Recovery to their handlers. No change to resource blocks or load logic.
- **`tests/test_class_features.py`** (new): unit (registry mechanics + gate-before-consume), integration (real `Character` + `ResourcePool` + `take_short_rest()`), and a **data↔registry parity guardrail** that fails CI if a declared `feature_id` has no handler.

### Cohort
| feature_id | Action cost | Pool / recovery | Effect |
|---|---|---|---|
| `fighter.second_wind` | Bonus action | `second_wind` / short rest | Heal 1d10 + level |
| `fighter.action_surge` | No action | `action_surge` / short rest | Grant an extra action |
| `wizard.arcane_recovery` | No action | handler-managed / long rest | Delegates to `use_arcane_recovery` (avoids double-consume) |

## Testing
- [x] New suite: 12/12 pass (unit + integration, real engine, no mocking)
- [x] Regression: actions / resources / leveling / rest — 108 passed, 0 regressions
- [x] Ruff lint + format clean
- [ ] CLI/MCP e2e — **explicitly deferred to #446** (no player-facing caller until the Magic-action dispatcher lands; recorded on #446)

## Related Issues
Closes #591. Unblocks #446 (Magic action dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)