### PR TITLE
plan-05 slice B: import monster special senses from catalog (#534)

### DIFF
--- a/dnd-engine/dnd_engine/rules/loader.py
+++ b/dnd-engine/dnd_engine/rules/loader.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from dnd_engine.core.creature import Abilities, Creature, MovementMode, Size
 from dnd_engine.core.dice import DiceRoller
+from dnd_engine.systems.perception import parse_senses
 
 
 class DataLoader:
@@ -137,6 +138,16 @@ class DataLoader:
         # attachment when the target is immune. SRD: "Immunity to a
         # condition means you aren't affected by it."
         creature.condition_immunities = list(data.get("condition_immunities") or [])
+
+        # Special senses (plan-05 #495). The catalog carries a free-form
+        # SRD stat-block string ("blindsight 60 ft. (blind beyond this
+        # radius), passive Perception 6"); parse it into the canonical
+        # {Sense: range_ft} map consumed by
+        # `dnd_engine.systems.perception.compute_visibility`. Passive
+        # Perception and parenthetical qualifiers are ignored, and
+        # ordinary sight is implicit. Empty when the monster has no
+        # special senses.
+        creature.senses = parse_senses(data.get("senses"))
 
         return creature
 

--- a/dnd-engine/dnd_engine/systems/perception.py
+++ b/dnd-engine/dnd_engine/systems/perception.py
@@ -22,6 +22,7 @@ SRD references:
 
 from __future__ import annotations
 
+import re
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -120,6 +121,40 @@ def observer_senses(creature: Creature) -> dict[Sense, int]:
     if legacy_darkvision:
         resolved[Sense.DARKVISION] = max(resolved.get(Sense.DARKVISION, 0), legacy_darkvision)
 
+    return resolved
+
+
+# Matches a special sense and its foot range in an SRD stat-block
+# `senses` string, e.g. "blindsight 60 ft. (blind beyond this radius)".
+# Passive Perception and parenthetical qualifiers are not captured.
+_SENSE_RANGE_RE = re.compile(
+    r"\b(darkvision|blindsight|tremorsense|truesight)\b\s+(\d+)\s*ft",
+    re.IGNORECASE,
+)
+
+
+def parse_senses(senses_text: str | None) -> dict[Sense, int]:
+    """Parse an SRD stat-block ``senses`` string into ``{Sense: range_ft}``.
+
+    Recognizes the four ranged special senses (Darkvision, Blindsight,
+    Tremorsense, Truesight). Passive Perception and parenthetical
+    qualifiers such as "(blind beyond this radius)" are ignored, and
+    ordinary sight is implicit so it is never stored. When the same
+    sense appears more than once, the wider range wins.
+
+    Args:
+        senses_text: The catalog ``senses`` value (may be ``None`` or
+            empty for a creature with only ordinary sight).
+
+    Returns:
+        A ``{Sense: range_ft}`` map suitable for ``Creature.senses``.
+    """
+    resolved: dict[Sense, int] = {}
+    if not senses_text:
+        return resolved
+    for keyword, range_ft in _SENSE_RANGE_RE.findall(senses_text):
+        sense = Sense(keyword.lower())
+        resolved[sense] = max(resolved.get(sense, 0), int(range_ft))
     return resolved
 
 

--- a/dnd-engine/tests/srd/playing_the_game/test_visibility.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_visibility.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import pytest
 
 from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.rules.loader import DataLoader
 from dnd_engine.systems.perception import (
     LightLevel,
     Obscurement,
@@ -29,6 +30,7 @@ from dnd_engine.systems.perception import (
     compute_visibility,
     effective_obscurement,
     observer_senses,
+    parse_senses,
 )
 
 pytestmark = pytest.mark.srd(
@@ -286,3 +288,68 @@ class TestEffectiveObscurement:
     )
     def test_worst_of_light_and_ambient_wins(self, light, ambient, expected):
         assert effective_obscurement(light, ambient) == expected
+
+
+class TestParseSenses:
+    """`parse_senses` reads SRD stat-block `senses` strings."""
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("darkvision 60 ft., passive Perception 9", {Sense.DARKVISION: 60}),
+            ("darkvision 120 ft., passive Perception 10", {Sense.DARKVISION: 120}),
+            (
+                "blindsight 60 ft. (blind beyond this radius), passive Perception 6",
+                {Sense.BLINDSIGHT: 60},
+            ),
+            ("tremorsense 30 ft., passive Perception 11", {Sense.TREMORSENSE: 30}),
+            ("truesight 120 ft., passive Perception 14", {Sense.TRUESIGHT: 120}),
+            (
+                "blindsight 10 ft., darkvision 60 ft., passive Perception 12",
+                {Sense.BLINDSIGHT: 10, Sense.DARKVISION: 60},
+            ),
+            ("passive Perception 13", {}),
+            ("", {}),
+            (None, {}),
+        ],
+    )
+    def test_parses_special_senses_and_ignores_passive_perception(self, text, expected):
+        assert parse_senses(text) == expected
+
+
+class TestMonsterCatalogSenses:
+    """SRD § Special Senses are imported from monsters.json (#495).
+
+    The monster catalog already carries a free-form `senses` stat-block
+    string. `DataLoader.create_monster` now parses it into the canonical
+    `Creature.senses` map so `compute_visibility` works for monsters.
+    """
+
+    def test_goblin_imports_darkvision_60(self):
+        goblin = DataLoader().create_monster("goblin")
+        assert goblin.senses.get(Sense.DARKVISION) == 60
+
+    def test_animated_armor_imports_blindsight_60(self):
+        armor = DataLoader().create_monster("animated_armor")
+        assert armor.senses.get(Sense.BLINDSIGHT) == 60
+
+    def test_bearded_devil_imports_darkvision_120(self):
+        devil = DataLoader().create_monster("bearded_devil")
+        assert devil.senses.get(Sense.DARKVISION) == 120
+
+    def test_imported_senses_drive_visibility_in_the_dark(self):
+        """A blindsight monster Sees a target in darkness within range."""
+        armor = DataLoader().create_monster("animated_armor")
+        target = _creature("Hero")
+        relation = compute_visibility(
+            armor,
+            target,
+            light_level=LightLevel.DARK,
+            distance=30.0,
+        )
+        assert relation == VisibilityRelation.SEEN
+
+    def test_sight_is_never_stored_as_a_special_sense(self):
+        """Ordinary sight is implicit — it is never put in the senses map."""
+        rat = DataLoader().create_monster("giant_rat")
+        assert Sense.SIGHT not in rat.senses


