### PR TITLE
plan-05 slice A: engine-side visibility & special-senses model (#534)

### DIFF
--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -172,6 +172,14 @@ class Creature:
         # Maps condition name -> metadata dict
         self.active_conditions: dict[str, dict] = {}
 
+        # SRD § Vision and Light › Special Senses: a map of special
+        # senses to their range in feet (e.g. {Sense.BLINDSIGHT: 60}).
+        # Ordinary sight is implicit and not stored here. Consumed by
+        # `dnd_engine.systems.perception` to compute visibility; defaults
+        # to empty (sight only). Keys may be `Sense` members or their
+        # string values — `perception.observer_senses` normalizes them.
+        self.senses: dict = {}
+
         # Alternate base-AC formulas (SRD § Playing the Game › Attack Rolls
         # › Armor Class › "Only One Base AC"). A creature may register
         # multiple ways to calculate its base AC (Mage Armor, Barbarian /

--- a/dnd-engine/dnd_engine/systems/perception.py
+++ b/dnd-engine/dnd_engine/systems/perception.py
@@ -1,0 +1,223 @@
+# ABOUTME: Engine-side visibility & special-senses model for D&D 5E (plan-05).
+# ABOUTME: Computes the VisibilityRelation between an observer and a target.
+
+"""First-class visibility / sense layer for the engine.
+
+Vision and obscurement used to live only in the ``client-2d`` rendering
+layer; the engine had no model of who can perceive whom. This module
+provides that model so rules — attack advantage/disadvantage, sight-based
+checks, the Hide gate — can consult a single source of truth.
+
+The core primitive is :func:`compute_visibility`, which answers, for an
+``(observer, target)`` pair under a given lighting / obscurement
+condition, whether the target is ``Seen``, ``UnseenButSensed`` (located
+by a non-visual sense such as tremorsense, but still unseen for the
+unseen-attacker/target rules), or ``Unseen``.
+
+SRD references:
+- Playing the Game › Vision and Light › Obscured Areas.
+- Rules glossary: Blindsight, Darkvision, Tremorsense, Truesight; the
+  Blinded and Invisible conditions.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+
+
+class LightLevel(str, Enum):
+    """Ambient illumination at a location (SRD § Vision and Light)."""
+
+    BRIGHT = "bright"
+    DIM = "dim"
+    DARK = "dark"
+
+
+class Obscurement(str, Enum):
+    """How obscured an area is for sight-based perception.
+
+    SRD: a Lightly Obscured area (Dim Light, patchy fog, moderate
+    foliage) imposes Disadvantage on sight-based Wisdom (Perception)
+    checks; a Heavily Obscured area (Darkness, heavy fog, dense foliage)
+    is opaque — a creature trying to see into it has the Blinded
+    condition with respect to that area.
+    """
+
+    CLEAR = "clear"
+    LIGHTLY = "lightly"
+    HEAVILY = "heavily"
+
+
+class Sense(str, Enum):
+    """Perception channels a creature can possess.
+
+    ``SIGHT`` is the default channel every creature has unless Blinded;
+    the others are special senses carried (with a range in feet) in
+    ``Creature.senses``.
+    """
+
+    SIGHT = "sight"
+    DARKVISION = "darkvision"
+    BLINDSIGHT = "blindsight"
+    TREMORSENSE = "tremorsense"
+    TRUESIGHT = "truesight"
+
+
+class VisibilityRelation(str, Enum):
+    """How an observer perceives a target.
+
+    - ``SEEN`` — perceived by a channel that counts as seeing (normal
+      sight, darkvision within range, blindsight, truesight). The
+      unseen-attacker / unseen-target rules do not apply.
+    - ``UNSEEN_BUT_SENSED`` — located by a non-visual sense (tremorsense)
+      but still unseen: the observer knows the square but attacks are
+      still made as against an unseen target.
+    - ``UNSEEN`` — not perceived at all.
+    """
+
+    SEEN = "seen"
+    UNSEEN_BUT_SENSED = "unseen_but_sensed"
+    UNSEEN = "unseen"
+
+
+# Sources of light/darkness map onto obscurement (SRD § Obscured Areas):
+# Dim Light *is* a Lightly Obscured area; Darkness *is* a Heavily
+# Obscured area. Bright Light contributes no obscurement of its own.
+_LIGHT_OBSCUREMENT: dict[LightLevel, Obscurement] = {
+    LightLevel.BRIGHT: Obscurement.CLEAR,
+    LightLevel.DIM: Obscurement.LIGHTLY,
+    LightLevel.DARK: Obscurement.HEAVILY,
+}
+
+# Severity ordering so we can take the "worst" of two obscurement sources.
+_OBSCUREMENT_SEVERITY: dict[Obscurement, int] = {
+    Obscurement.CLEAR: 0,
+    Obscurement.LIGHTLY: 1,
+    Obscurement.HEAVILY: 2,
+}
+
+
+def observer_senses(creature: Creature) -> dict[Sense, int]:
+    """Resolve a creature's special senses to a ``{Sense: range_ft}`` map.
+
+    Reconciles the canonical ``creature.senses`` dict (whose keys may be
+    :class:`Sense` members or their string values) with the legacy
+    ``creature.darkvision_range`` attribute that pre-dates this model.
+    When both name a range for the same sense, the wider range wins.
+    """
+    resolved: dict[Sense, int] = {}
+
+    raw = getattr(creature, "senses", None) or {}
+    for key, range_ft in raw.items():
+        sense = key if isinstance(key, Sense) else Sense(str(key).lower())
+        resolved[sense] = max(resolved.get(sense, 0), int(range_ft))
+
+    legacy_darkvision = int(getattr(creature, "darkvision_range", 0) or 0)
+    if legacy_darkvision:
+        resolved[Sense.DARKVISION] = max(resolved.get(Sense.DARKVISION, 0), legacy_darkvision)
+
+    return resolved
+
+
+def effective_obscurement(
+    light_level: LightLevel,
+    ambient: Obscurement = Obscurement.CLEAR,
+) -> Obscurement:
+    """Combine lighting-derived obscurement with an ambient source.
+
+    The result is the more severe of the obscurement implied by the
+    light level (Dim → Lightly, Darkness → Heavily) and any ambient
+    obscurement already present (fog, foliage). Obscurement never
+    improves: two sources stack to the worse of the two.
+    """
+    from_light = _LIGHT_OBSCUREMENT[light_level]
+    if _OBSCUREMENT_SEVERITY[ambient] >= _OBSCUREMENT_SEVERITY[from_light]:
+        return ambient
+    return from_light
+
+
+def compute_visibility(
+    observer: Creature,
+    target: Creature,
+    *,
+    light_level: LightLevel = LightLevel.BRIGHT,
+    obscurement: Obscurement = Obscurement.CLEAR,
+    distance: float = 0.0,
+    has_line_of_sight: bool = True,
+    target_on_ground: bool = True,
+) -> VisibilityRelation:
+    """Compute how ``observer`` perceives ``target``.
+
+    Args:
+        observer: The perceiving creature; its senses (sight, darkvision,
+            blindsight, tremorsense, truesight) and the Blinded condition
+            drive the result.
+        target: The creature being perceived; the Invisible and Hidden
+            conditions hide it from sight.
+        light_level: Ambient illumination at the target.
+        obscurement: Ambient obscurement at the target (fog, foliage).
+            This is *additional* to lighting; the effective obscurement
+            for sight is the worse of this and the lighting-derived one.
+        distance: Distance between observer and target, in feet.
+        has_line_of_sight: Whether an unobstructed path exists. Total
+            cover (a wall) blocks every channel modeled here, including
+            blindsight and truesight.
+        target_on_ground: Whether the target is in contact with a surface
+            tremorsense can travel through. Flying / incorporeal targets
+            are invisible to tremorsense.
+
+    Returns:
+        The :class:`VisibilityRelation` from observer to target.
+    """
+    if not has_line_of_sight:
+        # Total cover defeats every channel modeled here.
+        return VisibilityRelation.UNSEEN
+
+    senses = observer_senses(observer)
+    blinded = observer.has_condition("blinded")
+    target_invisible = target.has_condition("invisible")
+    target_hidden = target.has_condition("hidden")
+
+    # Truesight sees in darkness (normal and magical), pierces invisibility,
+    # and ignores obscurement, out to its range.
+    truesight = senses.get(Sense.TRUESIGHT, 0)
+    if truesight and distance <= truesight:
+        return VisibilityRelation.SEEN
+
+    # Blindsight perceives without relying on sight; light, invisibility,
+    # and obscurement do not impede it within range.
+    blindsight = senses.get(Sense.BLINDSIGHT, 0)
+    if blindsight and distance <= blindsight:
+        return VisibilityRelation.SEEN
+
+    # Normal sight (optionally aided by darkvision). Sight fails if the
+    # observer is Blinded, the target is Invisible or Hidden, or the area
+    # is Heavily Obscured. Darkness is Heavily Obscured to ordinary sight;
+    # darkvision downgrades it to Dim (still Seen) within range.
+    sight_obscurement = effective_obscurement(light_level, obscurement)
+    darkvision = senses.get(Sense.DARKVISION, 0)
+    darkvision_reaches = bool(darkvision) and distance <= darkvision
+    if light_level == LightLevel.DARK and darkvision_reaches:
+        # Darkvision turns darkness into dim light for this observer.
+        sight_obscurement = effective_obscurement(LightLevel.DIM, obscurement)
+
+    if (
+        not blinded
+        and not target_invisible
+        and not target_hidden
+        and sight_obscurement != Obscurement.HEAVILY
+    ):
+        return VisibilityRelation.SEEN
+
+    # Tremorsense locates a target through a shared surface, but does not
+    # let the observer see it — the target remains unseen for attack
+    # advantage/disadvantage purposes.
+    tremorsense = senses.get(Sense.TREMORSENSE, 0)
+    if tremorsense and target_on_ground and distance <= tremorsense:
+        return VisibilityRelation.UNSEEN_BUT_SENSED
+
+    return VisibilityRelation.UNSEEN

--- a/dnd-engine/tests/srd/playing_the_game/test_visibility.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_visibility.py
@@ -1,0 +1,288 @@
+# ABOUTME: SRD conformance for the engine-side visibility model (plan-05 slice A).
+# ABOUTME: Parametrized observer/target matrix → VisibilityRelation + obscurement.
+
+"""SRD conformance: engine-side Vision, Stealth & Special Senses.
+
+This is the executable form of plan-05's test matrix. Each row pairs an
+observer (with a set of senses) against a target (with a state) under a
+lighting / obscurement condition and asserts the resulting
+``VisibilityRelation``. The relation is the engine's first-class answer
+to "can this observer perceive this target, and how" — the rule that the
+``client-2d`` rendering layer mimics today for display only.
+
+SRD references:
+- Playing the Game › Vision and Light › Obscured Areas (Lightly / Heavily).
+- The rules glossary entries for Blindsight, Darkvision, Tremorsense, and
+  Truesight.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.systems.perception import (
+    LightLevel,
+    Obscurement,
+    Sense,
+    VisibilityRelation,
+    compute_visibility,
+    effective_obscurement,
+    observer_senses,
+)
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/vision-and-light.md",
+    lines="1537-1578",
+)
+
+
+def _creature(
+    name: str = "C",
+    *,
+    senses: dict[Sense, int] | None = None,
+    conditions: tuple[str, ...] = (),
+) -> Creature:
+    """Build a bare Creature with optional special senses and conditions."""
+    abilities = Abilities(
+        strength=10,
+        dexterity=10,
+        constitution=10,
+        intelligence=10,
+        wisdom=10,
+        charisma=10,
+    )
+    creature = Creature(name=name, max_hp=10, ac=10, abilities=abilities)
+    if senses:
+        creature.senses = dict(senses)
+    for condition in conditions:
+        creature.add_condition(condition)
+    return creature
+
+
+# (label, observer senses, target conditions, light, obscurement, distance,
+#  target_on_ground, expected relation)
+_MATRIX = [
+    (
+        "sight/normal/bright/clear",
+        {},
+        (),
+        LightLevel.BRIGHT,
+        Obscurement.CLEAR,
+        30.0,
+        True,
+        VisibilityRelation.SEEN,
+    ),
+    (
+        "sight/normal/dim/clear",
+        {},
+        (),
+        LightLevel.DIM,
+        Obscurement.CLEAR,
+        30.0,
+        True,
+        VisibilityRelation.SEEN,
+    ),
+    (
+        "sight/normal/dark/clear",
+        {},
+        (),
+        LightLevel.DARK,
+        Obscurement.CLEAR,
+        30.0,
+        True,
+        VisibilityRelation.UNSEEN,
+    ),
+    (
+        "sight/normal/bright/lightly",
+        {},
+        (),
+        LightLevel.BRIGHT,
+        Obscurement.LIGHTLY,
+        30.0,
+        True,
+        VisibilityRelation.SEEN,
+    ),
+    (
+        "sight/normal/bright/heavily",
+        {},
+        (),
+        LightLevel.BRIGHT,
+        Obscurement.HEAVILY,
+        30.0,
+        True,
+        VisibilityRelation.UNSEEN,
+    ),
+    (
+        "darkvision60/normal/dark<=60/clear",
+        {Sense.DARKVISION: 60},
+        (),
+        LightLevel.DARK,
+        Obscurement.CLEAR,
+        30.0,
+        True,
+        VisibilityRelation.SEEN,
+    ),
+    (
+        "darkvision60/normal/dark>60/clear",
+        {Sense.DARKVISION: 60},
+        (),
+        LightLevel.DARK,
+        Obscurement.CLEAR,
+        90.0,
+        True,
+        VisibilityRelation.UNSEEN,
+    ),
+    (
+        "blindsight60/hidden/dark/clear",
+        {Sense.BLINDSIGHT: 60},
+        ("hidden",),
+        LightLevel.DARK,
+        Obscurement.CLEAR,
+        30.0,
+        True,
+        VisibilityRelation.SEEN,
+    ),
+    (
+        "tremorsense30/flying/dark/clear",
+        {Sense.TREMORSENSE: 30},
+        (),
+        LightLevel.DARK,
+        Obscurement.CLEAR,
+        20.0,
+        False,
+        VisibilityRelation.UNSEEN,
+    ),
+    (
+        "tremorsense30/grounded/dark/clear",
+        {Sense.TREMORSENSE: 30},
+        (),
+        LightLevel.DARK,
+        Obscurement.CLEAR,
+        20.0,
+        True,
+        VisibilityRelation.UNSEEN_BUT_SENSED,
+    ),
+    (
+        "truesight60/invisible/dark/clear",
+        {Sense.TRUESIGHT: 60},
+        ("invisible",),
+        LightLevel.DARK,
+        Obscurement.CLEAR,
+        30.0,
+        True,
+        VisibilityRelation.SEEN,
+    ),
+    (
+        "sight/invisible/bright/clear",
+        {},
+        ("invisible",),
+        LightLevel.BRIGHT,
+        Obscurement.CLEAR,
+        30.0,
+        True,
+        VisibilityRelation.UNSEEN,
+    ),
+]
+
+
+class TestVisibilityRelation:
+    """plan-05 matrix: (observer, target, environment) → VisibilityRelation."""
+
+    @pytest.mark.parametrize(
+        "label,senses,conditions,light,obscurement,distance,on_ground,expected",
+        _MATRIX,
+        ids=[row[0] for row in _MATRIX],
+    )
+    def test_matrix(
+        self,
+        label,
+        senses,
+        conditions,
+        light,
+        obscurement,
+        distance,
+        on_ground,
+        expected,
+    ):
+        observer = _creature("Observer", senses=senses)
+        target = _creature("Target", conditions=conditions)
+        relation = compute_visibility(
+            observer,
+            target,
+            light_level=light,
+            obscurement=obscurement,
+            distance=distance,
+            target_on_ground=on_ground,
+        )
+        assert relation == expected, label
+
+    def test_total_cover_blocks_even_blindsight(self):
+        """No line of sight (total cover) defeats sight and blindsight alike."""
+        observer = _creature("Observer", senses={Sense.BLINDSIGHT: 60})
+        target = _creature("Target")
+        relation = compute_visibility(
+            observer,
+            target,
+            light_level=LightLevel.BRIGHT,
+            obscurement=Obscurement.CLEAR,
+            distance=10.0,
+            has_line_of_sight=False,
+        )
+        assert relation == VisibilityRelation.UNSEEN
+
+    def test_blinded_observer_cannot_use_sight(self):
+        """A Blinded observer fails all sight-based perception (SRD: Blinded)."""
+        observer = _creature("Observer", conditions=("blinded",))
+        target = _creature("Target")
+        relation = compute_visibility(
+            observer,
+            target,
+            light_level=LightLevel.BRIGHT,
+            obscurement=Obscurement.CLEAR,
+            distance=10.0,
+        )
+        assert relation == VisibilityRelation.UNSEEN
+
+
+class TestObserverSenses:
+    """`observer_senses` reconciles the senses dict with legacy attrs."""
+
+    def test_legacy_darkvision_range_attr_is_merged(self):
+        observer = _creature("Observer")
+        observer.darkvision_range = 60
+        senses = observer_senses(observer)
+        assert senses.get(Sense.DARKVISION) == 60
+
+    def test_senses_dict_keys_may_be_strings_or_enums(self):
+        observer = _creature("Observer")
+        observer.senses = {"blindsight": 30, Sense.TREMORSENSE: 15}
+        senses = observer_senses(observer)
+        assert senses.get(Sense.BLINDSIGHT) == 30
+        assert senses.get(Sense.TREMORSENSE) == 15
+
+    def test_wider_range_wins_when_attr_and_dict_disagree(self):
+        observer = _creature("Observer", senses={Sense.DARKVISION: 30})
+        observer.darkvision_range = 120
+        senses = observer_senses(observer)
+        assert senses.get(Sense.DARKVISION) == 120
+
+
+class TestEffectiveObscurement:
+    """SRD § Obscured Areas: Dim Light → Lightly, Darkness → Heavily."""
+
+    @pytest.mark.parametrize(
+        "light,ambient,expected",
+        [
+            (LightLevel.BRIGHT, Obscurement.CLEAR, Obscurement.CLEAR),
+            (LightLevel.DIM, Obscurement.CLEAR, Obscurement.LIGHTLY),
+            (LightLevel.DARK, Obscurement.CLEAR, Obscurement.HEAVILY),
+            # Ambient obscurement never improves on the lighting-derived one.
+            (LightLevel.BRIGHT, Obscurement.HEAVILY, Obscurement.HEAVILY),
+            (LightLevel.DIM, Obscurement.HEAVILY, Obscurement.HEAVILY),
+            (LightLevel.BRIGHT, Obscurement.LIGHTLY, Obscurement.LIGHTLY),
+            (LightLevel.DIM, Obscurement.LIGHTLY, Obscurement.LIGHTLY),
+        ],
+    )
+    def test_worst_of_light_and_ambient_wins(self, light, ambient, expected):
+        assert effective_obscurement(light, ambient) == expected

