### PR TITLE
Add #442: Honor creature size categories for map footprint (Large/Huge/Gargantuan)

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -4,7 +4,7 @@
 from enum import Enum
 from typing import Any
 
-from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.creature import Abilities, Creature, Size
 from dnd_engine.core.dice import DiceRoller
 from dnd_engine.core.spell import Spell
 from dnd_engine.systems.inventory import Inventory
@@ -98,6 +98,7 @@ class Character(Creature):
         prepared_spells: list[str] | None = None,
         vault_id: str | None = None,
         speed: int = 30,
+        size: Size = Size.MEDIUM,
     ):
         """
         Initialize a player character.
@@ -125,6 +126,8 @@ class Character(Creature):
             prepared_spells: List of spell IDs the character has prepared
             vault_id: UUID linking this character to their vault entry (for syncing progression)
             speed: Movement speed in feet per round (default 30, varies by race)
+            size: SRD size category (default Medium, varies by race — e.g.
+                Halflings and Gnomes are Small)
         """
         super().__init__(
             name=name,
@@ -133,6 +136,7 @@ class Character(Creature):
             abilities=abilities,
             current_hp=current_hp,
             speed=speed,
+            size=size,
         )
 
         self.character_class = character_class

--- a/dnd-engine/dnd_engine/core/character_factory.py
+++ b/dnd-engine/dnd_engine/core/character_factory.py
@@ -4,7 +4,7 @@
 from typing import Any
 
 from dnd_engine.core.character import Character, CharacterClass
-from dnd_engine.core.creature import Abilities
+from dnd_engine.core.creature import Abilities, Size
 from dnd_engine.core.dice import DiceRoller
 from dnd_engine.rules.loader import DataLoader
 from dnd_engine.systems.inventory import EquipmentSlot
@@ -635,6 +635,11 @@ class CharacterFactory:
         # Get speed from race data (default 30 ft if not specified)
         speed = race_data.get("speed", 30)
 
+        # Get size category from race data (default Medium). The canonical
+        # lowercase string matches Size.value, so a case-insensitive lookup
+        # round-trips "Small"/"Medium" cleanly from races.json.
+        size = Size(race_data.get("size", "medium").lower())
+
         # Auto-select skill proficiencies if not provided.
         # Prefer the class's thematic `default` list (signature skills first, e.g.
         # Stealth for a rogue) so the auto-pick is not biased by the order of `from`.
@@ -679,6 +684,7 @@ class CharacterFactory:
             tool_proficiencies=tool_proficiencies,
             saving_throw_proficiencies=saving_throw_proficiencies,
             speed=speed,
+            size=size,
         )
 
         # Store race and darkvision

--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -27,6 +27,26 @@ class Size(str, Enum):
     HUGE = "huge"
     GARGANTUAN = "gargantuan"
 
