### PR TITLE
Implement the Hide action (Dexterity (Stealth) check; hidden/unseen state) (plan-05, #443)

### DIFF
--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -206,6 +206,15 @@ class CombatEngine:
             advantage = True
             attacker.pending_help_from = None
 
+        # SRD § Hide: a hidden creature reveals its location when it
+        # makes an attack roll. The unseen-attacker Advantage below is
+        # derived from `defender_sees_attacker`, which the caller
+        # captured *before* this attack, so clearing the Hidden
+        # condition here preserves that one advantaged shot while
+        # revealing the attacker for everything that follows.
+        if hasattr(attacker, "has_condition") and attacker.has_condition("hidden"):
+            attacker.remove_condition("hidden")
+
         # SRD § Combat › Unseen Attackers and Targets: an attacker the
         # target can't see has Advantage; a target the attacker can't
         # see is attacked with Disadvantage. Both UNSEEN and

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -1694,7 +1694,17 @@ class GameState:
             List of action names (e.g., ["move", "attack", "search"])
         """
         if self.in_combat:
-            return ["attack", "use_item"]
+            actions = ["attack", "use_item"]
+            # SRD § Actions › Hide is offered only when the current
+            # combatant's surroundings permit it (the #496 gate).
+            current = (
+                self.initiative_tracker.get_current_combatant()
+                if self.initiative_tracker
+                else None
+            )
+            if current is not None and self.can_attempt_hide(current.creature):
+                actions.append("hide")
+            return actions
         else:
             actions = ["move"]
             room = self.get_current_room()

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -22,6 +22,7 @@ from dnd_engine.core.room_registry import RoomRegistry
 from dnd_engine.rules.damage import apply_damage_modifiers
 from dnd_engine.rules.loader import DataLoader
 from dnd_engine.systems.action_economy import ActionType, Terrain, cost_for
+from dnd_engine.systems.actions import hide
 from dnd_engine.systems.ai import EnemyAI
 from dnd_engine.systems.condition_manager import ConditionManager
 from dnd_engine.systems.initiative import InitiativeTracker
@@ -257,6 +258,27 @@ class StabilizeResult:
     modifier: int
     total: int
     dc: int
+
+
+@dataclass
+class HideAttemptResult:
+    """Result of a creature attempting the Hide action (SRD § Actions › Hide).
+
+    Carries everything the UI needs to narrate the attempt without
+    re-running engine logic. ``attempted`` is False when the Hide never
+    happened — the environment didn't permit it (the #496 gate) or the
+    required action slot was unavailable — in which case no roll was
+    made. When ``attempted`` is True the Dexterity (Stealth) check ran:
+    ``success`` says whether the creature is now Hidden, and the slot was
+    spent regardless of the outcome.
+    """
+
+    attempted: bool
+    success: bool
+    message: str
+    check_result: dict[str, Any] | None = None
+    dc: int | None = None
+    action_consumed: ActionType | None = None
 
 
 class EnemyTurnAction(Enum):
@@ -1547,6 +1569,122 @@ class GameState:
             cover = Cover.NONE
 
         return can_attempt_hide(obscurement, cover)
+
+    def _highest_enemy_passive_perception(self) -> int:
+        """Highest passive Perception among the active enemies (min 10).
+
+        Both the Hide action and the pre-combat surprise check contest a
+        Stealth roll against the most perceptive watching enemy. An
+        enemy's passive Perception comes from its own
+        ``passive_perception`` attribute when present, otherwise from the
+        monster catalog matched by name; enemies that resolve to neither
+        are skipped. Returns 10 (the SRD baseline passive Perception,
+        10 + a +0 Wisdom) when no enemy yields a value.
+        """
+        monsters_data = self.data_loader.load_monsters()
+        highest = 0
+        for enemy in self.active_enemies:
+            pp = getattr(enemy, "passive_perception", None)
+            if pp is None:
+                for _monster_id, monster_data in monsters_data.items():
+                    if monster_data["name"] == enemy.name:
+                        pp = monster_data.get("passive_perception", 10)
+                        break
+            if pp is not None:
+                highest = max(highest, int(pp))
+        return highest if highest > 0 else 10
+
+    def attempt_hide(
+        self, creature: "Character", *, as_bonus_action: bool = False
+    ) -> HideAttemptResult:
+        """Take the Hide action: contest Stealth vs the watchers' Perception.
+
+        Orchestrates the SRD Hide action on the actor's combat turn:
+
+        1. The environment must permit hiding (``can_attempt_hide`` — the
+           SRD 5.2.1 gate from issue #496); otherwise the attempt is
+           refused before any slot is spent.
+        2. The Hide costs an action slot — ``ActionType.ACTION`` by
+           default, or ``BONUS_ACTION`` when ``as_bonus_action`` is set
+           (Cunning Action / Nimble Escape).
+        3. A Dexterity (Stealth) check is rolled against the highest
+           passive Perception among the active enemies.
+        4. On success the actor gains the Hidden (unseen) condition that
+           the unseen-attacker/target rules consume; on failure it stays
+           visible. Either way the slot is spent.
+
+        Args:
+            creature: The acting character (must be the current
+                combatant — Hide reads the current turn's slot).
+            as_bonus_action: Spend a Bonus Action instead of the Action.
+
+        Returns:
+            A :class:`HideAttemptResult` describing the outcome.
+        """
+        if not self.can_attempt_hide(creature):
+            return HideAttemptResult(
+                attempted=False,
+                success=False,
+                message="There's no concealment or cover here to hide behind.",
+            )
+
+        turn_state = (
+            self.initiative_tracker.get_current_turn_state() if self.initiative_tracker else None
+        )
+        if turn_state is None:
+            return HideAttemptResult(
+                attempted=False,
+                success=False,
+                message="Hiding requires an active combat turn.",
+            )
+
+        action_type = ActionType.BONUS_ACTION if as_bonus_action else ActionType.ACTION
+        if not turn_state.is_action_available(action_type):
+            slot = "bonus action" if as_bonus_action else "action"
+            return HideAttemptResult(
+                attempted=False,
+                success=False,
+                message=f"No {slot} available this turn.",
+            )
+
+        dc = self._highest_enemy_passive_perception()
+        skills_data = self.data_loader.load_skills()
+        check = creature.make_skill_check("stealth", dc, skills_data)
+
+        ok, reason = hide(
+            creature, turn_state, succeeded=check["success"], action_type=action_type
+        )
+        if not ok:
+            return HideAttemptResult(
+                attempted=False,
+                success=False,
+                message=reason or "Could not take the Hide action.",
+            )
+
+        self.event_bus.emit(
+            Event(
+                type=EventType.SKILL_CHECK,
+                data={
+                    "character": creature.name,
+                    **check,
+                    "action": f"Hide (Stealth vs passive Perception {dc})",
+                },
+            )
+        )
+
+        message = (
+            f"{creature.name} slips out of sight."
+            if check["success"]
+            else f"{creature.name} fails to find concealment and stays visible."
+        )
+        return HideAttemptResult(
+            attempted=True,
+            success=check["success"],
+            message=message,
+            check_result=check,
+            dc=dc,
+            action_consumed=action_type,
+        )
 
     def get_available_actions(self) -> list[str]:
         """
@@ -3932,20 +4070,7 @@ class GameState:
         skills_data = self.data_loader.load_skills()
 
         # Get highest enemy passive Perception
-        monsters_data = self.data_loader.load_monsters()
-        max_enemy_perception = 0  # Start at 0, will take highest from actual enemies
-
-        for enemy in self.active_enemies:
-            # Find enemy's passive_perception from monster data
-            for _monster_id, monster_data in monsters_data.items():
-                if monster_data["name"] == enemy.name:
-                    enemy_pp = monster_data.get("passive_perception", 10)
-                    max_enemy_perception = max(max_enemy_perception, enemy_pp)
-                    break
-
-        # Fallback if no passive_perception found
-        if max_enemy_perception == 0:
-            max_enemy_perception = 10
+        max_enemy_perception = self._highest_enemy_passive_perception()
 
         # Group stealth check - ALL party members must beat enemy passive Perception
         party_hidden = True

--- a/dnd-engine/dnd_engine/scenarios/script_executor.py
+++ b/dnd-engine/dnd_engine/scenarios/script_executor.py
@@ -59,6 +59,7 @@ class ScriptContext:
     last_attack: Any | None = None
     last_attack_error: str | None = None
     last_attack_disadvantage: bool = False
+    last_hide: Any | None = None
     turn_count: int = 0
 
     def resolve_entity(self, entity_id: str) -> Any | None:
@@ -201,6 +202,8 @@ class ScriptExecutor:
         a_type = action.get("action")
         if a_type == "wait":
             self._action_wait()
+        elif a_type == "hide":
+            self._action_hide()
         elif a_type == "attack":
             target = action.get("target")
             if target is None:
@@ -232,6 +235,23 @@ class ScriptExecutor:
                 "wait: combat is not active (no initiative tracker)"
             )
         tracker.next_turn()
+        self.ctx.turn_count += 1
+
+    def _action_hide(self) -> None:
+        """Dispatch the Hide action for the current party member.
+
+        Delegates to ``GameState.attempt_hide`` (the SRD § Actions ›
+        Hide surface — env gate, Stealth check, action-slot use) and
+        records the :class:`HideAttemptResult` on the context for
+        assertion runners, then advances the turn like the other
+        turn-consuming actions.
+        """
+        hider, _hider_id = self._current_player_attacker()
+        self.ctx.last_hide = self.ctx.game_state.attempt_hide(hider)
+
+        tracker = self.ctx.game_state.initiative_tracker
+        if tracker is not None:
+            tracker.next_turn()
         self.ctx.turn_count += 1
 
     def _action_attack(self, target_id: str) -> None:

--- a/dnd-engine/dnd_engine/systems/actions.py
+++ b/dnd-engine/dnd_engine/systems/actions.py
@@ -119,6 +119,50 @@ def dodge(creature: Creature, turn_state: TurnState) -> ActionResult:
     return True, None
 
 
+def hide(
+    creature: Creature,
+    turn_state: TurnState,
+    *,
+    succeeded: bool,
+    action_type: ActionType = ActionType.ACTION,
+) -> ActionResult:
+    """Take the Hide action.
+
+    SRD § Actions › Hide: "Make a Dexterity (Stealth) check." The check
+    itself is rolled by the caller — it needs the skills data and a DC
+    drawn from observers' passive Perception, neither of which belongs
+    in this pure handler. This handler consumes the turn's slot and, on
+    a successful check (``succeeded``), gives the hider the Hidden
+    (unseen) condition consumed by the unseen-attacker/target rules.
+
+    The action is spent whether or not the check succeeds — taking the
+    Hide action costs the slot; the roll only decides whether the
+    creature ends up hidden. Cunning Action / Nimble Escape let some
+    creatures Hide as a Bonus Action, so ``action_type`` is configurable
+    (defaulting to the SRD's Action cost).
+
+    Args:
+        creature: The actor taking Hide. Becomes Hidden on success.
+        turn_state: The actor's TurnState; the chosen slot is consumed.
+        succeeded: Whether the caller's Dexterity (Stealth) check beat
+            the observers' passive Perception.
+        action_type: The slot the Hide costs. Defaults to
+            ``ActionType.ACTION``; pass ``BONUS_ACTION`` for Cunning
+            Action / Nimble Escape.
+
+    Returns:
+        ``(True, None)`` when the action was taken (regardless of the
+        check outcome). ``(False, "no action available")`` when the
+        required slot is already consumed; in that case no condition is
+        applied.
+    """
+    if not turn_state.consume_action(action_type):
+        return False, "no action available"
+    if succeeded:
+        creature.add_condition("hidden")
+    return True, None
+
+
 def help_action(helper: Creature, ally: Creature, turn_state: TurnState) -> ActionResult:
     """Take the Help action.
 

--- a/dnd-engine/tests/srd/playing_the_game/test_actions.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_actions.py
@@ -25,6 +25,7 @@ from dnd_engine.core.dice import DiceRoller
 from dnd_engine.core.game_state import GameState
 from dnd_engine.scenarios import script_executor as script_executor_mod
 from dnd_engine.systems.action_economy import ActionType, TurnState
+from dnd_engine.systems.actions import hide
 
 pytestmark = pytest.mark.srd(
     "playing-the-game/actions.md",
@@ -532,16 +533,25 @@ class TestAction_Hide:
     """
 
     def test_hide_makes_a_dexterity_stealth_check(self) -> None:
-        pytest.skip(
-            "GAP: There is no `Hide` action handler. A Stealth check "
-            "primitive exists "
-            "(`Character.make_skill_check('stealth', ...)` "
-            "in dnd_engine/core/character.py:726) and is used for "
-            "surprise rounds (game_state.py:3050), but no action "
-            "dispatches it on demand, no hidden/unseen flag is set on "
-            "the hider, and visibility is not consulted by attack "
-            "resolution. Tracked by issue #443."
+        """`GameState.attempt_hide` is the Hide-action surface.
+
+        SRD § Actions › Hide: "Make a Dexterity (Stealth) check." The
+        engine body lives at `GameState.attempt_hide`, which rolls
+        `make_skill_check("stealth", ...)` against the watching enemies'
+        passive Perception and consumes the turn's action slot via the
+        pure `actions.hide` handler. Source-level guard so this link
+        from the SRD Hide row to the engine can't silently regress.
+        """
+        assert callable(getattr(GameState, "attempt_hide", None))
+        src = inspect.getsource(GameState.attempt_hide)
+        assert '"stealth"' in src or "'stealth'" in src, (
+            "The Hide action must roll a Stealth check."
         )
+        assert "make_skill_check" in src, (
+            "The Hide action must consume the Stealth check primitive."
+        )
+        # The handler it delegates to spends an action slot.
+        assert "consume_action" in inspect.getsource(hide)
 
 
 class TestAction_Influence:

--- a/dnd-engine/tests/srd/playing_the_game/test_hiding.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_hiding.py
@@ -23,9 +23,12 @@ import inspect
 import pytest
 
 from dnd_engine.core.character import Character, CharacterClass
-from dnd_engine.core.creature import Abilities
+from dnd_engine.core.creature import Abilities, Creature
 from dnd_engine.core.game_state import GameState
 from dnd_engine.core.party import Party
+from dnd_engine.systems.action_economy import ActionType
+from dnd_engine.systems.initiative import InitiativeTracker
+from dnd_engine.systems.perception import VisibilityRelation
 
 pytestmark = pytest.mark.srd(
     "playing-the-game/hiding.md",
@@ -54,6 +57,49 @@ def _make_stealthy_character() -> Character:
         skill_proficiencies=["stealth"],
     )
     return char
+
+
+def _unmissable_hider() -> Character:
+    """A hider whose Stealth check clears the DC-10 baseline on any roll.
+
+    DEX 20 (+5) plus Stealth expertise (proficiency 2 doubled = +4) gives
+    a +9 modifier, so even a natural 1 totals 10 — guaranteeing success
+    against the no-enemies baseline DC of 10. Used to exercise the
+    success branch deterministically.
+    """
+    char = _make_stealthy_character()
+    char.abilities = Abilities(
+        strength=10, dexterity=20, constitution=10, intelligence=10, wisdom=10, charisma=10
+    )
+    char.expertise_skills = ["stealth"]
+    return char
+
+
+def _dummy_enemy(name: str = "Zombie") -> Creature:
+    return Creature(
+        name=name, max_hp=22, ac=8, abilities=Abilities(13, 6, 16, 3, 6, 5)
+    )
+
+
+def _combat_state(char: Character, *, concealing: bool = True) -> GameState:
+    """A crypt-room GameState in combat with ``char`` as the current turn.
+
+    When ``concealing`` the room is made Heavily Obscured (heavy fog) so
+    the SRD 5.2.1 hide gate is satisfied; otherwise it's an open, brightly
+    lit room where hiding isn't permitted (used by tests that set the
+    Hidden condition directly to probe the unseen-attacker rules).
+    """
+    party = Party([char])
+    gs = GameState(party, "crypt", campaign_id="the_unquiet_dead")
+    gs.current_room_id = "crypt.hall_of_the_dead"
+    room = gs.get_current_room()
+    room["lighting"] = "bright"
+    room["obscurement_sources"] = ["heavy_fog"] if concealing else []
+    room["cover"] = "none"
+    gs.in_combat = True
+    gs.initiative_tracker = InitiativeTracker(gs.dice_roller, gs.time_manager)
+    gs.initiative_tracker.add_combatant(char)
+    return gs
 
 
 class TestHiding_Intro:
@@ -246,72 +292,135 @@ class TestHiding_HideAction:
     """
 
     def test_hide_action_is_dispatchable_as_a_playable_action(self):
-        pytest.skip(
-            "GAP: there is no playable Hide action. The script "
-            "executor's action dispatcher "
-            "(`dnd-engine/dnd_engine/scenarios/script_executor.py:200-"
-            "224`) only accepts 'wait', 'attack', and 'monster_attack' "
-            "— `hide` is not a recognized action. The combat-mode "
-            "available-actions list (`dnd-engine/dnd_engine/core/"
-            "game_state.py:766`) is `['attack', 'use_item']` — no "
-            "'hide'. The string 'Hide' appears only as flavor text in "
-            "the rogue Cunning Action description "
-            "(`dnd-engine/dnd_engine/data/srd/classes.json`) and in "
-            "the spy monster's Nimble Escape "
-            "(`dnd-engine/dnd_engine/data/srd/monsters.json`). "
-            "Tracked by issue #443."
-        )
+        """Hide is surfaced as a combat action when the room permits it.
+
+        `GameState.get_available_actions` lists "hide" during combat
+        only when the current combatant's surroundings satisfy the SRD
+        5.2.1 gate, making it a real, player-selectable action (issue
+        #443). In an open, brightly lit room it is not offered.
+        """
+        char = _make_stealthy_character()
+        gs = _combat_state(char)
+        assert "hide" in gs.get_available_actions()
+
+        # Remove the concealment: the action is no longer offered.
+        gs.get_current_room()["obscurement_sources"] = []
+        assert "hide" not in gs.get_available_actions()
 
     def test_hide_action_makes_a_dexterity_stealth_check(self):
-        pytest.skip(
-            "GAP: same as above — there is no Hide action handler, so "
-            "no dispatcher invokes `make_skill_check('stealth', ...)` "
-            "on demand. The check primitive exists "
-            "(`dnd-engine/dnd_engine/core/character.py:697-738`) but "
-            "is currently only fired by the surprise-round path, not "
-            "by a player-initiated Hide. Tracked by issue #443."
-        )
+        """`GameState.attempt_hide` rolls a Dexterity (Stealth) check.
+
+        SRD § Actions › Hide: "Make a Dexterity (Stealth) check." The
+        attempt surfaces the rolled check (skill ``stealth``, ability
+        ``dex``) contested against a DC drawn from enemy passive
+        Perception.
+        """
+        char = _make_stealthy_character()
+        gs = _combat_state(char)
+
+        result = gs.attempt_hide(char)
+
+        assert result.attempted is True
+        assert result.check_result is not None
+        assert result.check_result["skill"] == "stealth"
+        assert result.check_result["ability"] == "dex"
+        assert result.dc is not None
 
     def test_hide_action_consumes_the_turn_action_slot(self):
-        pytest.skip(
-            "GAP: the Hide action should consume `ActionType.ACTION` "
-            "(or `BONUS_ACTION` via rogue Cunning Action / monster "
-            "Nimble Escape). Action economy is modeled — `TurnState` "
-            "in `dnd-engine/dnd_engine/systems/action_economy.py:26-"
-            "40` carries the slot — but no Hide handler consumes it. "
-            "Tracked by issue #443."
-        )
+        """Taking the Hide action spends the turn's Action slot."""
+        char = _make_stealthy_character()
+        gs = _combat_state(char)
+        turn_state = gs.initiative_tracker.get_current_turn_state()
+        assert turn_state.action_available is True
+
+        result = gs.attempt_hide(char)
+
+        assert result.action_consumed == ActionType.ACTION
+        assert turn_state.action_available is False
 
     def test_successful_hide_sets_unseen_state_on_the_hider(self):
-        pytest.skip(
-            "GAP: the SRD's Hide action produces an *unseen* state "
-            "(consumed by attack-roll rules — issue #475). No `hidden` "
-            "/ `unseen` / `is_hidden` flag exists on Creature or "
-            "Character in `dnd-engine/dnd_engine/core/creature.py` or "
-            "`character.py`. The `active_conditions` dict on Creature "
-            "could carry it, but no code writes 'hidden' there. "
-            "Tracked by issue #443."
-        )
+        """A successful Hide gives the hider the Hidden (unseen) condition.
+
+        The Hidden condition is what the unseen-attacker/target rules
+        consume (issue #475); ``compute_visibility`` already treats a
+        Hidden target as ``UNSEEN``.
+        """
+        char = _unmissable_hider()
+        gs = _combat_state(char)
+
+        result = gs.attempt_hide(char)
+
+        assert result.success is True
+        assert char.has_condition("hidden") is True
 
     def test_attacks_against_unseen_attacker_or_target_apply_visibility_advantage(self):
-        pytest.skip(
-            "GAP: even if the Hide action set an unseen flag, the "
-            "attack pipeline would not consume it. `CombatEngine."
-            "resolve_attack` (`dnd-engine/dnd_engine/core/combat.py:"
-            "91`) accepts `advantage` / `disadvantage` flags but no "
-            "caller derives them from attacker/target visibility "
-            "state. The Blinded condition is similarly unconsumed by "
-            "attack rolls (only the close-combat ranged helper "
-            "`dnd_engine/systems/ranged_attacks.py:71` reads it). "
-            "Tracked by issue #475 (which is the *consumer* of the "
-            "hidden state from #443)."
+        """A Hidden creature is unseen for the attack-roll rules.
+
+        SRD § Combat › Unseen Attackers and Targets: an attacker the
+        target can't see has Advantage; a target the attacker can't see
+        is attacked with Disadvantage. With the hider in a clear, lit
+        room (so only the Hidden condition — not ambient fog — drives
+        visibility), the relations resolve exactly that way.
+        """
+        char = _make_stealthy_character()
+        gs = _combat_state(char, concealing=False)
+        enemy = _dummy_enemy()
+        gs.active_enemies = [enemy]
+        char.add_condition("hidden")
+
+        # Enemy attacks the hidden hider → target unseen → Disadvantage.
+        attacker_sees, defender_sees = gs.attack_visibility(enemy, char)
+        assert attacker_sees == VisibilityRelation.UNSEEN
+        incoming = gs.combat_engine.resolve_attack(
+            attacker=enemy,
+            defender=char,
+            attack_bonus=3,
+            damage_dice="1d6",
+            attacker_sees_defender=attacker_sees,
+            defender_sees_attacker=defender_sees,
+            game_state=gs,
         )
+        assert incoming.disadvantage is True
+        assert incoming.advantage is False
+
+        # Hidden hider attacks the enemy → attacker unseen → Advantage.
+        char.add_condition("hidden")  # re-hide (the prior attack didn't reveal char)
+        saw_defender, saw_attacker = gs.attack_visibility(char, enemy)
+        assert saw_attacker == VisibilityRelation.UNSEEN
+        outgoing = gs.combat_engine.resolve_attack(
+            attacker=char,
+            defender=enemy,
+            attack_bonus=4,
+            damage_dice="1d6",
+            attacker_sees_defender=saw_defender,
+            defender_sees_attacker=saw_attacker,
+            game_state=gs,
+        )
+        assert outgoing.advantage is True
 
     def test_hidden_attacker_reveals_location_on_attack(self):
-        pytest.skip(
-            "GAP: the SRD says a hidden creature reveals its location "
-            "when it makes an attack roll. Today there is no hidden "
-            "state to reveal (issue #443) and no post-attack reveal "
-            "hook in `resolve_attack` (`dnd-engine/dnd_engine/core/"
-            "combat.py:91`). Tracked by issue #475."
+        """A Hidden creature reveals itself the moment it attacks.
+
+        SRD § Hide: making an attack roll ends the hidden state. The
+        hider keeps its one advantaged shot (the relation was captured
+        before the roll), then is no longer Hidden.
+        """
+        char = _make_stealthy_character()
+        gs = _combat_state(char, concealing=False)
+        enemy = _dummy_enemy()
+        gs.active_enemies = [enemy]
+        char.add_condition("hidden")
+        assert char.has_condition("hidden") is True
+
+        saw_defender, saw_attacker = gs.attack_visibility(char, enemy)
+        gs.combat_engine.resolve_attack(
+            attacker=char,
+            defender=enemy,
+            attack_bonus=4,
+            damage_dice="1d6",
+            attacker_sees_defender=saw_defender,
+            defender_sees_attacker=saw_attacker,
+            game_state=gs,
         )
+
+        assert char.has_condition("hidden") is False

--- a/dnd-engine/tests/test_actions.py
+++ b/dnd-engine/tests/test_actions.py
@@ -3,7 +3,7 @@
 
 from dnd_engine.core.creature import Abilities, Creature
 from dnd_engine.systems.action_economy import ActionType, TurnState
-from dnd_engine.systems.actions import dash, disengage, drop_prone, stand_up
+from dnd_engine.systems.actions import dash, disengage, drop_prone, hide, stand_up
 
 
 def _make_creature(name: str = "Hero", speed: int = 30) -> Creature:
@@ -169,3 +169,55 @@ class TestStandUp:
         assert ok is True
         # 25 // 2 = 12, leaving 13
         assert turn.movement_remaining == 13
+
+
+class TestHide:
+    """SRD § Actions › Hide: 'Make a Dexterity (Stealth) check.'
+
+    The caller rolls the Stealth check (it needs skills data and the DC
+    from observers' passive Perception); the handler consumes the turn's
+    slot and, on a successful check, gives the hider the Hidden (unseen)
+    condition.
+    """
+
+    def test_hide_consumes_action_and_sets_hidden_on_success(self):
+        actor = _make_creature()
+        turn = TurnState()
+        turn.reset(speed=30)
+        ok, reason = hide(actor, turn, succeeded=True)
+        assert ok is True
+        assert reason is None
+        assert turn.action_available is False
+        assert actor.has_condition("hidden") is True
+
+    def test_hide_consumes_action_but_stays_visible_on_failure(self):
+        actor = _make_creature()
+        turn = TurnState()
+        turn.reset(speed=30)
+        ok, reason = hide(actor, turn, succeeded=False)
+        assert ok is True
+        assert reason is None
+        assert turn.action_available is False  # the action is still spent
+        assert actor.has_condition("hidden") is False
+
+    def test_hide_fails_when_no_action_available(self):
+        actor = _make_creature()
+        turn = TurnState()
+        turn.reset(speed=30)
+        turn.consume_action(ActionType.ACTION)
+        ok, reason = hide(actor, turn, succeeded=True)
+        assert ok is False
+        assert reason == "no action available"
+        assert actor.has_condition("hidden") is False
+
+    def test_hide_can_use_a_bonus_action(self):
+        """Cunning Action / Nimble Escape let some creatures Hide as a
+        Bonus Action; the handler honors an explicit BONUS_ACTION cost."""
+        actor = _make_creature()
+        turn = TurnState()
+        turn.reset(speed=30)
+        ok, _ = hide(actor, turn, succeeded=True, action_type=ActionType.BONUS_ACTION)
+        assert ok is True
+        assert turn.bonus_action_available is False
+        assert turn.action_available is True  # Action slot untouched
+        assert actor.has_condition("hidden") is True

--- a/dnd-engine/tests/test_combat.py
+++ b/dnd-engine/tests/test_combat.py
@@ -331,6 +331,28 @@ class TestResolveAttackVisibility:
         assert result.advantage is False
         assert result.disadvantage is False
 
+    def test_hidden_attacker_reveals_itself_after_attacking(self):
+        """SRD § Hide: a hidden creature reveals its location when it
+        makes an attack roll. The Hidden condition is cleared by
+        ``resolve_attack`` once the attack resolves."""
+        self.attacker.add_condition("hidden")
+        self._attack(defender_sees_attacker=VisibilityRelation.UNSEEN)
+        assert self.attacker.has_condition("hidden") is False
+
+    def test_hidden_attacker_keeps_advantage_on_the_revealing_attack(self):
+        """The reveal does not rob the hider of its one advantaged shot:
+        the unseen-attacker Advantage (derived by the caller before the
+        attack) still applies to the attack that reveals it."""
+        self.attacker.add_condition("hidden")
+        result = self._attack(defender_sees_attacker=VisibilityRelation.UNSEEN)
+        assert result.advantage is True
+        assert self.attacker.has_condition("hidden") is False
+
+    def test_non_hidden_attacker_is_unaffected_by_the_reveal_hook(self):
+        """A visible attacker has no Hidden condition to clear."""
+        self._attack()
+        assert self.attacker.has_condition("hidden") is False
+
 
 class TestAttackResult:
     """Test the AttackResult class"""

--- a/dnd-engine/tests/test_hide_action_integration.py
+++ b/dnd-engine/tests/test_hide_action_integration.py
@@ -1,0 +1,122 @@
+# ABOUTME: Integration tests for GameState.attempt_hide (the Hide action, #443).
+# ABOUTME: Exercises the env gate, the Stealth-vs-passive-Perception roll, and slot use.
+
+"""Integration coverage for the player-initiated Hide action.
+
+`GameState.attempt_hide` ties together the #496 environmental gate
+(`can_attempt_hide`), the combat-turn action economy, and a Dexterity
+(Stealth) check contested against the most perceptive enemy. These tests
+drive the orchestration end-to-end against the shipped crypt campaign.
+"""
+
+from __future__ import annotations
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.game_state import GameState, HideAttemptResult
+from dnd_engine.core.party import Party
+from dnd_engine.systems.action_economy import ActionType
+from dnd_engine.systems.initiative import InitiativeTracker
+
+
+def _stealthy_rogue(*, dex: int = 16, expertise: bool = False) -> Character:
+    char = Character(
+        name="Sneak",
+        character_class=CharacterClass.ROGUE,
+        level=1,
+        abilities=Abilities(10, dex, 10, 10, 10, 10),
+        max_hp=8,
+        ac=14,
+        race="halfling",
+        skill_proficiencies=["stealth"],
+    )
+    if expertise:
+        char.expertise_skills = ["stealth"]
+    return char
+
+
+def _game_state_with_turn(char: Character) -> GameState:
+    """Build a crypt-room GameState with ``char`` as the current combatant."""
+    party = Party([char])
+    gs = GameState(party, "crypt", campaign_id="the_unquiet_dead")
+    gs.current_room_id = "crypt.hall_of_the_dead"
+    gs.in_combat = True
+    gs.initiative_tracker = InitiativeTracker(gs.dice_roller, gs.time_manager)
+    gs.initiative_tracker.add_combatant(char)
+    return gs
+
+
+def _make_room_concealing(gs: GameState) -> None:
+    room = gs.get_current_room()
+    room["lighting"] = "bright"
+    room["obscurement_sources"] = ["heavy_fog"]  # Heavily Obscured
+    room["cover"] = "none"
+
+
+def _make_room_open(gs: GameState) -> None:
+    room = gs.get_current_room()
+    room["lighting"] = "bright"
+    room["obscurement_sources"] = []
+    room["cover"] = "none"
+
+
+class TestAttemptHide:
+    def test_open_lit_room_blocks_hide_and_keeps_the_action(self):
+        char = _stealthy_rogue()
+        gs = _game_state_with_turn(char)
+        _make_room_open(gs)
+
+        result = gs.attempt_hide(char)
+
+        assert isinstance(result, HideAttemptResult)
+        assert result.attempted is False
+        assert result.success is False
+        assert char.has_condition("hidden") is False
+        # Gate refusal happens before any slot is spent.
+        assert gs.initiative_tracker.get_current_turn_state().action_available is True
+
+    def test_successful_hide_sets_hidden_and_spends_the_action(self):
+        # DEX 20 (+5) + Stealth expertise (prof 2 doubled = +4) → +9; with no
+        # enemies the DC is the baseline 10, so even a natural 1 clears it.
+        char = _stealthy_rogue(dex=20, expertise=True)
+        gs = _game_state_with_turn(char)
+        _make_room_concealing(gs)
+
+        result = gs.attempt_hide(char)
+
+        assert result.attempted is True
+        assert result.success is True
+        assert result.dc == 10
+        assert result.action_consumed == ActionType.ACTION
+        assert char.has_condition("hidden") is True
+        assert gs.initiative_tracker.get_current_turn_state().action_available is False
+
+    def test_failed_hide_stays_visible_but_still_spends_the_action(self):
+        char = _stealthy_rogue()
+        gs = _game_state_with_turn(char)
+        _make_room_concealing(gs)
+        # An impossibly perceptive watcher forces the Stealth check to fail.
+        watcher = Creature(
+            name="All-Seeing Eye", max_hp=1, ac=10, abilities=Abilities(10, 10, 10, 10, 10, 10)
+        )
+        watcher.passive_perception = 100
+        gs.active_enemies = [watcher]
+
+        result = gs.attempt_hide(char)
+
+        assert result.attempted is True
+        assert result.success is False
+        assert result.dc == 100
+        assert char.has_condition("hidden") is False
+        assert gs.initiative_tracker.get_current_turn_state().action_available is False
+
+    def test_hide_requires_an_active_turn(self):
+        char = _stealthy_rogue()
+        gs = _game_state_with_turn(char)
+        _make_room_concealing(gs)
+        gs.initiative_tracker = None  # no combat turn in progress
+
+        result = gs.attempt_hide(char)
+
+        assert result.attempted is False
+        assert char.has_condition("hidden") is False

--- a/dnd-engine/tests/test_script_executor.py
+++ b/dnd-engine/tests/test_script_executor.py
@@ -72,6 +72,27 @@ enemies:
     position: [8, 5]
 """
 
+# Hide body: a rogue and a goblin in the steam-choked boiler room
+# (obscurement_sources: ["heavy_fog"] → Heavily Obscured), so the SRD
+# 5.2.1 hide gate is satisfied and a Hide action can be dispatched.
+HIDE_YAML = """
+name: exec_hide
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.boiler_room
+party:
+  - class: rogue
+    race: halfling
+    weapons: [dagger]
+    position: [3, 5]
+    name: Sneaky
+enemies:
+  - monster_id: goblin
+    position: [10, 5]
+"""
+
 # Out-of-range body: dagger past long range. Distance 17 tiles
 # = 85 ft, beyond dagger long range of 60 ft. Attack must be
 # rejected without invoking the engine.
@@ -630,3 +651,55 @@ def test_monster_attack_missing_required_field_raises(tmp_path: Path) -> None:
         ])
     msg = str(exc.value).lower()
     assert "monster_attack" in msg or "target" in msg or "monster_action" in msg
+
+
+def _cycle_to_party_member(loaded) -> None:
+    """Advance initiative until the current combatant is a party member.
+
+    Hide acts on the current combatant; the boiler-room scenario's
+    initiative order isn't fixed, so spin the tracker until the rogue
+    holds the turn before dispatching the Hide action.
+    """
+    tracker = loaded.game_state.initiative_tracker
+    party = set(loaded.game_state.party.characters)
+    for _ in range(len(tracker.combatants)):
+        if tracker.get_current_combatant().creature in party:
+            return
+        tracker.next_turn()
+    raise AssertionError("no party member ever held the turn")
+
+
+def test_hide_action_is_dispatchable(tmp_path: Path) -> None:
+    """`{"action": "hide"}` is a recognized script action and records a result."""
+    path = _write(tmp_path, HIDE_YAML)
+    loaded = ScenarioLoader().load(path)
+    _cycle_to_party_member(loaded)
+
+    ctx = ScriptExecutor(loaded).run([{"action": "hide"}])
+
+    # The boiler room is Heavily Obscured, so the attempt happens.
+    assert ctx.last_hide is not None
+    assert ctx.last_hide.attempted is True
+    assert ctx.turn_count == 1
+
+
+def test_hide_sets_hidden_state_matching_the_check_outcome(tmp_path: Path) -> None:
+    """After a Hide, the hider's Hidden condition tracks the check result."""
+    path = _write(tmp_path, HIDE_YAML)
+    loaded = ScenarioLoader().load(path)
+    _cycle_to_party_member(loaded)
+    rogue = loaded.game_state.party.characters[0]
+
+    ctx = ScriptExecutor(loaded).run([{"action": "hide"}])
+
+    assert rogue.has_condition("hidden") == ctx.last_hide.success
+
+
+def test_unknown_action_still_rejected(tmp_path: Path) -> None:
+    """Adding `hide` to the dispatcher doesn't loosen unknown-action rejection."""
+    path = _write(tmp_path, HIDE_YAML)
+    loaded = ScenarioLoader().load(path)
+
+    with pytest.raises(ScriptExecutionError) as exc:
+        ScriptExecutor(loaded).run([{"action": "sneak"}])
+    assert "unknown script action" in str(exc.value).lower()


### PR DESCRIPTION
## Summary
Implements the SRD Hide action on top of the plan-05 visibility model and the #496 precondition gate. A creature can now take the Hide action on its turn: it rolls a Dexterity (Stealth) check against the most perceptive watching enemy and, on success, gains a `hidden` (unseen) state that the existing unseen-attacker/target rules already consume. A hidden creature is revealed the moment it attacks.

## Changes
- **`systems/actions.py`**: new pure `hide(creature, turn_state, *, succeeded, action_type)` handler mirroring `dash`/`dodge` — consumes the slot and applies the `hidden` condition on success.
- **`core/combat.py`**: `resolve_attack` clears the attacker's `hidden` condition once the roll resolves (SRD: a hidden creature reveals itself when it attacks). The advantaged shot is preserved because the visibility relation is captured by the caller before the attack.
- **`core/game_state.py`**: `HideAttemptResult` dataclass + `attempt_hide()` orchestration (env gate → action economy → Stealth check → condition). Extracts a shared `_highest_enemy_passive_perception()` helper now used by both Hide and the pre-combat surprise check (removes duplicated catalog lookup). `get_available_actions()` lists `hide` in combat when the gate permits.
- **`scenarios/script_executor.py`**: `{"action": "hide"}` dispatch + `ScriptContext.last_hide`.

## Testing
- [x] New unit tests: pure handler (`TestHide`), reveal-on-attack (`TestResolveAttackVisibility`)
- [x] New integration tests: `test_hide_action_integration.py`, script-executor dispatch
- [x] Flipped 7 skipped SRD conformance tests (`test_hiding.py::TestHiding_HideAction`, `test_actions.py::TestAction_Hide`) to real assertions
- [x] Full suite: 3191 passed, 199 skipped, 0 failed
- [x] ruff check clean; python-code-reviewer: no critical/high/medium issues

## Acceptance criteria
- [x] `hide` dispatchable, consumes `ActionType.ACTION` (bonus-action path parameterized)
- [x] Rolls `make_skill_check("stealth", …)` vs highest unaware-enemy passive Perception
- [x] Success sets `hidden`; failure stays visible
- [x] Attack resolution applies unseen-attacker advantage / unseen-target disadvantage
- [x] Hidden attacker reveals on attack
- [x] Gating test flips skip → assertion

## Out of scope (follow-ups)
Cunning Action / Nimble Escape bonus-action auto-detection; monster (non-Character) hiding; reveal-on-spell-cast.

## Related Issues
Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)