--- a/dnd-engine/tests/srd/playing_the_game/test_vision_and_light.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_vision_and_light.py
@@ -156,16 +156,21 @@ class TestVisionAndLight_ObscuredAreas:
     """
 
     def test_lightly_obscured_concept_exists_in_engine(self):
-        pytest.skip(
-            "GAP: the literal 'lightly_obscured' concept is not "
-            "modeled. The string appears nowhere in `dnd-engine/"
-            "dnd_engine/`. Dim light's mechanical effect is hard-coded "
-            "for the literal 'perception' skill in `GameState."
-            "_apply_lighting_penalties` (`dnd-engine/dnd_engine/core/"
-            "game_state.py:753-754`) but is not surfaced as a reusable "
-            "obscurement state that other sight-based rules could "
-            "consult. Tracked by issue #493."
+        """The Lightly Obscured concept is a first-class engine state.
+
+        plan-05 slice A introduces `Obscurement.LIGHTLY` as a reusable
+        obscurement state, and Dim Light maps onto it via
+        `effective_obscurement` — the reusable hook other sight-based
+        rules can consult. (issue #493)
+        """
+        from dnd_engine.systems.perception import (
+            LightLevel,
+            Obscurement,
+            effective_obscurement,
         )
+
+        assert Obscurement.LIGHTLY.value == "lightly"
+        assert effective_obscurement(LightLevel.DIM) == Obscurement.LIGHTLY
 
     def test_lightly_obscured_dim_light_imposes_disadvantage_on_sight_perception(self):
         """Dim Light imposes Disadvantage on Wisdom (Perception) checks.
@@ -199,13 +204,21 @@ class TestVisionAndLight_ObscuredAreas:
         )
 
     def test_heavily_obscured_concept_exists_in_engine(self):