+    @property
+    def footprint(self) -> int:
+        """
+        Width, in 5-ft tiles, of the square space this size occupies.
+
+        Per the SRD Creature Size and Space table, Tiny/Small/Medium each
+        fit within a single tile, Large fills a 2x2 block, Huge a 3x3, and
+        Gargantuan a 4x4. The returned value is the side length of that
+        square; the full set of tiles a creature claims is that length
+        squared (see `SpatialIndex.footprint_tiles`).
+        """
+        return {
+            Size.TINY: 1,
+            Size.SMALL: 1,
+            Size.MEDIUM: 1,
+            Size.LARGE: 2,
+            Size.HUGE: 3,
+            Size.GARGANTUAN: 4,
+        }[self]
+
 
 class MovementMode(str, Enum):
     """

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -9,7 +9,7 @@ from typing import Any
 from dnd_engine.core.campaign_progress import CampaignProgress, CampaignProgressTracker
 from dnd_engine.core.character import Character
 from dnd_engine.core.combat import AttackResult, CombatEngine
-from dnd_engine.core.creature import Creature
+from dnd_engine.core.creature import Creature, Size
 from dnd_engine.core.dice import DiceRoller, format_dice_with_modifier
 from dnd_engine.core.entity_ids import pc_entity_id
 from dnd_engine.core.map import Map
@@ -805,9 +805,14 @@ class GameState:
                 "(built from a Map) before calling set_position"
             )
         destination = Position(x, y)
+        creature = self._find_creature_by_id(entity_id)
         existing = self.spatial.position_of(entity_id)
         if existing is None:
-            self.spatial.place(entity_id, destination)
+            # Pass the creature's size so the SpatialIndex claims the full
+            # footprint (Large 2x2, Huge 3x3, …); unknown entities default to
+            # Medium. ``move`` reuses the size recorded here.
+            size = creature.size if creature is not None else Size.MEDIUM
+            self.spatial.place(entity_id, destination, size=size)
             self.event_bus.emit(
                 Event(
                     type=EventType.CREATURE_PLACED,
@@ -828,7 +833,6 @@ class GameState:
                     },
                 )
             )
-        creature = self._find_creature_by_id(entity_id)
         if creature is not None:
             creature.position = destination
         return destination

--- a/dnd-engine/dnd_engine/systems/spatial_index.py
+++ b/dnd-engine/dnd_engine/systems/spatial_index.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from collections.abc import Iterator, Mapping
 from types import MappingProxyType
 
+from dnd_engine.core.creature import Size
 from dnd_engine.core.distance import chebyshev_distance, is_adjacent
 from dnd_engine.core.map import Map
 from dnd_engine.core.position import Position
@@ -15,10 +16,15 @@ class SpatialIndex:
     """
     Engine-side registry mapping entity ids to grid Positions, plus spatial queries.
 
-    Maintains two synchronized dicts as its core invariant:
-        _by_entity[entity_id] == position  iff  _by_position[position] == entity_id
+    Maintains synchronized dicts as its core invariant:
+        _by_entity[entity_id] == anchor, and _by_position[tile] == entity_id
+        for every tile in the entity's footprint (a creature's size, per the
+        SRD Creature Size and Space table, determines whether that footprint
+        is a single tile or an N x N block).
     Every mutation updates both sides atomically; readers may rely on the
