### PR TITLE
Add #482: Implement Temporary Hit Points (plan-04)

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -1244,13 +1244,21 @@ class Character(Creature):
         if self.stabilized:
             self.stabilized = False
 
-        # Apply damage (parent implementation)
-        super().take_damage(amount)
+        # Apply damage (parent implementation). Temporary Hit Points are
+        # drained first; `hp_damage` is the carryover that actually
+        # landed on Hit Points. All death-save / massive-damage rules
+        # below key off `hp_damage`, not the raw incoming `amount`, so a
+        # blow absorbed by the Temp HP buffer doesn't trigger them. When
+        # there is no buffer, `hp_damage == amount` and behavior is
+        # unchanged.
+        hp_damage = super().take_damage(amount)
 
-        # Handle damage while at 0 HP (already-unconscious entry)
-        if was_unconscious:
+        # Handle damage while at 0 HP (already-unconscious entry). If the
+        # Temp HP buffer fully absorbed the blow (`hp_damage == 0`) no
+        # Hit Points were lost, so no death-save failure is incurred.
+        if was_unconscious and hp_damage > 0:
             # Check for massive damage (damage >= max HP = instant death)
-            if amount >= self.max_hp:
+            if hp_damage >= self.max_hp:
                 # Instant death
                 self.death_save_failures = 3
 
@@ -1258,7 +1266,11 @@ class Character(Creature):
                     event_bus.emit(
                         Event(
                             type=EventType.MASSIVE_DAMAGE_DEATH,
-                            data={"character": self.name, "damage": amount, "max_hp": self.max_hp},
+                            data={
+                                "character": self.name,
+                                "damage": hp_damage,
+                                "max_hp": self.max_hp,
+                            },
                         )
                     )
             else:
