### PR TITLE
Model Obscured Areas engine-side (plan-05, #493)

### DIFF
--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -1484,12 +1484,17 @@ class GameState:
         The engine's core combat is non-positional, so distance defaults
         to melee (0 ft) — every ranged special sense comfortably reaches,
         which is the relation that matters for adjacent attacks. Lighting
-        is room-wide at this layer, matching the rest of the engine's
-        Vision and Light model.
+        and ambient obscurement (fog, foliage) are room-wide at this
+        layer, matching the rest of the engine's Vision and Light model.
         """
         light_level = self._ambient_light_level()
-        attacker_sees_defender = compute_visibility(attacker, defender, light_level=light_level)
-        defender_sees_attacker = compute_visibility(defender, attacker, light_level=light_level)
+        obscurement = self.ambient_obscurement()
+        attacker_sees_defender = compute_visibility(
+            attacker, defender, light_level=light_level, obscurement=obscurement
+        )
+        defender_sees_attacker = compute_visibility(
+            defender, attacker, light_level=light_level, obscurement=obscurement
+        )
         return attacker_sees_defender, defender_sees_attacker
 
     def get_available_actions(self) -> list[str]:

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -32,8 +32,11 @@ from dnd_engine.systems.opportunity_attacks import (
 )
 from dnd_engine.systems.perception import (
     LightLevel,
+    Obscurement,
     VisibilityRelation,
     compute_visibility,
+    obscurement_from_sources,
+    relies_on_sight,
 )
 from dnd_engine.systems.reactions import ReactionDispatcher
 from dnd_engine.systems.spatial_index import SpatialIndex
@@ -1343,15 +1346,49 @@ class GameState:
         # Otherwise, return base room lighting
         return base_lighting
 
+    def ambient_obscurement(self) -> "Obscurement":
+        """Resolve the current room's ambient obscurement from environmental sources.
+
+        Reads the room's data-driven ``obscurement_sources`` (fog,
+        foliage) plus any active area effects that declare an
+        ``obscurement_source`` (e.g. the fog_cloud / poison_cloud
+        spells), and combines them into the worst applicable
+        ``Obscurement``. This is *additional* to lighting:
+        ``_apply_lighting_penalties`` and the perception model take the
+        worse of this and the lighting-derived obscurement.
+
+        Returns ``Obscurement.CLEAR`` when no room is resolvable (e.g.
+        combat-only states that never bootstrapped a dungeon).
+        """
+        try:
+            room = self.get_current_room()
+        except (KeyError, AttributeError, TypeError):
+            return Obscurement.CLEAR
+
+        sources: list[str] = list(room.get("obscurement_sources", []))
+        for effect in self.time_manager.active_effects:
+            source = effect.effect_data.get("obscurement_source")
+            if source:
+                sources.append(str(source))
+
+        return obscurement_from_sources(sources)
+
     def _apply_lighting_penalties(
         self, character: "Character", skill: str, dc: int, action: str
     ) -> tuple[bool, bool, dict[str, Any] | None]:
         """
-        Apply lighting penalties to a skill check.
+        Apply obscurement penalties to a sight-based skill check.
 
-        For sight-based checks (Perception) in poor lighting:
-        - Dim light: Apply disadvantage
-        - Darkness: Auto-fail
+        For checks that rely on sight, in a Lightly or Heavily Obscured
+        area (SRD § Obscured Areas):
+        - Lightly Obscured (Dim Light, patchy fog, moderate foliage):
+          Apply disadvantage.
+        - Heavily Obscured (Darkness, heavy fog, dense foliage): Auto-fail
+          (the Blinded-against-that-area consequence).
+
+        Obscurement is the worse of the lighting-derived level and the
+        room's ambient sources (``ambient_obscurement``), so a heavily
+        fogged room auto-fails sight-based checks even in Bright Light.
 
         Args:
             character: Character making the check
@@ -1361,16 +1398,18 @@ class GameState:
 
         Returns:
             Tuple of (should_continue, has_disadvantage, check_result_if_autofail)
