### PR TITLE
Activate engine spatial stack + monster Opportunity Attacks in scenario play (plan-10 W1)

### DIFF
--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -398,6 +398,56 @@ class GameSession:
         self.party_spread = True
         self._update_lighting()
 
+    def _bootstrap_spatial(self) -> None:
+        """Install the engine ``SpatialIndex`` and place every combatant.
+
+        This is the production wiring the plan-03 spatial/movement stack
+        depends on: without a bootstrapped ``GameState.spatial`` the
+        engine movement path (``attempt_combat_step``) stays dormant and
+        monster Opportunity Attacks never fire (plan-10 W1). Builds an
+        engine ``Map`` from the loaded ``RoomLayout``, installs it with
+        ``replace=True`` so a scenario reload or room transition rebuilds
+        cleanly, then mirrors each party / monster placement into the
+        index using the engine entity-id convention.
+
+        When combat is already active — the scenario loader starts combat
+        before the session gets control — re-registers default
+        Opportunity Attack handlers now that the index is populated; the
+        registration walk inside ``_start_combat`` is a no-op while
+        ``spatial`` is still None.
+        """
+        from dnd_engine.core.map import Map
+
+        game_state = self.engine.game_state
+        if game_state is None or self.room_layout is None:
+            return
+
+        engine_map = Map.from_room_layout(self.room_layout)
+        game_state.bootstrap_spatial(engine_map, replace=True)
+
+        # Only creatures belong in the combat spatial index. Items would
+        # occupy (and thus block) their tile; the visual layer renders
+        # them separately.
+        combatants = (
+            self.entity_manager.get_party_members()
+            + self.entity_manager.get_monsters()
+        )
+        for entity in combatants:
+            entity_id = getattr(entity, "entity_id", None)
+            if not entity_id:
+                continue
+            try:
+                game_state.set_position(entity_id, entity.grid_x, entity.grid_y)
+            except ValueError:
+                # Blocking / occupied tile per the freshly built index, or
+                # an entity_id outside the engine spawn convention. The
+                # visual layer still renders the entity; it just carries no
+                # spatial coordinate (matching EngineAdapter.spawn_*).
+                continue
+
+        if game_state.in_combat and game_state.reaction_dispatcher is not None:
+            game_state.register_opportunity_attacks()
+
     def _collapse_party_after_combat(self) -> None:
         """Collapse party back to single unit after combat ends."""
         if self.party_positions:
@@ -1241,7 +1291,25 @@ class GameSession:
             name = self._resolve_blocker_name(blocker_id)
             return f"Path blocked! {name} is in the way."
 
-        result = game_state.attempt_combat_step(entity_id, dx, dy)
+        # The step may provoke an Opportunity Attack, which the engine
+        # resolves synchronously and surfaces as a DAMAGE_DEALT event
+        # tagged ``opportunity_attack``. Capture those around the call so
+        # the hit lands in the wire response instead of only showing up
+        # as a silent HP delta in the next state dump (#W1).
+        from dnd_engine.utils.events import Event, EventType
+
+        oa_hits: list[dict[str, object]] = []
+
+        def _capture_oa(event: Event) -> None:
+            if event.data.get("opportunity_attack"):
+                oa_hits.append(event.data)
+
+        event_bus = game_state.event_bus
+        event_bus.subscribe(EventType.DAMAGE_DEALT, _capture_oa)
+        try:
+            result = game_state.attempt_combat_step(entity_id, dx, dy)
+        finally:
+            event_bus.unsubscribe(EventType.DAMAGE_DEALT, _capture_oa)
         if not result.ok:
             if result.reason == "out of bounds":
                 # Distinct legacy wire string for OOB vs in-bounds walls.
@@ -1283,9 +1351,24 @@ class GameSession:
             self.engine, self.player_x, self.player_y
         )
 
