### PR TITLE
Wire visibility into attack resolution (plan-05 slice C, #475)

### DIFF
--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -7,6 +7,7 @@ from typing import Any
 from dnd_engine.core.creature import Creature
 from dnd_engine.core.dice import DiceRoller
 from dnd_engine.rules.damage import apply_damage_adjustments, apply_damage_modifiers
+from dnd_engine.systems.perception import VisibilityRelation
 from dnd_engine.utils.events import Event, EventType
 
 
@@ -132,6 +133,8 @@ class CombatEngine:
         action: dict | None = None,
         game_state=None,
         damage_type: str | None = None,
+        attacker_sees_defender: VisibilityRelation | None = None,
+        defender_sees_attacker: VisibilityRelation | None = None,
     ) -> AttackResult:
         """
         Resolve a complete attack.
@@ -169,6 +172,18 @@ class CombatEngine:
                 this method (SRD: "Damage types ... have no rules of
                 their own"); it is purely a key for the modifier
                 chokepoint.
+            attacker_sees_defender: How the attacker perceives the
+                defender (a `VisibilityRelation`). When the attacker
+                can't see the target — `UNSEEN` or `UNSEEN_BUT_SENSED`
+                (tremorsense locates but does not see) — the attack is
+                made with Disadvantage (SRD § Unseen Attackers and
+                Targets). `None` (default) leaves the roll unmodified.
+            defender_sees_attacker: How the defender perceives the
+                attacker. When the defender can't see the attacker, the
+                attacker has Advantage. `None` leaves the roll
+                unmodified. When both an unseen attacker and an unseen
+                target apply, they cancel via the advantage/disadvantage
+                rule below.
 
         Returns:
             AttackResult containing full attack details including sneak attack if applicable
@@ -190,6 +205,19 @@ class CombatEngine:
         if getattr(attacker, "pending_help_from", None) is not None:
             advantage = True
             attacker.pending_help_from = None
+
+        # SRD § Combat › Unseen Attackers and Targets: an attacker the
+        # target can't see has Advantage; a target the attacker can't
+        # see is attacked with Disadvantage. Both UNSEEN and
+        # UNSEEN_BUT_SENSED count as "can't see" — tremorsense locates a
+        # creature but does not let you see it. When both apply they
+        # cancel via the advantage/disadvantage rule below. A `None`
+        # relation means the caller did not supply visibility state, so
+        # the roll is left unmodified (backward compatibility).
+        if defender_sees_attacker is not None and defender_sees_attacker != VisibilityRelation.SEEN:
+            advantage = True
+        if attacker_sees_defender is not None and attacker_sees_defender != VisibilityRelation.SEEN:
+            disadvantage = True
 
         # SRD: "If circumstances cause a roll to have both advantage
         # and disadvantage, you're considered to have neither of them"

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -30,6 +30,11 @@ from dnd_engine.systems.opportunity_attacks import (
     publish_movement_provoke,
     register_default_opportunity_attack,
 )
+from dnd_engine.systems.perception import (
+    LightLevel,
+    VisibilityRelation,
+    compute_visibility,
+)
 from dnd_engine.systems.reactions import ReactionDispatcher
 from dnd_engine.systems.spatial_index import SpatialIndex
 from dnd_engine.systems.time_manager import ActiveEffect, EffectType, TimeManager
@@ -1205,6 +1210,7 @@ class GameState:
         if action is None:
             return
 
+        attacker_sees_defender, defender_sees_attacker = self.attack_visibility(attacker, target)
         result = self.combat_engine.resolve_attack(
             attacker=attacker,
             defender=target,
@@ -1212,6 +1218,8 @@ class GameState:
             damage_dice=action["damage"],
             apply_damage=True,
             game_state=self,
+            attacker_sees_defender=attacker_sees_defender,
+            defender_sees_attacker=defender_sees_attacker,
         )
 
         if result.hit:
@@ -1394,6 +1402,55 @@ class GameState:
             return True, True, None
 
         return True, False, None
+
+    def _ambient_light_level(self) -> "LightLevel":
+        """Resolve the room's ambient light, before any observer's darkvision.
+
+        Mirrors `get_effective_lighting`'s room + temporary-effect
+        resolution but omits the per-observer darkvision downgrade: the
+        perception model (`compute_visibility`) applies darkvision itself
+        from each observer's senses, so feeding it the raw ambient level
+        avoids double-counting darkvision.
+        """
+        from dnd_engine.systems.time_manager import EffectType
+
+        room = self.get_current_room()
+        level = room.get("lighting", "bright")
+
+        for effect in self.time_manager.active_effects:
+            if effect.effect_type == EffectType.SPELL and effect.source.lower() == "light":
+                level = "bright"
+                break
+            if effect.effect_data.get("light_level"):
+                level = effect.effect_data["light_level"]
+                break
+
+        try:
+            return LightLevel(level)
+        except ValueError:
+            return LightLevel.BRIGHT
+
+    def attack_visibility(
+        self, attacker: "Creature", defender: "Creature"
+    ) -> tuple["VisibilityRelation", "VisibilityRelation"]:
+        """Compute the bidirectional visibility for an attack.
+
+        Returns ``(attacker_sees_defender, defender_sees_attacker)`` from
+        the engine perception model, using the room's ambient lighting
+        and each combatant's senses. `CombatEngine.resolve_attack`
+        consumes these to apply the SRD Unseen Attackers and Targets rule
+        (unseen attacker → Advantage; unseen target → Disadvantage).
+
+        The engine's core combat is non-positional, so distance defaults
+        to melee (0 ft) — every ranged special sense comfortably reaches,
+        which is the relation that matters for adjacent attacks. Lighting
+        is room-wide at this layer, matching the rest of the engine's
+        Vision and Light model.
+        """
+        light_level = self._ambient_light_level()
+        attacker_sees_defender = compute_visibility(attacker, defender, light_level=light_level)
+        defender_sees_attacker = compute_visibility(defender, attacker, light_level=light_level)
+        return attacker_sees_defender, defender_sees_attacker
 
     def get_available_actions(self) -> list[str]:
         """