-        pytest.skip(
-            "GAP: the 'heavily_obscured' concept is not modeled in the "
-            "engine. The string appears only as descriptive text in "
-            "`dnd-engine/dnd_engine/data/srd/spells.json:893` "
-            "(`poison_cloud` description) — no code path reads it. "
-            "Tracked by issue #493."
+        """The Heavily Obscured concept is a first-class engine state.
+
+        `Obscurement.HEAVILY` exists and Darkness maps onto it via
+        `effective_obscurement`; a sight-based observer is Unseen across
+        a heavily obscured area (the Blinded-against-that-area rule).
+        (issue #493)
+        """
+        from dnd_engine.systems.perception import (
+            LightLevel,
+            Obscurement,
+            effective_obscurement,
         )
+
+        assert Obscurement.HEAVILY.value == "heavily"
+        assert effective_obscurement(LightLevel.DARK) == Obscurement.HEAVILY
 
     def test_heavily_obscured_darkness_auto_fails_sight_based_perception(self):
         """Darkness short-circuits sight-based Perception to auto-fail.
@@ -472,33 +485,92 @@ class TestVisionAndLight_SpecialSenses:
         assert Capability.DARKVISION in racial.get("elf", [])
 
     def test_blindsight_is_modeled(self):
-        pytest.skip(
-            "GAP: Blindsight is not modeled as an engine concept. The "
-            "string appears only as descriptive text in `dnd-engine/"
-            "dnd_engine/data/srd/monsters.json:670` (zombie senses "
-            "field: 'blindsight 60 ft. (blind beyond this radius)'). "
-            "No `Capability.BLINDSIGHT` exists, no per-creature "
-            "`blindsight_range` field exists, and no engine code "
-            "consults it. Tracked by issue #495."
+        """Blindsight is a first-class engine sense (plan-05 slice A).
+
+        `Sense.BLINDSIGHT` exists and `compute_visibility` lets an
+        observer with blindsight perceive a target in darkness within
+        range — the rule the rendering layer could only approximate.
+        Catalog import of the monster `senses` field is wired in a
+        later slice (issue #495); here the engine *concept* exists.
+        """
+        from dnd_engine.systems.perception import (
+            LightLevel,
+            Sense,
+            VisibilityRelation,
+            compute_visibility,
         )
+
+        observer = _make_human_character()
+        observer.senses = {Sense.BLINDSIGHT: 60}
+        target = _make_human_character()
+        relation = compute_visibility(
+            observer,
+            target,
+            light_level=LightLevel.DARK,
+            distance=30.0,
+        )
+        assert relation == VisibilityRelation.SEEN
 
     def test_tremorsense_is_modeled(self):
-        pytest.skip(
-            "GAP: Tremorsense is not modeled. The string 'tremorsense' "
-            "does not appear anywhere in `dnd-engine/dnd_engine/`. No "
-            "capability, no per-creature range, no consumer. Tracked "
-            "by issue #495."
+        """Tremorsense is modeled and senses only grounded targets.
+
+        `Sense.TREMORSENSE` locates a grounded target through a shared
+        surface (UnseenButSensed) within range, but a flying target —
+        out of contact with the ground — is Unseen. (issue #495)
+        """
+        from dnd_engine.systems.perception import (
+            LightLevel,
+            Sense,
+            VisibilityRelation,
+            compute_visibility,
         )
 
-    def test_truesight_is_modeled(self):
-        pytest.skip(
-            "GAP: Truesight is not modeled. The string 'truesight' "
-            "does not appear anywhere in `dnd-engine/dnd_engine/`. No "
-            "capability, no per-creature range, no consumer — which "
-            "matters because Truesight is the only sense that sees "
-            "through magical Darkness (also unmodeled — see issue "
-            "#494). Tracked by issue #495."
+        observer = _make_human_character()
+        observer.senses = {Sense.TREMORSENSE: 30}
+        target = _make_human_character()
+        grounded = compute_visibility(
+            observer,
+            target,
+            light_level=LightLevel.DARK,
+            distance=20.0,
+            target_on_ground=True,
         )
+        flying = compute_visibility(
+            observer,
+            target,
+            light_level=LightLevel.DARK,
+            distance=20.0,
+            target_on_ground=False,
+        )
+        assert grounded == VisibilityRelation.UNSEEN_BUT_SENSED
+        assert flying == VisibilityRelation.UNSEEN
+
+    def test_truesight_is_modeled(self):
+        """Truesight sees through darkness and invisibility within range.
+
+        Truesight is the only sense that pierces magical Darkness and
+        the Invisible condition; `compute_visibility` returns Seen for a
+        truesighted observer against an invisible target in the dark,
+        within range. (issue #495)
+        """
+        from dnd_engine.systems.perception import (
+            LightLevel,
+            Sense,
+            VisibilityRelation,
+            compute_visibility,
+        )
+
+        observer = _make_human_character()
+        observer.senses = {Sense.TRUESIGHT: 60}
+        target = _make_human_character()
+        target.add_condition("invisible")
+        relation = compute_visibility(
+            observer,
+            target,
+            light_level=LightLevel.DARK,
+            distance=30.0,
+        )
+        assert relation == VisibilityRelation.SEEN
 
 
 class TestVisionAndLight_CombatVisibilityNotConsulted:


### PR DESCRIPTION
## Summary

First slice of plan-05 (**Vision, Stealth & Special Senses**, meta-issue #534), sliced A→E.

The root defect: vision/obscurement lived only in `client-2d` as a rendering concern; the engine had no model of who can perceive whom. This slice gives the engine a **first-class visibility/sense layer** that later slices (attack adv/disadv, Hide gate) and the client will consume.

## What's in this slice

**New `dnd_engine/systems/perception.py`** (100% coverage):
- `LightLevel` (bright/dim/dark), `Obscurement` (clear/lightly/heavily), `Sense` (sight/darkvision/blindsight/tremorsense/truesight), `VisibilityRelation` (seen/unseen_but_sensed/unseen) enums.
- `compute_visibility(observer, target, *, light_level, obscurement, distance, has_line_of_sight, target_on_ground)` — resolves the relation from line of sight, lighting, obscurement, observer senses, and the target's Invisible/Hidden state.
  - Truesight pierces darkness + invisibility within range.
  - Blindsight ignores light/invisibility/obscurement within range.
  - Darkvision downgrades Darkness → Dim within range (still Seen).
  - Tremorsense locates only **grounded** targets → `UNSEEN_BUT_SENSED`.
  - Total cover (no LOS) defeats every channel.
- `effective_obscurement()` — Dim → Lightly, Darkness → Heavily, worst-of-two stacking (SRD Obscured Areas, #493).
- `observer_senses()` — reconciles the new `Creature.senses` dict with the legacy `darkvision_range` attr.

**`Creature.senses: dict`** field added for special senses (#495 groundwork).

## Tests
- New parametrized `tests/srd/playing_the_game/test_visibility.py` encoding the plan-05 matrix (12 rows + LOS/blinded edges).
- Converted 5 gap tests in `test_vision_and_light.py` from `pytest.skip("GAP")` → passing assertions (blindsight/tremorsense/truesight modeled; lightly/heavily-obscured concepts exist).
- **Full SRD suite: 638 passed, 212 skipped, 0 failures.** Ruff clean.

## Deferred to later slices
The 10 remaining `test_vision_and_light.py` skips need attack-roll wiring (slice C, #475), the Blinded *condition* application + data-driven obscurement sources, monster-catalog senses import (slice B, #495), and `client-2d` migration (slice E, #494).

## Slicing
A (this) → B (monster senses import #495) → C (attack adv/disadv #475) → D (Hide gate + action #443/#496) → E (client-2d migration #494).

🤖 Generated with [Claude Code](https://claude.com/claude-code)