### PR TITLE
Add #625: Shared MenuList widget for launch-screen navigation

### DIFF
--- a/client-2d/src/client_2d/ui/menu_list.py
+++ b/client-2d/src/client_2d/ui/menu_list.py
@@ -1,0 +1,240 @@
+# ABOUTME: Shared keyboard-driven vertical menu widget for the launch screen.
+# ABOUTME: Arcade-free navigation/selection logic core plus a draw() render method.
+
+"""A reusable vertical menu list for the 2D client's launch-screen views.
+
+The widget follows the same pattern as ``input_handler``: an arcade-free logic
+core (navigation, selection, key handling) with its own integer ``KEY_*``
+constants matching ``arcade.key.*`` values, so it can be unit-tested without
+importing arcade. The ``draw`` method is the only part that touches arcade and is
+verified manually.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any
+
+from client_2d.core.constants import FONT_SIZE_BODY, UIColors
+
+# Key code constants (matching arcade.key.* values for arcade-free testing).
+KEY_UP = 65362
+KEY_DOWN = 65364
+KEY_W = 119
+KEY_S = 115
+KEY_ENTER = 65293
+KEY_SPACE = 32
+KEY_ESCAPE = 65307
+KEY_1 = 49
+KEY_2 = 50
+KEY_3 = 51
+KEY_4 = 52
+KEY_5 = 53
+KEY_6 = 54
+KEY_7 = 55
+KEY_8 = 56
+KEY_9 = 57
+
+_UP_KEYS = {KEY_UP, KEY_W}
+_DOWN_KEYS = {KEY_DOWN, KEY_S}
+_CONFIRM_KEYS = {KEY_ENTER, KEY_SPACE}
+
+
+class MenuEvent(Enum):
+    """The outcome of a key press handled by a :class:`MenuList`."""
+
+    MOVED = auto()
+    CONFIRM = auto()
+    BACK = auto()
+
+
+@dataclass
+class MenuItem:
+    """A single selectable row in a menu.
+
+    Attributes:
+        label: Display text for the row.
+        value: Identifier the consuming view acts on (e.g. "new_game").
+        enabled: Whether the row can be highlighted/selected.
+        annotation: Optional secondary text (e.g. "Recommended" or a grayed
+            reason), rendered dim beside the label.
+    """
+
+    label: str
+    value: Any
+    enabled: bool = True
+    annotation: str | None = None
+
+
+@dataclass
+class MenuList:
+    """A keyboard-navigable vertical menu.
+
+    Navigation moves between enabled rows only (wrapping at the ends) and is a
+    safe no-op when the list is empty or has no enabled rows. ``handle_key``
+    translates key codes into :class:`MenuEvent` values; the consuming view reads
+    :attr:`selected_item` on ``CONFIRM``.
+
+    Attributes:
+        items: The rows, in display order.
+        selected_index: Index of the highlighted row, or -1 when none is
+            selectable. Initialized to the first enabled row.
+        number_keys_confirm: When True (default), number keys 1-9 select the
+            matching row and confirm it (accelerator). When False, they only move
+            the highlight.
+    """
+
+    items: list[MenuItem] = field(default_factory=list)
+    selected_index: int = 0
+    number_keys_confirm: bool = True
+
+    def __post_init__(self) -> None:
+        """Highlight the first enabled row, or -1 if none is enabled."""
+        self.selected_index = self._first_enabled_index()
+
+    # -- state -----------------------------------------------------------------
+
+    @property
+    def is_empty(self) -> bool:
+        """True when the menu has no rows at all."""
+        return len(self.items) == 0
+
+    @property
+    def has_enabled(self) -> bool:
+        """True when at least one row can be selected."""
+        return any(item.enabled for item in self.items)
+
+    @property
+    def selected_item(self) -> MenuItem | None:
+        """The currently highlighted row, or None when nothing is selectable."""
+        if 0 <= self.selected_index < len(self.items):
+            return self.items[self.selected_index]
+        return None
+
+    # -- navigation ------------------------------------------------------------
+
+    def move_up(self) -> bool:
+        """Move the highlight to the previous enabled row, wrapping."""
+        return self._step(-1)
+
+    def move_down(self) -> bool:
+        """Move the highlight to the next enabled row, wrapping."""
+        return self._step(1)
+
+    def select_index(self, index: int) -> bool:
+        """Highlight ``index`` if it is a valid, enabled row.
+
+        Returns True if the highlight was set, False otherwise.
+        """
+        if 0 <= index < len(self.items) and self.items[index].enabled:
+            self.selected_index = index
+            return True
+        return False
+
+    # -- input -----------------------------------------------------------------
+
+    def handle_key(self, key: int) -> MenuEvent | None:
+        """Translate a key code into a :class:`MenuEvent`.
+
+        Returns None for keys that produce no action (including navigation on an
+        empty / fully-disabled list and out-of-range or disabled number keys).
+        """
+        if key == KEY_ESCAPE:
+            return MenuEvent.BACK
+
+        if key in _UP_KEYS:
+            return MenuEvent.MOVED if self.move_up() else None
+
+        if key in _DOWN_KEYS:
+            return MenuEvent.MOVED if self.move_down() else None
+
+        if key in _CONFIRM_KEYS:
+            return MenuEvent.CONFIRM if self.selected_item is not None else None
+
+        if KEY_1 <= key <= KEY_9:
+            index = key - KEY_1
+            if self.select_index(index):
+                return MenuEvent.CONFIRM if self.number_keys_confirm else MenuEvent.MOVED
+            return None
+
+        return None
+
+    # -- rendering (manual QA; not unit-tested) --------------------------------
+
+    def draw(
+        self,
+        center_x: float,
+        top_y: float,
+        *,
+        row_height: float = 36.0,
+        font_size: int = FONT_SIZE_BODY,
+        empty_message: str = "Nothing here yet.",
+    ) -> None:
+        """Render the menu with arcade.
+
+        The active row shows a caret and the torchlight-gold highlight colour
+        (never colour alone); disabled rows use the dimmed/disabled text colour;
+        annotations render dim beside the label. When the menu is empty, the
+        empty-state message is drawn instead. Verified manually.
+        """
+        import arcade
+
+        if self.is_empty:
+            arcade.draw_text(
+                empty_message,
+                center_x,
+                top_y,
+                UIColors.TEXT_DIM,
+                font_size=font_size,
+                anchor_x="center",
+            )
+            return
+
+        for row, item in enumerate(self.items):
+            y = top_y - row * row_height
+            is_active = row == self.selected_index
+            if not item.enabled:
+                color = UIColors.TEXT_DISABLED
+            elif is_active:
+                color = UIColors.HIGHLIGHT
+            else:
+                color = UIColors.TEXT
+
+            text = f"▸ {item.label}" if is_active else f"  {item.label}"
+            arcade.draw_text(
+                text,
+                center_x,
+                y,
+                color,
+                font_size=font_size,
+                anchor_x="center",
+            )
+            if item.annotation:
+                arcade.draw_text(
+                    item.annotation,
+                    center_x,
+                    y - font_size - 2,
+                    UIColors.TEXT_DIM,
+                    font_size=max(font_size - 2, 8),
+                    anchor_x="center",
+                )
+
+    # -- internals -------------------------------------------------------------
+
+    def _first_enabled_index(self) -> int:
+        for index, item in enumerate(self.items):
+            if item.enabled:
+                return index
+        return -1
+
+    def _step(self, direction: int) -> bool:
+        """Advance the highlight to the next enabled row in ``direction``."""
+        if not self.has_enabled:
+            return False
+        count = len(self.items)
+        start = self.selected_index if self.selected_index >= 0 else 0
+        for offset in range(1, count + 1):
+            candidate = (start + direction * offset) % count
+            if self.items[candidate].enabled:
+                self.selected_index = candidate
+                return True
+        return False

--- a/client-2d/tests/test_menu_list.py
+++ b/client-2d/tests/test_menu_list.py
@@ -1,0 +1,158 @@
+# ABOUTME: Unit tests for the shared MenuList widget logic core.
+# ABOUTME: Tests navigation, selection, disabled-row skipping, and key handling.
+
+"""Tests for the MenuList widget (arcade-free logic core)."""
+
+from client_2d.ui.menu_list import (
+    KEY_2,
+    KEY_3,
+    KEY_9,
+    KEY_DOWN,
+    KEY_ENTER,
+    KEY_ESCAPE,
+    KEY_S,
+    KEY_SPACE,
+    KEY_UP,
+    KEY_W,
+    MenuEvent,
+    MenuItem,
+    MenuList,
+)
+
+
+def make_menu(*specs, number_keys_confirm=True):
+    """Build a MenuList from (label, value[, enabled]) tuples."""
+    items = []
+    for spec in specs:
+        if len(spec) == 3:
+            label, value, enabled = spec
+        else:
+            label, value = spec
+            enabled = True
+        items.append(MenuItem(label=label, value=value, enabled=enabled))
+    return MenuList(items=items, number_keys_confirm=number_keys_confirm)
+
+
+class TestDefaultHighlight:
+    """Initial selection behaviour."""
+
+    def test_first_enabled_is_highlighted(self):
+        menu = make_menu(("New", "new"), ("Load", "load"))
+        assert menu.selected_index == 0
+        assert menu.selected_item.value == "new"
+
+    def test_skips_leading_disabled(self):
+        menu = make_menu(("Continue", "cont", False), ("New", "new", True))
+        assert menu.selected_index == 1
+        assert menu.selected_item.value == "new"
+
+    def test_all_disabled_has_no_selection(self):
+        menu = make_menu(("a", "a", False), ("b", "b", False))
+        assert menu.has_enabled is False
+        assert menu.selected_item is None
+
+
+class TestEmpty:
+    """Empty-list safety (three-state support)."""
+
+    def test_empty_is_empty(self):
+        menu = MenuList(items=[])
+        assert menu.is_empty is True
+        assert menu.selected_item is None
+
+    def test_empty_navigation_is_noop(self):
+        menu = MenuList(items=[])
+        assert menu.handle_key(KEY_DOWN) is None
+        assert menu.handle_key(KEY_ENTER) is None
+
+    def test_empty_escape_still_backs_out(self):
+        menu = MenuList(items=[])
+        assert menu.handle_key(KEY_ESCAPE) is MenuEvent.BACK
+
+
+class TestNavigation:
+    """Highlight movement, wrapping, and disabled skipping."""
+
+    def test_move_down_advances(self):
+        menu = make_menu(("a", "a"), ("b", "b"), ("c", "c"))
+        assert menu.handle_key(KEY_DOWN) is MenuEvent.MOVED
+        assert menu.selected_index == 1
+
+    def test_move_down_wraps_to_first(self):
+        menu = make_menu(("a", "a"), ("b", "b"))
+        menu.handle_key(KEY_DOWN)  # -> 1
+        menu.handle_key(KEY_DOWN)  # wrap -> 0
+        assert menu.selected_index == 0
+
+    def test_move_up_wraps_to_last(self):
+        menu = make_menu(("a", "a"), ("b", "b"), ("c", "c"))
+        assert menu.handle_key(KEY_UP) is MenuEvent.MOVED
+        assert menu.selected_index == 2
+
+    def test_navigation_skips_disabled(self):
+        menu = make_menu(("a", "a", True), ("b", "b", False), ("c", "c", True))
+        menu.handle_key(KEY_DOWN)  # skip disabled b -> c
+        assert menu.selected_index == 2
+
+    def test_w_and_s_mirror_arrows(self):
+        menu = make_menu(("a", "a"), ("b", "b"), ("c", "c"))
+        assert menu.handle_key(KEY_S) is MenuEvent.MOVED
+        assert menu.selected_index == 1
+        assert menu.handle_key(KEY_W) is MenuEvent.MOVED
+        assert menu.selected_index == 0
+
+
+class TestConfirm:
+    """Enter / Space confirm the current row."""
+
+    def test_enter_confirms_current(self):
+        menu = make_menu(("New", "new"), ("Load", "load"))
+        menu.handle_key(KEY_DOWN)
+        assert menu.handle_key(KEY_ENTER) is MenuEvent.CONFIRM
+        assert menu.selected_item.value == "load"
+
+    def test_space_confirms(self):
+        menu = make_menu(("New", "new"))
+        assert menu.handle_key(KEY_SPACE) is MenuEvent.CONFIRM
+
+
+class TestBack:
+    """Escape backs out."""
+
+    def test_escape_backs_out(self):
+        menu = make_menu(("New", "new"))
+        assert menu.handle_key(KEY_ESCAPE) is MenuEvent.BACK
+
+
+class TestNumberKeys:
+    """Number-key accelerators."""
+
+    def test_number_selects_and_confirms_by_default(self):
+        menu = make_menu(("a", "a"), ("b", "b"), ("c", "c"))
+        result = menu.handle_key(KEY_2)
+        assert menu.selected_index == 1
+        assert result is MenuEvent.CONFIRM
+
+    def test_number_moves_only_when_confirm_disabled(self):
+        menu = make_menu(("a", "a"), ("b", "b"), ("c", "c"), number_keys_confirm=False)
+        result = menu.handle_key(KEY_3)
+        assert menu.selected_index == 2
+        assert result is MenuEvent.MOVED
+
+    def test_number_out_of_range_is_noop(self):
+        menu = make_menu(("a", "a"), ("b", "b"))
+        assert menu.handle_key(KEY_9) is None
+        assert menu.selected_index == 0
+
+    def test_number_on_disabled_row_is_noop(self):
+        menu = make_menu(("a", "a", True), ("b", "b", False))
+        assert menu.handle_key(KEY_2) is None
+        assert menu.selected_index == 0
+
+
+class TestUnknownKey:
+    """Unmapped keys are ignored."""
+
+    def test_unknown_key_returns_none(self):
+        menu = make_menu(("a", "a"))
+        assert menu.handle_key(999999) is None


### PR DESCRIPTION
## Summary
First piece of the Phase-0 launch screen (epic #620). Adds a reusable keyboard-driven vertical menu widget that the launch views (#626–#630) will compose, instead of each reimplementing navigation.

## Changes
- **client-2d/src/client_2d/ui/menu_list.py** (new): `MenuList` + `MenuItem` + `MenuEvent`. Arcade-free logic core — navigation between enabled rows with wrapping, disabled-row skipping, number-key accelerators (configurable confirm-vs-move), three-state (empty/populated) safety. `draw()` renders with arcade (caret + torchlight-gold highlight, never colour alone) and is manual-QA UI. Mirrors the `input_handler` pattern (local `KEY_*` constants) so the logic tests need no arcade import.
- **client-2d/tests/test_menu_list.py** (new): 19 unit tests covering default highlight, disabled skipping, wrapping, confirm/back, number accelerators, and empty-list safety.

## Testing
- [x] 19 unit tests pass (`uv run pytest tests/test_menu_list.py`)
- [x] ruff lint + format clean
- [x] `draw()` (UI) deferred to manual visual QA when #626 consumes it

## Related Issues
Part of #620. Closes #625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)