@@ -1273,7 +1285,7 @@ class Character(Creature):
                             type=EventType.DAMAGE_AT_ZERO_HP,
                             data={
                                 "character": self.name,
-                                "damage": amount,
+                                "damage": hp_damage,
                                 "failures": self.death_save_failures,
                                 "failures_added": failures_added,
                                 "critical_hit": critical_hit,
@@ -1283,12 +1295,12 @@ class Character(Creature):
         elif pre_hp > 0 and self.current_hp == 0:
             # Positive HP → 0 transition this call. Detect the SRD
             # massive-damage overflow case: when the remainder of the
-            # incoming damage (after zeroing HP) meets or exceeds
-            # `max_hp`, the character dies outright rather than
-            # falling Unconscious. The "Unconscious" condition added
-            # by `_sync_dying_conditions` below will be replaced with
+            # HP damage (after zeroing HP) meets or exceeds `max_hp`,
+            # the character dies outright rather than falling
+            # Unconscious. The "Unconscious" condition added by
+            # `_sync_dying_conditions` below will be replaced with
             # "dead" because `death_save_failures` is forced to 3.
-            overflow = amount - pre_hp
+            overflow = hp_damage - pre_hp
             if overflow >= self.max_hp:
                 self.death_save_failures = 3
                 if event_bus is not None:
@@ -1297,7 +1309,7 @@ class Character(Creature):
                             type=EventType.MASSIVE_DAMAGE_DEATH,
                             data={
                                 "character": self.name,
-                                "damage": amount,
+                                "damage": hp_damage,
                                 "max_hp": self.max_hp,
                                 "overflow": overflow,
                             },

--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -1458,6 +1458,10 @@ class Character(Creature):
             self.process_stable_recovery(hours_elapsed=8.0)
             hp_recovered = self.recover_hp()
             resources_recovered = self.recover_resources("long_rest")
+            # SRD § Playing the Game › Temporary Hit Points › Duration:
+            # Temp HP "last until they're depleted or you finish a Long
+            # Rest." A Long Rest zeroes the buffer (a Short Rest does not).
+            self.temporary_hit_points = 0
             # Clear all non-permanent conditions (8 hours exceeds any timed condition)
             conditions_removed = self.clear_expired_conditions()
 

--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -368,6 +368,43 @@ class Creature:
 
         self.current_hp = min(self.max_hp, self.current_hp + amount)
 
+    def set_temporary_hit_points(self, amount: int, *, replace: bool = False) -> int:
+        """
+        Grant Temporary Hit Points to the creature.
+
+        SRD § Playing the Game › Temporary Hit Points › Don't Stack:
+        "Temporary Hit Points can't be added together. If you have
+        Temporary Hit Points and receive more of them, you decide
+        whether to keep the ones you have or to gain the new ones."
+
+        The default resolution keeps the greater of the existing and new
+        pools — the sensible automatic reading of "you decide" when no
+        explicit choice is supplied. A caller honoring a player's choice
+        to take the new pool (even when it is smaller) passes
+        ``replace=True`` to install ``amount`` unconditionally. Either
+        way the pools are never summed.
+
+        This is NOT healing (SRD: "receiving Temporary Hit Points
+        doesn't count as healing"): it never touches `current_hp`,
+        works at full HP, and does not revive a creature at 0 HP. It
+        emits no event and takes no event bus.
+
+        Args:
+            amount: Temp HP to grant. Negative values clamp to 0.
+            replace: When True, install `amount` as the pool even if it
+                is lower than the current value. When False (default),
+                keep whichever pool is greater.
+
+        Returns:
+            The resulting Temporary Hit Points pool.
+        """
+        amount = max(0, amount)
+        if replace:
+            self.temporary_hit_points = amount
+        else:
+            self.temporary_hit_points = max(self.temporary_hit_points, amount)
+        return self.temporary_hit_points
+
     def is_immune_to_condition(self, condition: str) -> bool:
         """
         Check whether this creature is immune to a named condition.

--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -145,6 +145,11 @@ class Creature:
         self.name = name
         self.max_hp = max_hp
         self.current_hp = current_hp if current_hp is not None else max_hp
+        # SRD § Playing the Game › Temporary Hit Points: a buffer pool,
+        # separate from Hit Points, that absorbs damage before HP is
+        # touched. Not Hit Points — healing cannot restore it and a
+        # grant is not a heal. Defaults to 0 (no buffer).
+        self.temporary_hit_points: int = 0
         self._base_ac = ac  # Store base AC (before modifiers from spells/effects)
         self.abilities = abilities
         self.size = size
@@ -322,16 +327,30 @@ class Creature:
         """
         return name in self._alt_base_ac_formulas
 
-    def take_damage(self, amount: int) -> None:
+    def take_damage(self, amount: int) -> int:
         """
         Apply damage to the creature.
 
-        HP cannot go below 0.
+        SRD § Playing the Game › Temporary Hit Points › Lose Temp HP
+        First: Temporary Hit Points are lost first, and any leftover
+        damage carries over to Hit Points (e.g. 5 Temp HP + 7 damage =
+        0 Temp HP, 2 HP lost). HP cannot go below 0.
 
         Args:
             amount: Amount of damage to apply
+
+        Returns:
+            The damage that actually landed on Hit Points — the
+            carryover after the Temp HP buffer absorbed what it could.
+            Equals `amount` when there is no Temp HP. Callers that drive
+            death-save / massive-damage logic should key off this value
+            rather than the raw incoming amount.
         """
-        self.current_hp = max(0, self.current_hp - amount)
+        absorbed = min(self.temporary_hit_points, amount)
+        self.temporary_hit_points -= absorbed
+        carryover = amount - absorbed
+        self.current_hp = max(0, self.current_hp - carryover)
+        return carryover
 
     def heal(self, amount: int) -> None:
         """

--- a/dnd-engine/dnd_engine/systems/item_effects.py
+++ b/dnd-engine/dnd_engine/systems/item_effects.py
@@ -380,10 +380,14 @@ def _apply_buff_effect(
         buff_conditions.append(condition_name)
 
     elif buff_type == "temporary_hp":
-        # TODO: Implement proper temporary HP system
-        # For now, just add a condition indicating they have the buff
-        target.add_condition("has_temporary_hp_buff")
-        buff_conditions.append("has_temporary_hp_buff")
+        # SRD § Playing the Game › Temporary Hit Points: grant a real
+        # buffer pool. The amount comes from the item's `temporary_hp`
+        # field (falling back to `amount`); Temp HP never stack, so the
+        # grant keeps the greater of the existing and new pool. A
+        # missing or non-positive amount grants nothing.
+        temp_hp_amount = int(item_info.get("temporary_hp", item_info.get("amount", 0)) or 0)
+        if temp_hp_amount > 0:
+            target.set_temporary_hit_points(temp_hp_amount)
 
     # Add any extra conditions specified
     extra_conditions = item_info.get("adds_conditions", [])

--- a/dnd-engine/tests/srd/playing_the_game/test_temporary_hit_points.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_temporary_hit_points.py
@@ -145,22 +145,28 @@ class TestTempHP_DontStack:
     """
 
     def test_receiving_new_temp_hp_does_not_sum_with_existing(self) -> None:
-        pytest.skip(
-            "GAP: no Temp HP grant API exists. The placeholder buff "
-            "at dnd_engine/systems/item_effects.py:364-368 attaches a "
-            "condition (`has_temporary_hp_buff`) without any amount. "
-            "There is nowhere to test the SRD's worked example "
-            "(10 + 12 = pick one, never 22). Tracked by issue #482."
-        )
+        # SRD worked example: 12 granted over an existing 10 yields 12,
+        # never 22 — Temp HP can't be added together.
+        creature = _make_creature()
+        creature.set_temporary_hit_points(10)
+        creature.set_temporary_hit_points(12)
+        assert creature.temporary_hit_points == 12
+        # A lower grant doesn't shrink the buffer either (keep-greater).
+        creature.set_temporary_hit_points(5)
+        assert creature.temporary_hit_points == 12
 
     def test_caller_chooses_to_keep_or_replace_temp_hp(self) -> None:
-        pytest.skip(
-            "GAP: depends on the grant API. The SRD lets the recipient "
-            "*decide* (keep the old or take the new). A real grant "
-            "API must surface this choice — defaulting to max() is a "
-            "common implementation but the SRD reserves the choice to "
-            "the player. Tracked by issue #482."
-        )
+        # SRD reserves the choice to the recipient. The default
+        # auto-resolves to the greater pool; a caller honoring an
+        # explicit "take the new pool" choice passes replace=True, which
+        # installs the new amount even when it is lower than the old.
+        creature = _make_creature()
+        creature.set_temporary_hit_points(10)
+        creature.set_temporary_hit_points(5)  # default: keep the greater
+        assert creature.temporary_hit_points == 10
+        result = creature.set_temporary_hit_points(5, replace=True)
+        assert creature.temporary_hit_points == 5
+        assert result == 5  # helper returns the resulting pool
 
 
 class TestTempHP_NotHitPointsNotHealing:
@@ -174,38 +180,41 @@ class TestTempHP_NotHitPointsNotHealing:
     """
 
     def test_healing_does_not_restore_temporary_hit_points(self) -> None:
-        pytest.skip(
-            "GAP: depends on the Temp HP pool field. `Creature.heal` "
-            "(dnd_engine/core/creature.py:226-240) and "
-            "`Character.recover_hp` "
-            "(dnd_engine/core/character.py:1150-1174) operate on "
-            "`current_hp` only; there is no Temp HP pool to inadvertently "
-            "modify, but also no way to assert the SRD's negative — "
-            "'healing can't restore them' — until the field exists. "
-            "Tracked by issue #482."
-        )
+        # Drain part of a buffer, then heal: healing restores HP only,
+        # never the depleted Temp HP pool.
+        creature = _make_creature(max_hp=20, current_hp=20)
+        creature.set_temporary_hit_points(5)
+        creature.take_damage(8)  # 5 absorbed, 3 to HP
+        assert creature.temporary_hit_points == 0
+        assert creature.current_hp == 17
+        creature.heal(5)
+        assert creature.current_hp == 20  # capped at max
+        assert creature.temporary_hit_points == 0  # heal can't refill Temp HP
 
     def test_full_hp_creature_can_still_receive_temp_hp(self) -> None:
-        pytest.skip(
-            "GAP: depends on the grant API. SRD: 'a creature can be at "
-            "full Hit Points and receive Temporary Hit Points.' "
-            "`Creature.heal` is a no-op at full HP "
-            "(dnd_engine/core/creature.py:240), which is *correct* for "
-            "healing — but a Temp HP grant must NOT short-circuit on "
-            "full HP. There is no grant path to exercise. Tracked by "
-            "issue #482."
-        )
+        # SRD: 'a creature can be at full Hit Points and receive
+        # Temporary Hit Points.' The grant must not short-circuit on
+        # full HP the way healing does.
+        creature = _make_creature(max_hp=20, current_hp=20)
+        creature.set_temporary_hit_points(7)
+        assert creature.current_hp == 20  # HP untouched
+        assert creature.temporary_hit_points == 7
 
     def test_temp_hp_grant_is_not_a_healing_event(self) -> None:
-        pytest.skip(
-            "GAP: depends on the Temp HP grant API. The SRD calls out "
-            "that 'receiving Temporary Hit Points doesn't count as "
-            "healing' — so a Temp HP grant must NOT emit a HEALING_DONE "
-            "event "
-            "(dnd_engine/utils/events.py) or otherwise be observable as "
-            "a heal. Today no such grant API exists. Tracked by "
-            "issue #482."
+        # 'Receiving Temporary Hit Points doesn't count as healing.' The
+        # grant API is a pure pool operation on Creature — it takes no
+        # event bus and cannot raise HP, so it can never be observed as
+        # a heal (no HEALING_DONE, no current_hp change).
+        import inspect
+
+        sig = inspect.signature(Creature.set_temporary_hit_points)
+        assert "event_bus" not in sig.parameters, (
+            "set_temporary_hit_points must not accept an event bus — a "
+            "Temp HP grant is not a healing event."
         )
+        creature = _make_creature(max_hp=20, current_hp=12)
+        creature.set_temporary_hit_points(6)
+        assert creature.current_hp == 12  # grant did not heal
 
 
 class TestTempHP_ZeroHpInteraction:

--- a/dnd-engine/tests/srd/playing_the_game/test_temporary_hit_points.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_temporary_hit_points.py
@@ -48,6 +48,30 @@ def _make_creature(max_hp: int = 20, current_hp: int | None = None) -> Creature:
     )
 
 
+def _make_character(max_hp: int = 20, current_hp: int | None = None):
+    """Build a level-1 Fighter for Temp HP assertions that need the
+    full Character rest / death-save machinery (the bare Creature has
+    neither)."""
+    from dnd_engine.core.character import Character, CharacterClass
+
+    return Character(
+        name="Hero",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=Abilities(
+            strength=14,
+            dexterity=12,
+            constitution=13,
+            intelligence=10,
+            wisdom=11,
+            charisma=8,
+        ),
+        max_hp=max_hp,
+        ac=16,
+        current_hp=current_hp,
+    )
+
+
 class TestTempHP_Intro:
     """SRD § Playing the Game › Temporary Hit Points › Intro.
 
@@ -117,21 +141,19 @@ class TestTempHP_Duration:
     """
 
     def test_long_rest_clears_temporary_hit_points(self) -> None:
-        pytest.skip(
-            "GAP: `Character.take_long_rest` "
-            "(dnd_engine/core/character.py:1236-1280) restores HP and "
-            "clears expired conditions but has no Temp HP pool to "
-            "zero out. Tracked by issue #482."
-        )
+        # SRD: Temp HP last until depleted or a Long Rest.
+        character = _make_character(max_hp=20, current_hp=15)
+        character.set_temporary_hit_points(8)
+        character.take_long_rest()
+        assert character.temporary_hit_points == 0
 
     def test_short_rest_does_not_clear_temporary_hit_points(self) -> None:
-        pytest.skip(
-            "GAP: depends on the Temp HP pool field. The SRD scopes "
-            "expiry to Long Rest specifically — short rest must NOT "
-            "drain Temp HP. `Character.take_short_rest` "
-            "(dnd_engine/core/character.py:1202-1234) has no Temp HP "
-            "branch to assert against. Tracked by issue #482."
-        )
+        # SRD scopes expiry to a Long Rest specifically — a Short Rest
+        # must leave the buffer intact.
+        character = _make_character(max_hp=20, current_hp=15)
+        character.set_temporary_hit_points(8)
+        character.take_short_rest()
+        assert character.temporary_hit_points == 8
 
 
 class TestTempHP_DontStack:

--- a/dnd-engine/tests/srd/playing_the_game/test_temporary_hit_points.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_temporary_hit_points.py
@@ -17,12 +17,35 @@ import inspect
 
 import pytest
 
-from dnd_engine.core.creature import Creature
+from dnd_engine.core.creature import Abilities, Creature
 
 pytestmark = pytest.mark.srd(
     "playing-the-game/temporary-hit-points.md",
     lines="2393-2433",
 )
+
+
+def _make_creature(max_hp: int = 20, current_hp: int | None = None) -> Creature:
+    """Build a bare Creature for Temp HP assertions.
+
+    Ability scores are arbitrary (Temp HP behavior doesn't depend on
+    them); only `max_hp`/`current_hp` matter for the buffer/carryover
+    rules under test.
+    """
+    return Creature(
+        name="Subject",
+        max_hp=max_hp,
+        ac=10,
+        abilities=Abilities(
+            strength=10,
+            dexterity=10,
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
+        ),
+        current_hp=current_hp,
+    )
 
 
 class TestTempHP_Intro:
@@ -33,15 +56,8 @@ class TestTempHP_Intro:
     """
 
     def test_creature_has_a_temporary_hit_points_field(self) -> None:
-        pytest.skip(
-            "GAP: `Creature` (dnd_engine/core/creature.py:57-102) has "
-            "no `temporary_hit_points` (or equivalent) field. The only "
-            "in-engine reference to temp HP is "
-            "dnd_engine/systems/item_effects.py:364-368 which attaches "
-            "a flavor `has_temporary_hp_buff` condition with a TODO "
-            "comment ('Implement proper temporary HP system') — no "
-            "actual pool is tracked. Tracked by issue #482."
-        )
+        creature = _make_creature(max_hp=10)
+        assert creature.temporary_hit_points == 0
 
     def test_item_effects_temporary_hp_buff_placeholder_is_documented(self) -> None:
         """Source-level guard: the placeholder is still labeled TODO.
@@ -72,22 +88,25 @@ class TestTempHP_LoseTempHPFirst:
     """
 
     def test_damage_subtracts_from_temp_hp_before_hp(self) -> None:
-        pytest.skip(
-            "GAP: `Creature.take_damage` "
-            "(dnd_engine/core/creature.py:215-224) subtracts the full "
-            "damage amount from `current_hp` directly. There is no "
-            "Temp HP pool to drain first, so the SRD's worked example "
-            "(5 Temp HP + 7 damage = 0 Temp HP + 2 HP lost) cannot be "
-            "exercised. Tracked by issue #482."
-        )
+        # SRD worked example: 5 Temp HP + 7 damage = 0 Temp HP, 2 HP lost.
+        creature = _make_creature(max_hp=20, current_hp=20)
+        creature.temporary_hit_points = 5
+        carryover = creature.take_damage(7)
+        assert creature.temporary_hit_points == 0
+        assert creature.current_hp == 18
+        # take_damage reports the HP damage that actually landed (the
+        # leftover after the buffer absorbed what it could).
+        assert carryover == 2
 
     def test_damage_exactly_equal_to_temp_hp_leaves_real_hp_untouched(self) -> None:
-        pytest.skip(
-            "GAP: depends on the Temp HP pool field. The SRD example "
-            "implies a clean boundary — 5 damage against 5 Temp HP "
-            "must consume all Temp HP and leave real HP untouched. "
-            "Tracked by issue #482."
-        )
+        # A clean boundary: 5 damage against 5 Temp HP consumes the
+        # whole buffer and leaves real HP untouched.
+        creature = _make_creature(max_hp=20, current_hp=20)
+        creature.temporary_hit_points = 5
+        carryover = creature.take_damage(5)
+        assert creature.temporary_hit_points == 0
+        assert creature.current_hp == 20
+        assert carryover == 0
 
 
 class TestTempHP_Duration:

--- a/dnd-engine/tests/srd/playing_the_game/test_temporary_hit_points.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_temporary_hit_points.py
@@ -83,22 +83,25 @@ class TestTempHP_Intro:
         creature = _make_creature(max_hp=10)
         assert creature.temporary_hit_points == 0
 
-    def test_item_effects_temporary_hp_buff_placeholder_is_documented(self) -> None:
-        """Source-level guard: the placeholder is still labeled TODO.
+    def test_item_effects_temporary_hp_buff_grants_real_pool(self) -> None:
+        """Source-level guard: the catalog branch grants a real pool.
 
-        Until the real Temp HP system lands (issue #482), the engine
-        carries a placeholder buff at
-        `dnd_engine/systems/item_effects.py:364-368`. This test pins
-        that placeholder so it can't silently start claiming Temp-HP
-        semantics without being rewritten.
+        The placeholder that attached a flavor `has_temporary_hp_buff`
+        condition with no amount has been replaced (issue #482). The
+        `temporary_hp` branch now grants a real Temp HP pool via
+        `set_temporary_hit_points`. This guard pins the real grant so
+        the branch can't silently regress to a flavor condition.
         """
         from dnd_engine.systems import item_effects
 
-        src = inspect.getsource(item_effects)
-        assert "TODO: Implement proper temporary HP system" in src, (
-            "Placeholder Temp-HP buff at "
-            "dnd_engine/systems/item_effects.py:364-368 must remain "
-            "labeled TODO until the real system (issue #482) lands."
+        src = inspect.getsource(item_effects._apply_buff_effect)
+        assert "set_temporary_hit_points" in src, (
+            "The `temporary_hp` catalog branch must grant a real pool "
+            "via set_temporary_hit_points (issue #482)."
+        )
+        assert "has_temporary_hp_buff" not in src, (
+            "The flavor `has_temporary_hp_buff` placeholder condition "
+            "must be gone now that the real Temp HP pool exists."
         )
 
 

--- a/dnd-engine/tests/srd/playing_the_game/test_temporary_hit_points.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_temporary_hit_points.py
@@ -225,16 +225,63 @@ class TestTempHP_ZeroHpInteraction:
     """
 
     def test_temp_hp_grant_does_not_revive_unconscious_creature(self) -> None:
-        pytest.skip(
-            "GAP: depends on Temp HP grant + Unconscious linkage. "
-            "`Character.recover_hp` "
-            "(dnd_engine/core/character.py:1162-1173) explicitly "
-            "resets death saves when leaving 0 HP — that path is "
-            "*correct* for healing, but the SRD requires a Temp HP "
-            "grant to NOT trigger the same revival. Without a grant "
-            "API the negative cannot be exercised. Tracked by "
-            "issue #482."
+        # SRD: at 0 HP, receiving Temp HP does NOT restore consciousness.
+        from dnd_engine.core.character import Character, CharacterClass
+
+        character = Character(
+            name="Downed",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=Abilities(
+                strength=14,
+                dexterity=12,
+                constitution=13,
+                intelligence=10,
+                wisdom=11,
+                charisma=8,
+            ),
+            max_hp=20,
+            ac=16,
+            current_hp=0,
         )
+        character.death_save_failures = 1
+        character.set_temporary_hit_points(8)
+        assert character.temporary_hit_points == 8
+        assert character.current_hp == 0  # still down — grant is not healing
+        assert character.is_unconscious  # not revived
+        assert character.death_save_failures == 1  # death saves untouched
+
+    def test_temp_hp_absorbs_damage_at_0_hp_without_a_death_save_failure(self) -> None:
+        # A downed creature holding Temp HP that fully absorbs a blow
+        # loses no Hit Points, so it suffers no new death-save failure.
+        # (When the buffer is empty — every existing death-save test —
+        # carryover equals the incoming amount and the failure still
+        # fires, so this path is purely additive.)
+        from dnd_engine.core.character import Character, CharacterClass
+
+        character = Character(
+            name="Downed",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=Abilities(
+                strength=14,
+                dexterity=12,
+                constitution=13,
+                intelligence=10,
+                wisdom=11,
+                charisma=8,
+            ),
+            max_hp=20,
+            ac=16,
+            current_hp=0,
+        )
+        character.death_save_failures = 0
+        character.set_temporary_hit_points(10)
+        character.take_damage(6)  # fully absorbed by the buffer
+        assert character.temporary_hit_points == 4
+        assert character.current_hp == 0
+        assert character.death_save_failures == 0  # no HP lost → no failure
+        assert character.is_unconscious
 
     def test_only_true_healing_revives_a_zero_hp_creature(self) -> None:
         """Healing (not Temp HP) is what revives a downed creature.

--- a/dnd-engine/tests/test_item_effects_phase5.py
+++ b/dnd-engine/tests/test_item_effects_phase5.py
@@ -348,18 +348,19 @@ class TestBuffEffect:
         assert target_creature.has_condition("has_resistance_fire")
 
     def test_apply_temporary_hp_buff(self, target_creature):
-        """Test applying temporary HP buff"""
+        """Temp HP buff grants a real Temporary Hit Points pool (issue #482)."""
         item_info = {
             "name": "Potion of Heroism",
             "effect_type": "buff",
             "buff_type": "temporary_hp",
+            "temporary_hp": 10,
             "duration_minutes": 60,
         }
 
         result = apply_item_effect(item_info, target_creature)
 
         assert result.success is True
-        assert target_creature.has_condition("has_temporary_hp_buff")
+        assert target_creature.temporary_hit_points == 10
 
     def test_apply_buff_with_extra_conditions(self, target_creature):
         """Test applying buff with additional conditions"""
@@ -367,6 +368,7 @@ class TestBuffEffect:
             "name": "Potion of Heroism",
             "effect_type": "buff",
             "buff_type": "temporary_hp",
+            "temporary_hp": 10,
             "duration_minutes": 60,
             "adds_conditions": ["immune_to_fear"],
         }
@@ -374,7 +376,7 @@ class TestBuffEffect:
         result = apply_item_effect(item_info, target_creature)
 
         assert result.success is True
-        assert target_creature.has_condition("has_temporary_hp_buff")
+        assert target_creature.temporary_hit_points == 10
         assert target_creature.has_condition("immune_to_fear")
 
     def test_buff_emits_event(self, target_creature):


### PR DESCRIPTION
## Summary
Implements SRD Temporary Hit Points — the last substantive gap in plan-04 (the 0-HP / death-saves / HP model). Before this change the engine had **no Temp HP pool at all**; the only reference was a placeholder buff condition in `item_effects.py` with a `TODO` and no tracked amount.

Converts the 11 pre-written `pytest.skip("GAP: ...")` conformance stubs in `test_temporary_hit_points.py` into real passing tests (suite now **15/15, 0 skipped**).

## SRD rules implemented
- **Buffer** — separate pool, not Hit Points
- **Lose Temp HP first** — damage drains the pool, leftover carries to HP (5 Temp HP + 7 damage → 0 Temp HP, 2 HP lost)
- **Don't stack** — grants never sum; keep-greater by default, `replace=True` honors an explicit player choice
- **Duration** — cleared on a Long Rest; preserved on a Short Rest
- **Not Hit Points / not healing** — healing can't restore Temp HP; a grant emits no healing event, works at full HP, and never revives a creature at 0 HP

## Changes
- **`core/creature.py`**: add `temporary_hit_points` pool (default 0); `take_damage` drains it first and returns the HP-damage carryover; new `set_temporary_hit_points(amount, *, replace=False)` grant helper.
- **`core/character.py`**: `take_damage` keys its death-save / massive-damage / overflow rules off the carryover instead of the raw amount, so a blow absorbed by the buffer at 0 HP incurs no failure; `take_long_rest` zeroes the buffer.
- **`systems/item_effects.py`**: the `temporary_hp` catalog branch now grants a real pool via `set_temporary_hit_points` (was a flavor condition).
- **tests**: converted conformance stubs; updated 2 phase-5 item tests and the source-level guard to pin the real pool.

## Design note
The SRD is silent on whether Temp-HP-absorbed damage at 0 HP triggers a death-save failure. This PR treats "no HP lost → no failure." Defaulting the pool to 0 keeps every existing damage/death-save path byte-identical (carryover == amount when there's no buffer).

## Testing
- [x] Temp HP conformance suite: 15 passed, 0 skipped (was 11 skipped)
- [x] Full engine suite: 3105 passed, 0 failed
- [x] Death-save / HP / healing / rest regression suites green
- [x] `ruff check` + `ruff format --check` clean on touched files
- [x] `python-code-reviewer`: no critical/high issues

## Related Issues
Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)