### PR TITLE
Gate Hide attempts on appropriate circumstances (plan-05, #496)

### DIFF
--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -31,10 +31,13 @@ from dnd_engine.systems.opportunity_attacks import (
     register_default_opportunity_attack,
 )
 from dnd_engine.systems.perception import (
+    Cover,
     LightLevel,
     Obscurement,
     VisibilityRelation,
+    can_attempt_hide,
     compute_visibility,
+    effective_obscurement,
     obscurement_from_sources,
     relies_on_sight,
 )
@@ -1496,6 +1499,54 @@ class GameState:
             defender, attacker, light_level=light_level, obscurement=obscurement
         )
         return attacker_sees_defender, defender_sees_attacker
+
+    def can_attempt_hide(self, creature: "Creature") -> bool:
+        """Whether the current room permits a Hide attempt (SRD 5.2.1).
+
+        The SRD grants the GM discretion over when hiding is allowed;
+        SRD 5.2.1 makes that concrete — a creature can try to hide only
+        when its area is Heavily Obscured or it has at least
+        Three-Quarters Cover. This resolves the room's effective
+        obscurement (the worse of ambient light and fog/foliage sources)
+        and its `cover` signal, then applies the rule in
+        `perception.can_attempt_hide`. This is the precondition gate
+        (issue #496); the Hide action mechanics and the resulting unseen
+        state are separate (issues #443 / #475).
+
+        Obscurement here is the area-level value (room lighting + ambient
+        sources), not a per-observer one: a darkvision creature still
+        treats a dark room as concealing for the purpose of *whether*
+        hiding is available. Per-observer visibility lives in
+        `attack_visibility` / `compute_visibility`.
+
+        Args:
+            creature: The creature attempting to hide. Currently unused —
+                the gate is environmental — but kept in the signature for
+                forward compatibility with per-creature room tracking
+                (#514), mirroring `creature_environment`.
+
+        Returns:
+            True when the environment offers concealment sufficient to
+            attempt the Hide action; False otherwise (e.g. an open,
+            brightly lit, featureless room). Returns False when no room
+            is resolvable.
+        """
+        try:
+            room = self.get_current_room()
+        except (KeyError, AttributeError, TypeError):
+            return False
+
+        obscurement = effective_obscurement(
+            self._ambient_light_level(), self.ambient_obscurement()
+        )
+
+        cover_value = str(room.get("cover", "none")).lower()
+        try:
+            cover = Cover(cover_value)
+        except ValueError:
+            cover = Cover.NONE
+
+        return can_attempt_hide(obscurement, cover)
 
     def get_available_actions(self) -> list[str]:
         """

--- a/dnd-engine/dnd_engine/data/content/campaigns/poisoned_laboratory/dungeons/laboratory.json
+++ b/dnd-engine/dnd_engine/data/content/campaigns/poisoned_laboratory/dungeons/laboratory.json
@@ -196,9 +196,10 @@
     },
     "laboratory.furnace_room": {
       "name": "Furnace Chamber",
-      "description": "A massive furnace roars in the center of this sweltering room, used to heat alchemical reactions. The heat is intense. A large wolf, its fur singed and eyes glowing red, lies near the furnace beside a pile of treasure. The beast's breath carries the acrid smell of sulfur.",
+      "description": "A massive furnace roars in the center of this sweltering room, used to heat alchemical reactions. The heat is intense. A large wolf, its fur singed and eyes glowing red, lies near the furnace beside a pile of treasure. The beast's breath carries the acrid smell of sulfur. A low archway to the north vents thick clouds of scalding steam from the boiler beyond.",
       "exits": {
-        "east": "laboratory.storage"
+        "east": "laboratory.storage",
+        "north": "laboratory.boiler_room"
       },
       "enemies": [
         "wolf"
@@ -354,6 +355,27 @@
         }
       ],
       "id": "laboratory.specimen_chamber"
+    },
+    "laboratory.boiler_room": {
+      "name": "Steam-Choked Boiler Room",
+      "description": "A ruptured boiler floods this cramped chamber with roiling clouds of scalding steam. Visibility drops to nothing more than an arm's length ahead, and shapes dissolve into the white haze. The dense vapor would hide a creature completely from anyone more than a few feet away.",
+      "lighting": "bright",
+      "obscurement_sources": ["heavy_fog"],
+      "cover": "none",
+      "exits": {
+        "south": "laboratory.furnace_room"
+      },
+      "enemies": [],
+      "items": [
+        {
+          "type": "item",
+          "id": "potion_of_healing",
+          "visible": false
+        }
+      ],
+      "searched": false,
+      "searchable": true,
+      "id": "laboratory.boiler_room"
     }
   }
 }

--- a/dnd-engine/dnd_engine/systems/perception.py
+++ b/dnd-engine/dnd_engine/systems/perception.py
@@ -54,6 +54,22 @@ class Obscurement(str, Enum):
     HEAVILY = "heavily"
 
 
+class Cover(str, Enum):
+    """Degree of cover a position offers against being seen / hit.
+
+    SRD § Cover: an obstacle between a creature and a hazard grants
+    Half Cover (+2 AC / Dexterity saves), Three-Quarters Cover (+5),
+    or Total Cover (can't be targeted directly). For the Hide action
+    (SRD 5.2.1) a creature needs at least Three-Quarters Cover to use
+    cover alone as a hiding circumstance.
+    """
+
+    NONE = "none"
+    HALF = "half"
+    THREE_QUARTERS = "three_quarters"
+    TOTAL = "total"
+
+
 class Sense(str, Enum):
     """Perception channels a creature can possess.
 
@@ -228,6 +244,22 @@ def obscurement_from_sources(sources: Iterable[str]) -> Obscurement:
         if _OBSCUREMENT_SEVERITY[level] > _OBSCUREMENT_SEVERITY[worst]:
             worst = level
     return worst
+
+
+def can_attempt_hide(obscurement: Obscurement, cover: Cover) -> bool:
+    """Whether the surroundings permit a Hide attempt (SRD 5.2.1).
+
+    The Game Master decides when circumstances are appropriate for
+    hiding; SRD 5.2.1 makes that concrete: a creature can try to hide
+    only when its area is **Heavily Obscured** or it has at least
+    **Three-Quarters Cover**. Lighter conditions — a Lightly Obscured
+    area, Half Cover, or open clear ground — do not qualify. This is
+    the precondition gate (issue #496); the Hide action mechanics and
+    the resulting unseen state are separate (issues #443 / #475).
+    """
+    if obscurement == Obscurement.HEAVILY:
+        return True
+    return cover in (Cover.THREE_QUARTERS, Cover.TOTAL)
 
 
 def compute_visibility(

--- a/dnd-engine/tests/srd/playing_the_game/test_hiding.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_hiding.py
@@ -25,6 +25,7 @@ import pytest
 from dnd_engine.core.character import Character, CharacterClass
 from dnd_engine.core.creature import Abilities
 from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
 
 pytestmark = pytest.mark.srd(
     "playing-the-game/hiding.md",
@@ -135,32 +136,107 @@ class TestHiding_GMDiscretion:
     """
 
     def test_engine_gates_hide_attempts_on_appropriate_circumstances(self):
-        pytest.skip(
-            "GAP: there is no engine-side gate that consults the "
-            "environment before allowing a hide attempt. The only "
-            "extant Stealth call — `GameState._check_for_surprise` "
-            "(`dnd-engine/dnd_engine/core/game_state.py:3014`) — fires "
-            "unconditionally before combat, regardless of whether the "
-            "current room offers cover, obscurement, or distraction. "
-            "There is no `can_attempt_hide(creature, context)` helper, "
-            "no per-room or per-tile `cover` / `concealment` data "
-            "field, and no per-tile obscurement model in the engine "
-            "(the bright/dim/dark per-tile model lives only in "
-            "`client-2d/src/client_2d/systems/lighting.py:111` and "
-            "`client-2d/src/client_2d/systems/fog_of_war.py:14`). "
-            "Tracked by issue #496."
+        """The engine consults the environment before allowing a hide.
+
+        SRD 5.2.1 makes hiding available only when the surroundings
+        offer concealment: a creature can attempt to hide when its area
+        is **Heavily Obscured** OR it has at least **three-quarters
+        cover**. Lighter conditions (Lightly Obscured, half cover, or a
+        clear open space) do not qualify — this is stricter than
+        plan-05's looser "Lightly Obscured" draft, and the SRD threshold
+        is canonical (issue #496).
+
+        Two layers are gated:
+
+        - The pure rule `perception.can_attempt_hide(obscurement, cover)`
+          decides eligibility from an area's obscurement and cover.
+        - `GameState.can_attempt_hide(creature)` resolves the current
+          room's effective obscurement (lighting + ambient sources) and
+          its cover signal, then delegates to the rule.
+        """
+        from dnd_engine.systems.perception import (
+            Cover,
+            Obscurement,
+            can_attempt_hide,
         )
 
+        # --- Pure rule: obscurement gate at the SRD threshold ---
+        # Heavily Obscured qualifies; nothing lighter does.
+        assert can_attempt_hide(Obscurement.HEAVILY, Cover.NONE) is True
+        assert can_attempt_hide(Obscurement.LIGHTLY, Cover.NONE) is False
+        assert can_attempt_hide(Obscurement.CLEAR, Cover.NONE) is False
+
+        # --- Pure rule: cover gate at the SRD threshold ---
+        # Three-quarters and total cover qualify; half cover does not.
+        assert can_attempt_hide(Obscurement.CLEAR, Cover.THREE_QUARTERS) is True
+        assert can_attempt_hide(Obscurement.CLEAR, Cover.TOTAL) is True
+        assert can_attempt_hide(Obscurement.CLEAR, Cover.HALF) is False
+
+        # --- GameState integration: room data drives the gate ---
+        char = _make_stealthy_character()
+        party = Party([char])
+        game_state = GameState(party, "crypt", campaign_id="the_unquiet_dead")
+        game_state.current_room_id = "crypt.hall_of_the_dead"
+        room = game_state.get_current_room()
+
+        # A heavily fogged room qualifies even in Bright Light: the area
+        # is Heavily Obscured regardless of illumination.
+        room["lighting"] = "bright"
+        room["obscurement_sources"] = ["heavy_fog"]
+        room["cover"] = "none"
+        assert game_state.can_attempt_hide(char) is True
+
+        # A clear, brightly lit room with no cover does not qualify.
+        room["obscurement_sources"] = []
+        room["cover"] = "none"
+        assert game_state.can_attempt_hide(char) is False
+
+        # Three-quarters cover qualifies even in a clear, bright room.
+        room["cover"] = "three_quarters"
+        assert game_state.can_attempt_hide(char) is True
+
     def test_party_cannot_hide_in_an_open_brightly_lit_empty_room(self):
-        pytest.skip(
-            "GAP: the SRD's GM-discretion clause should make hiding "
-            "*unavailable* in an open, brightly lit, featureless room. "
-            "Today, `GameState._check_for_surprise` would still run a "
-            "Stealth check there because it does not consult lighting "
-            "or cover. With the cover-gate from issue #496 implemented, "
-            "this test would assert the Hide action / surprise check "
-            "is refused in such an environment. Tracked by issue #496."
+        """Hiding is unavailable in an open, brightly lit, featureless room.
+
+        The SRD's GM-discretion clause means a creature standing in the
+        open with full illumination and nothing to hide behind cannot
+        attempt the Hide action: the area is not obscured and offers no
+        cover. `GameState.can_attempt_hide` must refuse here (issue
+        #496).
+        """
+        char = _make_stealthy_character()
+        party = Party([char])
+        game_state = GameState(party, "crypt", campaign_id="the_unquiet_dead")
+        game_state.current_room_id = "crypt.hall_of_the_dead"
+        room = game_state.get_current_room()
+        room["lighting"] = "bright"
+        room["obscurement_sources"] = []
+        room["cover"] = "none"
+
+        assert game_state.can_attempt_hide(char) is False
+
+    def test_shipped_dungeon_room_carries_the_obscurement_hide_signal(self):
+        """Shipped content exercises the hide gate from room data.
+
+        The acceptance criterion for issue #496 requires room data to
+        carry the obscurement / cover signal that drives the gate. The
+        Poisoned Laboratory's steam-choked boiler room declares
+        `obscurement_sources: ["heavy_fog"]`, making it Heavily Obscured,
+        so a creature there can attempt to hide — while the adjacent
+        open furnace room cannot. This guards the data wiring so the
+        signal can't silently disappear from the dungeon.
+        """
+        char = _make_stealthy_character()
+        party = Party([char])
+        game_state = GameState(
+            party, "laboratory", campaign_id="poisoned_laboratory"
         )
+
+        game_state.current_room_id = "laboratory.boiler_room"
+        assert game_state.can_attempt_hide(char) is True
+
+        game_state.current_room_id = "laboratory.furnace_room"
+        assert game_state.can_attempt_hide(char) is False
 
 
 class TestHiding_HideAction:


### PR DESCRIPTION
## Summary
- Implements the SRD 5.2.1 **precondition gate** for the Hide action: a creature may attempt to hide only when its area is **Heavily Obscured** or it has at least **Three-Quarters Cover**.
- Lighter conditions (Lightly Obscured, Half Cover, open ground) do **not** qualify — this follows the SRD threshold, which is intentionally stricter than plan-05's draft "Lightly Obscured" wording. The SRD threshold is treated as canonical.

## Changes
- **`dnd_engine/systems/perception.py`**: new `Cover` enum (`none`/`half`/`three_quarters`/`total`) and a pure `can_attempt_hide(obscurement, cover) -> bool` rule.
- **`dnd_engine/core/game_state.py`**: new `GameState.can_attempt_hide(creature)` — resolves the room's effective obscurement (ambient light + fog/foliage via `effective_obscurement`) and its `cover` signal, then applies the rule. Defensive handling for unresolvable rooms and unrecognized cover values.
- **`data/.../poisoned_laboratory/dungeons/laboratory.json`**: new **Steam-Choked Boiler Room** — a `heavy_fog` (Heavily Obscured) chamber off the furnace room, so the obscurement-driven gate is exercisable in shipped content.
- **`tests/srd/playing_the_game/test_hiding.py`**: flipped the two `TestHiding_GMDiscretion` gating tests from `skip` to real assertions, plus a guard test asserting the shipped boiler room enables hiding while the adjacent open furnace room does not.

## Testing
- [x] `test_hiding.py`: 6 passed, 6 skipped (skips are the #443/#475 Hide-*action* mechanics, out of scope here)
- [x] Vision/light + lighting + attack regression suites: 50 passed, no failures
- [x] Content/dungeon-loading regression: 208 passed
- [x] Verified the gate against real lab data: boiler_room → True, furnace_room → False, entrance → False
- [x] Confirmed client-2d `LayoutLoader` loads the new room with fields intact
- [x] `ruff check`: clean

## Notes
- This is the **precondition** side of hiding only. The Hide-action dispatcher that *consults* this gate is tracked by **#443** (no playable Hide action exists yet), so that acceptance-criteria checkbox remains blocked on #443.
- Pre-existing gap (not introduced here): client-2d's fog renderer doesn't yet consume engine `obscurement_sources`, so steam won't *visually* render as heavy fog — part of the outstanding plan-05/plan-10 client convergence.

## Related Issues
Part of #496 (engine precondition complete; full closure gated by #443)

🤖 Generated with [Claude Code](https://claude.com/claude-code)