### PR TITLE
Add #624: Extract GameView(arcade.View) from GameWindow

### DIFF
--- a/client-2d/src/client_2d/game.py
+++ b/client-2d/src/client_2d/game.py
@@ -114,34 +114,33 @@ def get_attack_range(weapon_data: dict | None) -> tuple[int, int]:
     return (5, 5)
 
 
-class GameWindow(arcade.Window):
-    """Main game window with real engine integration."""
+class GameView(arcade.View):
+    """Gameplay view: renders the dungeon and routes player input.
+
+    Hosted by :class:`GameWindow` via ``window.show_view``. Owns the
+    rendering + input surface and a :class:`GameSession` (the non-graphical
+    authority). Keeping gameplay in a View lets the host window swap between
+    this view and the launch-screen menu views (#626-#630).
+    """
 
     def __init__(
         self,
-        width: int = 1280,
-        height: int = 900,
-        fullscreen: bool = False,
         enable_mcp: bool = False,
         mcp_port: int = 8765,
         dev_mode: bool = False,
     ):
-        """Initialize the game window.
+        """Initialize the gameplay view.
 
         Args:
-            width: Window width in pixels.
-            height: Window height in pixels.
-            fullscreen: Whether to run in fullscreen mode.
             enable_mcp: Whether to start embedded MCP server.
             mcp_port: Port for MCP HTTP server.
             dev_mode: Whether to register --dev spawn/setup MCP tools.
         """
-        super().__init__(width, height, WINDOW_TITLE, fullscreen=fullscreen)
-        arcade.set_background_color(UIColors.PANEL_BG_DARK)
+        super().__init__()
 
         # Session owns the non-graphical state: engine adapter, entity
         # manager, MCP plumbing, room layout, combat state machine.
-        # GameWindow accesses these via property delegators below.
+        # GameView accesses these via property delegators below.
         self.session = GameSession(
             enable_mcp=enable_mcp,
             mcp_port=mcp_port,
@@ -172,12 +171,25 @@ class GameWindow(arcade.Window):
         # Boot the session: load party, room, optionally start MCP server.
         self.session.initialize()
         if enable_mcp:
-            # Pass self so the bridge can resolve back to this window for
+            # Pass the host window so the bridge can resolve back to it for
             # code paths that still consult its window reference.
-            self.session.initialize_mcp_server(window=self)
+            self.session.initialize_mcp_server(window=self.window)
+
+    # ========== Window geometry ==========
+    # A View has no surface of its own; the host Window owns width/height.
+    # Expose them so the rendering / input code keeps using self.width and
+    # self.height unchanged.
+
+    @property
+    def width(self) -> int:
+        return self.window.width
+
+    @property
+    def height(self) -> int:
+        return self.window.height
 
     # ========== Property delegators to GameSession ==========
-    # GameWindow holds a GameSession; these proxies let the existing
+    # GameView holds a GameSession; these proxies let the existing
     # drawing / input code read session-owned state through the
     # familiar self.X names without per-call updates.
 
@@ -262,7 +274,7 @@ class GameWindow(arcade.Window):
         return self.session.enemy_turn_timer
 
     # ========== Method delegators to GameSession ==========
-    # Thin wrappers for the methods that GameWindow's input handlers,
+    # Thin wrappers for the methods that GameView's input handlers,
     # drawing code, and mouse handlers still call directly. The real
     # logic lives in GameSession; these keep the call sites unchanged.
 
@@ -337,7 +349,7 @@ class GameWindow(arcade.Window):
 
         try:
             # Capture the framebuffer
-            image = arcade.get_image(0, 0, *self.get_size())
+            image = arcade.get_image(0, 0, *self.window.get_size())
             image.save(str(filepath))
 
             # Show feedback
@@ -415,9 +427,7 @@ class GameWindow(arcade.Window):
             if texture:
                 self.decoration_textures[deco_id] = texture
 
-    def _try_load_texture(
-        self, path: Path | None, name: str
-    ) -> arcade.Texture | None:
+    def _try_load_texture(self, path: Path | None, name: str) -> arcade.Texture | None:
         """Try to load a texture, logging success or fallback."""
         if path and path.exists():
             print(f"Loaded {name}: {path.name}")
@@ -494,9 +504,7 @@ class GameWindow(arcade.Window):
         else:
             combatant_x, combatant_y = combatant_pos
 
-        distance_ft = distance_in_feet(
-            combatant_x, combatant_y, entity.grid_x, entity.grid_y
-        )
+        distance_ft = distance_in_feet(combatant_x, combatant_y, entity.grid_x, entity.grid_y)
 
         # Get attacker's equipped weapon range
         current = self.engine.get_current_combatant()
@@ -738,9 +746,7 @@ class GameWindow(arcade.Window):
                     fallback_color = (50, 180, 50)  # Green for items
                 else:
                     fallback_color = (180, 140, 50)  # Gold for decorations
-                tile_rect = arcade.LBWH(
-                    screen_x + 4, screen_y + 4, tile_size - 8, tile_size - 8
-                )
+                tile_rect = arcade.LBWH(screen_x + 4, screen_y + 4, tile_size - 8, tile_size - 8)
                 arcade.draw_rect_filled(tile_rect, fallback_color)
 
             # Draw targeting overlays for monsters during combat
@@ -756,8 +762,7 @@ class GameWindow(arcade.Window):
                 if entity == self.selected_target:
                     # Calculate pulse value (0.0 to 1.0)
                     pulse = (
-                        math.sin(self.pulse_timer * 2 * math.pi / PULSE_CYCLE_DURATION)
-                        + 1
+                        math.sin(self.pulse_timer * 2 * math.pi / PULSE_CYCLE_DURATION) + 1
                     ) / 2
 
                     # Pulsing glow
@@ -783,8 +788,7 @@ class GameWindow(arcade.Window):
                 # Draw hover highlight
                 elif entity == self.hovered_entity:
                     arcade.draw_circle_outline(
-                        center_x, center_y, tile_size // 2 + 2,
-                        arcade.color.WHITE, 2
+                        center_x, center_y, tile_size // 2 + 2, arcade.color.WHITE, 2
                     )
 
         # Draw party/player
@@ -792,7 +796,9 @@ class GameWindow(arcade.Window):
             # Combat formation - draw each party member from EntityManager
             for party_entity in self.entity_manager.get_party_members():
                 char_screen_x = offset_x + party_entity.grid_x * tile_size
-                char_screen_y = offset_y + (self.room_layout.height - 1 - party_entity.grid_y) * tile_size
+                char_screen_y = (
+                    offset_y + (self.room_layout.height - 1 - party_entity.grid_y) * tile_size
+                )
 
                 char_class = party_entity.character_class
                 is_current_turn = party_entity.is_current_turn
@@ -803,8 +809,7 @@ class GameWindow(arcade.Window):
                     center_x = char_screen_x + tile_size // 2
                     center_y = char_screen_y + tile_size // 2
                     arcade.draw_circle_outline(
-                        center_x, center_y, tile_size // 2 + 2,
-                        UIColors.TEXT_HIGHLIGHT, 3
+                        center_x, center_y, tile_size // 2 + 2, UIColors.TEXT_HIGHLIGHT, 3
                     )
 
                 # Draw character texture or fallback
@@ -817,8 +822,12 @@ class GameWindow(arcade.Window):
                     arcade.draw_circle_filled(center_x, center_y, tile_size // 3, color)
                     # Show first letter of class
                     arcade.draw_text(
-                        char_class[0].upper(), center_x, center_y - 5,
-                        (255, 255, 255), 14, anchor_x="center"
+                        char_class[0].upper(),
+                        center_x,
+                        center_y - 5,
+                        (255, 255, 255),
+                        14,
+                        anchor_x="center",
                     )
 
                 # Draw torch glow on current turn character
@@ -838,7 +847,9 @@ class GameWindow(arcade.Window):
                 center_x = player_screen_x + tile_size // 2
                 center_y = player_screen_y + tile_size // 2
                 arcade.draw_circle_filled(center_x, center_y, tile_size // 3, UIColors.HP_FULL)
-                arcade.draw_text("@", center_x, center_y - 5, (255, 255, 255), 14, anchor_x="center")
+                arcade.draw_text(
+                    "@", center_x, center_y - 5, (255, 255, 255), 14, anchor_x="center"
+                )
 
             # Draw light indicator on player (torch glow)
             center_x = player_screen_x + tile_size // 2
@@ -853,7 +864,11 @@ class GameWindow(arcade.Window):
                 if exit_pos:
                     exit_x, exit_y = exit_pos
                     exit_screen_x = offset_x + exit_x * tile_size + tile_size // 2
-                    exit_screen_y = offset_y + (self.room_layout.height - 1 - exit_y) * tile_size + tile_size // 2
+                    exit_screen_y = (
+                        offset_y
+                        + (self.room_layout.height - 1 - exit_y) * tile_size
+                        + tile_size // 2
+                    )
                     arcade.draw_text(
                         direction[0].upper(),  # N, S, E, W
                         exit_screen_x,
@@ -1194,7 +1209,7 @@ class GameWindow(arcade.Window):
                 self._add_combat_log("Target deselected")
                 return
             # Otherwise: close window
-            self.close()
+            self.window.close()
             return
 
         # Ctrl-P to take screenshot
@@ -1271,9 +1286,7 @@ class GameWindow(arcade.Window):
             combatant_x, combatant_y = combatant_pos
 
         # Calculate distance in feet (each square = 5 ft)
-        distance_ft = distance_in_feet(
-            combatant_x, combatant_y, target.grid_x, target.grid_y
-        )
+        distance_ft = distance_in_feet(combatant_x, combatant_y, target.grid_x, target.grid_y)
 
         # Get attacker's equipped weapon and its range
         current = self.engine.get_current_combatant()
@@ -1302,9 +1315,7 @@ class GameWindow(arcade.Window):
         # Long-range attacks roll with disadvantage per D&D 5E.
         in_long_range = distance_ft > normal_range
         if in_long_range:
-            self._add_combat_log(
-                f"{weapon_name} at {distance_ft} ft (long range - disadvantage)"
-            )
+            self._add_combat_log(f"{weapon_name} at {distance_ft} ft (long range - disadvantage)")
 
         # Set selected enemy and execute attack
         self.selected_enemy = target.enemy_index
@@ -1330,9 +1341,7 @@ class GameWindow(arcade.Window):
         # Sort by distance (nearest first)
         sorted_monsters = sorted(
             monsters,
-            key=lambda m: chebyshev_distance(
-                combatant_x, combatant_y, m.grid_x, m.grid_y
-            ),
+            key=lambda m: chebyshev_distance(combatant_x, combatant_y, m.grid_x, m.grid_y),
         )
 
         # Find current index in sorted list
@@ -1432,6 +1441,46 @@ class GameWindow(arcade.Window):
 
         # Always show feedback in combat log
         self._add_combat_log(feedback)
+
+
+class GameWindow(arcade.Window):
+    """Thin host window that shows gameplay / menu views.
+
+    Owns the OS window + GL context only; gameplay lives in
+    :class:`GameView`. Constructing the window immediately shows a GameView
+    so the windowed entry point behaves exactly as before, while leaving
+    room to swap in the launch-screen views (#626-#630) via show_view.
+    """
+
+    def __init__(
+        self,
+        width: int = 1280,
+        height: int = 900,
+        fullscreen: bool = False,
+        enable_mcp: bool = False,
+        mcp_port: int = 8765,
+        dev_mode: bool = False,
+    ):
+        """Create the host window and show the gameplay view.
+
+        Args:
+            width: Window width in pixels.
+            height: Window height in pixels.
+            fullscreen: Whether to run in fullscreen mode.
+            enable_mcp: Whether to start embedded MCP server.
+            mcp_port: Port for MCP HTTP server.
+            dev_mode: Whether to register --dev spawn/setup MCP tools.
+        """
+        super().__init__(width, height, WINDOW_TITLE, fullscreen=fullscreen)
+        arcade.set_background_color(UIColors.PANEL_BG_DARK)
+
+        self.show_view(
+            GameView(
+                enable_mcp=enable_mcp,
+                mcp_port=mcp_port,
+                dev_mode=dev_mode,
+            )
+        )
 
 
 def run_2d_client(

--- a/client-2d/tests/test_game_view.py
+++ b/client-2d/tests/test_game_view.py
@@ -1,0 +1,72 @@
+# ABOUTME: Unit tests for the GameView / GameWindow host split (issue #624).
+# ABOUTME: Verifies the View subclass, window-geometry delegation, and host wiring.
+
+"""Tests for the GameView(arcade.View) extraction from GameWindow.
+
+These cover the new seams created by the refactor without needing a real
+GL window: the class hierarchy, the width/height delegation to the host
+window, and that the thin GameWindow host shows a GameView on construction.
+The gameplay rendering/input itself is verified by manual windowed
+playtest and by ``test_targeting.py`` (the moved pure methods).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import arcade
+from client_2d.game import GameView, GameWindow
+
+
+class TestClassHierarchy:
+    """The split must produce an arcade View hosted by an arcade Window."""
+
+    def test_gameview_is_arcade_view(self):
+        """GameView must be an arcade.View so the window can show_view it."""
+        assert issubclass(GameView, arcade.View)
+
+    def test_gamewindow_is_arcade_window(self):
+        """GameWindow remains the arcade.Window host."""
+        assert issubclass(GameWindow, arcade.Window)
+
+
+class TestWindowGeometryDelegation:
+    """GameView has no surface of its own; width/height come from the window."""
+
+    def test_width_delegates_to_window(self):
+        """self.width reads through to the host window's width."""
+        view = MagicMock()
+        view.window.width = 1280
+        assert GameView.width.fget(view) == 1280
+
+    def test_height_delegates_to_window(self):
+        """self.height reads through to the host window's height."""
+        view = MagicMock()
+        view.window.height = 900
+        assert GameView.height.fget(view) == 900
+
+
+class TestHostShowsGameView:
+    """The thin host constructs and shows a GameView on startup."""
+
+    def test_window_shows_gameview_on_init(self):
+        """GameWindow.__init__ must show exactly one GameView with the
+        MCP/dev arguments forwarded, without rendering anything itself."""
+        with (
+            patch("arcade.Window.__init__", return_value=None),
+            patch("client_2d.game.arcade.set_background_color"),
+            patch("client_2d.game.GameView") as mock_view_cls,
+            patch.object(GameWindow, "show_view") as mock_show_view,
+        ):
+            GameWindow(
+                width=800,
+                height=600,
+                enable_mcp=True,
+                mcp_port=9000,
+                dev_mode=True,
+            )
+
+        mock_view_cls.assert_called_once_with(
+            enable_mcp=True,
+            mcp_port=9000,
+            dev_mode=True,
+        )
+        mock_show_view.assert_called_once_with(mock_view_cls.return_value)

--- a/client-2d/tests/test_targeting.py
+++ b/client-2d/tests/test_targeting.py
@@ -15,7 +15,7 @@ class MockRoomLayout:
 
 
 def create_mock_game_window():
-    """Create a properly mocked GameWindow instance for testing."""
+    """Create a properly mocked GameView instance for testing."""
     # Mock arcade.Window to avoid GUI initialization
     mock_window = MagicMock()
     mock_window.room_layout = None
@@ -35,23 +35,23 @@ class TestScreenToGridConversion:
 
     def test_get_map_render_params_returns_none_without_layout(self):
         """Should return None when room_layout is not set."""
-        from client_2d.game import GameWindow
+        from client_2d.game import GameView
 
         mock_window = create_mock_game_window()
         mock_window.room_layout = None
 
         # Bind the method to our mock
-        result = GameWindow._get_map_render_params(mock_window)
+        result = GameView._get_map_render_params(mock_window)
         assert result is None
 
     def test_get_map_render_params_calculates_offsets(self):
         """Should calculate proper offsets for centering map."""
-        from client_2d.game import GameWindow
+        from client_2d.game import GameView
 
         mock_window = create_mock_game_window()
         mock_window.room_layout = MockRoomLayout(width=20, height=15)
 
-        result = GameWindow._get_map_render_params(mock_window)
+        result = GameView._get_map_render_params(mock_window)
         assert result is not None
         offset_x, offset_y, tile_size = result
 
@@ -63,41 +63,41 @@ class TestScreenToGridConversion:
 
     def test_screen_to_grid_returns_none_outside_bounds(self):
         """Should return None for coordinates outside the map."""
-        from client_2d.game import GameWindow
+        from client_2d.game import GameView
 
         mock_window = create_mock_game_window()
         mock_window.room_layout = MockRoomLayout(width=20, height=15)
 
         # Bind real method to mock for _get_map_render_params
-        mock_window._get_map_render_params = lambda: GameWindow._get_map_render_params(mock_window)
+        mock_window._get_map_render_params = lambda: GameView._get_map_render_params(mock_window)
 
         # Test far outside bounds
-        result = GameWindow._screen_to_grid(mock_window, -100, -100)
+        result = GameView._screen_to_grid(mock_window, -100, -100)
         assert result is None
 
-        result = GameWindow._screen_to_grid(mock_window, 2000, 2000)
+        result = GameView._screen_to_grid(mock_window, 2000, 2000)
         assert result is None
 
     def test_screen_to_grid_returns_valid_coords(self):
         """Should return valid grid coordinates for points on the map."""
-        from client_2d.game import GameWindow
+        from client_2d.game import GameView
 
         mock_window = create_mock_game_window()
         mock_window.room_layout = MockRoomLayout(width=20, height=15)
 
         # Get render params to understand the coordinate space
-        params = GameWindow._get_map_render_params(mock_window)
+        params = GameView._get_map_render_params(mock_window)
         assert params is not None
         offset_x, offset_y, tile_size = params
 
         # Bind real method to mock
-        mock_window._get_map_render_params = lambda: GameWindow._get_map_render_params(mock_window)
+        mock_window._get_map_render_params = lambda: GameView._get_map_render_params(mock_window)
 
         # Test center of map
         center_screen_x = int(offset_x + 10 * tile_size + tile_size // 2)
         center_screen_y = int(offset_y + (15 - 1 - 7) * tile_size + tile_size // 2)
 
-        result = GameWindow._screen_to_grid(mock_window, center_screen_x, center_screen_y)
+        result = GameView._screen_to_grid(mock_window, center_screen_x, center_screen_y)
         assert result is not None
         grid_x, grid_y = result
 
@@ -111,7 +111,7 @@ class TestTargetCycling:
 
     def test_cycle_target_sorts_by_distance(self):
         """Should cycle through targets nearest first."""
-        from client_2d.game import GameWindow
+        from client_2d.game import GameView
 
         mock_window = create_mock_game_window()
         mock_window.player_x = 5
@@ -153,27 +153,27 @@ class TestTargetCycling:
         mock_window.entity_manager.get_current_turn_position.return_value = (5, 5)
 
         # First cycle should select closest
-        GameWindow._cycle_target(mock_window)
+        GameView._cycle_target(mock_window)
         assert mock_window.selected_target == monster_close
         assert mock_window.selected_enemy == 0
 
         # Second cycle should select next closest (mid)
-        GameWindow._cycle_target(mock_window)
+        GameView._cycle_target(mock_window)
         assert mock_window.selected_target == monster_mid
         assert mock_window.selected_enemy == 2
 
         # Third cycle should select farthest
-        GameWindow._cycle_target(mock_window)
+        GameView._cycle_target(mock_window)
         assert mock_window.selected_target == monster_far
         assert mock_window.selected_enemy == 1
 
         # Fourth cycle should wrap back to closest
-        GameWindow._cycle_target(mock_window)
+        GameView._cycle_target(mock_window)
         assert mock_window.selected_target == monster_close
 
     def test_cycle_target_reverse(self):
         """Should cycle in reverse order with reverse=True."""
-        from client_2d.game import GameWindow
+        from client_2d.game import GameView
 
         mock_window = create_mock_game_window()
         mock_window.player_x = 5
@@ -199,16 +199,16 @@ class TestTargetCycling:
         mock_window.entity_manager.get_current_turn_position.return_value = (5, 5)
 
         # Forward: should select monster1 (closest)
-        GameWindow._cycle_target(mock_window, reverse=False)
+        GameView._cycle_target(mock_window, reverse=False)
         assert mock_window.selected_target == monster1
 
         # Reverse: should go to last (monster2)
-        GameWindow._cycle_target(mock_window, reverse=True)
+        GameView._cycle_target(mock_window, reverse=True)
         assert mock_window.selected_target == monster2
 
     def test_cycle_target_no_monsters(self):
         """Should log message when no targets available."""
-        from client_2d.game import GameWindow
+        from client_2d.game import GameView
 
         mock_window = create_mock_game_window()
         mock_window.combat_log = []
@@ -219,7 +219,7 @@ class TestTargetCycling:
         # Bind _add_combat_log to actually append
         mock_window._add_combat_log = lambda msg: mock_window.combat_log.append(msg)
 
-        GameWindow._cycle_target(mock_window)
+        GameView._cycle_target(mock_window)
 
         assert "No targets available" in mock_window.combat_log
 
@@ -344,9 +344,7 @@ class TestMCPAttackEntityID:
         mock_window.engine = MagicMock()
         mock_window.engine.in_combat = True
         mock_window.engine.is_player_turn.return_value = True
-        mock_window.engine.get_current_turn_state.return_value = MagicMock(
-            movement_remaining=30
-        )
+        mock_window.engine.get_current_turn_state.return_value = MagicMock(movement_remaining=30)
 
         # Mock current combatant as a player with a melee weapon
         mock_creature = MagicMock()
@@ -422,34 +420,32 @@ class TestMultiplyTints:
 
     def test_white_preserves_color(self):
         """Multiplying by white (255,255,255) should preserve the original color."""
-        from client_2d.game import GameWindow
+        from client_2d.game import GameView
 
         mock_window = create_mock_game_window()
 
-        result = GameWindow._multiply_tints(mock_window, (255, 255, 255), (128, 64, 32))
+        result = GameView._multiply_tints(mock_window, (255, 255, 255), (128, 64, 32))
         assert result == (128, 64, 32)
 
     def test_black_produces_black(self):
         """Multiplying by black (0,0,0) should produce black."""
-        from client_2d.game import GameWindow
+        from client_2d.game import GameView
 
         mock_window = create_mock_game_window()
 
-        result = GameWindow._multiply_tints(mock_window, (128, 128, 128), (0, 0, 0))
+        result = GameView._multiply_tints(mock_window, (128, 128, 128), (0, 0, 0))
         assert result == (0, 0, 0)
 
     def test_fog_plus_green_tint(self):
         """Fog tint combined with green targeting should produce muted green."""
         from client_2d.core.constants import TargetingColors
-        from client_2d.game import GameWindow
+        from client_2d.game import GameView
 
         mock_window = create_mock_game_window()
 
         # Dim fog (160, 160, 180) + green targeting (128, 255, 128)
         fog_tint = (160, 160, 180)
-        result = GameWindow._multiply_tints(
-            mock_window, fog_tint, TargetingColors.IN_RANGE_TINT
-        )
+        result = GameView._multiply_tints(mock_window, fog_tint, TargetingColors.IN_RANGE_TINT)
 
         # Verify green channel is boosted relative to red
         assert result[1] > result[0], "Green should be brighter than red"
@@ -457,27 +453,25 @@ class TestMultiplyTints:
     def test_fog_plus_red_tint(self):
         """Fog tint combined with red targeting should produce muted red."""
         from client_2d.core.constants import TargetingColors
-        from client_2d.game import GameWindow
+        from client_2d.game import GameView
 
         mock_window = create_mock_game_window()
 
         # Dim fog (160, 160, 180) + red targeting (255, 128, 128)
         fog_tint = (160, 160, 180)
-        result = GameWindow._multiply_tints(
-            mock_window, fog_tint, TargetingColors.OUT_OF_RANGE_TINT
-        )
+        result = GameView._multiply_tints(mock_window, fog_tint, TargetingColors.OUT_OF_RANGE_TINT)
 
         # Verify red channel is boosted relative to green
         assert result[0] > result[1], "Red should be brighter than green"
 
     def test_multiplication_math(self):
         """Verify the multiplication formula: (a * b) // 255."""
-        from client_2d.game import GameWindow
+        from client_2d.game import GameView
 
         mock_window = create_mock_game_window()
 
         # 128 * 128 / 255 = 64.25 -> 64
-        result = GameWindow._multiply_tints(mock_window, (128, 128, 128), (128, 128, 128))
+        result = GameView._multiply_tints(mock_window, (128, 128, 128), (128, 128, 128))
         assert result == (64, 64, 64)
 
 
@@ -530,8 +524,6 @@ class TestPulseAnimation:
 
         # At t=PULSE_CYCLE_DURATION, we should be back to the starting value
         pulse_start = (math.sin(0 * 2 * math.pi / PULSE_CYCLE_DURATION) + 1) / 2
-        pulse_end = (
-            math.sin(PULSE_CYCLE_DURATION * 2 * math.pi / PULSE_CYCLE_DURATION) + 1
-        ) / 2
+        pulse_end = (math.sin(PULSE_CYCLE_DURATION * 2 * math.pi / PULSE_CYCLE_DURATION) + 1) / 2
 
         assert abs(pulse_start - pulse_end) < 0.001, "Pulse should complete cycle"


### PR DESCRIPTION
## Summary
- Extract all gameplay rendering/input into a new `GameView(arcade.View)`; reduce `GameWindow` to a thin host that shows it via `show_view()`.
- This is the keystone for the Phase-0 launch screen (#620): it gives the window a place to host the Title / Campaign Select / Load Game views (#626–#630).
- Additive, behavior-preserving move — windowed gameplay is unchanged; headless/MCP paths are untouched.

## Changes
- **client-2d/src/client_2d/game.py**:
  - New `GameView(arcade.View)` owns the rendering, input, mouse targeting, and the `GameSession`.
  - `GameWindow(arcade.Window)` is now a thin host: creates the window and `show_view(GameView(...))`.
  - A `View` has no surface of its own, so `width`/`height` are properties reading from `self.window`; screenshot uses `self.window.get_size()`; ESC uses `self.window.close()`. Everything else moved unchanged.
  - `session.py`, `headless.py`, `main.py`, `mcp_bridge.py` unchanged — MCP routes through `session.tick()` as before.
- **client-2d/tests/test_targeting.py**: moved pure methods now live on `GameView` (regression net for the move).
- **client-2d/tests/test_game_view.py** (new): covers the View/Window split, `width`/`height` delegation, and that the host shows a `GameView` on construction.

## Testing
- [x] `uv run pytest tests/` — 542 passed, 1 skipped
- [x] ruff check + format clean
- [ ] Manual windowed run (`uv run dnd-2d`) — exploration/combat/targeting/screenshot/ESC
- [ ] Headless/MCP smoke (`uv run dnd-2d --headless --dev --mcp`)

## Related Issues
Fixes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)