-            - should_continue: False if check auto-failed in darkness
+            - should_continue: False if check auto-failed (heavily obscured)
             - has_disadvantage: True if check should be made with disadvantage
             - check_result_if_autofail: The failed check result dict if auto-failed, None otherwise
         """
-        if skill != "perception":
+        if not relies_on_sight(skill):
             return True, False, None
 
         lighting = self.get_effective_lighting(character)
-        if lighting == "dark":
-            # In complete darkness, sight-based Perception checks auto-fail
+        obscurement = self.ambient_obscurement()
+        if lighting == "dark" or obscurement == Obscurement.HEAVILY:
+            # Heavily Obscured: a creature trying to see is effectively
+            # Blinded, so sight-based checks auto-fail.
             check_result = {
                 "skill": skill,
                 "dc": dc,
@@ -1393,12 +1432,13 @@ class GameState:
                         "success": False,
                         "action": action,
                         "success_text": None,
-                        "failure_text": "You can't see anything in the complete darkness",
+                        "failure_text": "You can't see well enough to make anything out",
                     },
                 )
             )
             return False, False, check_result
-        elif lighting == "dim":
+        elif lighting == "dim" or obscurement == Obscurement.LIGHTLY:
+            # Lightly Obscured: disadvantage on the sight-based check.
             return True, True, None
 
         return True, False, None

--- a/dnd-engine/dnd_engine/data/srd/conditions.json
+++ b/dnd-engine/dnd_engine/data/srd/conditions.json
@@ -35,6 +35,16 @@
       "duration_type": "end_of_first_turn",
       "turn_start_message": "⚠️  {creature_name} is SURPRISED and cannot act this turn!",
       "turn_end_removal": true
+    },
+    "blinded": {
+      "name": "Blinded",
+      "description": "A Blinded creature can't see and automatically fails any ability check that requires sight. Attack rolls against the creature have Advantage, and the creature's attack rolls have Disadvantage. A creature trying to see into a Heavily Obscured area is Blinded with respect to that area.",
+      "effects": {
+        "cannot_see": true,
+        "auto_fail_sight_checks": true,
+        "attacks_against_have_advantage": true,
+        "attacks_have_disadvantage": true
+      }
     }
   }
 }

--- a/dnd-engine/dnd_engine/systems/perception.py
+++ b/dnd-engine/dnd_engine/systems/perception.py
@@ -23,6 +23,7 @@ SRD references:
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -101,6 +102,21 @@ _OBSCUREMENT_SEVERITY: dict[Obscurement, int] = {
     Obscurement.HEAVILY: 2,
 }
 
+# Named environmental obscurement sources (SRD § Obscured Areas). Patchy
+# fog and moderate foliage are Lightly Obscured; heavy fog, dense
+# foliage, and the fog_cloud / poison_cloud area effects are Heavily
+# Obscured. This is the data-driven catalog rooms and area effects draw
+# from; unrecognized names contribute no obscurement.
+_SOURCE_OBSCUREMENT: dict[str, Obscurement] = {
+    "patchy_fog": Obscurement.LIGHTLY,
+    "light_foliage": Obscurement.LIGHTLY,
+    "moderate_foliage": Obscurement.LIGHTLY,
+    "heavy_fog": Obscurement.HEAVILY,
+    "dense_foliage": Obscurement.HEAVILY,
+    "fog_cloud": Obscurement.HEAVILY,
+    "poison_cloud": Obscurement.HEAVILY,
+}
+
 
 def observer_senses(creature: Creature) -> dict[Sense, int]:
     """Resolve a creature's special senses to a ``{Sense: range_ft}`` map.
