### PR TITLE
Fix #634: Engine melee reach gate + range-aware monster targeting

### DIFF
--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -4,8 +4,10 @@
 from dataclasses import dataclass
 from typing import Any
 
+from dnd_engine.core.combat_geometry import attack_reach_for, is_ranged_action
 from dnd_engine.core.creature import Creature
 from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.distance import distance_in_feet
 from dnd_engine.rules.damage import apply_damage_adjustments, apply_damage_modifiers
 from dnd_engine.systems.perception import VisibilityRelation
 from dnd_engine.utils.events import Event, EventType
@@ -188,6 +190,58 @@ class CombatEngine:
         Returns:
             AttackResult containing full attack details including sneak attack if applicable
         """
+        # SRD § Playing the Game › Melee Attacks › Reach: a melee attack
+        # may only target a creature within the attacker's reach (5 ft
+        # by default; greater for some creatures/weapons as noted on
+        # the action). When the caller provides both spatial context
+        # (``game_state``) and an authored action with a ``reach``
+        # field, reject the attack before any side effects (dice roll,
+        # hidden-state revelation, help-flag consumption) when the
+        # defender sits beyond reach. Mirrors the seam #401 added for
+        # ranged-attack range enforcement.
+        #
+        # Skipped when:
+        #  - ``action`` is None — the caller (e.g. PC weapon attack at
+        #    ``game_state.py:3204``, OAs at ``:1246``/``:5397``, item
+        #    throws at ``:5676``) gates range upstream and intentionally
+        #    omits ``action`` here.
+        #  - ``game_state`` is None — unit tests without a spatial
+        #    index can still exercise the engine; they would otherwise
+        #    regress on a single-site change.
+        #  - The action is ranged (declares ``range`` rather than
+        #    ``reach``) — reach doesn't apply; range enforcement for
+        #    ranged monster attacks is still a separate gap.
+        #
+        # The short-circuit emits an ``AttackResult`` with
+        # ``attack_roll=0`` as a sentinel so callers / tests can
+        # distinguish a gate rejection from a missed roll.
+        if (
+            action is not None
+            and game_state is not None
+            and not is_ranged_action(action)
+        ):
+            attacker_pos = getattr(attacker, "position", None)
+            defender_pos = getattr(defender, "position", None)
+            if attacker_pos is not None and defender_pos is not None:
+                reach_ft = attack_reach_for(action)
+                distance_ft = distance_in_feet(
+                    attacker_pos.x, attacker_pos.y,
+                    defender_pos.x, defender_pos.y,
+                )
+                if distance_ft > reach_ft:
+                    return AttackResult(
+                        attacker_name=attacker.name,
+                        defender_name=defender.name,
+                        attack_roll=0,
+                        attack_bonus=attack_bonus,
+                        target_ac=defender._base_ac,
+                        hit=False,
+                        damage=0,
+                        critical_hit=False,
+                        advantage=advantage,
+                        disadvantage=disadvantage,
+                    )
+
         # SRD § Actions › Dodge: a dodging defender imposes Disadvantage
         # on incoming attacks, unless they are Incapacitated or their
         # Speed is 0. Recomputed each call so revocation conditions are

--- a/dnd-engine/dnd_engine/core/combat_geometry.py
+++ b/dnd-engine/dnd_engine/core/combat_geometry.py
@@ -1,0 +1,45 @@
+# ABOUTME: Shared geometry helpers for combat resolution (reach parsing, distance helpers).
+# ABOUTME: Lives in core so both the engine (resolve_attack) and scenario script executor share one parser.
+
+from typing import Any
+
+
+def attack_reach_for(monster_action: dict[str, Any] | None) -> int:
+    """Parse a monster action's ``reach`` string into feet.
+
+    ``monsters.json`` encodes reach per attack action as ``"5 ft."`` or
+    ``"10 ft."``. Per SRD § Playing the Game › Melee Attacks, a creature
+    has a 5-foot reach by default; creatures with greater reach declare
+    it on the action. This helper returns the integer feet so callers
+    can gate attack resolution on distance.
+
+    Missing or unparseable values fall back to the SRD default (5 ft) so
+    a malformed catalog row degrades to vanilla melee rather than
+    silently widening reach.
+    """
+    if not monster_action:
+        return 5
+    raw = monster_action.get("reach")
+    if not raw:
+        return 5
+    # "10 ft." -> "10"; tolerate stray whitespace too.
+    head = str(raw).strip().split()[0]
+    try:
+        return int(head)
+    except ValueError:
+        return 5
+
+
+def is_ranged_action(monster_action: dict[str, Any] | None) -> bool:
+    """Return True when a monster action is a ranged attack.
+
+    Monster catalog actions distinguish melee from ranged by which
+    field they carry: a melee action declares ``reach``, a ranged
+    action declares ``range``. The reach gate must skip ranged actions
+    so a Longbow at 80 ft isn't rejected as "out of reach". When both
+    fields are absent (rare; usually a malformed row) the action is
+    treated as melee so the conservative 5-ft default applies.
+    """
+    if not monster_action:
+        return False
+    return monster_action.get("range") is not None and monster_action.get("reach") is None

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -290,6 +290,12 @@ class EnemyTurnAction(Enum):
     DIED_START_OF_TURN = "died_start_of_turn"
     NO_TARGETS = "no_targets"
     NO_VALID_ATTACK = "no_valid_attack"
+    # Issue #634: the enemy has a valid attack and living party members
+    # to target, but every PC sits beyond the action's reach. Until the
+    # monster-movement layer ships (Layer 3 follow-up), the enemy stays
+    # put and the turn advances cleanly so the headless tick loop never
+    # hangs.
+    NO_REACHABLE_TARGET = "no_reachable_target"
 
 
 @dataclass
@@ -5102,15 +5108,8 @@ class GameState:
                 turn_advanced=True,
             )
 
-        # Use smart targeting based on enemy intelligence and combat history
-        target = self.enemy_ai.select_target_smart(
-            available_targets=living_party,
-            enemy_intelligence=enemy.abilities.intelligence,
-            combat_history=self.combat_history,
-            enemy_name=enemy.name,
-        )
-
-        # Get monster data for attack
+        # Get monster data for attack — load BEFORE target selection so
+        # the action's `reach` can range-filter the candidate list (#634).
         monsters = self.data_loader.load_monsters()
         monster_data = None
         for _mid, mdata in monsters.items():
@@ -5124,7 +5123,6 @@ class GameState:
                 enemy_name=enemy.name,
                 enemy_display_name=enemy_display_name,
                 action_taken=EnemyTurnAction.NO_VALID_ATTACK,
-                target_name=target.name,
                 turn_start_effects=turn_start_effects,
                 error="No monster data or actions found",
                 turn_advanced=True,
@@ -5143,11 +5141,63 @@ class GameState:
                 enemy_name=enemy.name,
                 enemy_display_name=enemy_display_name,
                 action_taken=EnemyTurnAction.NO_VALID_ATTACK,
-                target_name=target.name,
                 turn_start_effects=turn_start_effects,
                 error="No valid attack actions",
                 turn_advanced=True,
             )
+
+        # Range-aware target filtering (#634, Layer 2). When the enemy
+        # has spatial context (a position) and the action carries a
+        # reach value, restrict the candidate list to PCs the enemy can
+        # actually hit this turn. The smart targeting strategy then
+        # runs over the filtered subset so retaliation / lowest-HP /
+        # intelligence-based picks still apply — they just can't pick
+        # an out-of-reach PC. When no PC is in reach the enemy stays
+        # put and emits NO_REACHABLE_TARGET; Layer 3 will add movement
+        # to close the gap.
+        #
+        # Skip the filter when no spatial context exists (legacy
+        # integration tests that don't bootstrap_spatial), so this
+        # change is regression-free for the unit suite.
+        from dnd_engine.core.combat_geometry import attack_reach_for, is_ranged_action
+        from dnd_engine.core.distance import distance_in_feet
+        targeting_pool = living_party
+        if (
+            enemy.position is not None
+            and not is_ranged_action(action)
+        ):
+            reach_ft = attack_reach_for(action)
+            in_reach = [
+                pc for pc in living_party
+                if pc.position is not None
+                and distance_in_feet(
+                    enemy.position.x, enemy.position.y,
+                    pc.position.x, pc.position.y,
+                ) <= reach_ft
+            ]
+            if not in_reach:
+                # Architect blocker resolved: advance the turn so the
+                # headless tick loop never hangs on a stranded enemy.
+                self.initiative_tracker.next_turn()
+                return EnemyTurnResult(
+                    enemy_name=enemy.name,
+                    enemy_display_name=enemy_display_name,
+                    action_taken=EnemyTurnAction.NO_REACHABLE_TARGET,
+                    action_data=action,
+                    turn_start_effects=turn_start_effects,
+                    turn_end_effects=turn_end_effects,
+                    turn_advanced=True,
+                )
+            targeting_pool = in_reach
+
+        # Use smart targeting based on enemy intelligence and combat
+        # history, scoped to the range-filtered candidate pool.
+        target = self.enemy_ai.select_target_smart(
+            available_targets=targeting_pool,
+            enemy_intelligence=enemy.abilities.intelligence,
+            combat_history=self.combat_history,
+            enemy_name=enemy.name,
+        )
 
         # Track conditions before attack (for saving throw detection)
         conditions_before = set()

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -9,8 +9,10 @@ from typing import Any
 from dnd_engine.core.campaign_progress import CampaignProgress, CampaignProgressTracker
 from dnd_engine.core.character import Character
 from dnd_engine.core.combat import AttackResult, CombatEngine
+from dnd_engine.core.combat_geometry import attack_reach_for, is_ranged_action
 from dnd_engine.core.creature import Creature, Size
 from dnd_engine.core.dice import DiceRoller, format_dice_with_modifier
+from dnd_engine.core.distance import distance_in_feet
 from dnd_engine.core.entity_ids import pc_entity_id
 from dnd_engine.core.map import Map
 from dnd_engine.core.move_result import MoveResult
@@ -5159,8 +5161,6 @@ class GameState:
         # Skip the filter when no spatial context exists (legacy
         # integration tests that don't bootstrap_spatial), so this
         # change is regression-free for the unit suite.
-        from dnd_engine.core.combat_geometry import attack_reach_for, is_ranged_action
-        from dnd_engine.core.distance import distance_in_feet
         targeting_pool = living_party
         if (
             enemy.position is not None

--- a/dnd-engine/dnd_engine/scenarios/script_executor.py
+++ b/dnd-engine/dnd_engine/scenarios/script_executor.py
@@ -125,30 +125,13 @@ def _attack_range_for(weapon_data: dict[str, Any] | None) -> tuple[int, int]:
     return (5, 5)
 
 
-def _attack_reach_for(monster_action: dict[str, Any] | None) -> int:
-    """Parse a monster action's ``reach`` string into feet.
-
-    monsters.json encodes reach per attack action as ``"5 ft."`` or
-    ``"10 ft."``. Per SRD § Playing the Game › Melee Attacks, a creature
-    has a 5-foot reach by default; creatures with greater reach declare
-    it on the action. This helper returns the integer feet so the
-    executor can gate attack resolution on distance.
-
-    Missing or unparseable values fall back to the SRD default (5 ft) so
-    a malformed catalog row degrades to vanilla melee rather than
-    silently widening reach.
-    """
-    if not monster_action:
-        return 5
-    raw = monster_action.get("reach")
-    if not raw:
-        return 5
-    # "10 ft." → "10"; tolerate stray whitespace too.
-    head = str(raw).strip().split()[0]
-    try:
-        return int(head)
-    except ValueError:
-        return 5
+# Re-export the shared reach parser from ``dnd_engine.core.combat_geometry``
+# so callers that already import ``_attack_reach_for`` from this module
+# (notably ``tests/srd/playing_the_game/test_melee_attacks.py``) keep
+# working. The single implementation now lives in ``combat_geometry`` so
+# both the engine's ``resolve_attack`` reach gate (#634) and the scenario
+# script executor consult one parser.
+from dnd_engine.core.combat_geometry import attack_reach_for as _attack_reach_for  # noqa: E402
 
 
 def _is_ranged_attack(weapon_data: dict[str, Any] | None) -> bool:

--- a/dnd-engine/tests/test_combat_engine_reach_gate.py
+++ b/dnd-engine/tests/test_combat_engine_reach_gate.py
@@ -1,0 +1,367 @@
+# ABOUTME: Tests for the engine-level melee reach gate added to CombatEngine.resolve_attack (#634).
+# ABOUTME: Mirrors the ranged-range pattern (#401) — reject melee attacks when distance > action.reach.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.combat import CombatEngine
+from dnd_engine.core.combat_geometry import attack_reach_for, is_ranged_action
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.entity_ids import pc_entity_id
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.map import Map, TileType
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.utils.events import EventBus
+
+MONSTERS_JSON = (
+    Path(__file__).resolve().parents[1]
+    / "dnd_engine"
+    / "data"
+    / "srd"
+    / "monsters.json"
+)
+
+
+def _build_engine_fixture(
+    attacker_pos: tuple[int, int],
+    defender_pos: tuple[int, int],
+    *,
+    enemy_id: str = "giant_rat",
+) -> tuple[GameState, Creature, Character]:
+    """Construct a GameState with an enemy and a PC placed at given tiles.
+
+    The map is a 20x20 open floor — enough room for any small-grid
+    reach test (5/10/15/30 ft). The PC is a fighter (high AC so the
+    test doesn't depend on the attack roll happening to miss). The
+    enemy is loaded from the SRD catalog so its actions carry the
+    real `reach`/`range` fields the gate will read.
+    """
+    tiles: dict[tuple[int, int], TileType] = {}
+    for y in range(20):
+        for x in range(20):
+            tiles[(x, y)] = TileType.FLOOR
+    grid_map = Map(width=20, height=20, tiles=tiles)
+
+    fighter = Character(
+        name="Brick",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=Abilities(
+            strength=16, dexterity=14, constitution=15,
+            intelligence=10, wisdom=12, charisma=8,
+        ),
+        max_hp=20,
+        ac=16,
+        xp=0,
+    )
+    party = Party(characters=[fighter])
+
+    game_state = GameState(
+        party=party,
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+        dice_roller=DiceRoller(seed=42),
+    )
+    game_state.bootstrap_spatial(grid_map)
+
+    enemy = game_state.data_loader.create_monster(enemy_id)
+    game_state.active_enemies.append(enemy)
+
+    pc_id = pc_entity_id(fighter.name)
+    enemy_eid = f"{enemy_id}_0"
+    game_state.set_position(pc_id, defender_pos[0], defender_pos[1])
+    game_state.set_position(enemy_eid, attacker_pos[0], attacker_pos[1])
+
+    return game_state, enemy, fighter
+
+
+class TestAttackReachForHelper:
+    """The promoted attack_reach_for(action) helper parses monster reach.
+
+    Behavioral parity with the original `_attack_reach_for` in
+    `script_executor.py` (which now re-exports this implementation).
+    """
+
+    def test_parses_5_ft_reach(self):
+        assert attack_reach_for({"reach": "5 ft."}) == 5
+
+    def test_parses_10_ft_reach(self):
+        assert attack_reach_for({"reach": "10 ft."}) == 10
+
+    def test_missing_action_defaults_to_5(self):
+        assert attack_reach_for(None) == 5
+
+    def test_missing_reach_field_defaults_to_5(self):
+        assert attack_reach_for({"name": "Bite"}) == 5
+
+    def test_unparseable_reach_defaults_to_5(self):
+        assert attack_reach_for({"reach": "garbage"}) == 5
+
+
+class TestIsRangedAction:
+    """is_ranged_action(action) distinguishes ranged from melee."""
+
+    def test_melee_action_with_reach_is_not_ranged(self):
+        assert is_ranged_action({"name": "Bite", "reach": "5 ft."}) is False
+
+    def test_ranged_action_with_range_is_ranged(self):
+        assert is_ranged_action({"name": "Longbow", "range": "150/600"}) is True
+
+    def test_missing_action_is_not_ranged(self):
+        assert is_ranged_action(None) is False
+
+
+class TestMeleeReachGate:
+    """SRD § Playing the Game › Melee Attacks › Reach.
+
+    A melee attack rejects when distance > action.reach. Mirrors the
+    ranged-range pattern in `CombatEngine.resolve_attack` (#401's
+    successor — #401 left this for melee as future work).
+    """
+
+    def test_melee_attack_rejected_beyond_reach(self):
+        """Issue #634 repro: 5-ft Bite at 30 ft must NOT land.
+
+        Giant rat at (5, 5), fighter at (5, 11) — Chebyshev distance
+        6 tiles = 30 ft. Rat's Bite has 5-ft reach. The gate's
+        sentinel is ``attack_roll == 0`` — no d20 was rolled because
+        the attack was rejected before resolution. We also pin
+        ``hit=False`` and ``damage=0`` to guarantee no HP changed.
+
+        Using ``attack_bonus=99`` makes the test independent of dice
+        luck: without the gate, the attack would auto-hit
+        (99 + 1 = 100 vs AC 16), so any ``hit=False`` here proves
+        the gate fired rather than the roll happening to miss.
+        """
+        gs, rat, fighter = _build_engine_fixture(
+            attacker_pos=(5, 5), defender_pos=(5, 11),
+        )
+        bite = next(
+            a for a in gs.data_loader.load_monsters()["giant_rat"]["actions"]
+            if a["name"] == "Bite"
+        )
+
+        starting_hp = fighter.current_hp
+        result = gs.combat_engine.resolve_attack(
+            attacker=rat,
+            defender=fighter,
+            attack_bonus=99,  # auto-hit if the roll happens
+            damage_dice=bite["damage"],
+            apply_damage=True,
+            action=bite,
+            game_state=gs,
+        )
+
+        assert result.attack_roll == 0, (
+            "Reach gate did not fire: an attack_roll happened despite "
+            "the target being out of reach. Gate must short-circuit "
+            "before rolling."
+        )
+        assert result.hit is False
+        assert result.damage == 0
+        assert fighter.current_hp == starting_hp
+
+    def test_melee_attack_within_reach_resolves_normally(self):
+        """Adjacent rat (5 ft) — gate must NOT interfere.
+
+        Distance 5 ft equals reach 5 ft: the gate's condition is
+        `distance > reach`, so a 5/5 case passes through to a normal
+        attack roll. We can't assert hit/miss deterministically (the
+        roll varies even with seed=42 once the gate path is added),
+        but we can assert the gate didn't short-circuit: an attack roll
+        actually happened.
+        """
+        gs, rat, fighter = _build_engine_fixture(
+            attacker_pos=(5, 5), defender_pos=(6, 5),  # 5 ft east
+        )
+        bite = next(
+            a for a in gs.data_loader.load_monsters()["giant_rat"]["actions"]
+            if a["name"] == "Bite"
+        )
+
+        result = gs.combat_engine.resolve_attack(
+            attacker=rat,
+            defender=fighter,
+            attack_bonus=bite["attack_bonus"],
+            damage_dice=bite["damage"],
+            apply_damage=True,
+            action=bite,
+            game_state=gs,
+        )
+
+        # An attack roll happened (1..20). The reach gate returns a
+        # sentinel attack_roll=0 when it short-circuits.
+        assert 1 <= result.attack_roll <= 20
+
+    def test_reach_gate_skipped_when_game_state_is_none(self):
+        """Unit tests that call resolve_attack(game_state=None) keep working.
+
+        Backwards-compatibility guarantee: callers without spatial
+        context (the existing combat unit-test suite) see the legacy
+        no-gate behavior. Otherwise we'd break ~dozens of tests.
+        """
+        engine = CombatEngine(DiceRoller(seed=42))
+        attacker = Creature(
+            name="A", max_hp=10, ac=10,
+            abilities=Abilities(
+                strength=10, dexterity=10, constitution=10,
+                intelligence=10, wisdom=10, charisma=10,
+            ),
+        )
+        defender = Creature(
+            name="D", max_hp=10, ac=10,
+            abilities=Abilities(
+                strength=10, dexterity=10, constitution=10,
+                intelligence=10, wisdom=10, charisma=10,
+            ),
+        )
+        # action has reach=5 but no game_state means no positions to
+        # check — gate must no-op and the attack must roll.
+        result = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=2,
+            damage_dice="1d4",
+            action={"reach": "5 ft.", "name": "Bite"},
+            game_state=None,
+        )
+        assert 1 <= result.attack_roll <= 20
+
+    def test_reach_gate_skipped_when_action_is_none(self):
+        """Callers that don't pass action= also bypass the gate.
+
+        PC weapon attacks (`game_state.py:3204`), OA attacks
+        (`game_state.py:1246`, `:5397`), and improvised item-throws
+        (`game_state.py:5676`) all call resolve_attack without an
+        `action=` parameter. Their range/reach is enforced upstream
+        (UI gate, OA system's `reach_feet`). The engine gate is the
+        catch-all for the monster-turn path that DOES pass action;
+        all other call sites are unaffected.
+        """
+        gs, rat, fighter = _build_engine_fixture(
+            attacker_pos=(5, 5), defender_pos=(5, 11),  # 30 ft
+        )
+        result = gs.combat_engine.resolve_attack(
+            attacker=rat,
+            defender=fighter,
+            attack_bonus=4,
+            damage_dice="1d4",
+            apply_damage=False,
+            action=None,
+            game_state=gs,
+        )
+        # Without action, gate can't read reach — roll proceeds.
+        assert 1 <= result.attack_roll <= 20
+
+    def test_reach_gate_skipped_for_ranged_action(self):
+        """Ranged actions are governed by `range`, not `reach`.
+
+        A monster's Longbow action with range "150/600" must not be
+        rejected as "out of reach" — the reach gate only applies to
+        melee actions. Range enforcement for ranged monster attacks
+        is a separate concern (still a GAP per #401's audit).
+        """
+        gs, rat, fighter = _build_engine_fixture(
+            attacker_pos=(5, 5), defender_pos=(5, 11),  # 30 ft
+        )
+        fake_longbow = {
+            "name": "Longbow",
+            "attack_bonus": 4,
+            "damage": "1d8",
+            "range": "150/600",
+        }
+        result = gs.combat_engine.resolve_attack(
+            attacker=rat,
+            defender=fighter,
+            attack_bonus=4,
+            damage_dice="1d8",
+            apply_damage=False,
+            action=fake_longbow,
+            game_state=gs,
+        )
+        # Ranged: gate skipped; roll proceeds.
+        assert 1 <= result.attack_roll <= 20
+
+    def test_reach_10ft_action_lands_at_10ft_misses_at_15ft(self):
+        """10-ft reach action hits at 10 ft, rejects at 15 ft.
+
+        Covers the Large-creature / reach-weapon case. Uses an inline
+        action dict so the test doesn't depend on a specific catalog
+        monster carrying a reach-10 action.
+        """
+        gs, rat, fighter = _build_engine_fixture(
+            attacker_pos=(5, 5), defender_pos=(5, 7),  # 10 ft
+        )
+        action_reach_10 = {
+            "name": "TestGlaive",
+            "reach": "10 ft.",
+            "attack_bonus": 4,
+            "damage": "1d8",
+        }
+
+        result_at_10ft = gs.combat_engine.resolve_attack(
+            attacker=rat, defender=fighter,
+            attack_bonus=4, damage_dice="1d8",
+            apply_damage=False,
+            action=action_reach_10, game_state=gs,
+        )
+        # 10 ft <= 10 ft reach: gate passes, roll happens.
+        assert 1 <= result_at_10ft.attack_roll <= 20
+
+        # Now move defender to 15 ft; same gate, same action, rejects.
+        gs.set_position(pc_entity_id(fighter.name), 5, 8)  # 15 ft south
+        result_at_15ft = gs.combat_engine.resolve_attack(
+            attacker=rat, defender=fighter,
+            attack_bonus=99,  # auto-hit if not gated
+            damage_dice="1d8",
+            apply_damage=False,
+            action=action_reach_10, game_state=gs,
+        )
+        assert result_at_15ft.attack_roll == 0  # gate fired
+        assert result_at_15ft.hit is False
+        assert result_at_15ft.damage == 0
+
+
+class TestMonsterCatalogReachInvariant:
+    """Catch-future-author-drift: Large+ monsters must declare reach.
+
+    Per SRD, a Large creature's natural reach is 10 ft. The codebase
+    encodes reach on each action in monsters.json (not on the monster
+    size). This test fails-loud when someone adds a Large+ monster
+    without declaring `reach: "10 ft."` on its melee actions, so the
+    engine's reach gate doesn't silently apply the 5-ft default.
+    """
+
+    def test_large_and_bigger_creatures_declare_reach_on_melee_actions(self):
+        monsters = json.loads(MONSTERS_JSON.read_text())
+        LARGE_OR_BIGGER = {"Large", "Huge", "Gargantuan"}
+
+        offenders = []
+        for mid, mdata in monsters.items():
+            size = mdata.get("size", "")
+            if size not in LARGE_OR_BIGGER:
+                continue
+            for action in mdata.get("actions") or []:
+                # Melee action with an attack roll but no reach declared.
+                if "attack_bonus" not in action:
+                    continue
+                if action.get("range") is not None:
+                    # Ranged action — uses range, not reach.
+                    continue
+                if not action.get("reach"):
+                    offenders.append(
+                        f"{mid} [{size}] action {action.get('name')!r} "
+                        f"has attack_bonus but no reach"
+                    )
+
+        assert offenders == [], (
+            "Large+ monsters with melee actions must declare reach "
+            "explicitly (default 5 ft is wrong for them). Offenders: "
+            f"{offenders}"
+        )

--- a/dnd-engine/tests/test_enemy_turn_reach_targeting.py
+++ b/dnd-engine/tests/test_enemy_turn_reach_targeting.py
@@ -188,14 +188,16 @@ class TestRangeAwareTargeting:
         # the loop isn't stuck on the rat's turn.
         assert len(seen_turn_indices) >= 2
 
-    def test_smart_targeting_logic_preserved_within_in_reach_subset(self):
-        """Retaliation logic still picks the recent attacker — among in-reach PCs.
+    def test_in_reach_filter_passes_multiple_candidates_through_to_targeting(self):
+        """Three in-reach PCs all survive the filter; smart targeting then picks.
 
-        Three PCs adjacent to the rat. Without history, low-INT
-        creatures would pick by lowest HP (all equal here). We inject
-        a fake combat_history so the rat "remembers" being hit by
-        Charlie — retaliation should override into picking Charlie
-        despite the in-reach filter.
+        Pins the contract that the filter is *additive*, not *collapsing*:
+        when multiple PCs are within reach, all of them reach
+        select_target_smart so retaliation / lowest-HP / intelligence
+        strategies still see a real choice. We inject a fake
+        combat_history so the test exercises the retaliation code
+        path (without pinning a specific pick — low-INT rats use a
+        weighted retaliation, not a hard rule).
         """
         gs, _enemy_eid = _build_targeting_fixture(
             party_positions={

--- a/dnd-engine/tests/test_enemy_turn_reach_targeting.py
+++ b/dnd-engine/tests/test_enemy_turn_reach_targeting.py
@@ -1,0 +1,252 @@
+# ABOUTME: Tests for range-aware target preference in process_enemy_turn (#634, Layer 2).
+# ABOUTME: Enemies prefer in-reach PCs; if none reachable, emit NO_REACHABLE_TARGET and advance turn.
+
+from __future__ import annotations
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.entity_ids import pc_entity_id
+from dnd_engine.core.game_state import EnemyTurnAction, GameState
+from dnd_engine.core.map import Map, TileType
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.utils.events import EventBus
+
+
+def _make_character(
+    name: str, cls: CharacterClass, position: tuple[int, int]
+) -> Character:
+    """Build a level-1 PC for the targeting fixture.
+
+    Identical stats across PCs so retaliation / lowest-HP heuristics don't
+    bias the targeting outcome we're measuring — only distance does.
+    """
+    return Character(
+        name=name,
+        character_class=cls,
+        level=1,
+        abilities=Abilities(
+            strength=12, dexterity=12, constitution=12,
+            intelligence=10, wisdom=10, charisma=10,
+        ),
+        max_hp=15,
+        ac=12,
+        xp=0,
+    )
+
+
+def _build_targeting_fixture(
+    *,
+    party_positions: dict[str, tuple[int, int]],
+    enemy_position: tuple[int, int],
+    enemy_id: str = "giant_rat",
+) -> tuple[GameState, str]:
+    """Set up a combat with party members at given tiles and one enemy.
+
+    Returns ``(game_state, enemy_entity_id)``. The PCs are wizards
+    (cosmetic — we just want non-frontline names) so the fighter/wizard
+    labeling in the test docstrings reads naturally. All PCs share the
+    same stats so distance is the only differentiating factor for
+    targeting.
+    """
+    tiles: dict[tuple[int, int], TileType] = {}
+    for y in range(20):
+        for x in range(20):
+            tiles[(x, y)] = TileType.FLOOR
+    grid_map = Map(width=20, height=20, tiles=tiles)
+
+    characters = [
+        _make_character(name, CharacterClass.WIZARD, pos)
+        for name, pos in party_positions.items()
+    ]
+    party = Party(characters=characters)
+
+    game_state = GameState(
+        party=party,
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+        dice_roller=DiceRoller(seed=42),
+    )
+    game_state.bootstrap_spatial(grid_map)
+
+    enemy = game_state.data_loader.create_monster(enemy_id)
+    game_state.active_enemies.append(enemy)
+
+    for character, (x, y) in zip(characters, party_positions.values(), strict=True):
+        game_state.set_position(pc_entity_id(character.name), x, y)
+    enemy_eid = f"{enemy_id}_0"
+    game_state.set_position(enemy_eid, enemy_position[0], enemy_position[1])
+
+    # Start combat so initiative_tracker exists and the enemy can take
+    # turns. Force the enemy to be the current combatant.
+    game_state._start_combat()
+    tracker = game_state.initiative_tracker
+    assert tracker is not None
+    for idx, entry in enumerate(tracker.combatants):
+        if entry.creature is enemy:
+            tracker.current_turn_index = idx
+            break
+
+    # Clear the surprise condition that _check_for_surprise applies on
+    # combat start when the party stat-sneaks the enemy. The targeting
+    # tests assert on attack outcomes — a surprised enemy would skip
+    # its turn entirely, drowning the signal we want to measure. Plays
+    # well with how the tests construct combat from scratch.
+    if enemy.has_condition("surprised"):
+        enemy.remove_condition("surprised")
+
+    return game_state, enemy_eid
+
+
+class TestRangeAwareTargeting:
+    """SRD § Playing the Game › Melee Attacks (#634, Layer 2).
+
+    When choosing a target, an enemy must restrict to PCs within its
+    reach. The smart-targeting strategy (retaliation, lowest-HP, etc.)
+    then runs over that in-reach subset rather than the whole party.
+    """
+
+    def test_enemy_prefers_in_reach_target_over_distant_one(self):
+        """Issue #634 repro: rat picks the adjacent PC, not the 30-ft PC.
+
+        Bob (wizard) is adjacent to the rat (5 ft, in reach). Abe
+        (wizard) is 30 ft away. The rat's 5-ft Bite can only land on
+        Bob. Pre-fix, ``select_target_smart`` ignored distance and
+        could pick Abe; post-fix, only Bob is in the candidate list so
+        the rat targets and attacks Bob.
+        """
+        gs, _enemy_eid = _build_targeting_fixture(
+            party_positions={"Bob": (6, 5), "Abe": (5, 11)},
+            enemy_position=(5, 5),
+        )
+
+        result = gs.process_enemy_turn()
+
+        assert result is not None
+        assert result.action_taken == EnemyTurnAction.ATTACK
+        assert result.target_name == "Bob", (
+            f"rat should have targeted in-reach Bob, picked {result.target_name!r}"
+        )
+
+    def test_no_reachable_target_returns_dedicated_action_and_advances_turn(self):
+        """All PCs out of reach -> NO_REACHABLE_TARGET, turn advances.
+
+        Architect-flagged blocker: if the new "no in-reach" branch
+        forgets to advance the turn, the headless tick loop spins
+        forever and combat hangs. This test pins both the action enum
+        and the turn-advance contract so the regression is loud.
+        """
+        gs, _enemy_eid = _build_targeting_fixture(
+            party_positions={"Bob": (5, 11), "Abe": (5, 12)},  # both 30+ ft
+            enemy_position=(5, 5),
+        )
+        tracker = gs.initiative_tracker
+        assert tracker is not None
+        turn_index_before = tracker.current_turn_index
+
+        result = gs.process_enemy_turn()
+
+        assert result is not None
+        assert result.action_taken == EnemyTurnAction.NO_REACHABLE_TARGET
+        assert result.turn_advanced is True
+        assert tracker.current_turn_index != turn_index_before, (
+            "initiative did not advance — combat would hang in the "
+            "headless tick loop"
+        )
+        assert result.attack_result is None
+        # No PC took damage.
+        for character in gs.party.characters:
+            assert character.current_hp == character.max_hp
+
+    def test_combat_does_not_hang_when_all_enemies_stranded(self):
+        """Multiple stranded enemies across rounds — initiative keeps moving.
+
+        Catches the tick-loop hang risk by exercising several
+        consecutive ``process_enemy_turn`` calls when no PC is in
+        reach. Each call must advance the turn so the round eventually
+        rotates back to the PCs.
+        """
+        gs, _enemy_eid = _build_targeting_fixture(
+            party_positions={"Bob": (5, 14), "Abe": (5, 15)},  # both ~45 ft
+            enemy_position=(5, 5),
+        )
+        tracker = gs.initiative_tracker
+        assert tracker is not None
+
+        seen_turn_indices: set[int] = set()
+        for _ in range(6):
+            seen_turn_indices.add(tracker.current_turn_index)
+            result = gs.process_enemy_turn()
+            # Either the enemy's turn ran (NO_REACHABLE_TARGET) or
+            # initiative is on a PC and process_enemy_turn returned
+            # None — both are progress, neither hangs.
+            if result is not None:
+                assert result.turn_advanced is True
+        # Initiative cycled through more than one combatant — proof
+        # the loop isn't stuck on the rat's turn.
+        assert len(seen_turn_indices) >= 2
+
+    def test_smart_targeting_logic_preserved_within_in_reach_subset(self):
+        """Retaliation logic still picks the recent attacker — among in-reach PCs.
+
+        Three PCs adjacent to the rat. Without history, low-INT
+        creatures would pick by lowest HP (all equal here). We inject
+        a fake combat_history so the rat "remembers" being hit by
+        Charlie — retaliation should override into picking Charlie
+        despite the in-reach filter.
+        """
+        gs, _enemy_eid = _build_targeting_fixture(
+            party_positions={
+                "Bob": (6, 5),       # adjacent east
+                "Charlie": (4, 5),   # adjacent west
+                "Daniel": (5, 6),    # adjacent south
+            },
+            enemy_position=(5, 5),
+        )
+        # Seed combat_history with Charlie having hit the rat.
+        from dnd_engine.core.game_state import CombatEvent
+        gs.combat_history.append(
+            CombatEvent(
+                timestamp=0.0,
+                event_type="attack",
+                attacker="Charlie",
+                defender="Giant Rat",
+                damage=3,
+            )
+        )
+
+        result = gs.process_enemy_turn()
+        assert result is not None
+        assert result.action_taken == EnemyTurnAction.ATTACK
+        # All three are in reach; smart targeting must have picked one.
+        assert result.target_name in {"Bob", "Charlie", "Daniel"}
+        # We don't pin Charlie specifically: low-INT rats (INT=2)
+        # don't always retaliate (retaliation_weight defaults < 1.0).
+        # The contract this test pins: the in-reach filter didn't
+        # collapse the candidate list to just one PC; smart targeting
+        # still ran with three candidates.
+
+    def test_in_reach_filter_skipped_when_enemy_has_no_position(self):
+        """Backwards compatibility — pre-spatial fixtures still work.
+
+        Some integration tests place enemies without spatial context.
+        When ``enemy.position`` is ``None``, skip the in-reach filter
+        and fall through to the original full-party targeting (otherwise
+        we'd regress every test that doesn't bootstrap_spatial).
+        """
+        gs, _enemy_eid = _build_targeting_fixture(
+            party_positions={"Bob": (5, 11)},  # 30 ft — would be filtered out
+            enemy_position=(5, 5),
+        )
+        # Strip the enemy's position to simulate a non-spatial fixture.
+        gs.active_enemies[0].position = None
+
+        result = gs.process_enemy_turn()
+        # With no position, filter is skipped; rat targets Bob and
+        # attacks (engine reach gate also no-ops without positions, so
+        # the attack roll happens normally).
+        assert result is not None
+        assert result.action_taken == EnemyTurnAction.ATTACK
+        assert result.target_name == "Bob"


### PR DESCRIPTION
## Summary

- **Layer 1** — Engine-side melee reach gate added to `CombatEngine.resolve_attack`: reject an attack when `distance > action.reach`, with `attack_roll=0` sentinel so callers/tests can distinguish a gate rejection from a missed roll.
- **Layer 2** — `process_enemy_turn` now filters the candidate target list to in-reach PCs before `select_target_smart`. When no PC is in reach, emits the new `EnemyTurnAction.NO_REACHABLE_TARGET` and advances the turn so the headless tick loop never hangs on a stranded enemy.
- **Layer 3** — Monster movement is filed as follow-up #641 (the architect-reviewed design notes are attached there).

Issue #634 repro: a giant rat at (13,7) hit Abe the fighter at (9,13) with a 5-ft Bite from ~30 ft away. With this PR, the rat either picks the adjacent wizard (Layer 2 in-reach filter) or skips its turn cleanly (Layer 1 reach gate + new `NO_REACHABLE_TARGET` branch), depending on whether any PC is in reach.

## Changes

- **`dnd-engine/dnd_engine/core/combat_geometry.py` (new)** — promoted `_attack_reach_for` from `scenarios/script_executor.py:128` into a shared helper, plus `is_ranged_action(action)` so the reach gate can skip ranged actions.
- **`dnd-engine/dnd_engine/core/combat.py`** — `resolve_attack` gains a melee reach gate that fires only when both `game_state` and an `action` with `reach` are supplied. Skipped for `action=None` (PC weapon attack at `:3204`, OAs at `:1246`/`:5397`, item-throws at `:5676`) and `game_state=None` (existing unit suite). Mirrors #401's seam for ranged.
- **`dnd-engine/dnd_engine/core/game_state.py`** —
  - New `EnemyTurnAction.NO_REACHABLE_TARGET` enum value.
  - `process_enemy_turn` loads `monster_data` + chooses the attack action *before* target selection so the action's reach can range-filter `living_party`. Smart targeting then runs over the filtered subset (retaliation / lowest-HP / intelligence-based picks still apply). When the in-reach pool is empty, advances the turn and emits the new action.
  - Filter is skipped when `enemy.position is None` so non-spatial integration tests aren't regressed.
- **`dnd-engine/dnd_engine/scenarios/script_executor.py`** — re-exports `attack_reach_for` from the new module so `tests/srd/playing_the_game/test_melee_attacks.py` (which imports `_attack_reach_for`) keeps working.
- **`dnd-engine/tests/test_combat_engine_reach_gate.py` (new)** — 15 tests covering the reach gate (Bite at 30 ft rejected via auto-hit attack_bonus=99 sentinel, 5-ft action lands at 5 ft, gate skipped for `action=None` / `game_state=None` / ranged actions, 10-ft reach lands at 10 ft and rejects at 15 ft) plus a catalog invariant test that fails-loud once a Large+ monster is added without `reach: "10 ft."`.
- **`dnd-engine/tests/test_enemy_turn_reach_targeting.py` (new)** — 5 tests covering the target filter (in-reach preference, `NO_REACHABLE_TARGET` advances turn, no-hang across multiple stranded turns, filter passes multiple candidates through to smart targeting, filter skipped when enemy lacks position).

## Pre-implementation architecture review

A python-architect agent reviewed the proposed plan against SRD 5.1 before any code was written. Key blockers it flagged and how this PR addresses them:

- **Promote `_attack_reach_for`** — done; lives in `core/combat_geometry.py`, script_executor re-exports for compatibility.
- **PC `_attack_entity` doesn't pass `action=`** — verified across all 5 `resolve_attack` call sites in `game_state.py`. Only `process_enemy_turn` (line 5159) passes `action=` with `reach`. PC paths keep their existing UI-layer range gate (`get_attack_range` returns `(5,5)` for melee), OAs use `register_default_opportunity_attack(reach_feet=…)`, item-throws are ranged. The engine reach gate is therefore the monster-turn catch-all by design — exactly the bug surface.
- **Stranded-monster turn hang** — `NO_REACHABLE_TARGET` branch calls `initiative_tracker.next_turn()` and returns `turn_advanced=True`; `test_combat_does_not_hang_when_all_enemies_stranded` pins the invariant.
- **Chebyshev (5/5/5) stays** — confirmed in `dnd_engine/core/distance.py`; no diagonal-cost change.
- **Large+ creatures missing reach** — catalog audit returned empty (none in SRD pack yet); added a fail-loud catalog invariant test for future additions.

## Testing

- [x] 20 new unit tests, all green
- [x] Full regression sweep on touched modules: 828 passed, 0 regressions (`uv run pytest -k 'combat or enemy or process_enemy or melee or attack or oa or opportunity or script_executor'`)
- [x] Ruff lint clean
- [x] python-code-reviewer skill: no critical/high issues; two polish items addressed in commit cf6ce60
- [ ] Manual playtest (Mr. C runs): spawn a giant rat 6+ tiles from the party in `uv run dnd-2d --headless --dev --mcp` and confirm the rat no longer hits a distant fighter

## Related issues

Fixes #634
Follow-up: #641 (Layer 3 — monster movement in combat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)