### PR TITLE
Add #608: Wire the Hide action into the player-facing surface (MCP tool + combat menu)

### DIFF
--- a/client-2d/src/client_2d/embedded_mcp_server.py
+++ b/client-2d/src/client_2d/embedded_mcp_server.py
@@ -50,6 +50,7 @@ class EmbeddedMCPServer:
         - game_move: Move party north/south/east/west
         - game_attack: Attack enemy by index in combat
         - game_wait: Pass turn in combat
+        - game_hide: Take the Hide action (Dexterity (Stealth) check)
 
     Note: Unlike the standalone mcp_server.py, this server does NOT
     have a game_new tool since the game is already running.
@@ -171,6 +172,29 @@ class EmbeddedMCPServer:
                 Updated game state after all enemy turns complete.
             """
             request = CommandRequest(command_type=CommandType.WAIT)
+            return bridge.submit_command(request, timeout=10.0)
+
+        @mcp.tool()
+        def game_hide() -> str:
+            """Take the Hide action: a Dexterity (Stealth) check to become unseen.
+
+            Only works during combat on a player's turn, and only when the
+            surroundings allow it (heavy obscurement or three-quarters cover —
+            check the Available Actions in game_state). The check is contested
+            against the most perceptive enemy's passive Perception.
+
+            Hide spends your action but NOT your turn — you keep any remaining
+            movement and can reposition, then game_wait() to end the turn.
+            Attacking from hidden grants advantage and reveals you.
+
+            Example:
+                game_hide()  # Roll Stealth; on success you become unseen
+
+            Returns:
+                The Hide outcome (roll vs DC, success/fail) and updated state.
+                A no-op message (not a crash) when Hide isn't available.
+            """
+            request = CommandRequest(command_type=CommandType.HIDE)
             return bridge.submit_command(request, timeout=10.0)
 
         if self._dev_mode:

--- a/client-2d/src/client_2d/game.py
+++ b/client-2d/src/client_2d/game.py
@@ -305,6 +305,17 @@ class GameWindow(arcade.Window):
     def _pass_turn(self) -> None:
         self.session.pass_turn()
 
+    def _hide(self) -> None:
+        """Take the Hide action for the current PC.
+
+        Delegates to GameSession.hide, which routes into
+        GameState.attempt_hide and logs the outcome (including the
+        environment-gate refusal when there's no concealment) to the
+        combat log. Hide spends the action but leaves the turn with the
+        player, so no enemy turns are drained here.
+        """
+        self.session.hide()
+
     def _mcp_combat_move(self, direction: str) -> str:
         return self.session.combat_move(direction)
 
@@ -896,9 +907,15 @@ class GameWindow(arcade.Window):
             anchor_x="center",
         )
 
-        # Controls hint
+        # Controls hint. Hide is offered only when the engine's #496 gate
+        # passes for the current combatant (heavy obscurement or cover),
+        # matching GameState.get_available_actions().
+        controls = "1-9: Select  |  A: Attack  |  WASD/Arrows: Move  |  Space: Wait"
+        game_state = self.engine.game_state
+        if game_state is not None and "hide" in game_state.get_available_actions():
+            controls += "  |  H: Hide"
         arcade.draw_text(
-            "1-9: Select  |  A: Attack  |  WASD/Arrows: Move  |  Space: Wait",
+            controls,
             x + w // 2,
             y + UI_PADDING,
             UIColors.TEXT_DIM,
@@ -1378,6 +1395,11 @@ class GameWindow(arcade.Window):
         # Space to wait/pass
         elif key == arcade.key.SPACE:
             self._pass_turn()
+
+        # H to take the Hide action (gated on concealment/cover; the
+        # session logs the refusal when the #496 environment gate fails)
+        elif key == arcade.key.H:
+            self._hide()
 
         # WASD/Arrow movement during combat (uses action economy)
         elif key in (arcade.key.W, arcade.key.UP):

--- a/client-2d/src/client_2d/mcp_bridge.py
+++ b/client-2d/src/client_2d/mcp_bridge.py
@@ -29,6 +29,7 @@ class CommandType(Enum):
     MOVE = auto()
     ATTACK = auto()
     WAIT = auto()
+    HIDE = auto()
 
     # Dev-mode commands (only dispatched when EmbeddedMCPServer was started
     # with dev_mode=True, gated upstream by --dev or DND_DEBUG=1).

--- a/client-2d/src/client_2d/mcp_proxy.py
+++ b/client-2d/src/client_2d/mcp_proxy.py
@@ -306,6 +306,23 @@ def create_proxy_server() -> FastMCP:
             return "Game not running. Use game_start() first."
         return await proxy.call_tool_async("game_wait")
 
+    @mcp.tool()
+    async def game_hide() -> str:
+        """Take the Hide action: a Dexterity (Stealth) check to become unseen.
+
+        Combat-turn action, available only when the surroundings allow it
+        (heavy obscurement or three-quarters cover — see Available Actions in
+        game_state). Hide spends your action but not your turn; attacking from
+        hidden grants advantage and reveals you.
+
+        Returns:
+            The Hide outcome (roll vs DC) and updated state, or a no-op
+            message when Hide isn't available.
+        """
+        if not game_manager.is_running:
+            return "Game not running. Use game_start() first."
+        return await proxy.call_tool_async("game_hide")
+
     # === Dev-Mode Tools (only registered when DND_DEBUG=1) ===
     # Forward to the matching tools on the game's embedded MCP server, which
     # itself only registers them when launched with --dev / DND_DEBUG=1.

--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -881,6 +881,8 @@ class GameSession:
                 result = self.attack(target)
             elif request.command_type == CommandType.WAIT:
                 result = self.wait()
+            elif request.command_type == CommandType.HIDE:
+                result = self.hide()
             elif request.command_type == CommandType.SPAWN_MONSTER:
                 result = self.spawn_monster(
                     request.args.get("monster_id", ""),
@@ -1080,6 +1082,11 @@ class GameSession:
                 lines.append(f"  Movement: {turn_state.movement_remaining} ft remaining")
             lines.append("  - game_move(direction) - Move north/south/east/west")
             lines.append("  - game_attack(target) - Attack enemy in weapon range")
+            # SRD § Actions › Hide is offered only when the engine's #496
+            # gate passes for the current combatant (concealment or cover).
+            game_state = self.engine.game_state
+            if game_state is not None and "hide" in game_state.get_available_actions():
+                lines.append("  - game_hide() - Hide (Dexterity (Stealth) check)")
             lines.append("  - game_wait() - Pass turn")
         else:
             lines.append("  - game_move(direction) - Move north/south/east/west")
@@ -1537,6 +1544,63 @@ class GameSession:
         if between:
             return f"{between}\n\n{state}"
         return state
+
+    def hide(self) -> str:
+        """Take the Hide action (Dexterity (Stealth) check) for the current PC.
+
+        Routes the player-facing surface (the ``game_hide`` MCP tool and the
+        windowed ``H`` key) into ``GameState.attempt_hide``. Hide spends the
+        action slot but does NOT end the turn — the player keeps any remaining
+        movement and ends the turn explicitly with ``game_wait()``. Because the
+        turn stays with the player, no enemy turns are drained here.
+
+        Refusals (not in combat, not the player's turn, the #496 environment
+        gate, or no action slot) come back as a message-with-state rather than
+        a crash, mirroring how ``attack``/``wait`` report ineligible inputs.
+        """
+        if not self.engine.in_combat:
+            return "Not in combat! Use game_move() to explore."
+
+        if not self.engine.is_player_turn():
+            return "Not your turn! Wait for enemies to act."
+
+        current = self.engine.get_current_combatant()
+        if current is None:
+            return "Error: Could not get current combatant."
+
+        game_state = self.engine.game_state
+        if game_state is None:
+            return "Error: Game state unavailable."
+
+        result = game_state.attempt_hide(current["creature"])
+        self._add_combat_log(result.message)
+
+        report = self._format_hide_report(result)
+        state = self.get_state()
+        return f"{report}\n\n{state}" if report else state
+
+    def _format_hide_report(self, result: Any) -> str:
+        """Render the Hide outcome for the player surface.
+
+        For a refused attempt (gate or slot), the reason is surfaced as-is —
+        no roll happened. When the attempt ran, the contested check is shown
+        (Stealth roll vs the watchers' passive Perception DC) so players can
+        audit the math the same way they can for attacks (#570).
+        """
+        if not result.attempted:
+            return result.message
+
+        lines = [result.message]
+        check = result.check_result or {}
+        roll = check.get("roll")
+        total = check.get("total")
+        if roll is not None and total is not None and result.dc is not None:
+            outcome = "SUCCESS" if result.success else "FAIL"
+            lines.append(
+                f"Stealth check: roll {roll} -> {total} vs passive "
+                f"Perception {result.dc} -> {outcome}"
+            )
+        return "\n".join(lines)
 
     # ========== Public dev/MCP API (gated upstream by dev_mode) ==========
 

--- a/client-2d/tests/test_dev_mode_mcp.py
+++ b/client-2d/tests/test_dev_mode_mcp.py
@@ -24,7 +24,7 @@ DEV_TOOL_NAMES = {
     "reset_game",
 }
 
-PLAY_TOOL_NAMES = {"game_state", "game_move", "game_attack", "game_wait"}
+PLAY_TOOL_NAMES = {"game_state", "game_move", "game_attack", "game_wait", "game_hide"}
 
 
 def _registered_tool_names(server: EmbeddedMCPServer) -> set[str]:

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -2316,11 +2316,11 @@ class TestSessionHide:
 
         result = session.hide()
 
+        from dnd_engine.systems.action_economy import ActionType
+
         assert "no concealment or cover" in result.lower()
         turn_state = session.engine.get_current_turn_state()
-        assert turn_state.is_action_available(
-            __import__("dnd_engine.systems.action_economy", fromlist=["ActionType"]).ActionType.ACTION
-        )
+        assert turn_state.is_action_available(ActionType.ACTION)
 
     def test_hide_in_concealing_room_runs_stealth_check(self, session) -> None:
         """A Heavily Obscured room opens the gate; Hide rolls Stealth vs the
@@ -2333,9 +2333,9 @@ class TestSessionHide:
         result = session.hide()
 
         # Either outcome phrasing from HideAttemptResult, plus the state block.
-        assert (
-            "slips out of sight" in result or "stays visible" in result
-        ), f"missing hide outcome:\n{result}"
+        assert "slips out of sight" in result or "stays visible" in result, (
+            f"missing hide outcome:\n{result}"
+        )
         assert "Available Actions:" in result
 
     def test_hide_command_dispatches_through_bridge(self, session) -> None:
@@ -2357,9 +2357,9 @@ class TestSessionHide:
         session._process_mcp_commands()
 
         result = request.response_future.result(timeout=1.0)
-        assert (
-            "slips out of sight" in result or "stays visible" in result
-        ), f"bridge HIDE did not reach hide():\n{result}"
+        assert "slips out of sight" in result or "stays visible" in result, (
+            f"bridge HIDE did not reach hide():\n{result}"
+        )
 
 
 class TestSessionStateSurfacesHide:

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -2269,3 +2269,112 @@ class TestIssue570Reproduction:
         assert " damage" in response or "MISS" in response, (
             f"response carries neither damage nor MISS:\n{response}"
         )
+
+
+def _make_room_concealing(session) -> None:
+    """Flip the current room to Heavily Obscured so the #496 Hide gate
+    opens, mirroring the engine's hide integration fixture."""
+    room = session.engine.game_state.get_current_room()
+    room["lighting"] = "bright"
+    room["obscurement_sources"] = ["heavy_fog"]
+    room["cover"] = "none"
+
+
+def _make_room_open(session) -> None:
+    """Flip the current room to open/lit so the Hide gate refuses."""
+    room = session.engine.game_state.get_current_room()
+    room["lighting"] = "bright"
+    room["obscurement_sources"] = []
+    room["cover"] = "none"
+
+
+class TestSessionHide:
+    """Coverage for ``GameSession.hide`` — the player-facing Hide action
+    (#608) that routes the MCP/key surface into ``GameState.attempt_hide``.
+    """
+
+    def test_hide_refused_when_not_in_combat(self, session) -> None:
+        """Hiding is a combat-turn action; outside combat it refuses with
+        the same guidance the other combat verbs use."""
+        session.engine.game_state.in_combat = False
+        result = session.hide()
+        assert "Not in combat" in result
+
+    def test_hide_refused_when_not_players_turn(self, session) -> None:
+        """When an enemy holds the turn, Hide refuses rather than spending
+        someone else's slot."""
+        goblin = session.engine.game_state.active_enemies[0]
+        _force_combatant_turn(session, goblin)
+        result = session.hide()
+        assert "Not your turn" in result
+
+    def test_hide_refused_in_open_room_keeps_action(self, session) -> None:
+        """An open, lit room fails the #496 gate. The refusal is surfaced
+        and the action slot is preserved (the gate runs before any spend)."""
+        _force_player_turn(session)
+        _make_room_open(session)
+
+        result = session.hide()
+
+        assert "no concealment or cover" in result.lower()
+        turn_state = session.engine.get_current_turn_state()
+        assert turn_state.is_action_available(
+            __import__("dnd_engine.systems.action_economy", fromlist=["ActionType"]).ActionType.ACTION
+        )
+
+    def test_hide_in_concealing_room_runs_stealth_check(self, session) -> None:
+        """A Heavily Obscured room opens the gate; Hide rolls Stealth vs the
+        watchers' passive Perception and reports the outcome alongside the
+        map state."""
+        _force_player_turn(session)
+        _make_room_concealing(session)
+        session.set_seed(42)
+
+        result = session.hide()
+
+        # Either outcome phrasing from HideAttemptResult, plus the state block.
+        assert (
+            "slips out of sight" in result or "stays visible" in result
+        ), f"missing hide outcome:\n{result}"
+        assert "Available Actions:" in result
+
+    def test_hide_command_dispatches_through_bridge(self, session) -> None:
+        """``CommandType.HIDE`` on the bridge routes to ``GameSession.hide``."""
+        from concurrent.futures import Future
+
+        from client_2d.mcp_bridge import CommandRequest, CommandType, MCPBridge
+
+        bridge = MCPBridge()
+        session._mcp_bridge = bridge
+        _force_player_turn(session)
+        _make_room_concealing(session)
+        session.set_seed(42)
+
+        request = CommandRequest(command_type=CommandType.HIDE)
+        request.response_future = Future()
+        bridge._command_queue.put(request)
+
+        session._process_mcp_commands()
+
+        result = request.response_future.result(timeout=1.0)
+        assert (
+            "slips out of sight" in result or "stays visible" in result
+        ), f"bridge HIDE did not reach hide():\n{result}"
+
+
+class TestSessionStateSurfacesHide:
+    """``get_state`` must advertise ``game_hide()`` exactly when the engine
+    reports Hide as available (#608 acceptance: client offers Hide when
+    ``get_available_actions()`` includes ``"hide"``)."""
+
+    def test_state_lists_hide_when_available(self, session) -> None:
+        _force_player_turn(session)
+        _make_room_concealing(session)
+        state = session.get_state()
+        assert "game_hide()" in state
+
+    def test_state_omits_hide_in_open_room(self, session) -> None:
+        _force_player_turn(session)
+        _make_room_open(session)
+        state = session.get_state()
+        assert "game_hide()" not in state

--- a/client-2d/tests/test_mcp_bridge.py
+++ b/client-2d/tests/test_mcp_bridge.py
@@ -29,6 +29,7 @@ class TestCommandType:
         assert CommandType.MOVE is not None
         assert CommandType.ATTACK is not None
         assert CommandType.WAIT is not None
+        assert CommandType.HIDE is not None
 
     def test_command_types_unique(self) -> None:
         """Each command type has a unique value."""
@@ -37,6 +38,7 @@ class TestCommandType:
             CommandType.MOVE,
             CommandType.ATTACK,
             CommandType.WAIT,
+            CommandType.HIDE,
         ]
         assert len(types) == len(set(types))
 

--- a/dnd-engine/tests/scenarios/yaml/hide_action_basic.yaml
+++ b/dnd-engine/tests/scenarios/yaml/hide_action_basic.yaml
@@ -1,0 +1,27 @@
+# Scenario: hide_action_basic
+#
+# Exercises the player-facing Hide action (#608) end-to-end. The party
+# starts in laboratory.boiler_room, which is Heavily Obscured by
+# heavy_fog, so the SRD 5.2.1 / #496 environment gate permits hiding.
+# A goblin stands a few tiles away as the watcher whose passive
+# Perception sets the Stealth DC.
+#
+# Use with `load_scenario("...hide_action_basic.yaml")`, then `game_hide()`
+# to take the Hide action and `game_attack("goblin_0")` to verify that
+# attacking from hidden reveals the attacker and grants advantage.
+
+name: hide_action_basic
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.boiler_room
+party:
+  - class: rogue
+    race: halfling
+    weapons: [shortbow]
+    position: [3, 5]
+    name: Sneak
+enemies:
+  - monster_id: goblin
+    position: [8, 5]


### PR DESCRIPTION
## Summary
Exposes the engine-side Hide action (#443) to players. Until now `GameState.attempt_hide` was only reachable from the script executor (scenario YAML); there was no `game_hide` MCP tool and no Hide affordance in the 2D client. This wires Hide through every player-facing layer, gated on the SRD 5.2.1 / #496 concealment-or-cover check.

**Semantics:** Hide spends the action slot but **keeps the turn** with the player — they retain remaining movement and end the turn explicitly with `game_wait()`. No enemy turns are drained on a Hide.

## Changes
- **`mcp_bridge.py`**: new `CommandType.HIDE` routing key.
- **`session.py`**: `GameSession.hide()` mirrors the attack/wait guards, routes the current PC into `GameState.attempt_hide`, and reports the contested Stealth-vs-passive-Perception roll. Dispatches `CommandType.HIDE`; advertises `game_hide()` in the state's available-actions block only when the engine's `get_available_actions()` includes `"hide"`.
- **`embedded_mcp_server.py`**: `game_hide()` MCP tool submitting `CommandType.HIDE`.
- **`mcp_proxy.py`**: forwarding `game_hide()` (Claude/playtester-facing), mirroring `game_wait`.
- **`game.py`**: `H` key in combat → `GameSession.hide()`, plus an "H: Hide" controls hint shown only when Hide is available.
- **`hide_action_basic.yaml`**: playtest scenario starting in `laboratory.boiler_room` (Heavily Obscured by heavy_fog), the one shipped room that opens the #496 gate.

## Testing
- [x] `CommandType.HIDE` exists/unique (`test_mcp_bridge.py`).
- [x] `TestSessionHide`: not-in-combat, not-your-turn, gate-refused (action preserved), concealing-room attempt, and bridge `HIDE` → `hide()` dispatch.
- [x] `TestSessionStateSurfacesHide`: `game_hide()` listed iff the engine reports Hide available.
- [x] Embedded `game_hide` tool registration (`test_dev_mode_mcp.py`).
- [x] Full client-2d suite: 516 passing; lint + format clean on changed code.
- [x] **End-to-end playtest over real MCP/SSE transport**: loaded `hide_action_basic`, `game_hide()` surfaced in available actions, Stealth check applied the `hidden` condition with the turn retained, then a shortbow attack from hidden (25 ft, normal range, advantage) hit and revealed the rogue (`hidden → healthy`).

### Acceptance criteria
- [x] `game_hide()` MCP tool routes MCPBridge → GameSession → `GameState.attempt_hide`, returning a roll/DC/outcome summary.
- [x] No-op-with-message (not a crash) when Hide isn't available — surfaces `attempt_hide`'s refusal messages.
- [x] 2D client offers Hide when `get_available_actions()` includes `"hide"`, dispatches it, and reflects the hidden state.
- [x] `/playtester` can drive a full Hide → attack-from-hidden flow end-to-end via MCP.
- [x] MCP-bridge test (available + refused paths) and client action-dispatch test.

## Out of scope (deferred per #443/#608)
Bonus-action Hide (Cunning Action / Nimble Escape), monster hiding, reveal-on-spell-cast.

## Notes for reviewers
- The windowed `H`-key wiring in `game.py` is arcade-UI glue (no display in unit tests) and was the one declared TDD exception; the `GameSession.hide()` it calls is fully covered.
- Playtest gotcha: the MCP **proxy** process loads its forwarder tool list at startup and does not hot-reload, so `game_hide` only appears over the live MCP tools after a Claude Code reconnect. The end-to-end run above drove `game_hide` over the same SSE transport the proxy uses to confirm the embedded tool works.

Related: #443 (engine Hide action), #496 (Hide gate), #534 ([plan-05] Vision, Stealth & Special Senses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)