+        # Surface any provoked Opportunity Attack(s) above the state dump
+        # and mirror them into the combat log so the windowed HUD and the
+        # MCP between-turns buffer both see the hit.
+        oa_block = ""
+        if oa_hits:
+            lines = [
+                f"Opportunity attack! {hit.get('attacker', 'Something')} hits "
+                f"{hit.get('defender', 'the target')} for {hit.get('damage', 0)} damage."
+                for hit in oa_hits
+            ]
+            for line in lines:
+                self._add_combat_log(line)
+            oa_block = "\n".join(lines) + "\n"
+
         return (
             f"Moved {direction}. Movement remaining: "
             f"{result.movement_remaining} ft.\n"
+            + oa_block
             + self.get_state()
         )
 
@@ -1865,5 +1948,10 @@ class GameSession:
             self.current_mode = GameMode.COMBAT
         else:
             self.current_mode = GameMode.EXPLORATION
+
+        # Activate the engine spatial/movement stack now that entities are
+        # placed: bootstrap the SpatialIndex from the room layout and wire
+        # Opportunity Attack handlers so combat movement provokes (#W1).
+        self._bootstrap_spatial()
 
         return f"Loaded scenario '{result['name']}' (seed={result['seed']}). " + self.get_state()

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -560,8 +560,10 @@ class TestSessionCombatMoveAnchorsToActiveCombatant:
         party = session.entity_manager.get_party_members()
         assert len(party) == 1
         pc_entity = party[0]
-        pc_entity.grid_x = 3
-        pc_entity.grid_y = 4
+        # Establish the PC's TRUE tile in BOTH the spatial index and the
+        # entity layer (set_position syncs both); the `@` cursor stays at
+        # the scenario-seeded (3, 5), one tile south — the #578 desync.
+        session.set_position(pc_entity.entity_id, 3, 4)
         assert (session.player_x, session.player_y) == (3, 5)
 
         starting_movement = session.engine.get_current_turn_state().movement_remaining
@@ -593,9 +595,9 @@ class TestSessionCombatMoveAnchorsToActiveCombatant:
         party = session.entity_manager.get_party_members()
         assert len(party) == 1
         pc_entity = party[0]
-        # PC at (3, 4); `@` lags at (3, 5).
-        pc_entity.grid_x = 3
-        pc_entity.grid_y = 4
+        # PC truly at (3, 4) in both spatial + entity layers; `@` lags at
+        # (3, 5). set_position syncs both layers the way production does.
+        session.set_position(pc_entity.entity_id, 3, 4)
         assert (session.player_x, session.player_y) == (3, 5)
 
         starting_movement = session.engine.get_current_turn_state().movement_remaining
@@ -662,7 +664,7 @@ class TestSessionCombatMoveSpatialDelegation:
         # Use the session's existing RoomLayout to seed the engine Map.
         game_state = session.engine.game_state
         engine_map = Map.from_room_layout(session.room_layout)
-        game_state.bootstrap_spatial(engine_map)
+        game_state.bootstrap_spatial(engine_map, replace=True)
 
         # Place the current PC at the session's player tile.
         current = session.engine.get_current_combatant()
@@ -736,7 +738,7 @@ class TestSessionCombatMoveSpatialDelegation:
         }
         engine_map = Map(width=3, height=3, tiles=tiles)
         game_state = session.engine.game_state
-        game_state.bootstrap_spatial(engine_map)
+        game_state.bootstrap_spatial(engine_map, replace=True)
         pc = session.engine.party.characters[0]
         entity_id = f"pc_{pc.name.lower().replace(' ', '_')}"
         game_state.set_position(entity_id, target_x, target_y)
@@ -769,7 +771,7 @@ class TestSessionCombatMoveSpatialDelegation:
         # Bootstrap spatial but DO NOT call set_position for the PC.
         game_state = session.engine.game_state
         engine_map = Map.from_room_layout(session.room_layout)
-        game_state.bootstrap_spatial(engine_map)
+        game_state.bootstrap_spatial(engine_map, replace=True)
         current = session.engine.get_current_combatant()
         entity_id = f"pc_{current['creature'].name.lower().replace(' ', '_')}"
         assert game_state.spatial.position_of(entity_id) is None