@@ -173,6 +189,45 @@ def effective_obscurement(
     if _OBSCUREMENT_SEVERITY[ambient] >= _OBSCUREMENT_SEVERITY[from_light]:
         return ambient
     return from_light
+
+
+# Skills whose checks can rely on sight, and so suffer in obscured areas
+# (SRD § Obscured Areas). Perception is the canonical case; Investigation
+# (spotting clues), Insight (reading a creature), Medicine (diagnosing by
+# sight), and Survival (tracking) likewise depend on sight here. Whether a
+# check relies on sight is a rule, not content, so the set lives in the
+# engine's perception layer rather than in skill data.
+_SIGHT_BASED_SKILLS: frozenset[str] = frozenset(
+    {"perception", "investigation", "insight", "medicine", "survival"}
+)
+
+
+def relies_on_sight(skill: str) -> bool:
+    """Whether a skill check relies on sight (SRD § Obscured Areas).
+
+    Sight-reliant checks take Disadvantage in a Lightly Obscured area and
+    auto-fail (the Blinded consequence) in a Heavily Obscured area.
+    """
+    return str(skill).lower() in _SIGHT_BASED_SKILLS
+
+
+def obscurement_from_sources(sources: Iterable[str]) -> Obscurement:
+    """Resolve named environmental sources to an effective Obscurement.
+
+    Recognized sources (SRD § Obscured Areas): patchy fog and moderate
+    foliage are Lightly Obscured; heavy fog, dense foliage, and the
+    fog_cloud / poison_cloud area effects are Heavily Obscured. Multiple
+    sources stack to the more severe; unrecognized names contribute
+    nothing. An empty or all-unrecognized set is CLEAR.
+    """
+    worst = Obscurement.CLEAR
+    for source in sources:
+        level = _SOURCE_OBSCUREMENT.get(str(source).lower())
+        if level is None:
+            continue
+        if _OBSCUREMENT_SEVERITY[level] > _OBSCUREMENT_SEVERITY[worst]:
+            worst = level
+    return worst
 
 
 def compute_visibility(

--- a/dnd-engine/tests/srd/playing_the_game/test_vision_and_light.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_vision_and_light.py
@@ -94,20 +94,20 @@ class TestVisionAndLight_Intro:
     """
 
     def test_perception_in_darkness_is_affected_by_sight(self):
-        """Sight-based Perception auto-fails in darkness (the "noticing danger" branch).
+        """Sight-based checks auto-fail in darkness (the "noticing danger" branch).
 
         The SRD's first promise — that "noticing danger" is sight-
         affected — has a real engine implementation in
         `GameState._apply_lighting_penalties`
         (`dnd-engine/dnd_engine/core/game_state.py:698-756`): in dark
-        rooms, sight-based Perception is short-circuited with an
-        auto-fail result. The path is gated to the literal "perception"
-        skill only, but the intro promise that *some* sight check
-        respects darkness is honored.
+        rooms, sight-based checks are short-circuited with an auto-fail
+        result. The path gates on sight-reliance via `relies_on_sight`
+        (Perception, Investigation, Insight, Medicine, Survival), so the
+        intro promise that sight checks respect darkness is honored.
         """
         src = inspect.getsource(GameState._apply_lighting_penalties)
-        assert "perception" in src.lower(), (
-            "Sight-based Perception must be a recognized branch of the "
+        assert "relies_on_sight" in src or "sight" in src.lower(), (
+            "Sight-based checks must be a recognized branch of the "
             "lighting-penalty logic so 'effects that obscure vision can "
             "hinder you' has at least one enforcement site."
         )
@@ -243,15 +243,43 @@ class TestVisionAndLight_ObscuredAreas:
         )
 
     def test_lightly_obscured_disadvantage_extends_to_all_sight_based_wis_checks(self):
-        pytest.skip(
-            "GAP: the dim-light disadvantage in `GameState."
-            "_apply_lighting_penalties` (`dnd-engine/dnd_engine/core/"
-            "game_state.py:720-721`) is gated to the literal "
-            "'perception' skill. Other sight-based WIS checks (Insight, "
-            "Medicine, Survival) and non-WIS sight-based checks "
-            "(Investigation — INT, Sleight of Hand observation — DEX) "
-            "get no penalty. Tracked by issue #493."
+        """Disadvantage in a Lightly Obscured area is not gated to literal "perception".
+
+        The SRD imposes Disadvantage on sight-based checks in a Lightly
+        Obscured area. The engine classifies sight-reliance via
+        `relies_on_sight`, so Investigation, Insight, Medicine, and
+        Survival — not just the literal "perception" skill — take
+        Disadvantage in Dim Light, and a non-sight skill is unaffected.
+        (issue #493)
+        """
+        from dnd_engine.systems.perception import relies_on_sight
+
+        assert relies_on_sight("perception") is True
+        assert relies_on_sight("investigation") is True
+        assert relies_on_sight("insight") is True
+        assert relies_on_sight("athletics") is False
+
+        char = _make_human_character()
+        party = Party([char])
+        game_state = GameState(party, "crypt", campaign_id="the_unquiet_dead")
+        game_state.current_room_id = "crypt.hall_of_the_dead"
+        room = game_state.get_current_room()
+        room["lighting"] = "dim"
+        room["obscurement_sources"] = []
+
+        # A sight-based check other than the literal "perception" skill
+        # still takes Disadvantage in Dim Light.
+        should_continue, disadvantage, _auto_fail = game_state._apply_lighting_penalties(
+            char, "investigation", dc=10, action="search for tracks"
         )
+        assert should_continue is True
+        assert disadvantage is True
+
+        # A non-sight skill is unaffected by the obscured area.
+        should_continue, disadvantage, _auto_fail = game_state._apply_lighting_penalties(
+            char, "athletics", dc=10, action="climb the wall"
+        )
+        assert disadvantage is False
 
     def test_heavily_obscured_concept_exists_in_engine(self):
         """The Heavily Obscured concept is a first-class engine state.
@@ -293,31 +321,85 @@ class TestVisionAndLight_ObscuredAreas:
         )
 
     def test_heavily_obscured_applies_blinded_condition_when_trying_to_see(self):
-        pytest.skip(
-            "GAP: the SRD specifies the Blinded *condition* applies "
-            "while trying to see into a heavily obscured area. The "
-            "`blinded` condition exists as a string only — referenced "
-            "by `dnd-engine/dnd_engine/systems/ranged_attacks.py:71` "
-            "(close-combat ranged disadvantage) and as a monster "
-            "`condition_immunity` in `monsters.json:661`. No code "
-            "applies the condition to a creature looking into a "
-            "heavily obscured area. The Blinded condition is not even "
-            "in `dnd-engine/dnd_engine/data/srd/conditions.json` (only "
-            "`on_fire` and `surprised` are catalogued there). Tracked "
-            "by issue #493."
+        """The Blinded condition is catalogued and has teeth in the perception model.
+
+        The SRD: a creature trying to see into a Heavily Obscured area
+        has the Blinded condition with respect to that area. Blinded is a
+        first-class catalogued condition, and the perception model honors
+        it — a Blinded observer cannot see its target even in Bright,
+        clear conditions. (issue #493)
+        """
+        import json
+        from pathlib import Path
+
+        from dnd_engine.systems.perception import (
+            LightLevel,
+            VisibilityRelation,
+            compute_visibility,
         )
 
-    def test_obscurement_sources_are_data_driven(self):
-        pytest.skip(
-            "GAP: the SRD lists six environmental triggers for "
-            "obscurement — Dim Light, patchy fog, moderate foliage "
-            "(lightly); Darkness, heavy fog, dense foliage (heavily). "
-            "Only `room.lighting` (`dnd-engine/dnd_engine/core/"
-            "game_state.py:677`) is consulted by `get_effective_"
-            "lighting`. Fog, foliage, and other obscurement sources "
-            "have no data model on rooms or per-tile in client-2d. "
-            "Tracked by issue #493."
+        conditions_path = (
+            Path(__file__).resolve().parents[3] / "dnd_engine" / "data" / "srd" / "conditions.json"
         )
+        conditions = json.loads(conditions_path.read_text())["conditions"]
+        assert "blinded" in conditions, (
+            "The Blinded condition must be catalogued in conditions.json "
+            "so the Heavily-Obscured 'Blinded against that area' rule has "
+            "a first-class data presence."
+        )
+        assert "sight" in json.dumps(conditions["blinded"]).lower(), (
+            "The catalogued Blinded condition must describe its sight "
+            "consequence (can't see / auto-fails checks that require sight)."
+        )
+
+        # The condition has teeth: a Blinded observer cannot see its
+        # target, even in Bright Light with no obscurement.
+        observer = _make_human_character()
+        target = _make_human_character()
+        observer.add_condition("blinded")
+        relation = compute_visibility(observer, target, light_level=LightLevel.BRIGHT)
+        assert relation == VisibilityRelation.UNSEEN
+
+    def test_obscurement_sources_are_data_driven(self):
+        """Obscurement is derivable from data-driven environmental sources.
+
+        The SRD lists six environmental triggers for obscurement — Dim
+        Light, patchy fog, moderate foliage (Lightly); Darkness, heavy
+        fog, dense foliage (Heavily). Beyond room lighting, fog and
+        foliage are sourced from room data (`obscurement_sources`) and
+        combined into the effective `Obscurement` that sight-based rules
+        consult. (issue #493)
+        """
+        from dnd_engine.systems.perception import (
+            Obscurement,
+            obscurement_from_sources,
+        )
+
+        # Named environmental sources map onto obscurement severity.
+        assert obscurement_from_sources([]) == Obscurement.CLEAR
+        assert obscurement_from_sources(["patchy_fog"]) == Obscurement.LIGHTLY
+        assert obscurement_from_sources(["moderate_foliage"]) == Obscurement.LIGHTLY
+        assert obscurement_from_sources(["heavy_fog"]) == Obscurement.HEAVILY
+        assert obscurement_from_sources(["dense_foliage"]) == Obscurement.HEAVILY
+        # Stacked sources take the worse of the two.
+        assert obscurement_from_sources(["patchy_fog", "dense_foliage"]) == Obscurement.HEAVILY
+
+        # Room data carries the sources, and GameState resolves them into
+        # the ambient obscurement the sight-based rules consult.
+        char = _make_human_character()
+        party = Party([char])
+        game_state = GameState(party, "crypt", campaign_id="the_unquiet_dead")
+        game_state.current_room_id = "crypt.hall_of_the_dead"
+        room = game_state.get_current_room()
+        room["lighting"] = "bright"
+        room["obscurement_sources"] = ["heavy_fog"]
+        assert game_state.ambient_obscurement() == Obscurement.HEAVILY
+        # A heavily obscured area auto-fails a sight-based check even in
+        # Bright Light — the Blinded-against-that-area consequence.
+        should_continue, _disadvantage, _auto_fail = game_state._apply_lighting_penalties(
+            char, "perception", dc=10, action="spot the ambush"
+        )
+        assert should_continue is False
 
 
 class TestVisionAndLight_Light:

--- a/dnd-engine/tests/test_lighting.py
+++ b/dnd-engine/tests/test_lighting.py
@@ -438,3 +438,21 @@ class TestAttackVisibility:
         )
         assert result.advantage is False
         assert result.disadvantage is False
+
+    def test_heavy_fog_blinds_both_combatants_in_bright_light(
+        self, human_character, dwarf_character
+    ):
+        """Heavy fog Heavily Obscures the room, so attack_visibility reports
+        each combatant Unseen to the other — even in Bright Light and even
+        with darkvision, since fog is opaque to sight (issue #493)."""
+        from dnd_engine.systems.perception import VisibilityRelation
+
+        party = Party([human_character, dwarf_character])
+        game_state = GameState(party, "test_dungeon")
+        room = game_state.get_current_room()
+        room["lighting"] = "bright"
+        room["obscurement_sources"] = ["heavy_fog"]
+
+        saw_def, saw_atk = game_state.attack_visibility(human_character, dwarf_character)
+        assert saw_def == VisibilityRelation.UNSEEN
+        assert saw_atk == VisibilityRelation.UNSEEN


### PR DESCRIPTION
## Summary

Step 2 of plan-05 (#534): give the engine a first-class **Obscured Areas** model so the SRD § Vision and Light "Obscured Areas" rule is *enforced*, not just rendered. Closes the three remaining `TestVisionAndLight_ObscuredAreas` gating gaps (consolidated issue #493).

## Changes

- **`systems/perception.py`**
  - `obscurement_from_sources()` — maps data-driven environmental sources (patchy/heavy fog, moderate/dense foliage, `fog_cloud`/`poison_cloud`) to an `Obscurement`, taking the worst.
  - `relies_on_sight()` + `_SIGHT_BASED_SKILLS` — classifies which checks suffer in obscured areas (Perception, Investigation, Insight, Medicine, Survival). A rule, not content, so it lives in the engine.
- **`core/game_state.py`**
  - `ambient_obscurement()` — resolves the current room's `obscurement_sources` plus active area effects into the worst `Obscurement` (CLEAR when no room is resolvable).
  - `_apply_lighting_penalties` now gates on sight-reliance (not the literal `"perception"` string) and folds ambient obscurement into the dim→disadvantage / heavy→auto-fail branches, so heavy fog blinds sight-based checks even in Bright Light.
  - `attack_visibility` feeds `ambient_obscurement()` into `compute_visibility` both directions, so a Heavily Obscured area drives unseen-attacker Advantage / unseen-target Disadvantage in combat.
- **`data/srd/conditions.json`** — `blinded` catalogued as a first-class condition (SRD text + effects). The perception model already honors it (`UNSEEN`).

## Testing

- [x] `TestVisionAndLight_ObscuredAreas`: 4-pass/3-skip → **7-pass/0-skip** (all three gating skips flipped to real assertions)
- [x] New `TestAttackVisibility::test_heavy_fog_blinds_both_combatants_in_bright_light`
- [x] Stale Intro source-test (`test_perception_in_darkness_is_affected_by_sight`) updated to match the closed gap (behavior preserved)
- [x] Full engine suite: **3167 passed, 208 skipped, 0 failures**
- [x] Ruff lint + format clean

## Follow-ups (noted from code review, not in scope here)

- `fog_cloud`/`poison_cloud` are catalogued as obscurement sources but the spell effects don't yet populate `effect_data["obscurement_source"]`, so they're inert until that wiring lands (separate spell-side change).

## Related Issues

Part of #534 (plan-05). Implements the obscured-areas work consolidated from #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)