### PR TITLE
Fix #617/#598: Thread damage_type through all attack paths so physical resistances apply

### DIFF
--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -5669,6 +5669,7 @@ class GameState:
 
         # Get damage from item
         damage_dice = used_item_data.get("damage", "1d4")
+        damage_type = used_item_data.get("damage_type")
 
         # Resolve the attack
         attacker_sees_defender, defender_sees_attacker = self.attack_visibility(user, target)
@@ -5680,6 +5681,7 @@ class GameState:
             apply_damage=True,
             event_bus=self.event_bus,
             game_state=self,
+            damage_type=damage_type,
             attacker_sees_defender=attacker_sees_defender,
             defender_sees_attacker=defender_sees_attacker,
         )

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -1250,6 +1250,7 @@ class GameState:
             damage_dice=action["damage"],
             apply_damage=True,
             game_state=self,
+            damage_type=action.get("damage_type"),
             attacker_sees_defender=attacker_sees_defender,
             defender_sees_attacker=defender_sees_attacker,
         )

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -3163,6 +3163,7 @@ class GameState:
             damage_dice = weapon_data.get("damage", "1d8")
             damage_dice = format_dice_with_modifier(damage_dice, damage_bonus)
             weapon_name = weapon_data.get("name", equipped_weapon)
+            damage_type = weapon_data.get("damage_type")
 
             # Check if weapon requires ammunition
             weapon_properties = weapon_data.get("properties", [])
@@ -3194,6 +3195,8 @@ class GameState:
             damage_bonus = attacker.melee_damage_bonus
             damage_dice = format_dice_with_modifier("1d8", damage_bonus)
             weapon_name = "unarmed strike"
+            # SRD § Unarmed Strike: deals bludgeoning damage.
+            damage_type = "bludgeoning"
 
         # Resolve attack via combat engine
         attacker_sees_defender, defender_sees_attacker = self.attack_visibility(attacker, target)
@@ -3205,6 +3208,7 @@ class GameState:
             disadvantage=disadvantage,
             apply_damage=True,
             game_state=self,
+            damage_type=damage_type,
             attacker_sees_defender=attacker_sees_defender,
             defender_sees_attacker=defender_sees_attacker,
         )

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -5164,6 +5164,7 @@ class GameState:
             event_bus=self.event_bus,
             action=action,
             game_state=self,
+            damage_type=action.get("damage_type"),
             attacker_sees_defender=attacker_sees_defender,
             defender_sees_attacker=defender_sees_attacker,
         )

