### PR TITLE
Close plan-05 Hide follow-ups: rogue Stealth proficiency (#607) + cover concealment content (#606)

### DIFF
--- a/dnd-engine/dnd_engine/core/character_factory.py
+++ b/dnd-engine/dnd_engine/core/character_factory.py
@@ -635,12 +635,18 @@ class CharacterFactory:
         # Get speed from race data (default 30 ft if not specified)
         speed = race_data.get("speed", 30)
 
-        # Auto-select skill proficiencies if not provided
+        # Auto-select skill proficiencies if not provided.
+        # Prefer the class's thematic `default` list (signature skills first, e.g.
+        # Stealth for a rogue) so the auto-pick is not biased by the order of `from`.
+        # Any remaining slots are filled from `from` in order, skipping duplicates.
         if skill_proficiencies is None:
             skill_profs = class_data.get("skill_proficiencies", {})
             num_skills = skill_profs.get("choose", 0)
             available_skills = skill_profs.get("from", [])
-            skill_proficiencies = available_skills[:num_skills]
+            available_set = set(available_skills)
+            ordered = [s for s in skill_profs.get("default", []) if s in available_set]
+            ordered += [s for s in available_skills if s not in ordered]
+            skill_proficiencies = ordered[:num_skills]
 
         # Auto-select expertise for rogues if not provided
         if expertise_skills is None and class_name == "rogue":

--- a/dnd-engine/dnd_engine/data/content/campaigns/poisoned_laboratory/dungeons/laboratory.json
+++ b/dnd-engine/dnd_engine/data/content/campaigns/poisoned_laboratory/dungeons/laboratory.json
@@ -199,7 +199,8 @@
       "description": "A massive furnace roars in the center of this sweltering room, used to heat alchemical reactions. The heat is intense. A large wolf, its fur singed and eyes glowing red, lies near the furnace beside a pile of treasure. The beast's breath carries the acrid smell of sulfur. A low archway to the north vents thick clouds of scalding steam from the boiler beyond.",
       "exits": {
         "east": "laboratory.storage",
-        "north": "laboratory.boiler_room"
+        "north": "laboratory.boiler_room",
+        "west": "laboratory.machine_gallery"
       },
       "enemies": [
         "wolf"
@@ -236,6 +237,33 @@
         "note": "Potion of Fire Resistance prevents this damage"
       },
       "id": "laboratory.furnace_room"
+    },
+    "laboratory.machine_gallery": {
+      "name": "Collapsed Machine Gallery",
+      "description": "A workroom of toppled brass apparatus and overturned shipping crates, lit clearly by a sputtering work-lamp that still clings to one wall. The wreckage is chest-high in places — more than enough to crouch behind and break an onlooker's line of sight while leaving your own view of the room unobstructed. A skeletal sentry, reassembled from mismatched bones, scrapes back and forth across the open floor, oblivious to anyone tucked among the machinery.",
+      "lighting": "bright",
+      "cover": "three_quarters",
+      "exits": {
+        "east": "laboratory.furnace_room"
+      },
+      "enemies": [
+        "skeleton"
+      ],
+      "items": [
+        {
+          "type": "currency",
+          "gold": 18,
+          "visible": false
+        },
+        {
+          "type": "item",
+          "id": "potion_of_healing",
+          "visible": false
+        }
+      ],
+      "searched": false,
+      "searchable": true,
+      "id": "laboratory.machine_gallery"
     },
     "laboratory.sanctum": {
       "name": "The Mad Alchemist's Sanctum",

--- a/dnd-engine/dnd_engine/data/srd/classes.json
+++ b/dnd-engine/dnd_engine/data/srd/classes.json
@@ -10,7 +10,8 @@
     "weapon_proficiencies": ["simple", "martial"],
     "skill_proficiencies": {
       "choose": 2,
-      "from": ["acrobatics", "animal_handling", "athletics", "history", "insight", "intimidation", "perception", "survival"]
+      "from": ["acrobatics", "animal_handling", "athletics", "history", "insight", "intimidation", "perception", "survival"],
+      "default": ["athletics", "perception"]
     },
     "starting_equipment": ["longsword", "chain_mail", "potion_of_healing", "potion_of_healing", "potion_of_healing", "potion_of_healing", "potion_of_healing"],
     "starting_gold": 10,
@@ -83,7 +84,8 @@
     "tool_proficiencies": ["thieves_tools"],
     "skill_proficiencies": {
       "choose": 4,
-      "from": ["acrobatics", "athletics", "deception", "insight", "intimidation", "investigation", "perception", "performance", "persuasion", "sleight_of_hand", "stealth"]
+      "from": ["acrobatics", "athletics", "deception", "insight", "intimidation", "investigation", "perception", "performance", "persuasion", "sleight_of_hand", "stealth"],
+      "default": ["stealth", "sleight_of_hand", "perception", "acrobatics"]
     },
     "starting_equipment": ["rapier", "shortbow", "leather_armor", "thieves_tools", "potion_of_healing", "potion_of_healing"],
     "starting_gold": 15,
@@ -148,7 +150,8 @@
     "weapon_proficiencies": ["daggers", "darts", "slings", "quarterstaffs", "light_crossbows"],
     "skill_proficiencies": {
       "choose": 2,
-      "from": ["arcana", "history", "insight", "investigation", "medicine", "religion"]
+      "from": ["arcana", "history", "insight", "investigation", "medicine", "religion"],
+      "default": ["arcana", "investigation"]
     },
     "starting_equipment": ["quarterstaff", "dagger", "potion_of_healing"],
     "starting_gold": 5,

--- a/dnd-engine/tests/scenarios/yaml/hide_cover_advantage.yaml
+++ b/dnd-engine/tests/scenarios/yaml/hide_cover_advantage.yaml
@@ -1,0 +1,28 @@
+# Scenario: hide_cover_advantage
+#
+# Exercises the cover-based Hide payoff (#606) end-to-end. The party starts
+# in laboratory.machine_gallery, which is brightly lit (clear sight) and
+# offers Three-Quarters Cover, so the SRD 5.2.1 / #496 environment gate
+# permits hiding *and* the hidden attacker can still see the target. Unlike
+# the heavy-fog boiler room (hide_action_basic), the unseen-attacker
+# advantage does NOT cancel here — the attacker is not blinded.
+#
+# Use with `load_scenario("...hide_cover_advantage.yaml")`, then `game_hide()`
+# to take the Hide action and `game_attack("skeleton_0")` to verify that
+# attacking from hidden reveals the attacker and lands with advantage.
+
+name: hide_cover_advantage
+seed: 42
+map:
+  dungeon: laboratory
+  campaign: poisoned_laboratory
+  start_room: laboratory.machine_gallery
+party:
+  - class: rogue
+    race: halfling
+    weapons: [shortbow]
+    position: [3, 5]
+    name: Sneak
+enemies:
+  - monster_id: skeleton
+    position: [8, 5]

--- a/dnd-engine/tests/test_character_factory.py
+++ b/dnd-engine/tests/test_character_factory.py
@@ -446,3 +446,64 @@ class TestApplyStartingEquipment:
         CharacterFactory.apply_starting_equipment(character, classes_data["fighter"], items_data)
 
         assert character.inventory.gold == 10
+
+
+class TestDefaultSkillSelection:
+    """Auto-selected skill proficiencies should be thematically aware (issue #607).
+
+    The class-list-order slice (`available_skills[:n]`) never reached Stealth for
+    rogues because Stealth is last in the rogue `from` list. Default selection must
+    guarantee a class's signature skills.
+    """
+
+    def _make_factory(self):
+        return CharacterFactory(dice_roller=DiceRoller(seed=1)), DataLoader(
+            dice_roller=DiceRoller(seed=1)
+        )
+
+    def test_default_rogue_gets_stealth_proficiency(self):
+        """A factory-built rogue with no explicit skills must be proficient in Stealth."""
+        factory, loader = self._make_factory()
+        rogue = factory.create_character(
+            class_name="rogue", race_name="human", data_loader=loader
+        )
+        assert "stealth" in rogue.skill_proficiencies
+
+    def test_default_rogue_skill_count_matches_class_choose(self):
+        """Rogue chooses 4 skills; auto-selection must yield exactly that many."""
+        factory, loader = self._make_factory()
+        rogue = factory.create_character(
+            class_name="rogue", race_name="human", data_loader=loader
+        )
+        assert len(rogue.skill_proficiencies) == 4
+
+    def test_default_rogue_skills_are_unique_and_in_class_list(self):
+        """Auto-selected skills must be distinct and drawn from the class `from` list."""
+        factory, loader = self._make_factory()
+        rogue = factory.create_character(
+            class_name="rogue", race_name="human", data_loader=loader
+        )
+        assert len(set(rogue.skill_proficiencies)) == len(rogue.skill_proficiencies)
+        class_data = loader.load_classes()["rogue"]
+        allowed = set(class_data["skill_proficiencies"]["from"])
+        assert set(rogue.skill_proficiencies) <= allowed
+
+    def test_default_rogue_expertise_includes_stealth(self):
+        """Rogue expertise auto-pick should favor signature skills (Stealth among them)."""
+        factory, loader = self._make_factory()
+        rogue = factory.create_character(
+            class_name="rogue", race_name="human", data_loader=loader
+        )
+        assert "stealth" in rogue.expertise_skills
+        assert all(s in rogue.skill_proficiencies for s in rogue.expertise_skills)
+
+    def test_explicit_skills_override_defaults(self):
+        """Explicitly provided skills are respected verbatim (no auto-selection)."""
+        factory, loader = self._make_factory()
+        rogue = factory.create_character(
+            class_name="rogue",
+            race_name="human",
+            data_loader=loader,
+            skill_proficiencies=["acrobatics", "insight"],
+        )
+        assert rogue.skill_proficiencies == ["acrobatics", "insight"]

--- a/dnd-engine/tests/test_hide_cover_content.py
+++ b/dnd-engine/tests/test_hide_cover_content.py
@@ -1,0 +1,180 @@
+# ABOUTME: Content test for #606 — a shipped room must offer cover-based concealment.
+# ABOUTME: Verifies the laboratory dungeon ships a ¾-cover room where Hide yields advantage.
+
+"""Content coverage for cover-based concealment (issue #606).
+
+The Hide gate (#496) admits a room when it is Heavily Obscured *or* offers at
+least Three-Quarters Cover. Before this content existed, the only shipped
+hideable room (`laboratory.boiler_room`) qualified purely via heavy fog, which
+blinds both directions — a hidden attacker's advantage and the can't-see-target
+disadvantage cancel, so the classic Hide payoff was never reachable in shipped
+play.
+
+These tests pin a shipped room that qualifies via cover with *clear* sight, so a
+hidden attacker still sees the target and lands the advantaged shot.
+"""
+
+from __future__ import annotations
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.combat import CombatEngine
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.systems.perception import (
+    Cover,
+    LightLevel,
+    Obscurement,
+    VisibilityRelation,
+    compute_visibility,
+)
+
+CAMPAIGN_ID = "poisoned_laboratory"
+DUNGEON_NAME = "laboratory"
+
+
+def _cover_concealment_rooms() -> list[dict]:
+    """Rooms that qualify for Hide via cover (not heavy fog) with clear sight."""
+    dungeon = DataLoader().load_dungeon(DUNGEON_NAME, CAMPAIGN_ID)
+    rooms = dungeon["rooms"].values()
+    qualifying = []
+    for room in rooms:
+        cover = str(room.get("cover", "none")).lower()
+        obscured = "heavy_fog" in [s.lower() for s in room.get("obscurement_sources", [])]
+        if cover in ("three_quarters", "total") and not obscured:
+            qualifying.append(room)
+    return qualifying
+
+
+class TestCoverConcealmentContentShipped:
+    def test_laboratory_ships_a_cover_concealment_room(self):
+        """At least one shipped room offers ¾+ cover with clear sight."""
+        rooms = _cover_concealment_rooms()
+        assert rooms, (
+            "No shipped laboratory room offers cover-based concealment "
+            "(cover three_quarters/total with clear sight); Hide-for-advantage "
+            "is unreachable in shipped content (#606)."
+        )
+
+    def test_cover_concealment_room_has_an_enemy_to_snipe(self):
+        """The payoff room hosts an enemy so the advantaged shot is reachable."""
+        rooms = _cover_concealment_rooms()
+        assert any(room.get("enemies") for room in rooms), (
+            "A cover-concealment room must host an enemy so a player can take "
+            "the advantaged shot from hiding."
+        )
+
+    def test_cover_concealment_room_is_reachable(self):
+        """The payoff room is wired into the dungeon graph (an exit leads to it)."""
+        dungeon = DataLoader().load_dungeon(DUNGEON_NAME, CAMPAIGN_ID)
+        rooms = dungeon["rooms"]
+        target_ids = {r["id"] for r in _cover_concealment_rooms()}
+        destinations = set()
+        for room in rooms.values():
+            for dest in room.get("exits", {}).values():
+                # Exits are either a room-id string or a {"destination": ...} dict.
+                destinations.add(dest["destination"] if isinstance(dest, dict) else dest)
+        assert target_ids & destinations, (
+            "The cover-concealment room is not reachable from any other room."
+        )
+
+
+class TestCoverConcealmentGate:
+    def test_room_passes_the_hide_gate(self):
+        """`can_attempt_hide` admits the shipped cover room."""
+        rooms = _cover_concealment_rooms()
+        room = rooms[0]
+        party = Party(
+            [
+                Character(
+                    name="Sneak",
+                    character_class=CharacterClass.ROGUE,
+                    level=1,
+                    abilities=Abilities(10, 16, 10, 10, 10, 10),
+                    max_hp=8,
+                    ac=14,
+                    skill_proficiencies=["stealth"],
+                )
+            ]
+        )
+        gs = GameState(party, DUNGEON_NAME, campaign_id=CAMPAIGN_ID)
+        gs.current_room_id = room["id"]
+        assert gs.can_attempt_hide(party.characters[0]) is True
+
+
+class TestCoverConcealmentPayoff:
+    def test_hidden_attacker_in_clear_cover_room_gains_advantage(self):
+        """In clear sight behind cover, the hidden attacker sees the target while
+        the target cannot see the attacker — the unseen-attacker advantage stands
+        (it does not cancel, because the attacker is not blinded by fog)."""
+        rooms = _cover_concealment_rooms()
+        room = rooms[0]
+        assert str(room.get("cover")).lower() in ("three_quarters", "total")
+
+        attacker = Creature(
+            name="Hidden Rogue", max_hp=8, ac=14, abilities=Abilities(10, 16, 10, 10, 10, 10)
+        )
+        attacker.add_condition("hidden")
+        defender = Creature(
+            name="Skeleton", max_hp=13, ac=13, abilities=Abilities(10, 14, 15, 6, 8, 5)
+        )
+
+        attacker_sees_defender = compute_visibility(
+            attacker,
+            defender,
+            light_level=LightLevel.BRIGHT,
+            obscurement=Obscurement.CLEAR,
+            distance=10,
+        )
+        defender_sees_attacker = compute_visibility(
+            defender,
+            attacker,
+            light_level=LightLevel.BRIGHT,
+            obscurement=Obscurement.CLEAR,
+            distance=10,
+        )
+
+        assert attacker_sees_defender == VisibilityRelation.SEEN
+        assert defender_sees_attacker == VisibilityRelation.UNSEEN
+
+    def test_room_cover_string_round_trips_to_enum(self):
+        """The shipped `cover` value parses into a Hide-qualifying Cover enum."""
+        room = _cover_concealment_rooms()[0]
+        cover = Cover(str(room["cover"]).lower())
+        assert cover in (Cover.THREE_QUARTERS, Cover.TOTAL)
+
+    def test_attack_from_cover_resolves_with_advantage(self):
+        """End-to-end: feeding the room's visibility relations into combat yields
+        an advantaged attack (the unseen-attacker advantage does not cancel)."""
+        room = _cover_concealment_rooms()[0]
+        # The shipped room must be clear-sighted cover for the advantage to stand.
+        assert str(room["cover"]).lower() in ("three_quarters", "total")
+        attacker = Creature(
+            name="Hidden Rogue", max_hp=8, ac=14, abilities=Abilities(10, 16, 10, 10, 10, 10)
+        )
+        attacker.add_condition("hidden")
+        defender = Creature(
+            name="Skeleton", max_hp=13, ac=13, abilities=Abilities(10, 14, 15, 6, 8, 5)
+        )
+
+        attacker_sees_defender = compute_visibility(
+            attacker, defender, light_level=LightLevel.BRIGHT, obscurement=Obscurement.CLEAR
+        )
+        defender_sees_attacker = compute_visibility(
+            defender, attacker, light_level=LightLevel.BRIGHT, obscurement=Obscurement.CLEAR
+        )
+
+        engine = CombatEngine(dice_roller=DiceRoller(seed=42))
+        result = engine.resolve_attack(
+            attacker,
+            defender,
+            attack_bonus=5,
+            damage_dice="1d6+3",
+            attacker_sees_defender=attacker_sees_defender,
+            defender_sees_attacker=defender_sees_attacker,
+        )
+
+        assert result.advantage is True
+        assert result.disadvantage is False


### PR DESCRIPTION
## Summary

Closes the two follow-up gaps that surfaced while playtesting the Hide action (#443 / #608) — the last items standing between plan-05 (Vision, Stealth & Special Senses, umbrella #534) and done. All six plan-05 child issues were already closed; this PR addresses the two playtest-surfaced follow-ups.

### #607 — Rogues never received Stealth proficiency
`CharacterFactory.create_character` auto-selected skills with `available_skills[:n]` — the first N of the class's `from` list. Stealth is **last** in the rogue list, so a default rogue never got its signature proficiency, and expertise auto-pick inherited the same first-N bias.

**Fix:** skill selection is now thematically aware and data-driven. Each class carries an ordered `default` priority list in `classes.json`; the factory prefers it, then fills remaining slots from `from` in order (skipping duplicates).
- Default rogue now gets `['stealth', 'sleight_of_hand', 'perception', 'acrobatics']` + Stealth expertise.
- Backward compatible: classes without `default` keep first-N; explicitly provided skills still win.

### #606 — No shipped room offered cover-based concealment
The only shipped hideable room (`laboratory.boiler_room`) qualified purely via heavy fog (Heavily Obscured), which blinds **both** directions — so the unseen-attacker advantage and the can't-see-target disadvantage cancel (RAW-correct mutual blindness), and the classic Hide payoff was never reachable in shipped play.

**Fix:** adds `laboratory.machine_gallery` — a brightly lit room (clear sight) with **Three-Quarters Cover**, wired off the furnace hub, hosting a skeleton sentry. A player can now Hide behind cover, still see the target, and land the advantaged shot. Includes a `hide_cover_advantage` playtest scenario.

## Testing
- `TestDefaultSkillSelection` (factory): rogue gets Stealth proficiency + expertise; count/uniqueness/`from`-membership; explicit-skills override.
- `test_hide_cover_content`: room shipped + reachable + has enemy; Hide gate opens; visibility yields SEEN(attacker→target)/UNSEEN(target→attacker); **combat `resolve_attack` resolves with `advantage=True`, no cancel**.
- Live MCP check: loading the scenario into `machine_gallery` now offers `game_hide()` (gate opens in a clear ¾-cover room).
- Full engine suite green: **3203 passed, 199 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)