@@ -2891,6 +2948,7 @@ class GameState:
             weapon_name = "unarmed strike"
 
         # Resolve attack via combat engine
+        attacker_sees_defender, defender_sees_attacker = self.attack_visibility(attacker, target)
         attack_result = self.combat_engine.resolve_attack(
             attacker=attacker,
             defender=target,
@@ -2899,6 +2957,8 @@ class GameState:
             disadvantage=disadvantage,
             apply_damage=True,
             game_state=self,
+            attacker_sees_defender=attacker_sees_defender,
+            defender_sees_attacker=defender_sees_attacker,
         )
 
         # Consume ammunition after the attack (hit or miss, the ammo is still used)
@@ -4841,6 +4901,7 @@ class GameState:
             conditions_before = set(target.active_conditions.keys())
 
         # Resolve attack
+        attacker_sees_defender, defender_sees_attacker = self.attack_visibility(enemy, target)
         attack_result = self.combat_engine.resolve_attack(
             attacker=enemy,
             defender=target,
@@ -4850,6 +4911,8 @@ class GameState:
             event_bus=self.event_bus,
             action=action,
             game_state=self,
+            attacker_sees_defender=attacker_sees_defender,
+            defender_sees_attacker=defender_sees_attacker,
         )
 
         # Check concentration if target was hit and took damage
@@ -5075,6 +5138,7 @@ class GameState:
                             break
 
                     if action:
+                        saw_defender, saw_attacker = self.attack_visibility(enemy, target)
                         result = self.combat_engine.resolve_attack(
                             attacker=enemy,
                             defender=target,
@@ -5082,6 +5146,8 @@ class GameState:
                             damage_dice=action["damage"],
                             apply_damage=True,
                             game_state=self,
+                            attacker_sees_defender=saw_defender,
+                            defender_sees_attacker=saw_attacker,
                         )
                         opportunity_attacks.append(result)
 