### PR DESCRIPTION
## Summary

Slice B of plan-05 (#534). Wires the SRD stat-block `senses` string from `monsters.json` into the engine's first-class sense model (introduced in Slice A, #600) so monsters actually populate `Creature.senses`.

## What's in this slice
- **`perception.parse_senses(senses_text)`** — parses a stat-block string like `"blindsight 60 ft. (blind beyond this radius), passive Perception 6"` into `{Sense.BLINDSIGHT: 60}`. Recognizes darkvision/blindsight/tremorsense/truesight; ignores passive Perception and parenthetical qualifiers; ordinary sight stays implicit. Wider range wins on duplicates.
- **`DataLoader.create_monster()`** — assigns `creature.senses = parse_senses(data.get("senses"))` alongside the existing damage/condition catalog fields.

Result: goblin → darkvision 60, animated_armor → blindsight 60, bearded_devil → darkvision 120 now flow straight into `compute_visibility`.

## Tests
- `TestParseSenses` — parser unit matrix (all four senses, multi-sense strings, passive-only, empty, `None`).
- `TestMonsterCatalogSenses` — `DataLoader` integration for goblin/animated_armor/bearded_devil + a visibility check (blindsight monster Sees in darkness) + sight-never-stored invariant.
- **Full engine suite: 3148 passed, 213 skipped, 0 failures.** Ruff clean.

## Slicing
A (#600, merged) → **B (this)** → C (attack adv/disadv #475) → D (Hide gate + action #443/#496) → E (client-2d migration #494).

Closes the catalog-import half of #495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)