@@ -824,7 +826,7 @@ class TestSessionCombatMoveSpatialDelegation:
         # the new goblin).
         game_state = session.engine.game_state
         engine_map = Map.from_room_layout(session.room_layout)
-        game_state.bootstrap_spatial(engine_map)
+        game_state.bootstrap_spatial(engine_map, replace=True)
         pc = session.engine.party.characters[0]
         entity_id = f"pc_{pc.name.lower().replace(' ', '_')}"
         game_state.set_position(entity_id, target_x, target_y)
@@ -861,7 +863,7 @@ class TestSessionCombatMoveSpatialDelegation:
 
         game_state = session.engine.game_state
         engine_map = Map.from_room_layout(session.room_layout)
-        game_state.bootstrap_spatial(engine_map)
+        game_state.bootstrap_spatial(engine_map, replace=True)
         current = session.engine.get_current_combatant()
         entity_id = f"pc_{current['creature'].name.lower().replace(' ', '_')}"
         game_state.set_position(entity_id, target_x, target_y)

--- a/client-2d/tests/test_opportunity_attack_surface_integration.py
+++ b/client-2d/tests/test_opportunity_attack_surface_integration.py
@@ -1,0 +1,72 @@
+# ABOUTME: Integration test — the 2D client surfaces monster Opportunity Attacks
+# ABOUTME: triggered when a PC moves out of reach during combat (plan-10 W1).
+
+"""When a PC leaves a hostile creature's reach, the engine already fires
+and resolves the Opportunity Attack and emits ``DAMAGE_DEALT`` tagged
+``opportunity_attack`` (see dnd-engine test_oa_combat_step_integration).
+
+This test asserts the *client* surfaces that hit in the ``combat_move``
+wire response, rather than letting the PC silently take damage that only
+shows up as an HP delta in the next state dump.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+SCENARIO_DIR = Path(__file__).parent.parent.parent / "dnd-engine" / "tests" / "scenarios" / "yaml"
+
+
+@pytest.fixture
+def combat_session():
+    """A scenario-loaded session in combat with one goblin and Archy."""
+    from client_2d.session import GameSession
+
+    s = GameSession(enable_mcp=False, dev_mode=True)
+    s.load_scenario(SCENARIO_DIR / "ranged_attack_basic.yaml")
+    return s
+
+
+def _force_player_turn(session, pc) -> None:
+    """Make the PC the current combatant with a full movement budget so
+    ``combat_move`` runs the engine step instead of bouncing on
+    'Not your turn'."""
+    tracker = session.engine.game_state.initiative_tracker
+    pc_index = next(
+        i for i, entry in enumerate(tracker.combatants) if entry.creature is pc
+    )
+    tracker.current_turn_index = pc_index
+    tracker.turn_states[pc].reset(speed=pc.speed)
+
+
+class TestClientSurfacesOpportunityAttack:
+    def test_combat_move_out_of_reach_surfaces_oa_hit(self, combat_session) -> None:
+        session = combat_session
+        game_state = session.engine.game_state
+        assert game_state.spatial is not None, "scenario must bootstrap spatial"
+
+        pc = session.engine.party.characters[0]
+        # Force the goblin's Opportunity Attack to connect deterministically:
+        # AC 1 means only a natural 1 misses, and we pin the dice seed.
+        pc.ac = 1
+        session.set_seed(7)
+
+        # Stand the PC and the goblin adjacent (5 ft) so a single step puts
+        # the PC 10 ft away — leaving the goblin's reach and provoking.
+        session.set_position("pc_archy", 5, 5)
+        session.set_position("goblin_0", 5, 6)
+        _force_player_turn(session, pc)
+
+        # PC steps north (5,5) -> (5,4): now 10 ft from the goblin.
+        response = session.combat_move("north")
+
+        # The move itself succeeds...
+        assert "Moved north" in response
+        # ...and the provoked Opportunity Attack is surfaced to the player.
+        assert "opportunity attack" in response.lower(), (
+            "combat_move must surface the goblin's Opportunity Attack, not "
+            f"drop it silently. Got:\n{response}"
+        )
+        assert "Goblin" in response

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -4195,6 +4195,20 @@ class GameState:
         # stays empty and harmless.
         self._register_default_opportunity_attacks()
 
+    def register_opportunity_attacks(self) -> None:
+        """Public entry to (re)register default Opportunity Attack handlers.
+
+        Combat can begin (``_start_combat``) before the SpatialIndex is
+        bootstrapped: the scenario loader starts combat, then the
+        client-side session installs ``spatial`` from its room layout and
+        places entities. In that ordering the registration walk inside
+        ``_start_combat`` runs against an absent index and subscribes
+        nobody. A caller that bootstraps ``spatial`` *after* combat has
+        started invokes this once placements exist so every combatant
+        gets its 5-ft handler.
+        """
+        self._register_default_opportunity_attacks()
+
     def _register_default_opportunity_attacks(self) -> None:
         """Subscribe every placed combatant to ``OPPORTUNITY_PROVOKED``.
 