@@ -5350,6 +5416,7 @@ class GameState:
         damage_dice = used_item_data.get("damage", "1d4")
 
         # Resolve the attack
+        attacker_sees_defender, defender_sees_attacker = self.attack_visibility(user, target)
         attack_result = self.combat_engine.resolve_attack(
             attacker=user,
             defender=target,
@@ -5358,6 +5425,8 @@ class GameState:
             apply_damage=True,
             event_bus=self.event_bus,
             game_state=self,
+            attacker_sees_defender=attacker_sees_defender,
+            defender_sees_attacker=defender_sees_attacker,
         )
 
         # Apply special effects on hit

--- a/dnd-engine/tests/srd/playing_the_game/test_vision_and_light.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_vision_and_light.py
@@ -118,19 +118,69 @@ class TestVisionAndLight_Intro:
         )
 
     def test_hitting_an_enemy_is_affected_by_sight(self):
-        pytest.skip(
-            "GAP: the SRD intro names 'hitting an enemy' as one of the "
-            "sight-affected adventuring tasks, but `CombatEngine."
-            "resolve_attack` (`dnd-engine/dnd_engine/core/combat.py:91`) "
-            "does not take any lighting / obscurement / visibility "
-            "parameter. Attacks resolve identically in bright light, "
-            "dim light, and darkness. The per-tile visibility model "
-            "lives in `client-2d/src/client_2d/systems/lighting.py:111` "
-            "and `client-2d/src/client_2d/systems/fog_of_war.py:14` but "
-            "the engine never reads it back. Tracked by issue #494 "
-            "(vision rules in client-2d) and issue #475 (visibility "
-            "advantage/disadvantage)."
+        """'Hitting an enemy' reads visibility: darkness flips adv/disadv.
+
+        In darkness, ordinary sight fails in both directions (each
+        creature is `UNSEEN` to the other), so `compute_visibility`
+        reports the relations that `resolve_attack` turns into the
+        unseen-attacker Advantage and unseen-target Disadvantage — the
+        engine-level enforcement of the SRD intro's 'hitting an enemy is
+        affected by sight'. Issue #475."""
+        from dnd_engine.core.combat import CombatEngine
+        from dnd_engine.core.creature import Creature
+        from dnd_engine.core.dice import DiceRoller
+        from dnd_engine.systems.perception import (
+            LightLevel,
+            VisibilityRelation,
+            compute_visibility,
         )
+
+        abilities = Abilities(
+            strength=10,
+            dexterity=10,
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
+        )
+        attacker = Creature(name="Attacker", max_hp=10, ac=12, abilities=abilities)
+        defender = Creature(name="Defender", max_hp=10, ac=12, abilities=abilities)
+
+        # No darkvision on either side: in darkness each is Unseen to the other.
+        attacker_view = compute_visibility(
+            attacker, defender, light_level=LightLevel.DARK, distance=10.0
+        )
+        defender_view = compute_visibility(
+            defender, attacker, light_level=LightLevel.DARK, distance=10.0
+        )
+        assert attacker_view == VisibilityRelation.UNSEEN
+        assert defender_view == VisibilityRelation.UNSEEN
+
+        engine = CombatEngine(DiceRoller(seed=1))
+
+        # Attacker unseen by defender → Advantage; bright/seen target.
+        unseen_attacker = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=4,
+            damage_dice="1d6",
+            attacker_sees_defender=VisibilityRelation.SEEN,
+            defender_sees_attacker=VisibilityRelation.UNSEEN,
+        )
+        assert unseen_attacker.advantage is True
+        assert unseen_attacker.disadvantage is False
+
+        # Target unseen by attacker → Disadvantage.
+        unseen_target = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=4,
+            damage_dice="1d6",
+            attacker_sees_defender=VisibilityRelation.UNSEEN,
+            defender_sees_attacker=VisibilityRelation.SEEN,
+        )
+        assert unseen_target.disadvantage is True
+        assert unseen_target.advantage is False
 
     def test_targeting_certain_spells_is_affected_by_sight(self):
         pytest.skip(
@@ -308,11 +358,7 @@ class TestVisionAndLight_Light:
         from pathlib import Path
 
         items_path = (
-            Path(__file__).resolve().parents[3]
-            / "dnd_engine"
-            / "data"
-            / "srd"
-            / "items.json"
+            Path(__file__).resolve().parents[3] / "dnd_engine" / "data" / "srd" / "items.json"
         )
         items = json.loads(items_path.read_text())
         # items.json is keyed by category (weapons, armor, consumables, …);
@@ -414,9 +460,7 @@ class TestVisionAndLight_Light:
         """
         char = _make_human_character()
         party = Party([char])
-        game_state = GameState(
-            party, "crypt", campaign_id="the_unquiet_dead"
-        )
+        game_state = GameState(party, "crypt", campaign_id="the_unquiet_dead")
         game_state.current_room_id = "crypt.hall_of_the_dead"
         room = game_state.get_current_room()
         assert room.get("lighting") == "dark", (
@@ -457,9 +501,7 @@ class TestVisionAndLight_SpecialSenses:
         """
         dwarf = _make_dwarf_character()
         party = Party([dwarf])
-        game_state = GameState(
-            party, "crypt", campaign_id="the_unquiet_dead"
-        )
+        game_state = GameState(party, "crypt", campaign_id="the_unquiet_dead")
         game_state.current_room_id = "crypt.hall_of_the_dead"
         assert game_state.get_current_room().get("lighting") == "dark"
         assert game_state.get_effective_lighting(dwarf) == "dim"
@@ -573,28 +615,25 @@ class TestVisionAndLight_SpecialSenses:
         assert relation == VisibilityRelation.SEEN
 
 
-class TestVisionAndLight_CombatVisibilityNotConsulted:
-    """Cross-cut: combat does not consult Vision and Light state.
+class TestVisionAndLight_CombatConsultsVisibility:
+    """Cross-cut: combat consults Vision and Light state (#475).
 
     The SRD intro ("hitting an enemy ... affected by sight") and the
     Obscured Areas rules ("Heavily Obscured ... Blinded condition")
-    together imply that the attack pipeline must read visibility. The
-    engine's attack pipeline does not, so a single source-level guard
-    captures that absence here.
+    together require the attack pipeline to read visibility.
+    `CombatEngine.resolve_attack` now accepts the per-direction
+    `VisibilityRelation` and derives the unseen-attacker Advantage /
+    unseen-target Disadvantage from it.
     """
 
-    def test_resolve_attack_does_not_take_lighting_or_visibility_parameters(self):
-        pytest.skip(
-            "GAP: confirmed absence. `CombatEngine.resolve_attack` "
-            "(`dnd-engine/dnd_engine/core/combat.py:91`) signature is "
-            "`(attacker, defender, attack_bonus, damage_dice, "
-            "advantage=False, disadvantage=False, apply_damage=False, "
-            "event_bus=None, action=None, game_state=None)`. There is "
-            "no `lighting`, `obscurement`, `visibility`, or `can_see` "
-            "parameter, and no caller derives `advantage`/`disadvantage` "
-            "from visibility state today. The closest helper — "
-            "`dnd_engine/systems/ranged_attacks.is_close_combat_ranged_"
-            "disadvantage` — accepts a `attacker_visible_to` callable "
-            "but it defaults to always-True. Tracked by issues #475 "
-            "and #494."
-        )
+    def test_resolve_attack_takes_visibility_parameters(self):
+        """`resolve_attack` exposes the per-direction visibility relations."""
+        from dnd_engine.core.combat import CombatEngine
+
+        params = inspect.signature(CombatEngine.resolve_attack).parameters
+        assert "attacker_sees_defender" in params
+        assert "defender_sees_attacker" in params
+        # Defaulting to None keeps callers that don't pass visibility on
+        # the legacy unmodified-roll path.
+        assert params["attacker_sees_defender"].default is None
+        assert params["defender_sees_attacker"].default is None

--- a/dnd-engine/tests/test_combat.py
+++ b/dnd-engine/tests/test_combat.py
@@ -5,6 +5,7 @@ from dnd_engine.core.character import Character, CharacterClass
 from dnd_engine.core.combat import AttackResult, CombatEngine
 from dnd_engine.core.creature import Abilities, Creature
 from dnd_engine.core.dice import DiceRoller
+from dnd_engine.systems.perception import VisibilityRelation
 
 
 class TestCombatEngine:
@@ -245,6 +246,90 @@ class TestCombatEngine:
                 if result.hit and not result.critical_hit:
                     assert min_dmg <= result.damage <= max_dmg
                     break
+
+
+class TestResolveAttackVisibility:
+    """SRD § Combat › Unseen Attackers and Targets (#475).
+
+    `resolve_attack` consults the `VisibilityRelation` in each direction:
+    an attacker the defender can't see has Advantage; a target the
+    attacker can't see is attacked with Disadvantage; when both apply
+    they cancel. Both `UNSEEN` and `UNSEEN_BUT_SENSED` count as "can't
+    see" — tremorsense locates a target but does not let you see it.
+    """
+
+    def setup_method(self):
+        self.roller = DiceRoller(seed=42)
+        self.engine = CombatEngine(self.roller)
+        abilities = Abilities(
+            strength=16, dexterity=14, constitution=15, intelligence=10, wisdom=12, charisma=8
+        )
+        self.attacker = Creature(name="Attacker", max_hp=20, ac=16, abilities=abilities)
+        self.defender = Creature(name="Defender", max_hp=20, ac=16, abilities=abilities)
+
+    def _attack(self, **kwargs):
+        return self.engine.resolve_attack(
+            attacker=self.attacker,
+            defender=self.defender,
+            attack_bonus=5,
+            damage_dice="1d8+3",
+            **kwargs,
+        )
+
+    def test_unseen_attacker_gains_advantage(self):
+        """Defender can't see the attacker → attacker has Advantage."""
+        result = self._attack(defender_sees_attacker=VisibilityRelation.UNSEEN)
+        assert result.advantage is True
+        assert result.disadvantage is False
+
+    def test_unseen_target_imposes_disadvantage(self):
+        """Attacker can't see the target → attack has Disadvantage."""
+        result = self._attack(attacker_sees_defender=VisibilityRelation.UNSEEN)
+        assert result.disadvantage is True
+        assert result.advantage is False
+
+    def test_both_unseen_cancel(self):
+        """Unseen attacker + unseen target cancel to a straight roll."""
+        result = self._attack(
+            attacker_sees_defender=VisibilityRelation.UNSEEN,
+            defender_sees_attacker=VisibilityRelation.UNSEEN,
+        )
+        assert result.advantage is False
+        assert result.disadvantage is False
+
+    def test_unseen_but_sensed_attacker_still_grants_advantage(self):
+        """Tremorsense locates but doesn't see — attacker still unseen."""
+        result = self._attack(defender_sees_attacker=VisibilityRelation.UNSEEN_BUT_SENSED)
+        assert result.advantage is True
+
+    def test_unseen_but_sensed_target_still_imposes_disadvantage(self):
+        """A target only sensed (not seen) is still attacked at Disadvantage."""
+        result = self._attack(attacker_sees_defender=VisibilityRelation.UNSEEN_BUT_SENSED)
+        assert result.disadvantage is True
+
+    def test_seen_relations_change_nothing(self):
+        """Mutual SEEN → no visibility-driven advantage or disadvantage."""
+        result = self._attack(
+            attacker_sees_defender=VisibilityRelation.SEEN,
+            defender_sees_attacker=VisibilityRelation.SEEN,
+        )
+        assert result.advantage is False
+        assert result.disadvantage is False
+
+    def test_visibility_defaults_preserve_legacy_behavior(self):
+        """Omitting the relations leaves the attack unmodified (backward compat)."""
+        result = self._attack()
+        assert result.advantage is False
+        assert result.disadvantage is False
+
+    def test_explicit_advantage_and_unseen_target_cancel(self):
+        """A pre-existing Advantage cancels against an unseen-target Disadvantage."""
+        result = self._attack(
+            advantage=True,
+            attacker_sees_defender=VisibilityRelation.UNSEEN,
+        )
+        assert result.advantage is False
+        assert result.disadvantage is False
 
 
 class TestAttackResult:

--- a/dnd-engine/tests/test_lighting.py
+++ b/dnd-engine/tests/test_lighting.py
@@ -316,3 +316,125 @@ class TestCreatureEnvironment:
         game_state.current_room_id = "does_not_exist"
 
         assert game_state.creature_environment(human_character) is None
+
+
+class TestAttackVisibility:
+    """`GameState.attack_visibility` feeds the Unseen Attackers rule (#475).
+
+    The engine derives the per-direction `VisibilityRelation` from the
+    room's ambient lighting and each combatant's senses, and
+    `resolve_attack` turns those into the SRD Advantage/Disadvantage for
+    an unseen attacker / unseen target.
+    """
+
+    def _dark_room_state(self, party):
+        game_state = GameState(party, "crypt", campaign_id="the_unquiet_dead")
+        game_state.current_room_id = "crypt.hall_of_the_dead"
+        assert game_state.get_current_room().get("lighting") == "dark"
+        return game_state
+
+    def test_bright_room_sees_both_ways(self, human_character, dwarf_character):
+        """In bright light each combatant sees the other (no adv/disadv)."""
+        from dnd_engine.systems.perception import VisibilityRelation
+
+        party = Party([human_character, dwarf_character])
+        game_state = GameState(party, "test_dungeon")
+
+        saw_def, saw_atk = game_state.attack_visibility(human_character, dwarf_character)
+        assert saw_def == VisibilityRelation.SEEN
+        assert saw_atk == VisibilityRelation.SEEN
+
+    def test_darkvision_attacker_unseen_by_sighted_defender_in_dark(
+        self, human_character, dwarf_character
+    ):
+        """Dwarf (darkvision) sees the human; the human can't see the dwarf."""
+        from dnd_engine.systems.perception import VisibilityRelation
+
+        party = Party([human_character, dwarf_character])
+        game_state = self._dark_room_state(party)
+
+        saw_def, saw_atk = game_state.attack_visibility(dwarf_character, human_character)
+        # Dwarf sees the human (darkvision); human can't see the dwarf.
+        assert saw_def == VisibilityRelation.SEEN
+        assert saw_atk == VisibilityRelation.UNSEEN
+
+    def test_darkvision_attacker_gains_advantage_in_dark(self, human_character, dwarf_character):
+        """The dwarf, unseen by the human, attacks with Advantage."""
+        party = Party([human_character, dwarf_character])
+        game_state = self._dark_room_state(party)
+
+        saw_def, saw_atk = game_state.attack_visibility(dwarf_character, human_character)
+        result = game_state.combat_engine.resolve_attack(
+            attacker=dwarf_character,
+            defender=human_character,
+            attack_bonus=4,
+            damage_dice="1d8",
+            game_state=game_state,
+            attacker_sees_defender=saw_def,
+            defender_sees_attacker=saw_atk,
+        )
+        assert result.advantage is True
+        assert result.disadvantage is False
+
+    def test_sighted_attacker_has_disadvantage_against_darkvision_foe_in_dark(
+        self, human_character, dwarf_character
+    ):
+        """The human, blind in the dark, attacks the dwarf with Disadvantage."""
+        party = Party([human_character, dwarf_character])
+        game_state = self._dark_room_state(party)
+
+        saw_def, saw_atk = game_state.attack_visibility(human_character, dwarf_character)
+        result = game_state.combat_engine.resolve_attack(
+            attacker=human_character,
+            defender=dwarf_character,
+            attack_bonus=4,
+            damage_dice="1d8",
+            game_state=game_state,
+            attacker_sees_defender=saw_def,
+            defender_sees_attacker=saw_atk,
+        )
+        assert result.disadvantage is True
+        assert result.advantage is False
+
+    def test_two_blind_combatants_in_dark_cancel_to_straight_roll(self, basic_abilities):
+        """Two sightless-in-the-dark combatants each grant the other adv/disadv → cancel."""
+        from dnd_engine.systems.perception import VisibilityRelation
+
+        a = Character(
+            name="Human A",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=basic_abilities,
+            max_hp=12,
+            ac=16,
+            race="human",
+        )
+        b = Character(
+            name="Human B",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=basic_abilities,
+            max_hp=12,
+            ac=16,
+            race="human",
+        )
+        a.darkvision_range = 0
+        b.darkvision_range = 0
+        party = Party([a, b])
+        game_state = self._dark_room_state(party)
+
+        saw_def, saw_atk = game_state.attack_visibility(a, b)
+        assert saw_def == VisibilityRelation.UNSEEN
+        assert saw_atk == VisibilityRelation.UNSEEN
+
+        result = game_state.combat_engine.resolve_attack(
+            attacker=a,
+            defender=b,
+            attack_bonus=4,
+            damage_dice="1d8",
+            game_state=game_state,
+            attacker_sees_defender=saw_def,
+            defender_sees_attacker=saw_atk,
+        )
+        assert result.advantage is False
+        assert result.disadvantage is False


### PR DESCRIPTION
## Plan-05 Slice C — Visibility-driven attack advantage/disadvantage (#475)

Implements step 5 of plan-05: the engine's attack pipeline now reads the first-class `VisibilityRelation` from slice A, enforcing the SRD **Unseen Attackers and Targets** rule.

### Engine
- **`CombatEngine.resolve_attack`** gains two optional params, `attacker_sees_defender` / `defender_sees_attacker` (`VisibilityRelation`):
  - defender can't see attacker → **advantage**
  - attacker can't see target → **disadvantage**
  - both → cancel (rides the existing advantage/disadvantage cancellation)
  - `UNSEEN` **and** `UNSEEN_BUT_SENSED` both count as "can't see" — tremorsense locates but doesn't let you see
  - `None` defaults preserve the legacy unmodified roll (backward compatible)
- Separation of concerns held: `perception.py` computes visibility, `combat.py` only consumes the relation.

### GameState integration
- **`GameState.attack_visibility(attacker, defender)`** derives the bidirectional relations from ambient room lighting + each combatant's senses via the perception model.
- **`GameState._ambient_light_level()`** resolves room + temporary-effect lighting *without* the per-observer darkvision downgrade (so `compute_visibility` applies darkvision once, from senses — no double-counting).
- All **five** `resolve_attack` call sites in `game_state.py` now pass the relations (player attack, enemy turn, two opportunity-attack paths, combat item use).

### Out of scope
- **Spell-attack visibility** (`resolve_spell_attack`, no `game_state`) is tracked by #494; its conformance test stays skipped.

### Tests
- `tests/test_combat.py::TestResolveAttackVisibility` — 8 unit tests (each direction, both-cancel, sensed-not-seen, seen-noop, default-legacy, explicit-adv-cancels)
- Un-skipped + inverted `test_hitting_an_enemy_is_affected_by_sight`; renamed `TestVisionAndLight_CombatVisibilityNotConsulted` → `TestVisionAndLight_CombatConsultsVisibility` and inverted its assertion
- `tests/test_lighting.py::TestAttackVisibility` — 5 GameState integration tests (darkvision attacker gains advantage in the dark; sighted attacker takes disadvantage; two blind combatants cancel; bright-room no-op)

237 passed, 8 skipped across the touched suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)