### PR TITLE
Fix #639: Auto-drain enemy turns in windowed+MCP mode

### DIFF
--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -163,6 +163,13 @@ class GameSession:
         self._enable_mcp = enable_mcp
         self._mcp_port = mcp_port
         self._dev_mode = dev_mode
+        # True when the session is hosting a windowed GameView (set by
+        # ``initialize_mcp_server`` when a window is passed in). Lets
+        # ``tick`` distinguish headless+MCP (where MCP is the sole
+        # driver and must own enemy-turn pacing per #577) from
+        # windowed+MCP (where the keyboard is the driver and tick must
+        # auto-drain so the player can see enemy turns animate, #639).
+        self._is_windowed: bool = False
 
     # ========== Initialization ==========
 
@@ -236,6 +243,12 @@ class GameSession:
         self._mcp_bridge.set_session(self)
         if window is not None:
             self._mcp_bridge.set_game_window(window)
+            # GameView is the only caller that passes a window (game.py
+            # at ``GameView.__init__``); ``run_headless`` never does.
+            # Treat the window arg as the canonical "windowed mode"
+            # signal that tick() consults to decide whether to auto-
+            # drain enemy turns (#639).
+            self._is_windowed = True
 
         width = self.room_layout.width if self.room_layout else 25
         height = self.room_layout.height if self.room_layout else 18
@@ -276,14 +289,21 @@ class GameSession:
             return
 
         if self.processing_enemy_turn:
-            # When MCP is driving, wait()/attack()/spawn_monster() drain
+            # Headless+MCP only: wait()/attack()/spawn_monster() drain
             # enemy turns synchronously via _drain_enemy_turns(). Letting
             # the tick loop also auto-drain races against user commands:
             # after ENEMY_TURN_DELAY seconds of think-time the ticker
             # silently advances one enemy turn and lands on the next PC,
             # so the user's next wait() burns that PC's turn instead of
             # resolving the enemy's (#577). Hand pacing to the bridge.
-            if self._mcp_bridge is not None:
+            #
+            # Windowed+MCP is different: the human + keyboard is the
+            # driver, and the tick auto-drain is what animates enemy
+            # turns on screen. Skipping it strands the FSM and freezes
+            # the game until an MCP command happens by (#639). The
+            # ``_is_windowed`` flag, raised when ``initialize_mcp_server``
+            # receives a window, distinguishes the two cases.
+            if self._mcp_bridge is not None and not self._is_windowed:
                 return
             self.enemy_turn_timer -= delta_time
             if self.enemy_turn_timer <= 0:

--- a/client-2d/tests/test_game_session.py
+++ b/client-2d/tests/test_game_session.py
@@ -308,6 +308,62 @@ class TestSessionTick:
         )
         assert current_after.creature.name == "Goblin"
 
+    def test_tick_auto_drains_enemy_turns_in_windowed_mcp_mode(self) -> None:
+        """Regression for #639: in windowed+MCP mode, ``tick`` must
+        auto-drain enemy turns just like pure windowed mode.
+
+        The #577 early-return that hands pacing to the MCP bridge is
+        only correct for headless+MCP, where MCP is the sole driver.
+        In windowed+MCP the human + keyboard is the driver — the
+        on-screen auto-drain pacing is what shows them what enemies do
+        between their turns. Stranding the FSM there freezes the game
+        until an MCP command happens to come in. The ``_is_windowed``
+        flag, raised by ``initialize_mcp_server(window=...)``, is the
+        signal that distinguishes the two modes.
+        """
+        import random
+
+        from client_2d.mcp_bridge import MCPBridge
+        from client_2d.session import GameSession
+
+        s = GameSession(enable_mcp=False, dev_mode=True)
+        s.initialize()
+        s._mcp_bridge = MCPBridge()
+        # Simulate the windowed-mode wiring: GameView calls
+        # initialize_mcp_server(window=self.window) at game.py:176, which
+        # raises this flag. Tests skip the full mcp-server boot and set
+        # the flag directly.
+        s._is_windowed = True
+        # Deterministic seed matching the #577 repro for parity.
+        s.engine.game_state.dice_roller.random = random.Random(42)
+
+        s.spawn_monster("goblin", 9, 7)
+        tracker = s.engine.game_state.initiative_tracker
+        assert tracker is not None
+
+        # After spawn the goblin owns the turn and the drain gate is up.
+        current_before = tracker.get_current_combatant()
+        assert current_before is not None
+        assert current_before.creature.name == "Goblin"
+        assert s.processing_enemy_turn is True
+        idx_before = tracker.current_turn_index
+
+        # Tick well past ENEMY_TURN_DELAY (1.5s) — the auto-drain must
+        # advance the goblin's turn and hand control back to a PC.
+        for _ in range(120):
+            s.tick(0.05)
+
+        assert s.processing_enemy_turn is False, (
+            "tick failed to auto-drain enemy turn in windowed+MCP mode; "
+            "the keyboard would be frozen waiting for a drain that never "
+            "comes (#639)"
+        )
+        assert tracker.current_turn_index != idx_before, (
+            "tick did not advance initiative in windowed+MCP; the goblin "
+            "is still the current combatant and the screen would never "
+            "animate the enemy turn"
+        )
+
 
 class TestMCPServerWiring:
     def test_enable_mcp_creates_bridge_and_server(self) -> None:


### PR DESCRIPTION
## Summary

- Windowed `--mcp` combat froze the moment an enemy won initiative — keypresses bounced off `"Can't move during combat!"` / `"Wait — it's <Enemy>'s turn!"` and the FSM never advanced.
- Pre-existing race from #577: `GameSession.tick()` hands enemy-turn pacing to the MCP bridge whenever `_mcp_bridge is not None`. Correct for headless+MCP (MCP is the sole driver), wrong for windowed+MCP (keyboard is the driver and the tick auto-drain is what animates enemy turns).
- PR #638 didn't introduce this — it just made it reproducible by reliably landing the player in the destination room mid-doorway where combat starts.

## Changes

- **`client-2d/src/client_2d/session.py`** — added `_is_windowed: bool` flag (default `False`), raised inside `initialize_mcp_server` when a `window` is passed. Changed the tick early-return to `if self._mcp_bridge is not None and not self._is_windowed:` and updated the rationale comment.
- **`client-2d/tests/test_game_session.py`** — added `test_tick_auto_drains_enemy_turns_in_windowed_mcp_mode` as the regression. Mirrors the existing #577 sibling test (same seed, same spawn, same tick budget) but flips `_is_windowed = True` and asserts the drain runs.

## Testing

- [x] `pytest tests/test_game_session.py::TestSessionTick` — 5/5 green, including the #577 headless-MCP regression
- [x] Full `client-2d` suite — 555 passed, 2 pre-existing skips
- [x] Ruff lint clean on changed files
- [ ] Manual playtest of `uv run dnd-2d --dev --mcp` → giant rats — not yet run (cannot drive the windowed keyboard from this session)

## Related

Fixes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)