--- a/dnd-engine/dnd_engine/systems/item_effects.py
+++ b/dnd-engine/dnd_engine/systems/item_effects.py
@@ -189,7 +189,11 @@ def _apply_damage_effect(
         ItemEffectResult with damage details
     """
     damage_dice = item_info.get("damage", "1d4")
-    damage_type = item_info.get("damage_type", "fire")
+    # A missing damage_type means conceptually untyped damage. The pipeline
+    # treats None as "no per-type scaling" (no Immunity/Resistance can apply),
+    # so do not fabricate a type — defaulting to a real type (e.g. "fire")
+    # would wrongly let fire Immunity/Resistance/Vulnerability touch it.
+    damage_type = item_info.get("damage_type")
     item_name = item_info.get("name", "Unknown Damage Item")
 
     # Roll damage dice
@@ -245,14 +249,17 @@ def _apply_damage_effect(
         else:
             message = f"{target.name} takes no damage"
     else:
+        # Untyped damage (damage_type is None) names no type; typed damage
+        # includes the type word ("7 fire damage" vs "7 damage").
+        type_word = f"{damage_type} " if damage_type else ""
         # Annotate the modifier the pipeline applied, if any.
         if has_resistance:
-            message = f"{target.name} takes {actual_damage} {damage_type} damage ({damage_roll_str}, halved by resistance)"
+            message = f"{target.name} takes {actual_damage} {type_word}damage ({damage_roll_str}, halved by resistance)"
         elif is_vulnerable:
-            message = f"{target.name} takes {actual_damage} {damage_type} damage ({damage_roll_str}, doubled by vulnerability)"
+            message = f"{target.name} takes {actual_damage} {type_word}damage ({damage_roll_str}, doubled by vulnerability)"
         else:
             message = (
-                f"{target.name} takes {actual_damage} {damage_type} damage ({damage_roll_str})"
+                f"{target.name} takes {actual_damage} {type_word}damage ({damage_roll_str})"
             )
 
         if not target.is_alive:

--- a/dnd-engine/dnd_engine/systems/item_effects.py
+++ b/dnd-engine/dnd_engine/systems/item_effects.py
@@ -258,9 +258,7 @@ def _apply_damage_effect(
         elif is_vulnerable:
             message = f"{target.name} takes {actual_damage} {type_word}damage ({damage_roll_str}, doubled by vulnerability)"
         else:
-            message = (
-                f"{target.name} takes {actual_damage} {type_word}damage ({damage_roll_str})"
-            )
+            message = f"{target.name} takes {actual_damage} {type_word}damage ({damage_roll_str})"
 
         if not target.is_alive:
             message += " - KILLED!"

--- a/dnd-engine/tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py
@@ -107,6 +107,35 @@ class TestPlayerWeaponDamageType:
         assert resisted.damage == normal.damage // 2
 
 
+class TestUntypedItemDamage:
+    """#598: a damage item with no declared damage_type is untyped, not fire."""
+
+    def test_untyped_item_is_not_treated_as_fire(self):
+        """A fire-immune creature takes FULL damage from an untyped item."""
+        from dnd_engine.systems.item_effects import _apply_damage_effect
+
+        target = Creature(name="Fire Elemental", max_hp=50, ac=10, abilities=Abilities(10, 10, 10, 10, 10, 10))
+        target.damage_immunities = ["fire"]
+        item_info = {"name": "Mystery Vial", "damage": "2d6"}  # no damage_type
+
+        result = _apply_damage_effect(item_info, target, DiceRoller(seed=1), event_bus=None)
+
+        assert result.amount > 0, "untyped damage must not be zeroed by fire immunity"
+        assert target.current_hp < 50
+
+    def test_untyped_item_message_has_no_type_word(self):
+        """The result message for untyped damage omits a damage-type word."""
+        from dnd_engine.systems.item_effects import _apply_damage_effect
+
+        target = Creature(name="Dummy", max_hp=50, ac=10, abilities=Abilities(10, 10, 10, 10, 10, 10))
+        item_info = {"name": "Mystery Vial", "damage": "2d6"}  # no damage_type
+
+        result = _apply_damage_effect(item_info, target, DiceRoller(seed=1), event_bus=None)
+
+        assert "None" not in result.message
+        assert "fire" not in result.message.lower()
+
+
 def _floor_map(size: int = 7) -> Map:
     tiles = {(x, y): TileType.FLOOR for x in range(size) for y in range(size)}
     return Map(width=size, height=size, tiles=tiles)

--- a/dnd-engine/tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py
@@ -1,0 +1,104 @@
+# ABOUTME: Verifies weapon/enemy/OA/item attacks thread damage_type into the resistance pipeline (#617, #598).
+# ABOUTME: Guards that physical-damage Resistance/Vulnerability/Immunity actually apply in normal combat, not just spells.
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.systems.inventory import EquipmentSlot
+from dnd_engine.utils.events import EventBus
+
+
+@pytest.fixture
+def data_loader():
+    return DataLoader()
+
+
+@pytest.fixture
+def fighter_abilities():
+    # STR 16 (+3): longsword (slashing) and unarmed strike both swing off STR.
+    return Abilities(strength=16, dexterity=14, constitution=14, intelligence=10, wisdom=12, charisma=8)
+
+
+def _make_fighter(abilities, *, with_weapon=True):
+    fighter = Character(
+        name="Conan",
+        character_class=CharacterClass.FIGHTER,
+        level=3,
+        abilities=abilities,
+        max_hp=28,
+        ac=16,
+    )
+    if with_weapon:
+        fighter.inventory.add_item("longsword", 1)
+        fighter.inventory.equip_item("longsword", EquipmentSlot.WEAPON)
+    return fighter
+
+
+def _run_player_attack(data_loader, fighter, *, seed, resistances=None, vulnerabilities=None):
+    """Run one player weapon attack with a fixed seed against an always-hit dummy.
+
+    Returns the underlying AttackResult. Same seed -> identical attack and
+    damage rolls, so the only variable across runs is the target's per-type
+    modifiers.
+    """
+    dice_roller = DiceRoller(seed=seed)
+    party = Party([fighter])
+    gs = GameState(
+        party=party,
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=data_loader,
+        dice_roller=dice_roller,
+    )
+    target = Creature(
+        name="Dummy",
+        max_hp=999,  # never dies, so damage is never HP-capped
+        ac=1,  # guarantees the attack lands
+        abilities=Abilities(8, 14, 10, 10, 8, 8),
+    )
+    if resistances:
+        target.damage_resistances = resistances
+    if vulnerabilities:
+        target.damage_vulnerabilities = vulnerabilities
+    gs.active_enemies = [target]
+    return gs.execute_player_attack(fighter, target).attack_result
+
+
+class TestPlayerWeaponDamageType:
+    def test_slashing_resistance_halves_longsword_damage(self, data_loader, fighter_abilities):
+        """A target resistant to slashing takes half from a longsword (slashing)."""
+        fighter = _make_fighter(fighter_abilities)
+        normal = _run_player_attack(data_loader, fighter, seed=7)
+        resisted = _run_player_attack(data_loader, fighter, seed=7, resistances=["slashing"])
+
+        assert normal.hit and resisted.hit
+        assert normal.damage > 1, "need a non-trivial hit to observe halving"
+        assert resisted.damage == normal.damage // 2
+
+    def test_slashing_vulnerability_doubles_longsword_damage(self, data_loader, fighter_abilities):
+        """A target vulnerable to slashing takes double from a longsword."""
+        fighter = _make_fighter(fighter_abilities)
+        normal = _run_player_attack(data_loader, fighter, seed=7)
+        vulnerable = _run_player_attack(
+            data_loader, fighter, seed=7, vulnerabilities=["slashing"]
+        )
+
+        assert normal.hit and vulnerable.hit
+        assert vulnerable.damage == normal.damage * 2
+
+    def test_unarmed_strike_deals_bludgeoning(self, data_loader, fighter_abilities):
+        """An unarmed strike is bludgeoning, so bludgeoning resistance halves it."""
+        fighter = _make_fighter(fighter_abilities, with_weapon=False)
+        normal = _run_player_attack(data_loader, fighter, seed=7)
+        resisted = _run_player_attack(
+            data_loader, fighter, seed=7, resistances=["bludgeoning"]
+        )
+
+        assert normal.hit and resisted.hit
+        assert normal.damage > 1
+        assert resisted.damage == normal.damage // 2

--- a/dnd-engine/tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py
@@ -207,3 +207,54 @@ class TestEnemyTurnDamageType:
         assert normal.hit and resisted.hit
         assert normal.damage > 1
         assert resisted.damage == normal.damage // 2
+
+
+def _run_combat_attack_item(data_loader, item_id, *, seed, resistances=None):
+    """Throw a combat attack item (acid_vial → acid) at an always-hit dummy.
+    Returns the AttackResult. Same seed -> identical attack and damage rolls.
+    """
+    dice_roller = DiceRoller(seed=seed)
+    fighter = Character(
+        name="Conan",
+        character_class=CharacterClass.FIGHTER,
+        level=3,
+        abilities=Abilities(16, 14, 14, 10, 10, 10),
+        max_hp=28,
+        ac=16,
+    )
+    fighter.inventory.add_item(item_id, "consumables", 1)
+    target = Creature(name="Dummy", max_hp=999, ac=1, abilities=Abilities(8, 14, 10, 10, 8, 8))
+    if resistances:
+        target.damage_resistances = resistances
+    gs = GameState(
+        party=Party([fighter]),
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=data_loader,
+        dice_roller=dice_roller,
+    )
+    gs.active_enemies = [target]
+    gs.in_combat = True
+    gs.initiative_tracker = InitiativeTracker(dice_roller=dice_roller)
+    gs.initiative_tracker.combatants = [
+        InitiativeEntry(creature=fighter, initiative_roll=20),
+        InitiativeEntry(creature=target, initiative_roll=10),
+    ]
+    gs.initiative_tracker.turn_states[fighter] = TurnState()
+    gs.initiative_tracker.turn_states[target] = TurnState()
+    gs.initiative_tracker.round_number = 1
+    gs.initiative_tracker.current_turn_index = 0  # fighter's turn
+    return gs.use_combat_attack_item(fighter, item_id, target).attack_result
+
+
+class TestCombatAttackItemDamageType:
+    def test_thrown_item_respects_target_resistance(self, data_loader):
+        """An acid vial (acid) is halved against an acid-resistant target."""
+        normal = _run_combat_attack_item(data_loader, "acid_vial", seed=3)
+        resisted = _run_combat_attack_item(
+            data_loader, "acid_vial", seed=3, resistances=["acid"]
+        )
+
+        assert normal.hit and resisted.hit
+        assert normal.damage > 1
+        assert resisted.damage == normal.damage // 2

--- a/dnd-engine/tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py
@@ -9,6 +9,8 @@ from dnd_engine.core.dice import DiceRoller
 from dnd_engine.core.game_state import GameState
 from dnd_engine.core.party import Party
 from dnd_engine.rules.loader import DataLoader
+from dnd_engine.systems.action_economy import TurnState
+from dnd_engine.systems.initiative import InitiativeEntry, InitiativeTracker
 from dnd_engine.systems.inventory import EquipmentSlot
 from dnd_engine.utils.events import EventBus
 
@@ -98,6 +100,53 @@ class TestPlayerWeaponDamageType:
         resisted = _run_player_attack(
             data_loader, fighter, seed=7, resistances=["bludgeoning"]
         )
+
+        assert normal.hit and resisted.hit
+        assert normal.damage > 1
+        assert resisted.damage == normal.damage // 2
+
+
+def _run_enemy_turn(data_loader, *, seed, resistances=None):
+    """Run one goblin enemy turn (Scimitar → slashing) against a PC that always
+    gets hit. Returns the AttackResult. Same seed -> identical rolls.
+    """
+    dice_roller = DiceRoller(seed=seed)
+    fighter = Character(
+        name="Conan",
+        character_class=CharacterClass.FIGHTER,
+        level=3,
+        abilities=Abilities(16, 12, 14, 10, 10, 10),
+        max_hp=999,  # survives, so damage is never HP-capped
+        ac=1,  # guarantees the goblin lands its attack
+    )
+    if resistances:
+        fighter.damage_resistances = resistances
+    goblin = Creature(name="Goblin", max_hp=7, ac=13, abilities=Abilities(8, 14, 10, 10, 8, 8))
+    gs = GameState(
+        party=Party([fighter]),
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=data_loader,
+        dice_roller=dice_roller,
+    )
+    gs.active_enemies = [goblin]
+    gs.in_combat = True
+    gs.initiative_tracker = InitiativeTracker(dice_roller=dice_roller)
+    gs.initiative_tracker.combatants = [
+        InitiativeEntry(creature=goblin, initiative_roll=20),
+        InitiativeEntry(creature=fighter, initiative_roll=10),
+    ]
+    gs.initiative_tracker.turn_states[goblin] = TurnState()
+    gs.initiative_tracker.turn_states[fighter] = TurnState()
+    gs.initiative_tracker.round_number = 1
+    return gs.process_enemy_turn().attack_result
+
+
+class TestEnemyTurnDamageType:
+    def test_enemy_attack_respects_target_resistance(self, data_loader):
+        """A PC resistant to slashing takes half from the goblin's Scimitar."""
+        normal = _run_enemy_turn(data_loader, seed=7)
+        resisted = _run_enemy_turn(data_loader, seed=7, resistances=["slashing"])
 
         assert normal.hit and resisted.hit
         assert normal.damage > 1

--- a/dnd-engine/tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py
@@ -7,6 +7,7 @@ from dnd_engine.core.character import Character, CharacterClass
 from dnd_engine.core.creature import Abilities, Creature
 from dnd_engine.core.dice import DiceRoller
 from dnd_engine.core.game_state import GameState
+from dnd_engine.core.map import Map, TileType
 from dnd_engine.core.party import Party
 from dnd_engine.rules.loader import DataLoader
 from dnd_engine.systems.action_economy import TurnState
@@ -104,6 +105,61 @@ class TestPlayerWeaponDamageType:
         assert normal.hit and resisted.hit
         assert normal.damage > 1
         assert resisted.damage == normal.damage // 2
+
+
+def _floor_map(size: int = 7) -> Map:
+    tiles = {(x, y): TileType.FLOOR for x in range(size) for y in range(size)}
+    return Map(width=size, height=size, tiles=tiles)
+
+
+def _run_opportunity_attack(data_loader, *, resistances=None):
+    """Provoke a goblin Opportunity Attack (Scimitar → slashing) against an
+    AC-1 fighter and return the HP the fighter lost. Fixed seed -> identical
+    OA roll, so resistance is the only variable.
+    """
+    fighter = Character(
+        name="Fighter 1",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=Abilities(15, 14, 13, 10, 12, 8),
+        max_hp=30,
+        ac=1,  # the OA reliably connects
+    )
+    if resistances:
+        fighter.damage_resistances = resistances
+    gs = GameState(
+        party=Party(characters=[fighter]),
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=data_loader,
+        dice_roller=DiceRoller(seed=1),
+    )
+    gs.bootstrap_spatial(_floor_map())
+    goblin = gs.data_loader.create_monster("goblin")
+    gs.active_enemies.append(goblin)
+    pc_id = f"pc_{fighter.name.lower().replace(' ', '_')}"
+    gs.set_position("goblin_0", 3, 3)
+    gs.set_position(pc_id, 3, 4)  # 5 ft south — within the goblin's reach
+    gs._start_combat()
+    fighter_idx = next(
+        i for i, e in enumerate(gs.initiative_tracker.combatants) if e.creature is fighter
+    )
+    gs.initiative_tracker.current_turn_index = fighter_idx
+    gs.initiative_tracker.turn_states[fighter].reset(speed=fighter.speed)
+
+    hp_before = fighter.current_hp
+    gs.attempt_combat_step(pc_id, 0, 1)  # step out of reach -> provokes the OA
+    return hp_before - fighter.current_hp
+
+
+class TestOpportunityAttackDamageType:
+    def test_opportunity_attack_respects_target_resistance(self, data_loader):
+        """A connecting goblin OA (slashing) is halved against a slashing-resistant PC."""
+        normal_loss = _run_opportunity_attack(data_loader)
+        resisted_loss = _run_opportunity_attack(data_loader, resistances=["slashing"])
+
+        assert normal_loss > 1, "OA must connect for a non-trivial amount"
+        assert resisted_loss == normal_loss // 2
 
 
 def _run_enemy_turn(data_loader, *, seed, resistances=None):

--- a/dnd-engine/tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py
@@ -24,7 +24,9 @@ def data_loader():
 @pytest.fixture
 def fighter_abilities():
     # STR 16 (+3): longsword (slashing) and unarmed strike both swing off STR.
-    return Abilities(strength=16, dexterity=14, constitution=14, intelligence=10, wisdom=12, charisma=8)
+    return Abilities(
+        strength=16, dexterity=14, constitution=14, intelligence=10, wisdom=12, charisma=8
+    )
 
 
 def _make_fighter(abilities, *, with_weapon=True):
@@ -87,9 +89,7 @@ class TestPlayerWeaponDamageType:
         """A target vulnerable to slashing takes double from a longsword."""
         fighter = _make_fighter(fighter_abilities)
         normal = _run_player_attack(data_loader, fighter, seed=7)
-        vulnerable = _run_player_attack(
-            data_loader, fighter, seed=7, vulnerabilities=["slashing"]
-        )
+        vulnerable = _run_player_attack(data_loader, fighter, seed=7, vulnerabilities=["slashing"])
 
         assert normal.hit and vulnerable.hit
         assert vulnerable.damage == normal.damage * 2
@@ -98,9 +98,7 @@ class TestPlayerWeaponDamageType:
         """An unarmed strike is bludgeoning, so bludgeoning resistance halves it."""
         fighter = _make_fighter(fighter_abilities, with_weapon=False)
         normal = _run_player_attack(data_loader, fighter, seed=7)
-        resisted = _run_player_attack(
-            data_loader, fighter, seed=7, resistances=["bludgeoning"]
-        )
+        resisted = _run_player_attack(data_loader, fighter, seed=7, resistances=["bludgeoning"])
 
         assert normal.hit and resisted.hit
         assert normal.damage > 1
@@ -114,7 +112,9 @@ class TestUntypedItemDamage:
         """A fire-immune creature takes FULL damage from an untyped item."""
         from dnd_engine.systems.item_effects import _apply_damage_effect
 
-        target = Creature(name="Fire Elemental", max_hp=50, ac=10, abilities=Abilities(10, 10, 10, 10, 10, 10))
+        target = Creature(
+            name="Fire Elemental", max_hp=50, ac=10, abilities=Abilities(10, 10, 10, 10, 10, 10)
+        )
         target.damage_immunities = ["fire"]
         item_info = {"name": "Mystery Vial", "damage": "2d6"}  # no damage_type
 
@@ -127,7 +127,9 @@ class TestUntypedItemDamage:
         """The result message for untyped damage omits a damage-type word."""
         from dnd_engine.systems.item_effects import _apply_damage_effect
 
-        target = Creature(name="Dummy", max_hp=50, ac=10, abilities=Abilities(10, 10, 10, 10, 10, 10))
+        target = Creature(
+            name="Dummy", max_hp=50, ac=10, abilities=Abilities(10, 10, 10, 10, 10, 10)
+        )
         item_info = {"name": "Mystery Vial", "damage": "2d6"}  # no damage_type
 
         result = _apply_damage_effect(item_info, target, DiceRoller(seed=1), event_bus=None)
@@ -280,9 +282,7 @@ class TestCombatAttackItemDamageType:
     def test_thrown_item_respects_target_resistance(self, data_loader):
         """An acid vial (acid) is halved against an acid-resistant target."""
         normal = _run_combat_attack_item(data_loader, "acid_vial", seed=3)
-        resisted = _run_combat_attack_item(
-            data_loader, "acid_vial", seed=3, resistances=["acid"]
-        )
+        resisted = _run_combat_attack_item(data_loader, "acid_vial", seed=3, resistances=["acid"])
 
         assert normal.hit and resisted.hit
         assert normal.damage > 1


### PR DESCRIPTION
## Summary

The plan-02 damage-type pipeline was **dormant for weapon/melee/ranged attacks in real combat**: `CombatEngine.resolve_attack` only scales by per-type Resistance/Vulnerability/Immunity when `damage_type` is supplied, but every physical-attack call site omitted it — even though the data each loaded already carried the type. Net effect: monster resistance to nonmagical B/P/S, a skeleton's bludgeoning vulnerability, etc. were all silently inert; only spell damage was typed.

Found during the 2026-05-31 "verify activation" dormancy audit (same class of latent gap as the SpatialIndex bootstrap, #613).

## Changes

- **`core/game_state.py`** — thread the already-loaded `damage_type` into the four `resolve_attack` call sites:
  - Player weapon attack (equipped weapon's type; `bludgeoning` for unarmed strikes)
  - Enemy-turn attack (`action["damage_type"]`)
  - Opportunity attack (`action["damage_type"]`)
  - Thrown combat-attack item (`used_item_data["damage_type"]`)
- **`systems/item_effects.py`** — **#598**: stop defaulting a missing item `damage_type` to `"fire"` (use `None` = untyped, which the pipeline already handles); omit the type word from the result message when untyped.

No signature or pipeline changes — `resolve_attack` already accepted `damage_type` and sources `environment` itself. `None` remains a documented no-op.

## Testing
- [x] 8 new tests in `tests/srd/playing_the_game/test_weapon_attack_damage_type_threading.py` (player weapon/unarmed, slashing vulnerability, enemy turn, opportunity attack, thrown item, 2× untyped-item #598) — each RED before its fix.
- [x] Full engine suite: **3244 passed, 0 failed**.
- [x] `ruff check`/`format` clean on changed lines (pre-existing whole-file drift #396 left untouched).

## Related Issues
Fixes #617
Fixes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)