--- a/dnd-engine/tests/test_oa_combat_step_integration.py
+++ b/dnd-engine/tests/test_oa_combat_step_integration.py
@@ -1,0 +1,211 @@
+# ABOUTME: Integration test — monster Opportunity Attacks fire through the real
+# ABOUTME: _start_combat bootstrap + attempt_combat_step path (plan-10 W1).
+
+from __future__ import annotations
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.map import Map, TileType
+from dnd_engine.core.party import Party
+from dnd_engine.core.position import Position
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.utils.events import Event, EventBus, EventType
+
+
+def _floor_map(size: int = 7) -> Map:
+    """An all-floor square map so movement geometry is the only variable."""
+    tiles = {(x, y): TileType.FLOOR for x in range(size) for y in range(size)}
+    return Map(width=size, height=size, tiles=tiles)
+
+
+def _pc_id(name: str) -> str:
+    """Mirror the EngineAdapter / GameState PC entity-id convention."""
+    return f"pc_{name.lower().replace(' ', '_')}"
+
+
+def _make_game_state() -> tuple[GameState, str, str]:
+    """Build a combat-ready GameState with one PC and one goblin, both
+    placed in the spatial index BEFORE ``_start_combat`` so the OA
+    registration walk subscribes them. The PC starts 5 ft south of the
+    goblin (within its reach) and is forced to be the current combatant.
+
+    The PC's AC is set to 1 so the goblin's Opportunity Attack reliably
+    connects — but the load-bearing assertions key off Reaction-slot
+    consumption, which is roll-independent.
+    """
+    abilities = Abilities(
+        strength=15, dexterity=14, constitution=13,
+        intelligence=10, wisdom=12, charisma=8,
+    )
+    fighter = Character(
+        name="Fighter 1",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=abilities,
+        max_hp=30,
+        ac=1,
+        xp=0,
+    )
+    party = Party(characters=[fighter])
+    gs = GameState(
+        party=party,
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+        dice_roller=DiceRoller(seed=1),
+    )
+    gs.bootstrap_spatial(_floor_map())
+
+    goblin = gs.data_loader.create_monster("goblin")
+    gs.active_enemies.append(goblin)
+
+    pc_id = _pc_id(fighter.name)
+    goblin_id = "goblin_0"  # index 0 in active_enemies
+    # Place both BEFORE combat starts: _register_default_opportunity_attacks
+    # walks the spatial index at _start_combat time and only subscribes
+    # entities already placed.
+    gs.set_position(goblin_id, 3, 3)
+    gs.set_position(pc_id, 3, 4)  # 5 ft south of the goblin — within reach.
+
+    gs._start_combat()
+
+    # attempt_combat_step consults the *current* turn state, not the mover's
+    # id — force the PC's turn so its movement budget is the one consumed.
+    fighter_idx = next(
+        i
+        for i, entry in enumerate(gs.initiative_tracker.combatants)
+        if entry.creature is fighter
+    )
+    gs.initiative_tracker.current_turn_index = fighter_idx
+    gs.initiative_tracker.turn_states[fighter].reset(speed=fighter.speed)
+    return gs, pc_id, goblin_id
+
+
+class TestMonsterOpportunityAttackFiresOnMovement:
+    def test_moving_out_of_reach_consumes_reactor_reaction(self) -> None:
+        """SRD: leaving a hostile creature's reach provokes an Opportunity
+        Attack, spending the reactor's Reaction."""
+        gs, pc_id, _goblin_id = _make_game_state()
+        goblin = gs.active_enemies[0]
+        assert gs.initiative_tracker.turn_states[goblin].reaction_available is True
+
+        # PC steps south (3,4) -> (3,5): now 10 ft from the goblin, leaving
+        # its 5 ft reach.
+        result = gs.attempt_combat_step(pc_id, 0, 1)
+
+        assert result.ok is True
+        assert result.position == Position(3, 5)
+        assert gs.initiative_tracker.turn_states[goblin].reaction_available is False
+
+    def test_moving_within_reach_does_not_provoke(self) -> None:
+        """Moving while staying inside the reactor's reach must NOT provoke,
+        so the reaction slot survives for a genuine departure."""
+        gs, pc_id, _goblin_id = _make_game_state()
+        goblin = gs.active_enemies[0]
+
+        # PC steps east (3,4) -> (4,4): still 5 ft (diagonal) from the goblin.
+        result = gs.attempt_combat_step(pc_id, 1, 0)
+
+        assert result.ok is True
+        assert result.position == Position(4, 4)
+        assert gs.initiative_tracker.turn_states[goblin].reaction_available is True
+
+    def test_oa_hit_emits_damage_dealt_with_flag(self) -> None:
+        """The full resolution path: a connecting OA emits DAMAGE_DEALT
+        tagged ``opportunity_attack`` so clients can surface it."""
+        gs, pc_id, _goblin_id = _make_game_state()
+        captured: list[Event] = []
+        gs.event_bus.subscribe(EventType.DAMAGE_DEALT, captured.append)
+
+        gs.attempt_combat_step(pc_id, 0, 1)  # provoking move
+
+        oa_events = [e for e in captured if e.data.get("opportunity_attack")]
+        assert len(oa_events) == 1
+        assert oa_events[0].data["attacker"] == "Goblin"
+        assert oa_events[0].data["defender"] == "Fighter 1"
+
+
+def _make_late_bootstrap_state() -> tuple[GameState, str, str]:
+    """Build a combat-ready GameState the way the scenario loader does:
+    ``_start_combat`` runs *before* the SpatialIndex exists, so the
+    registration walk inside it subscribes nobody. The caller is expected
+    to bootstrap spatial, place the combatants, and then invoke
+    ``register_opportunity_attacks`` to wire the handlers.
+    """
+    abilities = Abilities(
+        strength=15, dexterity=14, constitution=13,
+        intelligence=10, wisdom=12, charisma=8,
+    )
+    fighter = Character(
+        name="Fighter 1",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=abilities,
+        max_hp=30,
+        ac=1,
+        xp=0,
+    )
+    party = Party(characters=[fighter])
+    gs = GameState(
+        party=party,
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+        dice_roller=DiceRoller(seed=1),
+    )
+    goblin = gs.data_loader.create_monster("goblin")
+    gs.active_enemies.append(goblin)
+
+    # Combat starts with spatial still None — mirrors ScenarioLoader.load.
+    gs._start_combat()
+
+    # Only now does the client-side bootstrap happen: install the index,
+    # place the combatants, then re-register OA handlers.
+    gs.bootstrap_spatial(_floor_map())
+    pc_id = _pc_id(fighter.name)
+    goblin_id = "goblin_0"
+    gs.set_position(goblin_id, 3, 3)
+    gs.set_position(pc_id, 3, 4)
+
+    fighter_idx = next(
+        i
+        for i, entry in enumerate(gs.initiative_tracker.combatants)
+        if entry.creature is fighter
+    )
+    gs.initiative_tracker.current_turn_index = fighter_idx
+    gs.initiative_tracker.turn_states[fighter].reset(speed=fighter.speed)
+    return gs, pc_id, goblin_id
+
+
+class TestRegisterAfterLateBootstrap:
+    """The scenario-loader ordering: combat starts before spatial exists.
+    ``register_opportunity_attacks`` is the public entry that wires the
+    handlers once the index is populated."""
+
+    def test_register_after_bootstrap_arms_opportunity_attacks(self) -> None:
+        """After a late bootstrap, calling the public registration entry
+        makes a provoking move spend the reactor's Reaction."""
+        gs, pc_id, _goblin_id = _make_late_bootstrap_state()
+        goblin = gs.active_enemies[0]
+
+        gs.register_opportunity_attacks()
+
+        result = gs.attempt_combat_step(pc_id, 0, 1)  # leaves 5 ft reach
+
+        assert result.ok is True
+        assert gs.initiative_tracker.turn_states[goblin].reaction_available is False
+
+    def test_without_registration_no_opportunity_attack_fires(self) -> None:
+        """Negative control: skipping the public registration after a late
+        bootstrap leaves the handlers unwired, so the same move provokes
+        nothing — proving the call is load-bearing."""
+        gs, pc_id, _goblin_id = _make_late_bootstrap_state()
+        goblin = gs.active_enemies[0]
+
+        # Deliberately do NOT call register_opportunity_attacks().
+        result = gs.attempt_combat_step(pc_id, 0, 1)
+
+        assert result.ok is True
+        assert gs.initiative_tracker.turn_states[goblin].reaction_available is True


