### PR TITLE
Add #613: Bootstrap SpatialIndex in the normal-game room flow

### DIFF
--- a/client-2d/src/client_2d/entities/entity_manager.py
+++ b/client-2d/src/client_2d/entities/entity_manager.py
@@ -23,6 +23,7 @@ from client_2d.entities.entity import (
     MonsterEntity,
     PartyMemberEntity,
 )
+from dnd_engine.core.entity_ids import pc_entity_id
 
 if TYPE_CHECKING:
 
@@ -106,7 +107,11 @@ class EntityManager:
             # Strip trailing numbers for texture lookup
             base_type = monster_type.rstrip("0123456789").rstrip("_")
 
-            entity_id = f"monster_{i}"
+            # Engine spatial convention is ``<monster_id>_<index>`` (e.g.
+            # "giant_rat_0"), matching GameState._find_creature_by_id and the
+            # scenario loader so the bootstrapped SpatialIndex can place and
+            # address this monster.
+            entity_id = f"{base_type}_{i}"
             monster = MonsterEntity(
                 entity_id=entity_id,
                 grid_x=ex,
@@ -315,9 +320,23 @@ class EntityManager:
             if party and i < len(party.characters):
                 creature_ref = party.characters[i]
 
+            # Engine spatial convention addresses PCs as
+            # ``pc_<name_lower_underscored>`` (see
+            # GameState._find_creature_by_id). Deriving the id from the
+            # creature name keeps the visual layer in lockstep with the
+            # bootstrapped SpatialIndex so placement and OA registration
+            # resolve to a live Character. Fall back to the index-keyed id
+            # only when no creature is available (defensive; real play always
+            # has one).
+            entity_id = (
+                pc_entity_id(creature_ref.name)
+                if creature_ref is not None
+                else f"party_{i}"
+            )
+
             char_class = char_data["class"].lower()
             entity = PartyMemberEntity(
-                entity_id=f"party_{i}",
+                entity_id=entity_id,
                 grid_x=px,
                 grid_y=py,
                 entity_type=EntityType.PARTY_MEMBER,

--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -398,6 +398,14 @@ class GameSession:
         self.party_spread = True
         self._update_lighting()
 
+        # Activate the engine spatial/movement stack now that every combatant
+        # is placed: bootstrap the SpatialIndex from the room layout and wire
+        # Opportunity Attack handlers so combat movement provokes. This is the
+        # single combat-start seam for the normal flow — initialize(),
+        # _transition_room(), and the spawn_monster room-entry path all funnel
+        # through here. The scenario path bootstraps separately (#613).
+        self._bootstrap_spatial()
+
     def _bootstrap_spatial(self) -> None:
         """Install the engine ``SpatialIndex`` and place every combatant.
 

--- a/client-2d/tests/test_normal_flow_opportunity_attack_integration.py
+++ b/client-2d/tests/test_normal_flow_opportunity_attack_integration.py
@@ -1,0 +1,100 @@
+# ABOUTME: Integration test — the normal vault-party room-entry flow bootstraps
+# ABOUTME: the engine SpatialIndex and surfaces monster Opportunity Attacks (#613).
+
+"""The scenario load path already bootstraps spatial and surfaces Opportunity
+Attacks (see test_opportunity_attack_surface_integration.py). This test proves
+the *normal game* flow — vault party -> peaceful start room -> walk into a
+hostile room (``_transition_room``) -> combat + party spread — does the same,
+rather than leaving ``GameState.spatial`` dormant (``None``) so OAs never fire
+in real play.
+
+Driven through the genuine room-entry flow: ``initialize()`` lands in the
+peaceful ``cellar.stairs`` (no enemies), then a step ``north`` transitions into
+``cellar.storage`` (4 giant rats) which starts combat. This mirrors how
+monsters actually enter play — ``_transition_room`` moves first (populating
+``active_enemies``), then loads the room layout (creating monster entities),
+then spreads the party — unlike a combat start-room where the layout loads
+before enemies exist.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dnd_engine.core.entity_ids import pc_entity_id
+
+
+@pytest.fixture
+def combat_session():
+    """A normal-flow session that walked into the rat storage room."""
+    from client_2d.session import GameSession
+
+    s = GameSession(enable_mcp=False, dev_mode=True)
+    s.initialize(
+        dungeon_name="cellar",
+        campaign_id="poisoned_laboratory",
+        start_room="cellar.stairs",
+    )
+    if s.engine.in_combat:
+        pytest.skip("start room unexpectedly started combat")
+
+    # Walk north into cellar.storage — the real room-entry-into-combat path.
+    s._move_player("north")
+    if not s.engine.in_combat:
+        pytest.skip("transition into cellar.storage did not start combat")
+    return s
+
+
+def _force_player_turn(session, pc) -> None:
+    """Make the PC the current combatant with a full movement budget so
+    ``combat_move`` runs the engine step instead of bouncing on
+    'Not your turn'."""
+    tracker = session.engine.game_state.initiative_tracker
+    pc_index = next(i for i, entry in enumerate(tracker.combatants) if entry.creature is pc)
+    tracker.current_turn_index = pc_index
+    tracker.turn_states[pc].reset(speed=pc.speed)
+
+
+class TestNormalFlowSurfacesOpportunityAttack:
+    def test_initialize_bootstraps_spatial(self, combat_session) -> None:
+        """The normal room-entry flow must install the SpatialIndex; without
+        it the plan-03 movement stack and Opportunity Attacks stay dormant."""
+        game_state = combat_session.engine.game_state
+        assert game_state.spatial is not None, (
+            "normal-game initialize() must bootstrap spatial like the scenario "
+            "path; otherwise OAs never fire in real vault-party play"
+        )
+
+    def test_combat_move_out_of_reach_surfaces_oa_hit(self, combat_session) -> None:
+        session = combat_session
+        game_state = session.engine.game_state
+        assert game_state.spatial is not None, "normal flow must bootstrap spatial"
+
+        monsters = session.entity_manager.get_monsters()
+        if not monsters:
+            pytest.skip("no monster entities to provoke an Opportunity Attack")
+        monster = monsters[0]
+
+        pc = session.engine.party.characters[0]
+        # Force the monster's Opportunity Attack to connect deterministically:
+        # AC 1 means only a natural 1 misses, and we pin the dice seed.
+        pc.ac = 1
+        session.set_seed(7)
+
+        # Stand the PC and the monster adjacent (5 ft) so a single step north
+        # puts the PC 10 ft away — leaving the monster's reach and provoking.
+        session.set_position(pc_entity_id(pc.name), 5, 5)
+        session.set_position(monster.entity_id, 5, 6)
+        _force_player_turn(session, pc)
+
+        # PC steps north (5,5) -> (5,4): now 10 ft from the monster.
+        response = session.combat_move("north")
+
+        # The move itself succeeds...
+        assert "Moved north" in response
+        # ...and the provoked Opportunity Attack is surfaced to the player.
+        assert "opportunity attack" in response.lower(), (
+            "combat_move must surface the monster's Opportunity Attack, not "
+            f"drop it silently. Got:\n{response}"
+        )
+        assert monster.creature.name in response


### PR DESCRIPTION
## Summary
- Activates the plan-03 spatial/movement stack in **normal vault-party play**, not just scenarios. Before this, `GameState.spatial` stayed `None` outside scenarios, so monster Opportunity Attacks (and difficult-terrain cost / creature footprints) never fired in a real game.
- The keystone was an entity-id impedance mismatch: the visual layer used `party_{i}` / `monster_{i}`, while the engine spatial convention is `pc_<name>` / `<monster_id>_<index>`. `party_{i}` never resolved to a `Character`, so OA registration silently skipped every PC.

## Changes
- **`entities/entity_manager.py`**: reconcile visual entity ids with the engine convention — PCs → `pc_entity_id(name)`, monsters → `f"{base_type}_{i}"` (e.g. `giant_rat_0`). Matches the scenario loader so the bootstrapped `SpatialIndex` can place and address every combatant. Targeting is unaffected (uses the `enemy_index` attribute, not id-parsing).
- **`session.py`**: call the existing `_bootstrap_spatial()` from `_spread_party_for_combat()` — the single combat-start seam every normal flow funnels through (`initialize`, `_transition_room`, spawn room-entry). It builds the engine `Map` from the room layout, places combatants, and re-registers OA handlers now that the index is populated. The scenario path bootstraps separately, so there's no double-bootstrap.
- **`tests/test_normal_flow_opportunity_attack_integration.py`** (new): TDD integration test driven through the genuine room-entry flow — `initialize()` into peaceful `cellar.stairs`, then walk `north` into the rat room — asserting spatial bootstraps and the provoked OA surfaces in `combat_move`. Mirrors `test_opportunity_attack_surface_integration.py` but through normal play instead of a scenario.

## Testing
- [x] New test: red (spatial `None`) → green, TDD
- [x] Full client-2d suite: **516 passed**, no regressions from the id reconciliation
- [x] Ruff lint clean; new test file ruff-format clean

## Notes
- MCP wire output now shows `pc_abe` / `giant_rat_0` in normal play — already the case in scenarios; this just makes normal play consistent.
- Surfaced a **pre-existing** ~10% flake in `TestSessionEnemyTurnSingleAdvance` (4/40 on untouched `main`, engine double-advance under unseeded RNG) — filed as #615, unrelated to this change.

## Related Issues
Closes #613. Part of #539 (plan-10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)