-    invariant in any externally observable state.
+    invariant in any externally observable state. Medium (and smaller)
+    occupants claim exactly one tile, so the model degrades to the original
+    one-tile-per-entity mapping.
 
     Mutations (`place`, `move`, `remove`) reject blocking tiles via
     ``Map.is_blocking`` and reject double-occupancy. Queries (`distance`,
@@ -49,75 +55,127 @@ class SpatialIndex:
         # ``list(map(...))`` inside the class would otherwise hit
         # ``TypeError: 'Map' object is not callable``.
         self._map = grid_map
+        # ``_by_entity`` stores each entity's *anchor* (minimum-x / minimum-y
+        # corner of its footprint); ``_by_position`` maps *every* tile a
+        # footprint covers back to its entity. For Medium (1x1) occupants the
+        # two are one-to-one, matching the original single-tile model.
         self._by_entity: dict[str, Position] = {}
         self._by_position: dict[Position, str] = {}
+        self._size_by_entity: dict[str, Size] = {}
         self._occupants_view: MappingProxyType[str, Position] = MappingProxyType(
             self._by_entity
+        )
+
+    @staticmethod
+    def footprint_tiles(
+        anchor: Position, size: Size = Size.MEDIUM
+    ) -> frozenset[Position]:
+        """Tiles a creature of ``size`` occupies when anchored at ``anchor``.
+
+        The anchor is the minimum-x / minimum-y corner; the square block
+        extends toward +x and +y. Medium (and smaller) sizes return just
+        ``{anchor}``; Large/Huge/Gargantuan return the 2x2 / 3x3 / 4x4 block
+        per the SRD Creature Size and Space table. Pure geometry — it does
+        not consult map bounds or occupancy.
+        """
+        side = size.footprint
+        return frozenset(
+            Position(anchor.x + dx, anchor.y + dy)
+            for dx in range(side)
+            for dy in range(side)
         )
 
     # ------------------------------------------------------------------ #
     # Mutations
     # ------------------------------------------------------------------ #
 
-    def place(self, entity_id: str, position: Position) -> None:
-        """Place a new occupant at ``position``.
+    def place(
+        self, entity_id: str, position: Position, size: Size = Size.MEDIUM
+    ) -> None:
+        """Place a new occupant anchored at ``position``.
+
+        ``size`` drives the footprint: Medium (the default) claims the single
+        anchor tile, preserving the original single-tile behavior; Large+
+        creatures claim their full N x N block (see ``footprint_tiles``). The
+        anchor and the creature's size are retained so ``move`` and ``remove``
+        can relocate or clear the whole footprint.
 
         Raises:
-            ValueError: If ``entity_id`` is already placed, ``position`` is
-                blocking per ``map.is_blocking``, or another entity already
-                occupies ``position``.
+            ValueError: If ``entity_id`` is already placed, or if *any* tile
+                of the footprint is blocking per ``map.is_blocking`` (this
+                also rejects footprints that spill off the map) or is already
+                occupied by another entity.
         """
         if entity_id in self._by_entity:
             raise ValueError(f"entity {entity_id!r} is already placed")
-        if self._map.is_blocking(position.x, position.y):
-            raise ValueError(f"position {position!r} is blocking")
-        if position in self._by_position:
-            raise ValueError(
-                f"position {position!r} is occupied by "
-                f"{self._by_position[position]!r}"
-            )
+        tiles = self.footprint_tiles(position, size)
+        for tile in tiles:
+            if self._map.is_blocking(tile.x, tile.y):
+                raise ValueError(f"footprint tile {tile!r} is blocking")
+            occupant = self._by_position.get(tile)
+            if occupant is not None:
+                raise ValueError(
+                    f"footprint tile {tile!r} is occupied by {occupant!r}"
+                )
         self._by_entity[entity_id] = position
-        self._by_position[position] = entity_id
+        self._size_by_entity[entity_id] = size
+        for tile in tiles:
+            self._by_position[tile] = entity_id
 
     def move(self, entity_id: str, position: Position) -> None:
-        """Move an existing occupant to ``position``.
+        """Move an existing occupant so its footprint is anchored at ``position``.
 
-        Moving to the entity's current position is a no-op.
+        The creature's size is preserved from ``place``; the whole footprint
+        relocates. Moving to the entity's current anchor is a no-op. Tiles the
+        creature already occupies do not count as obstructions to itself, so a
+        Large creature may slide into a position whose new block overlaps its
+        old one.
 
         Raises:
             KeyError: If ``entity_id`` is not currently placed.
-            ValueError: If ``position`` is blocking or occupied by another
-                entity.
+            ValueError: If any tile of the destination footprint is blocking
+                or occupied by another entity.
         """
         if entity_id not in self._by_entity:
             raise KeyError(entity_id)
         current = self._by_entity[entity_id]
         if position == current:
             return
-        if self._map.is_blocking(position.x, position.y):
-            raise ValueError(f"position {position!r} is blocking")
-        occupant = self._by_position.get(position)
-        if occupant is not None and occupant != entity_id:
-            raise ValueError(
-                f"position {position!r} is occupied by {occupant!r}"
-            )
-        del self._by_position[current]
+        size = self._size_by_entity[entity_id]
+        old_tiles = self.footprint_tiles(current, size)
+        new_tiles = self.footprint_tiles(position, size)
+        for tile in new_tiles:
+            if self._map.is_blocking(tile.x, tile.y):
+                raise ValueError(f"footprint tile {tile!r} is blocking")
+            occupant = self._by_position.get(tile)
+            if occupant is not None and occupant != entity_id:
+                raise ValueError(
+                    f"footprint tile {tile!r} is occupied by {occupant!r}"
+                )
+        # Vacate the old footprint first so an overlapping new block does not
+        # collide with the creature's own former tiles, then claim the new one.
+        for tile in old_tiles:
+            if self._by_position.get(tile) == entity_id:
+                del self._by_position[tile]
         self._by_entity[entity_id] = position
-        self._by_position[position] = entity_id
+        for tile in new_tiles:
+            self._by_position[tile] = entity_id
 
     def remove(self, entity_id: str) -> None:
-        """Remove a placed occupant.
+        """Remove a placed occupant, clearing every tile of its footprint.
 
         No-op if ``entity_id`` is not placed; cleanup paths can call this
         unconditionally without guarding.
         """
         position = self._by_entity.pop(entity_id, None)
-        if position is not None:
-            # Defensive: only drop the reverse entry if it still points at us
-            # (the invariant guarantees it does, but guarding keeps stray
+        size = self._size_by_entity.pop(entity_id, None)
+        if position is not None and size is not None:
+            # Defensive: only drop reverse entries that still point at us
+            # (the invariant guarantees they do, but guarding keeps stray
             # external corruption from cascading).
-            if self._by_position.get(position) == entity_id:
-                del self._by_position[position]
+            for tile in self.footprint_tiles(position, size):
+                if self._by_position.get(tile) == entity_id:
+                    del self._by_position[tile]
 
     # ------------------------------------------------------------------ #
     # Queries
@@ -135,8 +193,23 @@ class SpatialIndex:
         return self._map
 
     def position_of(self, entity_id: str) -> Position | None:
-        """Return the placed position of ``entity_id``, or ``None``."""
+        """Return the anchor position of ``entity_id``, or ``None``.
+
+        The anchor is the minimum-x / minimum-y corner of the footprint; for
+        Large+ creatures the full set of occupied tiles is ``footprint_of``.
+        """
         return self._by_entity.get(entity_id)
+
+    def footprint_of(self, entity_id: str) -> frozenset[Position]:
+        """Return every tile ``entity_id`` occupies, or an empty set if unplaced.
+
+        A Medium occupant returns its single anchor tile; Large/Huge/
+        Gargantuan creatures return their full N x N block.
+        """
+        anchor = self._by_entity.get(entity_id)
+        if anchor is None:
+            return frozenset()
+        return self.footprint_tiles(anchor, self._size_by_entity[entity_id])
 
     def occupant_at(self, position: Position) -> str | None:
         """Return the entity id occupying ``position``, or ``None``."""

--- a/dnd-engine/tests/srd/playing_the_game/test_movement_and_position.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_movement_and_position.py
@@ -18,8 +18,9 @@ from pathlib import Path
 
 import pytest
 
-from dnd_engine.core.creature import Abilities, Creature, MovementMode
+from dnd_engine.core.creature import Abilities, Creature, MovementMode, Size
 from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.map import Map, TileType
 from dnd_engine.core.position import Position
 from dnd_engine.systems.action_economy import ActionType, Terrain, TurnState, cost_for
 from dnd_engine.systems.actions import disengage
@@ -29,6 +30,7 @@ from dnd_engine.systems.opportunity_attacks import (
     register_default_opportunity_attack,
 )
 from dnd_engine.systems.reactions import ReactionDispatcher
+from dnd_engine.systems.spatial_index import SpatialIndex
 
 pytestmark = pytest.mark.srd(
     "playing-the-game/movement-and-position.md",
@@ -489,17 +491,55 @@ class TestCreatureSize_SpaceFromSizeCategory:
                 f"monster '{mid}' has unrecognized size '{mdata['size']}'"
             )
 
+    def _clear_index(self, n: int = 6) -> SpatialIndex:
+        """A wall-free n x n SpatialIndex for unobstructed footprint geometry."""
+        tiles = {(x, y): TileType.FLOOR for x in range(n) for y in range(n)}
+        return SpatialIndex(Map(width=n, height=n, tiles=tiles))
+
     def test_engine_computes_occupied_tiles_from_size_category(self) -> None:
-        pytest.skip(
-            "GAP: creature size does not drive map footprint. The SRD "
-            "Size table maps Large -> 2x2 tiles, Huge -> 3x3, "
-            "Gargantuan -> 4x4. The `Size` enum and `Creature.size` field "
-            "DID ship (dnd_engine/core/creature.py:13, :155) but are a "
-            "data-model foundation only — nothing consumes them "
-            "geometrically. `SpatialIndex` maps each entity to a single "
-            "`Position` (dnd_engine/systems/spatial_index.py) with no "
-            "multi-tile footprint, and no SRD size->tile table exists in "
-            "dnd_engine/data/srd/. Tracked by issue #442."
+        """Creature size drives the set of tiles a creature occupies.
+
+        The SRD Creature Size and Space table maps Medium -> 1 tile,
+        Large -> 2x2, Huge -> 3x3, Gargantuan -> 4x4. The engine reads
+        `Creature.size` and the `SpatialIndex` claims the full footprint,
+        so occupancy queries resolve every covered tile — not just the
+        anchor.
+        """
+        abilities = Abilities(
+            strength=19,
+            dexterity=10,
+            constitution=16,
+            intelligence=6,
+            wisdom=10,
+            charisma=7,
+        )
+
+        # Side length of the square space matches the SRD table.
+        assert Size.MEDIUM.footprint == 1
+        assert Size.LARGE.footprint == 2
+        assert Size.HUGE.footprint == 3
+        assert Size.GARGANTUAN.footprint == 4
+
+        # A Large creature anchored at (1,1) claims the 2x2 block, and
+        # occupancy is footprint-aware across every covered tile.
+        ogre = Creature(
+            name="Ogre", max_hp=59, ac=11, abilities=abilities, size=Size.LARGE
+        )
+        index = self._clear_index()
+        index.place("ogre", Position(1, 1), size=ogre.size)
+        assert index.footprint_of("ogre") == frozenset(
+            {Position(1, 1), Position(2, 1), Position(1, 2), Position(2, 2)}
+        )
+        assert index.occupant_at(Position(2, 2)) == "ogre"  # not just the anchor
+        assert index.occupant_at(Position(3, 3)) is None  # outside the block
+
+        # A Huge creature claims the full 3x3 block.
+        giant = Creature(
+            name="Hill Giant", max_hp=105, ac=13, abilities=abilities, size=Size.HUGE
+        )
+        index.place("giant", Position(3, 3), size=giant.size)
+        assert index.footprint_of("giant") == frozenset(
+            Position(3 + dx, 3 + dy) for dx in range(3) for dy in range(3)
         )
 
 

--- a/dnd-engine/tests/srd/playing_the_game/test_spatial_index.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_spatial_index.py
@@ -361,3 +361,154 @@ class TestOccupantsView:
         assert isinstance(view, MappingProxyType)
         with pytest.raises(TypeError):
             view["intruder"] = Position(1, 1)  # type: ignore[index]
+
+
+class TestFootprint:
+    """SpatialIndex honors multi-tile creature footprints (#442).
+
+    SRD § Playing the Game › Movement and Position › Creature Size:
+    Large creatures fill a 2x2 block, Huge 3x3, Gargantuan 4x4. The
+    anchor Position is the minimum-x / minimum-y corner; the block
+    extends toward +x and +y.
+    """
+
+    def _clear_index(self, n: int = 6) -> SpatialIndex:
+        """A wall-free n x n index, for unobstructed footprint geometry."""
+        tiles = {(x, y): TileType.FLOOR for x in range(n) for y in range(n)}
+        return SpatialIndex(Map(width=n, height=n, tiles=tiles))
+
+    # -- pure geometry ---------------------------------------------------- #
+
+    def test_footprint_tiles_medium_is_single_anchor(self) -> None:
+        from dnd_engine.core.creature import Size
+
+        assert SpatialIndex.footprint_tiles(
+            Position(2, 2), Size.MEDIUM
+        ) == frozenset({Position(2, 2)})
+
+    def test_footprint_tiles_large_is_2x2_extending_positive(self) -> None:
+        from dnd_engine.core.creature import Size
+
+        assert SpatialIndex.footprint_tiles(Position(1, 1), Size.LARGE) == frozenset(
+            {Position(1, 1), Position(2, 1), Position(1, 2), Position(2, 2)}
+        )
+
+    def test_footprint_tiles_huge_is_3x3(self) -> None:
+        from dnd_engine.core.creature import Size
+
+        tiles = SpatialIndex.footprint_tiles(Position(0, 0), Size.HUGE)
+        assert tiles == frozenset(
+            Position(x, y) for x in range(3) for y in range(3)
+        )
+
+    # -- placement -------------------------------------------------------- #
+
+    def test_place_large_registers_full_2x2_footprint(self) -> None:
+        from dnd_engine.core.creature import Size
+
+        idx = self._clear_index()
+        idx.place("ogre", Position(1, 1), size=Size.LARGE)
+        assert idx.footprint_of("ogre") == frozenset(
+            {Position(1, 1), Position(2, 1), Position(1, 2), Position(2, 2)}
+        )
+
+    def test_occupant_at_is_footprint_aware(self) -> None:
+        from dnd_engine.core.creature import Size
+
+        idx = self._clear_index()
+        idx.place("ogre", Position(1, 1), size=Size.LARGE)
+        # The anchor and every covered tile resolve to the ogre.
+        assert idx.occupant_at(Position(1, 1)) == "ogre"
+        assert idx.occupant_at(Position(2, 1)) == "ogre"
+        assert idx.occupant_at(Position(2, 2)) == "ogre"
+        # A tile outside the footprint is clear; the anchor is the
+        # reported position.
+        assert idx.occupant_at(Position(3, 3)) is None
+        assert idx.position_of("ogre") == Position(1, 1)
+
+    def test_place_onto_existing_footprint_tile_raises(self) -> None:
+        from dnd_engine.core.creature import Size
+
+        idx = self._clear_index()
+        idx.place("ogre", Position(1, 1), size=Size.LARGE)
+        with pytest.raises(ValueError, match="occupied"):
+            idx.place("goblin", Position(2, 2))  # inside the ogre's 2x2 block
+
+    def test_place_footprint_off_map_raises(self) -> None:
+        from dnd_engine.core.creature import Size
+
+        idx = self._clear_index()  # 6x6, valid indices 0..5
+        with pytest.raises(ValueError, match="blocking"):
+            # A 2x2 anchored at (5,5) would spill onto x=6 / y=6.
+            idx.place("ogre", Position(5, 5), size=Size.LARGE)
+
+    def test_place_footprint_onto_wall_raises(self) -> None:
+        from dnd_engine.core.creature import Size
+
+        tiles = {(x, y): TileType.FLOOR for x in range(6) for y in range(6)}
+        tiles[(2, 1)] = TileType.WALL
+        idx = SpatialIndex(Map(width=6, height=6, tiles=tiles))
+        with pytest.raises(ValueError, match="blocking"):
+            # The 2x2 block from (1,1) covers the wall at (2,1).
+            idx.place("ogre", Position(1, 1), size=Size.LARGE)
+
+    def test_place_without_size_keeps_single_tile_behavior(self) -> None:
+        idx = self._clear_index()
+        idx.place("goblin", Position(2, 2))
+        assert idx.footprint_of("goblin") == frozenset({Position(2, 2)})
+        # Default size is Medium → one tile, leaving neighbors clear.
+        assert idx.occupant_at(Position(3, 2)) is None
+
+    # -- movement --------------------------------------------------------- #
+
+    def test_move_relocates_whole_block_and_clears_old_tiles(self) -> None:
+        from dnd_engine.core.creature import Size
+
+        idx = self._clear_index()
+        idx.place("ogre", Position(0, 0), size=Size.LARGE)
+        idx.move("ogre", Position(3, 3))
+        # Old tiles are vacated.
+        assert idx.occupant_at(Position(0, 0)) is None
+        assert idx.occupant_at(Position(1, 1)) is None
+        # The full new footprint is registered.
+        assert idx.footprint_of("ogre") == frozenset(
+            {Position(3, 3), Position(4, 3), Position(3, 4), Position(4, 4)}
+        )
+        assert idx.occupant_at(Position(4, 4)) == "ogre"
+
+    def test_move_into_own_overlapping_footprint_succeeds(self) -> None:
+        from dnd_engine.core.creature import Size
+
+        # Sliding a Large creature so the new block overlaps the old must
+        # not trip the occupied-tile guard against the creature itself.
+        idx = self._clear_index()
+        idx.place("ogre", Position(1, 1), size=Size.LARGE)
+        idx.move("ogre", Position(2, 2))  # new block overlaps old (2,2)
+        assert idx.position_of("ogre") == Position(2, 2)
+        assert idx.occupant_at(Position(1, 1)) is None
+        assert idx.occupant_at(Position(3, 3)) == "ogre"
+
+    def test_move_blocked_by_other_entity_in_target_footprint(self) -> None:
+        from dnd_engine.core.creature import Size
+
+        idx = self._clear_index()
+        idx.place("ogre", Position(0, 0), size=Size.LARGE)
+        idx.place("goblin", Position(3, 3))
+        with pytest.raises(ValueError, match="occupied"):
+            # The 2x2 block anchored at (2,2) would cover the goblin (3,3).
+            idx.move("ogre", Position(2, 2))
+
+    def test_remove_clears_entire_footprint(self) -> None:
+        from dnd_engine.core.creature import Size
+
+        idx = self._clear_index()
+        idx.place("ogre", Position(1, 1), size=Size.LARGE)
+        idx.remove("ogre")
+        for tile in (
+            Position(1, 1),
+            Position(2, 1),
+            Position(1, 2),
+            Position(2, 2),
+        ):
+            assert idx.occupant_at(tile) is None
+        assert idx.position_of("ogre") is None

--- a/dnd-engine/tests/test_character_factory.py
+++ b/dnd-engine/tests/test_character_factory.py
@@ -507,3 +507,37 @@ class TestDefaultSkillSelection:
             skill_proficiencies=["acrobatics", "insight"],
         )
         assert rogue.skill_proficiencies == ["acrobatics", "insight"]
+
+
+class TestCharacterRaceSize:
+    """A factory-built character's size category comes from its race.
+
+    SRD § Creature Statistics › Size: most player races are Medium, but a
+    few (Halfling, Gnome) are Small. The factory must surface that so the
+    spatial layer can size the character's footprint correctly.
+    """
+
+    def _make_factory(self) -> tuple[CharacterFactory, DataLoader]:
+        return CharacterFactory(dice_roller=DiceRoller(seed=1)), DataLoader(
+            dice_roller=DiceRoller(seed=1)
+        )
+
+    def test_human_is_medium(self):
+        """The Human race is Medium per races.json."""
+        from dnd_engine.core.creature import Size
+
+        factory, loader = self._make_factory()
+        human = factory.create_character(
+            class_name="fighter", race_name="human", data_loader=loader
+        )
+        assert human.size is Size.MEDIUM
+
+    def test_halfling_is_small(self):
+        """The Halfling race is Small per races.json."""
+        from dnd_engine.core.creature import Size
+
+        factory, loader = self._make_factory()
+        halfling = factory.create_character(
+            class_name="rogue", race_name="halfling", data_loader=loader
+        )
+        assert halfling.size is Size.SMALL

--- a/dnd-engine/tests/test_creature_size.py
+++ b/dnd-engine/tests/test_creature_size.py
@@ -37,6 +37,28 @@ class TestSizeEnum:
         assert Size("gargantuan") is Size.GARGANTUAN
 
 
+class TestSizeFootprint:
+    """Test the SRD Creature Size and Space table → square footprint.
+
+    SRD § Playing the Game › Movement and Position › Creature Size:
+    a creature's size determines the width of the square space it
+    occupies on a map — Tiny/Small/Medium share one tile, Large is
+    2×2, Huge is 3×3, Gargantuan is 4×4.
+    """
+
+    def test_small_sizes_occupy_a_single_tile(self):
+        """Tiny, Small, and Medium all occupy a 1-tile-wide square."""
+        assert Size.TINY.footprint == 1
+        assert Size.SMALL.footprint == 1
+        assert Size.MEDIUM.footprint == 1
+
+    def test_large_sizes_scale_with_category(self):
+        """Large/Huge/Gargantuan widen to 2/3/4 tiles per the SRD table."""
+        assert Size.LARGE.footprint == 2
+        assert Size.HUGE.footprint == 3
+        assert Size.GARGANTUAN.footprint == 4
+
+
 class TestCreatureSizeField:
     """Test that the Creature class carries a size field defaulting to Medium."""
 

--- a/dnd-engine/tests/test_gamestate_spatial.py
+++ b/dnd-engine/tests/test_gamestate_spatial.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import pytest
 
 from dnd_engine.core.character import Character, CharacterClass
-from dnd_engine.core.creature import Abilities
+from dnd_engine.core.creature import Abilities, Creature, Size
 from dnd_engine.core.dice import DiceRoller
 from dnd_engine.core.game_state import GameState
 from dnd_engine.core.map import Map, TileType
@@ -303,6 +303,41 @@ class TestSetPositionCreatureSync:
         game_state.remove_creature_position(entity_id)
 
         assert character.position is None
+
+    def test_set_position_threads_creature_size_into_footprint(
+        self, game_state: GameState, map_5x5: Map
+    ) -> None:
+        """A Large creature placed via set_position claims its full 2x2 block.
+
+        ``_find_creature_by_id`` resolves ``<id>_<index>`` to
+        ``active_enemies[index]``, so an enemy's size flows through to the
+        SpatialIndex footprint rather than collapsing to a single tile.
+        """
+        game_state.spatial = SpatialIndex(map_5x5)
+        ogre = Creature(
+            name="Ogre",
+            max_hp=59,
+            ac=11,
+            abilities=Abilities(
+                strength=19,
+                dexterity=8,
+                constitution=16,
+                intelligence=5,
+                wisdom=7,
+                charisma=7,
+            ),
+            size=Size.LARGE,
+        )
+        game_state.active_enemies.append(ogre)
+
+        # (0,0) anchors a 2x2 block clear of the fixture walls.
+        game_state.set_position("ogre_0", 0, 0)
+
+        assert game_state.spatial.footprint_of("ogre_0") == frozenset(
+            {Position(0, 0), Position(1, 0), Position(0, 1), Position(1, 1)}
+        )
+        # Occupancy resolves a non-anchor footprint tile to the ogre.
+        assert game_state.spatial.occupant_at(Position(1, 1)) == "ogre_0"
 
 
 class TestBootstrapSpatial:


### PR DESCRIPTION
## Summary
Plan-03 shipped the `Size` enum and `Creature.size` field, but nothing consumed them geometrically — every entity occupied a single tile, so SRD Large/Huge/Gargantuan creatures could not be placed faithfully on the tactical grid. This wires creature size through to multi-tile footprints per the SRD Creature Size and Space table.

This is the **foundational slice** for finishing plan-03's residual gaps (Option A) and a **prerequisite for #445** (the Tiny / two-sizes-apart pass-through carve-outs need size-aware footprints to exist first).

> Note: #442 was previously closed NOT_PLANNED on 2026-05-23; the 2026-05-30 movement conformance audit re-confirmed it as a real, unshipped gap and it was reopened.

## Changes
- **`core/creature.py`**: add `Size.footprint` — side length of the square a size occupies (Tiny/Small/Medium 1, Large 2, Huge 3, Gargantuan 4).
- **`systems/spatial_index.py`**: track each entity's size; register every footprint tile. New `footprint_tiles(anchor, size)` (pure geometry, anchor = min-x/min-y corner) and `footprint_of(entity_id)`. `place`/`move`/`remove` operate over the whole block; placement rejects any blocking (incl. off-map) or occupied tile; `move` excludes the creature's own tiles so an overlapping slide is allowed. Default Medium = 1x1, so single-tile callers are unchanged.
- **`core/game_state.py`**: `set_position` resolves the entity's `Creature` and passes its size to `spatial.place`; `move` reuses the recorded size.
- **`core/character.py` + `core/character_factory.py`**: accept a size on `Character` and populate it from `races.json` (Halfling = Small), mirroring how speed is threaded.

## Design notes
- Footprint is expressed as a **code rule** (`Size.footprint`), mirroring the sibling `cost_for(feet, terrain)` in `action_economy.py`, rather than a new `data/srd/` table.
- **Out of scope** (tracked elsewhere): pass-through carve-outs / involuntary-Prone (#445), per-mode movement costs (#433), adding Large+ monster *content* to `monsters.json` (all shipped monsters are Medium/Small today — the gating test constructs Large/Huge creatures directly), and client-2d multi-tile sprite rendering.

## Testing
- [x] Un-skipped the gating conformance test `TestCreatureSize_SpaceFromSizeCategory::test_engine_computes_occupied_tiles_from_size_category` (movement-and-position skips 11 → 10).
- [x] New unit tests: `Size.footprint`, footprint-aware `SpatialIndex` (place/move/remove/occupancy/self-overlap/off-map/wall), `set_position` size threading, PC race size.
- [x] Full engine suite: **3231 passed, 191 skipped, 0 failures**.
- [x] `ruff check` clean; `python-code-reviewer` — no critical/high/medium issues.

## Related Issues
Fixes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)