### PR TITLE
Fix #637: Room transition requires stepping onto the exit/door tile

### DIFF
--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -551,7 +551,16 @@ class GameSession:
         This is the seam for SRD door mechanics: stuck/locked/barred
         doors (Strength checks, thieves' tools, the Knock spell) and
         similar door states gate passage here rather than in movement.
+        Blocked attempts log the reason to the combat log.
         """
+        game_state = self.engine.game_state
+        if game_state is None:
+            return False
+
+        exit_data = game_state.get_current_room().get("exits", {}).get(direction)
+        if isinstance(exit_data, dict) and exit_data.get("locked", False):
+            self._add_combat_log("The door is locked.")
+            return False
         return True
 
     # ========== Exploration movement ==========

--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -616,6 +616,7 @@ class GameSession:
 
         if result:
             self._load_room_layout()
+            self._place_player_at_entry(direction)
 
             room = game_state.get_current_room()
             room_name = room.get("name", "Unknown")
@@ -637,6 +638,47 @@ class GameSession:
                 if not self.engine.is_player_turn():
                     self.processing_enemy_turn = True
                     self.enemy_turn_timer = ENEMY_TURN_DELAY
+
+    def _place_player_at_entry(self, travel_direction: str) -> None:
+        """Position the player just inside the door they entered through.
+
+        Traveling north means entering through the destination room's
+        south door, so the player lands one tile inward from it. Rooms
+        without a matching door keep the layout's default spawn point
+        (already set by ``_load_room_layout``).
+        """
+        if not self.room_layout:
+            return
+
+        opposite = {
+            "north": "south",
+            "south": "north",
+            "east": "west",
+            "west": "east",
+        }.get(travel_direction)
+        if opposite is None:
+            return
+
+        door = self.room_layout.spawn_points.exits.get(opposite)
+        if door is None:
+            return
+
+        # Inward = away from the entry door, i.e. the travel direction.
+        dx, dy = {
+            "north": (0, -1),
+            "south": (0, 1),
+            "east": (1, 0),
+            "west": (-1, 0),
+        }[travel_direction]
+        inward_x, inward_y = door[0] + dx, door[1] + dy
+
+        if (
+            0 <= inward_x < self.room_layout.width
+            and 0 <= inward_y < self.room_layout.height
+            and not self.room_layout.is_blocking(inward_x, inward_y)
+        ):
+            self.player_x, self.player_y = inward_x, inward_y
+            self._update_lighting()
 
     # ========== Combat state machine ==========
 

--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -605,6 +605,15 @@ class GameSession:
                 self.player_x = new_x
                 self.player_y = new_y
                 self._update_lighting()
+                return
+
+        # Fallback for layouts that define an exit but no door tile for
+        # it: a failed step (wall or room edge) in the exit's direction
+        # still uses the exit, keeping such rooms traversable.
+        if direction in exits and exit_tiles.get(direction) is None:
+            if self._can_pass_exit(direction):
+                self._add_combat_log(f"Moving {direction}...")
+                self._transition_room(direction)
 
     def _transition_room(self, direction: str) -> None:
         """Transition to a new room via an exit."""

--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -545,18 +545,26 @@ class GameSession:
                 exits[direction] = dest
         return exits
 
+    def _can_pass_exit(self, direction: str) -> bool:
+        """Check whether the exit in ``direction`` can be passed through.
+
+        This is the seam for SRD door mechanics: stuck/locked/barred
+        doors (Strength checks, thieves' tools, the Knock spell) and
+        similar door states gate passage here rather than in movement.
+        """
+        return True
+
     # ========== Exploration movement ==========
 
     def _move_player(self, direction: str) -> None:
-        """Attempt to move the player in a direction during exploration."""
+        """Attempt to move the player in a direction during exploration.
+
+        Direction keys always perform a one-tile grid move; a room
+        transition only fires when the step lands on an exit/door tile
+        (and the door is passable — see ``_can_pass_exit``).
+        """
         if self.engine.in_combat:
             self._add_combat_log("Can't move during combat!")
-            return
-
-        exits = self._get_available_exits()
-        if direction in exits:
-            self._add_combat_log(f"Moving {direction}...")
-            self._transition_room(direction)
             return
 
         dx, dy = {
@@ -568,9 +576,22 @@ class GameSession:
         new_x = self.player_x + dx
         new_y = self.player_y + dy
 
-        if self.room_layout and (
-            0 <= new_x < self.room_layout.width and 0 <= new_y < self.room_layout.height
-        ):
+        if not self.room_layout:
+            return
+
+        # Stepping onto an exit/door tile uses that door, regardless of
+        # approach direction. Hidden exits never appear in the available
+        # set, so their door tiles behave as plain walkable floor.
+        exits = self._get_available_exits()
+        exit_tiles = self.room_layout.spawn_points.exits
+        for exit_dir in exits:
+            if exit_tiles.get(exit_dir) == (new_x, new_y):
+                if self._can_pass_exit(exit_dir):
+                    self._add_combat_log(f"Moving {exit_dir}...")
+                    self._transition_room(exit_dir)
+                return
+
+        if 0 <= new_x < self.room_layout.width and 0 <= new_y < self.room_layout.height:
             if not self.room_layout.is_blocking(new_x, new_y):
                 self.player_x = new_x
                 self.player_y = new_y

--- a/client-2d/tests/test_room_transition.py
+++ b/client-2d/tests/test_room_transition.py
@@ -1,0 +1,134 @@
+# ABOUTME: Tests for exploration movement and room transitions (#637) -
+# ABOUTME: direction keys grid-move; transitions fire only on exit/door tiles.
+
+"""Tests for room-transition behavior in GameSession.
+
+Issue #637: pressing a direction key that matched any room exit used to
+teleport the player to the destination room from anywhere. These tests
+pin the fixed behavior: direction keys always perform one-tile grid
+moves, and a room transition only fires when the player steps onto the
+exit/door tile itself (gated by the SRD door-state passability seam).
+
+The engine GameState is faked with a tiny two-room graph; room layouts
+come from the loader's procedural fallback (generate_basic_room), which
+places real DOOR tiles at the wall border for each exit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class FakeGameState:
+    """Minimal stand-in for the engine GameState room graph."""
+
+    def __init__(self, rooms: dict[str, dict] | None = None) -> None:
+        self.dungeon_name = "fake_dungeon"
+        self.campaign_id = "fake_campaign"
+        self.current_room_id = "entry"
+        self.in_combat = False
+        self.active_enemies: list = []
+        self.rooms = rooms or {
+            "entry": {"name": "Entry Hall", "exits": {"north": "north_room"}},
+            "north_room": {"name": "North Room", "exits": {"south": "entry"}},
+        }
+
+    def get_current_room(self) -> dict:
+        return self.rooms[self.current_room_id]
+
+    def move(self, direction: str) -> bool:
+        dest = self.get_current_room().get("exits", {}).get(direction)
+        if isinstance(dest, dict):
+            if dest.get("hidden", False):
+                return False
+            dest = dest.get("destination")
+        if dest:
+            self.current_room_id = dest
+            return True
+        return False
+
+
+def make_session(rooms: dict[str, dict] | None = None):
+    """GameSession wired to a FakeGameState two-room graph.
+
+    The layout loader's file lookup is redirected to the fake room
+    dicts so load_room_with_fallback generates layouts (with DOOR
+    tiles) from the fake exits instead of reading dungeon JSON.
+    """
+    from client_2d.session import GameSession
+
+    s = GameSession(enable_mcp=False, dev_mode=True)
+    fake = FakeGameState(rooms)
+    s.engine._game_state = fake
+    s.layout_loader.get_room_data = (  # type: ignore[method-assign]
+        lambda dungeon_name, room_id, campaign_id=None: fake.rooms.get(room_id)
+    )
+    s._load_room_layout()
+    return s, fake
+
+
+@pytest.fixture
+def session_and_state():
+    return make_session()
+
+
+class TestGridMovement:
+    """Direction keys always grid-move within the room (#637)."""
+
+    def test_move_toward_exit_direction_is_one_tile_step(self, session_and_state) -> None:
+        """Pressing north mid-room must NOT teleport to the north room."""
+        session, fake = session_and_state
+        start_x, start_y = session.player_x, session.player_y
+
+        session._move_player("north")
+
+        assert fake.current_room_id == "entry"
+        assert (session.player_x, session.player_y) == (start_x, start_y - 1)
+
+    def test_backtracking_returns_to_starting_tile(self, session_and_state) -> None:
+        """South then north lands back on the original tile, same room."""
+        session, fake = session_and_state
+        start = (session.player_x, session.player_y)
+
+        session._move_player("south")
+        session._move_player("north")
+
+        assert fake.current_room_id == "entry"
+        assert (session.player_x, session.player_y) == start
+
+    def test_walking_onto_exit_tile_transitions(self, session_and_state) -> None:
+        """Stepping onto the north door tile fires the room transition."""
+        session, fake = session_and_state
+        door_x, door_y = session.room_layout.spawn_points.exits["north"]
+        # Place the player one tile inside the door, then step onto it.
+        session.player_x, session.player_y = door_x, door_y + 1
+
+        session._move_player("north")
+
+        assert fake.current_room_id == "north_room"
+
+    def test_lateral_step_onto_door_tile_transitions_in_door_direction(self) -> None:
+        """Approaching a door tile sideways still uses that door's exit."""
+        from client_2d.integration.layout_schema import RoomLayout, TileType
+
+        session, fake = make_session()
+        # Hand-craft a layout where the north door tile is reachable
+        # from the side (inset one row, floor neighbors on the row).
+        f, d, w = TileType.FLOOR.value, TileType.DOOR.value, TileType.WALL.value
+        session.room_layout = RoomLayout(
+            width=5,
+            height=5,
+            tiles=[
+                [w, w, w, w, w],
+                [w, f, d, f, w],
+                [w, f, f, f, w],
+                [w, f, f, f, w],
+                [w, w, w, w, w],
+            ],
+            spawn_points={"player": (2, 2), "exits": {"north": (2, 1)}},
+        )
+        session.player_x, session.player_y = 1, 1  # beside the door
+
+        session._move_player("east")
+
+        assert fake.current_room_id == "north_room"

--- a/client-2d/tests/test_room_transition.py
+++ b/client-2d/tests/test_room_transition.py
@@ -132,3 +132,70 @@ class TestGridMovement:
         session._move_player("east")
 
         assert fake.current_room_id == "north_room"
+
+
+class TestDoorPassability:
+    """SRD door-state seam (#637): locked doors block, hidden exits inert."""
+
+    def test_locked_exit_blocks_transition_and_step(self) -> None:
+        """A locked door refuses passage; the player stays put."""
+        session, fake = make_session(
+            rooms={
+                "entry": {
+                    "name": "Entry Hall",
+                    "exits": {"north": {"destination": "north_room", "locked": True}},
+                },
+                "north_room": {"name": "North Room", "exits": {"south": "entry"}},
+            }
+        )
+        door_x, door_y = session.room_layout.spawn_points.exits["north"]
+        session.player_x, session.player_y = door_x, door_y + 1
+
+        session._move_player("north")
+
+        assert fake.current_room_id == "entry"
+        assert (session.player_x, session.player_y) == (door_x, door_y + 1)
+        assert any("locked" in msg.lower() for msg in session.combat_log)
+
+    def test_dict_exit_without_locked_flag_passes(self) -> None:
+        """Dict-form exits without door-state flags behave as open doors."""
+        session, fake = make_session(
+            rooms={
+                "entry": {
+                    "name": "Entry Hall",
+                    "exits": {"north": {"destination": "north_room"}},
+                },
+                "north_room": {"name": "North Room", "exits": {"south": "entry"}},
+            }
+        )
+        door_x, door_y = session.room_layout.spawn_points.exits["north"]
+        session.player_x, session.player_y = door_x, door_y + 1
+
+        session._move_player("north")
+
+        assert fake.current_room_id == "north_room"
+
+    def test_hidden_exit_door_tile_is_inert(self) -> None:
+        """An undiscovered secret door never fires a transition; its
+        tile behaves as plain walkable floor."""
+        session, fake = make_session(
+            rooms={
+                "entry": {
+                    "name": "Entry Hall",
+                    "exits": {
+                        "north": "north_room",
+                        "east": {"destination": "secret_room", "hidden": True},
+                    },
+                },
+                "north_room": {"name": "North Room", "exits": {"south": "entry"}},
+                "secret_room": {"name": "Secret Room", "exits": {}},
+            }
+        )
+        # The layout still places a door tile for the hidden exit.
+        door_x, door_y = session.room_layout.spawn_points.exits["east"]
+        session.player_x, session.player_y = door_x - 1, door_y
+
+        session._move_player("east")
+
+        assert fake.current_room_id == "entry"
+        assert (session.player_x, session.player_y) == (door_x, door_y)

--- a/client-2d/tests/test_room_transition.py
+++ b/client-2d/tests/test_room_transition.py
@@ -242,3 +242,69 @@ class TestEntrySpawn:
             session.player_x,
             session.player_y,
         ) == session.room_layout.spawn_points.player
+
+
+class TestExitWithoutDoorTile:
+    """Layouts missing a door tile for a defined exit stay traversable:
+    a failed step (wall/edge) in the exit's direction uses the exit."""
+
+    def _custom_layout(self, session, tiles) -> None:
+        from client_2d.integration.layout_schema import RoomLayout
+
+        session.room_layout = RoomLayout(
+            width=len(tiles[0]),
+            height=len(tiles),
+            tiles=tiles,
+            spawn_points={"player": (1, 1), "exits": {}},
+        )
+
+    def test_wall_bump_in_exit_direction_transitions(self) -> None:
+        session, fake = make_session()
+        from client_2d.integration.layout_schema import TileType
+
+        f, w = TileType.FLOOR.value, TileType.WALL.value
+        self._custom_layout(
+            session,
+            [
+                [w, w, w],
+                [w, f, w],
+                [w, w, w],
+            ],
+        )
+        session.player_x, session.player_y = 1, 1
+
+        session._move_player("north")
+
+        assert fake.current_room_id == "north_room"
+
+    def test_edge_step_in_exit_direction_transitions(self) -> None:
+        session, fake = make_session()
+        from client_2d.integration.layout_schema import TileType
+
+        f = TileType.FLOOR.value
+        self._custom_layout(session, [[f, f], [f, f]])
+        session.player_x, session.player_y = 1, 0
+
+        session._move_player("north")
+
+        assert fake.current_room_id == "north_room"
+
+    def test_wall_bump_in_non_exit_direction_does_not_transition(self) -> None:
+        session, fake = make_session()
+        from client_2d.integration.layout_schema import TileType
+
+        f, w = TileType.FLOOR.value, TileType.WALL.value
+        self._custom_layout(
+            session,
+            [
+                [w, w, w],
+                [w, f, w],
+                [w, w, w],
+            ],
+        )
+        session.player_x, session.player_y = 1, 1
+
+        session._move_player("east")  # no east exit in room data
+
+        assert fake.current_room_id == "entry"
+        assert (session.player_x, session.player_y) == (1, 1)

--- a/client-2d/tests/test_room_transition.py
+++ b/client-2d/tests/test_room_transition.py
@@ -199,3 +199,46 @@ class TestDoorPassability:
 
         assert fake.current_room_id == "entry"
         assert (session.player_x, session.player_y) == (door_x, door_y)
+
+
+class TestEntrySpawn:
+    """After a transition the player appears just inside the entry door."""
+
+    def _walk_through_north_door(self, session) -> None:
+        door_x, door_y = session.room_layout.spawn_points.exits["north"]
+        session.player_x, session.player_y = door_x, door_y + 1
+        session._move_player("north")
+
+    def test_player_spawns_inside_matching_entry_door(self, session_and_state) -> None:
+        """Going north places the player one tile in from the south door."""
+        session, fake = session_and_state
+        self._walk_through_north_door(session)
+
+        assert fake.current_room_id == "north_room"
+        south_x, south_y = session.room_layout.spawn_points.exits["south"]
+        assert (session.player_x, session.player_y) == (south_x, south_y - 1)
+
+    def test_cross_room_backtracking(self, session_and_state) -> None:
+        """Stepping back through the entry door returns to the prior room."""
+        session, fake = session_and_state
+        self._walk_through_north_door(session)
+
+        session._move_player("south")
+
+        assert fake.current_room_id == "entry"
+
+    def test_falls_back_to_default_spawn_without_matching_door(self) -> None:
+        """A destination with no door on the entry side uses its spawn point."""
+        session, fake = make_session(
+            rooms={
+                "entry": {"name": "Entry Hall", "exits": {"north": "dead_end"}},
+                "dead_end": {"name": "Dead End", "exits": {}},
+            }
+        )
+        self._walk_through_north_door(session)
+
+        assert fake.current_room_id == "dead_end"
+        assert (
+            session.player_x,
+            session.player_y,
+        ) == session.room_layout.spawn_points.player


### PR DESCRIPTION
## Summary
- Direction keys now always perform a one-tile grid move; the old behavior teleported the party to the destination room whenever the pressed direction matched any room exit (holdover from the terminal game's room-graph navigation).
- A room transition fires only when the step lands on the exit/door tile itself, from any approach direction.
- After a transition, the player spawns just inside the matching entry door (go north → appear at the south door), making cross-room backtracking coherent. Rooms without a matching door keep their default spawn.
- New `_can_pass_exit()` seam for SRD door mechanics: a `locked: true` flag on an exit's data blocks passage with a log message today; stuck/barred doors (Strength checks), lockpicking, the Knock spell, and secret-door discovery hook in here later without touching movement. Hidden exits stay inert.
- Layouts that define an exit but no door tile stay traversable: a failed step (wall/edge) in the exit's direction falls back to using the exit.

## Changes
- **client-2d/src/client_2d/session.py**: `_move_player()` rewritten around tile-based transitions; new `_can_pass_exit()` and `_place_player_at_entry()`.
- **client-2d/tests/test_room_transition.py**: 13 new tests (FakeGameState two-room graph + real generated layouts) covering grid steps, in-room and cross-room backtracking, lateral door approach, locked/hidden exits, entry-door spawn, and door-tile-less fallback.

## Testing
- [x] client-2d suite: 554 passed, 2 skipped
- [x] Headless MCP playtest: mid-room moves no longer teleport, reverse moves return to the prior tile, walking onto the crypt's north door transitions and places the party at the destination's entry door

## Related Issues
Fixes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)