### PR DESCRIPTION
## Summary
- Closes the **keystone wiring gap**: `GameState.bootstrap_spatial` was never called in production, leaving the plan-03 spatial/movement stack dormant — so monster Opportunity Attacks never fired in the real game.
- Bootstraps the engine `SpatialIndex` from the loaded room layout on scenario load, places combatants, registers OA handlers, and surfaces provoked OAs in the `combat_move` wire response.

## Changes
- **client-2d/src/client_2d/session.py**
  - New `_bootstrap_spatial()`: builds an engine `Map` from the `RoomLayout`, installs the `SpatialIndex` (`replace=True` for clean reloads), places party + monsters, and re-registers OA handlers when combat is already live. Called at the end of `load_scenario`.
  - `_combat_move_via_engine` subscribes to `DAMAGE_DEALT` around `attempt_combat_step` (via `try/finally`, leak-free) and surfaces any `opportunity_attack`-tagged hit in the response + combat log — no more silent HP deltas.
- **dnd-engine/dnd_engine/core/game_state.py**
  - New public `register_opportunity_attacks()`. The scenario loader calls `_start_combat()` *before* spatial exists, so the in-combat registration walk is a no-op until placements exist; this is the public entry to wire handlers after a late bootstrap.

## Scope
Scoped to the **scenario path** (engine-compatible entity ids `pc_<name>` / `<monster_id>_<index>`). The normal-game `load_from_room` path uses incompatible `monster_{i}`/`party_{i}` ids that must be reconciled with the engine convention before spatial can be bootstrapped there — filed as #613.

## Testing
- [x] Red surface integration test now green: `test_opportunity_attack_surface_integration.py`
- [x] New engine tests pin the late-bootstrap ordering, incl. a negative control proving `register_opportunity_attacks()` is load-bearing
- [x] Adjusted #578 anchor tests to model the cursor desync the production way (sync both layers via `set_position`)
- [x] Full suites green: **client-2d 516 passed / 1 skipped**, **dnd-engine 3236 passed / 191 skipped**
- [x] Ruff lint clean (format drift flagged is pre-existing repo-wide, tracked in #396)

## Related Issues
Part of #539 (plan-10). Follow-up: #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)