### PR TITLE
Add #641: Monster movement in combat (Layer 3)

### DIFF
--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -5175,6 +5175,10 @@ class GameState:
         # integration tests that don't bootstrap_spatial), so this
         # change is regression-free for the unit suite.
         targeting_pool = living_party
+        # Defaults for the new Layer 3 (#641) movement-result fields.
+        # Stay 0/None on the ATTACK path when the enemy was already in
+        # reach; updated by the movement loop below when it runs.
+        moved_squares = 0
         if (
             enemy.position is not None
             and not is_ranged_action(action)
@@ -5188,7 +5192,6 @@ class GameState:
                     pc.position.x, pc.position.y,
                 ) <= reach_ft
             ]
-            moved_squares = 0
             if not in_reach:
                 # Layer 3 (#641): close distance toward the nearest PC.
                 # Loop attempt_combat_step (single 5-ft tile per call);
@@ -5216,6 +5219,13 @@ class GameState:
                         ]
                         if not candidates:
                             break
+                        # Re-pick the nearest PC every iteration so a
+                        # mid-loop change (an OA killing a target,
+                        # plan-04 instant kill, etc.) is handled. The
+                        # ``pc.name`` tiebreaker is load-bearing: it
+                        # makes the pick stable when two PCs are
+                        # equidistant, so the enemy doesn't oscillate
+                        # between them step-to-step.
                         target_pc = min(
                             candidates,
                             key=lambda pc: (
@@ -5263,12 +5273,20 @@ class GameState:
 
                 if not in_reach:
                     # Either moved without reaching (MOVED) or couldn't
-                    # move at all (NO_REACHABLE_TARGET — speed 0 or
-                    # blocked from the start).
+                    # move at all (NO_REACHABLE_TARGET — speed 0,
+                    # blocked from the start, or no resolvable
+                    # enemy_eid).
                     self.initiative_tracker.next_turn()
                     action_taken = (
                         EnemyTurnAction.MOVED if moved_squares > 0
                         else EnemyTurnAction.NO_REACHABLE_TARGET
+                    )
+                    # Match the EnemyTurnResult contract (game_state.py
+                    # comment above the field): movement_end_position
+                    # is None when no movement happened.
+                    end_position = (
+                        (enemy.position.x, enemy.position.y)
+                        if moved_squares > 0 else None
                     )
                     return EnemyTurnResult(
                         enemy_name=enemy.name,
@@ -5276,9 +5294,7 @@ class GameState:
                         action_taken=action_taken,
                         action_data=action,
                         moved_squares=moved_squares,
-                        movement_end_position=(
-                            enemy.position.x, enemy.position.y,
-                        ),
+                        movement_end_position=end_position,
                         turn_start_effects=turn_start_effects,
                         turn_end_effects=turn_end_effects,
                         turn_advanced=True,
@@ -5400,15 +5416,14 @@ class GameState:
             turn_advanced=True,
             combat_ended=combat_ended,
             # Layer 3 (#641): if the enemy closed distance before
-            # attacking, surface the step count on the result. Defaults
-            # to 0 / None when the enemy was already in reach.
-            moved_squares=(
-                moved_squares if "moved_squares" in locals() else 0
-            ),
+            # attacking, surface the step count and final tile on the
+            # result. ``moved_squares`` is hoisted above the in-reach
+            # branch so it's always defined; stays 0 when the enemy
+            # was already in reach.
+            moved_squares=moved_squares,
             movement_end_position=(
                 (enemy.position.x, enemy.position.y)
-                if "moved_squares" in locals() and moved_squares > 0
-                else None
+                if moved_squares > 0 else None
             ),
         )
 

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -293,11 +293,16 @@ class EnemyTurnAction(Enum):
     NO_TARGETS = "no_targets"
     NO_VALID_ATTACK = "no_valid_attack"
     # Issue #634: the enemy has a valid attack and living party members
-    # to target, but every PC sits beyond the action's reach. Until the
-    # monster-movement layer ships (Layer 3 follow-up), the enemy stays
-    # put and the turn advances cleanly so the headless tick loop never
+    # to target, but every PC sits beyond the action's reach AND the
+    # enemy cannot close the gap this turn (speed 0 / blocked twice in
+    # a row). Turn advances cleanly so the headless tick loop never
     # hangs.
     NO_REACHABLE_TARGET = "no_reachable_target"
+    # Issue #641: the enemy moved toward the nearest PC but its speed
+    # budget ran out before reaching attack range. Movement-only turn;
+    # no attack was attempted. ``moved_squares`` and
+    # ``movement_end_position`` on EnemyTurnResult carry the detail.
+    MOVED = "moved"
 
 
 @dataclass
@@ -384,6 +389,14 @@ class EnemyTurnResult:
     # Turn management
     turn_advanced: bool = True  # Whether initiative moved to next turn
     combat_ended: bool = False  # Whether combat ended this turn
+
+    # Movement (Issue #641, Layer 3): set when the enemy stepped during
+    # its turn. ``moved_squares`` counts successful 5-ft steps; non-zero
+    # on an ATTACK result means the monster closed distance before
+    # attacking. ``movement_end_position`` records the final tile so
+    # the UI can describe the path without snapshotting spatial state.
+    moved_squares: int = 0
+    movement_end_position: tuple[int, int] | None = None
 
     # Error handling
     error: str | None = None
@@ -5175,19 +5188,101 @@ class GameState:
                     pc.position.x, pc.position.y,
                 ) <= reach_ft
             ]
+            moved_squares = 0
             if not in_reach:
-                # Architect blocker resolved: advance the turn so the
-                # headless tick loop never hangs on a stranded enemy.
-                self.initiative_tracker.next_turn()
-                return EnemyTurnResult(
-                    enemy_name=enemy.name,
-                    enemy_display_name=enemy_display_name,
-                    action_taken=EnemyTurnAction.NO_REACHABLE_TARGET,
-                    action_data=action,
-                    turn_start_effects=turn_start_effects,
-                    turn_end_effects=turn_end_effects,
-                    turn_advanced=True,
-                )
+                # Layer 3 (#641): close distance toward the nearest PC.
+                # Loop attempt_combat_step (single 5-ft tile per call);
+                # OAs publish automatically via that primitive. Break
+                # on: (a) a PC entering reach -> fall through to attack,
+                # (b) speed budget exhausted (no movement remaining),
+                # (c) two consecutive step failures (anti-loop guard
+                # for monster-vs-monster collisions and walls), or
+                # (d) the hard step ceiling as a paranoia backstop.
+                #
+                # MVP limits intentionally not addressed:
+                # - Greedy sign(dx, dy) pathing; will clump in doorways
+                #   and may provoke avoidable OAs.
+                # - No Dash. Targets beyond `speed` feet trigger MOVED.
+                # - No split movement around the attack.
+                # A* / flowfield deferred until friction shows up.
+                enemy_eid = self.spatial.occupant_at(enemy.position)
+                if enemy_eid is not None:
+                    consecutive_failures = 0
+                    max_steps = 12  # speed=30 only needs 6; hard ceiling
+                    while moved_squares < max_steps:
+                        candidates = [
+                            pc for pc in living_party
+                            if pc.position is not None
+                        ]
+                        if not candidates:
+                            break
+                        target_pc = min(
+                            candidates,
+                            key=lambda pc: (
+                                distance_in_feet(
+                                    enemy.position.x, enemy.position.y,
+                                    pc.position.x, pc.position.y,
+                                ),
+                                pc.name,
+                            ),
+                        )
+                        dx = (
+                            1 if target_pc.position.x > enemy.position.x
+                            else -1 if target_pc.position.x < enemy.position.x
+                            else 0
+                        )
+                        dy = (
+                            1 if target_pc.position.y > enemy.position.y
+                            else -1 if target_pc.position.y < enemy.position.y
+                            else 0
+                        )
+                        if dx == 0 and dy == 0:
+                            break  # standing on the target tile (shouldn't happen)
+                        move_result = self.attempt_combat_step(
+                            enemy_eid, dx, dy,
+                        )
+                        if move_result.ok:
+                            moved_squares += 1
+                            consecutive_failures = 0
+                            in_reach = [
+                                pc for pc in living_party
+                                if pc.position is not None
+                                and distance_in_feet(
+                                    enemy.position.x, enemy.position.y,
+                                    pc.position.x, pc.position.y,
+                                ) <= reach_ft
+                            ]
+                            if in_reach:
+                                break  # fall through to attack
+                        else:
+                            consecutive_failures += 1
+                            if move_result.reason == "no movement remaining":
+                                break
+                            if consecutive_failures >= 2:
+                                break  # stuck (e.g., walls, other monster)
+
+                if not in_reach:
+                    # Either moved without reaching (MOVED) or couldn't
+                    # move at all (NO_REACHABLE_TARGET — speed 0 or
+                    # blocked from the start).
+                    self.initiative_tracker.next_turn()
+                    action_taken = (
+                        EnemyTurnAction.MOVED if moved_squares > 0
+                        else EnemyTurnAction.NO_REACHABLE_TARGET
+                    )
+                    return EnemyTurnResult(
+                        enemy_name=enemy.name,
+                        enemy_display_name=enemy_display_name,
+                        action_taken=action_taken,
+                        action_data=action,
+                        moved_squares=moved_squares,
+                        movement_end_position=(
+                            enemy.position.x, enemy.position.y,
+                        ),
+                        turn_start_effects=turn_start_effects,
+                        turn_end_effects=turn_end_effects,
+                        turn_advanced=True,
+                    )
             targeting_pool = in_reach
 
         # Use smart targeting based on enemy intelligence and combat
@@ -5304,6 +5399,17 @@ class GameState:
             narrative_context=narrative_context,
             turn_advanced=True,
             combat_ended=combat_ended,
+            # Layer 3 (#641): if the enemy closed distance before
+            # attacking, surface the step count on the result. Defaults
+            # to 0 / None when the enemy was already in reach.
+            moved_squares=(
+                moved_squares if "moved_squares" in locals() else 0
+            ),
+            movement_end_position=(
+                (enemy.position.x, enemy.position.y)
+                if "moved_squares" in locals() and moved_squares > 0
+                else None
+            ),
         )
 
     def process_unconscious_turn(self) -> DeathSaveTurnResult | None:

--- a/dnd-engine/tests/test_enemy_turn_movement.py
+++ b/dnd-engine/tests/test_enemy_turn_movement.py
@@ -11,7 +11,7 @@ from dnd_engine.core.game_state import EnemyTurnAction, GameState
 from dnd_engine.core.map import Map, TileType
 from dnd_engine.core.party import Party
 from dnd_engine.rules.loader import DataLoader
-from dnd_engine.utils.events import EventBus
+from dnd_engine.utils.events import Event, EventBus, EventType
 
 
 def _make_character(
@@ -181,3 +181,63 @@ class TestMonsterClosesAndAttacks:
         # PC took no damage — confirming attack truly didn't run.
         for character in gs.party.characters:
             assert character.current_hp == character.max_hp
+
+
+class TestMonsterMovementProvokesOpportunityAttacks:
+    """The OA dispatch already publishes OPPORTUNITY_PROVOKED for any
+    mover (PC or monster) via ``attempt_combat_step``. Layer 3 just has
+    to plumb monster movement through that primitive — this test
+    verifies the integration.
+    """
+
+    def test_monster_leaving_reach_to_chase_distant_pc_provokes_oa(self):
+        """Issue #641 acceptance criterion 3: enemy 1 walks south past
+        enemy 2's 5-ft reach to reach a distant PC; enemy 2's reaction
+        slot is consumed by the OA.
+
+        Why two enemies (not two PCs)? Our greedy "nearest target"
+        strategy will always pick an adjacent PC first and attack it
+        instead of moving — there's no scenario where a monster
+        rationally walks past a PC it could bite. ``_register_default_
+        opportunity_attacks`` walks every placed combatant, though, so
+        enemy 2 IS a registered reactor and its OA handler fires on
+        any mover (including another monster) leaving its 5-ft reach.
+
+        Geometry:
+          enemy 1 (mover) at (5, 5), enemy 2 (reactor) at (4, 5).
+          PC at (5, 12) — 35 ft south.
+          Step 1: (5,5)->(5,6). Enemy 1 still 5 ft from enemy 2 → no OA.
+          Step 2: (5,6)->(5,7). Enemy 1 now 10 ft from enemy 2 — leaves
+          reach → enemy 2's reaction fires, slot consumed.
+        """
+        gs, _eids = _build_movement_fixture(
+            party_positions={"Alice": (5, 12)},
+            enemy_positions=[(5, 5), (4, 5)],
+        )
+        mover = gs.active_enemies[0]
+
+        captured: list[Event] = []
+        gs.event_bus.subscribe(EventType.DAMAGE_DEALT, captured.append)
+
+        result = gs.process_enemy_turn()
+        assert result is not None
+
+        # The OA fires when the mover leaves the reactor's reach on
+        # step 2. Reaction-slot consumption can't be asserted directly
+        # here — ``process_enemy_turn`` calls ``next_turn`` before
+        # returning, and per SRD the reactor's slot resets at the
+        # start of its own turn (initiative.py:208). The roll-
+        # independent signal we DO get is the ``DAMAGE_DEALT`` event
+        # tagged ``opportunity_attack`` emitted by
+        # ``_resolve_opportunity_attack_outcome`` when an OA connects.
+        # Matches the canonical observation in
+        # tests/test_oa_combat_step_integration.py:115-127.
+        oa_events = [e for e in captured if e.data.get("opportunity_attack")]
+        assert len(oa_events) >= 1, (
+            f"expected at least one OA DAMAGE_DEALT event; got {len(oa_events)}"
+        )
+        # The mover (enemy 1) is the defender of the OA. The reactor
+        # (enemy 2) is the attacker — both happen to be "Giant Rat",
+        # which is correct: the OA system makes no friend/foe check
+        # (a known limitation, not introduced by this change).
+        assert oa_events[0].data["defender"] == mover.name

--- a/dnd-engine/tests/test_enemy_turn_movement.py
+++ b/dnd-engine/tests/test_enemy_turn_movement.py
@@ -1,0 +1,139 @@
+# ABOUTME: Tests for monster movement AI in process_enemy_turn (#641, Layer 3).
+# ABOUTME: When no PC is in reach, the enemy closes distance via attempt_combat_step.
+
+from __future__ import annotations
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.entity_ids import pc_entity_id
+from dnd_engine.core.game_state import EnemyTurnAction, GameState
+from dnd_engine.core.map import Map, TileType
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.utils.events import EventBus
+
+
+def _make_character(
+    name: str, cls: CharacterClass, position: tuple[int, int]
+) -> Character:
+    """Level-1 wizard PC. Stats identical across PCs so distance is the
+    only differentiating factor for targeting / movement decisions.
+    """
+    return Character(
+        name=name,
+        character_class=cls,
+        level=1,
+        abilities=Abilities(
+            strength=12, dexterity=12, constitution=12,
+            intelligence=10, wisdom=10, charisma=10,
+        ),
+        max_hp=15,
+        ac=12,
+        xp=0,
+    )
+
+
+def _build_movement_fixture(
+    *,
+    party_positions: dict[str, tuple[int, int]],
+    enemy_positions: list[tuple[int, int]] | tuple[int, int],
+    enemy_id: str = "giant_rat",
+    map_size: int = 20,
+) -> tuple[GameState, list[str]]:
+    """Build a flat-floor combat with PCs and one or more enemies.
+
+    Returns ``(game_state, enemy_entity_ids)``. Initiative is forced to
+    the first enemy so ``process_enemy_turn`` can be called directly.
+
+    Mirrors ``test_enemy_turn_reach_targeting._build_targeting_fixture``
+    so we share the same regression-tested wiring (bootstrap_spatial,
+    _start_combat, surprise scrub).
+    """
+    tiles: dict[tuple[int, int], TileType] = {}
+    for y in range(map_size):
+        for x in range(map_size):
+            tiles[(x, y)] = TileType.FLOOR
+    grid_map = Map(width=map_size, height=map_size, tiles=tiles)
+
+    characters = [
+        _make_character(name, CharacterClass.WIZARD, pos)
+        for name, pos in party_positions.items()
+    ]
+    party = Party(characters=characters)
+
+    game_state = GameState(
+        party=party,
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+        dice_roller=DiceRoller(seed=42),
+    )
+    game_state.bootstrap_spatial(grid_map)
+
+    if isinstance(enemy_positions, tuple):
+        enemy_positions = [enemy_positions]
+
+    enemy_eids: list[str] = []
+    for idx, pos in enumerate(enemy_positions):
+        enemy = game_state.data_loader.create_monster(enemy_id)
+        game_state.active_enemies.append(enemy)
+        eid = f"{enemy_id}_{idx}"
+        game_state.set_position(eid, pos[0], pos[1])
+        enemy_eids.append(eid)
+
+    for character, (x, y) in zip(characters, party_positions.values(), strict=True):
+        game_state.set_position(pc_entity_id(character.name), x, y)
+
+    game_state._start_combat()
+    tracker = game_state.initiative_tracker
+    assert tracker is not None
+    # Force the first enemy to act first.
+    for idx, entry in enumerate(tracker.combatants):
+        if entry.creature is game_state.active_enemies[0]:
+            tracker.current_turn_index = idx
+            break
+
+    # Strip surprise so the movement test isn't sidetracked by a skipped
+    # turn — same scrub used by the reach-targeting suite.
+    for enemy in game_state.active_enemies:
+        if enemy.has_condition("surprised"):
+            enemy.remove_condition("surprised")
+
+    return game_state, enemy_eids
+
+
+class TestMonsterClosesAndAttacks:
+    """SRD § Movement: a monster with no in-reach target moves toward
+    the nearest PC, then attacks if it lands inside reach.
+    """
+
+    def test_speed_30_enemy_closes_30_ft_and_attacks_in_one_turn(self):
+        """Giant rat (speed 30, 5-ft bite) 30 ft from a PC closes and bites.
+
+        Issue #641 acceptance criterion 1: ``process_enemy_turn`` must
+        consume movement to reach an out-of-reach PC and then resolve
+        the attack in the same turn.
+
+        Geometry: enemy at (5, 5), PC at (5, 11) → 6 squares = 30 ft.
+        After 5 steps the enemy lands at (5, 10), 5 ft from the PC and
+        in bite reach. The 6th step is unnecessary; the loop must
+        notice the in-reach pool became non-empty and break to attack.
+        """
+        gs, _eids = _build_movement_fixture(
+            party_positions={"Bob": (5, 11)},
+            enemy_positions=(5, 5),
+        )
+
+        result = gs.process_enemy_turn()
+
+        assert result is not None
+        assert result.action_taken == EnemyTurnAction.ATTACK
+        assert result.target_name == "Bob"
+        assert result.moved_squares >= 5, (
+            "enemy needed at least 5 steps to reach bite range — "
+            f"got {result.moved_squares}"
+        )
+        # Attack happened (hit or miss — seeded roll, but the contract
+        # is that the attack code ran, not that it landed).
+        assert result.attack_result is not None

--- a/dnd-engine/tests/test_enemy_turn_movement.py
+++ b/dnd-engine/tests/test_enemy_turn_movement.py
@@ -241,3 +241,43 @@ class TestMonsterMovementProvokesOpportunityAttacks:
         # which is correct: the OA system makes no friend/foe check
         # (a known limitation, not introduced by this change).
         assert oa_events[0].data["defender"] == mover.name
+
+
+class TestMonsterCannotMove:
+    """SRD: a creature with speed 0 (Grappled, Restrained, etc.) can't
+    move. Layer 3 must surface this cleanly as NO_REACHABLE_TARGET so
+    the headless tick loop doesn't hang, and must not infinite-loop on
+    a step that always fails.
+    """
+
+    def test_speed_0_enemy_stays_put_and_advances_turn(self):
+        """Issue #641 acceptance criterion 4: a speed=0 enemy (e.g.,
+        grappled) returns NO_REACHABLE_TARGET with moved_squares=0.
+
+        ``attempt_combat_step`` fails the first step with
+        ``"no movement remaining"`` because TurnState was initialized
+        from ``enemy.speed = 0``. The movement loop's exhausted-budget
+        branch breaks out without spinning, the turn advances, and no
+        attack happens.
+        """
+        gs, _eids = _build_movement_fixture(
+            party_positions={"Alice": (5, 11)},  # 30 ft away
+            enemy_positions=(5, 5),
+            enemy_speed_override=0,
+        )
+        tracker = gs.initiative_tracker
+        assert tracker is not None
+        turn_index_before = tracker.current_turn_index
+
+        result = gs.process_enemy_turn()
+
+        assert result is not None
+        assert result.action_taken == EnemyTurnAction.NO_REACHABLE_TARGET
+        assert result.moved_squares == 0
+        assert result.turn_advanced is True
+        assert tracker.current_turn_index != turn_index_before, (
+            "initiative did not advance — combat would hang"
+        )
+        # Enemy position unchanged.
+        assert gs.active_enemies[0].position.x == 5
+        assert gs.active_enemies[0].position.y == 5

--- a/dnd-engine/tests/test_enemy_turn_movement.py
+++ b/dnd-engine/tests/test_enemy_turn_movement.py
@@ -39,6 +39,7 @@ def _build_movement_fixture(
     party_positions: dict[str, tuple[int, int]],
     enemy_positions: list[tuple[int, int]] | tuple[int, int],
     enemy_id: str = "giant_rat",
+    enemy_speed_override: int | None = None,
     map_size: int = 20,
 ) -> tuple[GameState, list[str]]:
     """Build a flat-floor combat with PCs and one or more enemies.
@@ -77,6 +78,11 @@ def _build_movement_fixture(
     enemy_eids: list[str] = []
     for idx, pos in enumerate(enemy_positions):
         enemy = game_state.data_loader.create_monster(enemy_id)
+        if enemy_speed_override is not None:
+            # Set speed BEFORE _start_combat() so TurnState init at
+            # initiative.py:102 picks up the override
+            # (TurnState(movement_remaining=creature.speed)).
+            enemy.speed = enemy_speed_override
         game_state.active_enemies.append(enemy)
         eid = f"{enemy_id}_{idx}"
         game_state.set_position(eid, pos[0], pos[1])
@@ -137,3 +143,41 @@ class TestMonsterClosesAndAttacks:
         # Attack happened (hit or miss — seeded roll, but the contract
         # is that the attack code ran, not that it landed).
         assert result.attack_result is not None
+
+    def test_speed_20_enemy_stops_10_ft_short_and_emits_moved(self):
+        """Speed=20 enemy 30 ft from a PC moves 4 squares and stops.
+
+        Issue #641 acceptance criterion 2: a monster whose speed
+        budget doesn't reach the nearest PC takes what movement it
+        has, ends the turn with a MOVED action, and does NOT attempt
+        an attack (the engine reach gate would reject it anyway).
+
+        Geometry: enemy at (5, 5), PC at (5, 11) → 30 ft. With
+        speed=20, the enemy takes 4 steps (4 × 5 ft = 20 ft) and
+        lands at (5, 9), still 10 ft from the PC.
+        """
+        gs, _eids = _build_movement_fixture(
+            party_positions={"Bob": (5, 11)},
+            enemy_positions=(5, 5),
+            enemy_speed_override=20,
+        )
+
+        result = gs.process_enemy_turn()
+
+        assert result is not None
+        assert result.action_taken == EnemyTurnAction.MOVED, (
+            f"speed=20 enemy should have emitted MOVED; got {result.action_taken}"
+        )
+        assert result.moved_squares == 4, (
+            f"speed=20 = 4 steps of 5 ft; got {result.moved_squares}"
+        )
+        assert result.movement_end_position == (5, 9), (
+            "enemy should have stopped at (5, 9), 10 ft from PC; "
+            f"ended at {result.movement_end_position}"
+        )
+        assert result.attack_result is None
+        assert result.target_killed is False
+        assert result.turn_advanced is True
+        # PC took no damage — confirming attack truly didn't run.
+        for character in gs.party.characters:
+            assert character.current_hp == character.max_hp

--- a/dnd-engine/tests/test_enemy_turn_movement.py
+++ b/dnd-engine/tests/test_enemy_turn_movement.py
@@ -344,3 +344,59 @@ class TestMonsterMovementDoesNotDeadlock:
             "enemy 2 never got a turn within 10 initiative steps — "
             "something is hanging combat"
         )
+
+
+class TestTickLoopClosesAndAttacks:
+    """Integration: drive the headless tick loop forward; the only path
+    to victory is monsters closing distance. Mirrors the hang-detector
+    pattern from
+    tests/test_enemy_turn_reach_targeting.py::TestRangeAwareTargeting
+    ::test_combat_does_not_hang_when_all_enemies_stranded.
+    """
+
+    def test_monster_closes_distance_and_lands_an_attack_within_one_round(self):
+        """Issue #641 acceptance criterion 6: when the enemy is 30 ft
+        from the PC, ``process_enemy_turn`` should — within a single
+        call — move into reach and attack.
+
+        Speed=30 = 6 squares of movement; the gap closes in 5 steps
+        (the 6th step is unnecessary, the loop must recognize the
+        in-reach pool became non-empty and break to attack). We loop
+        ``process_enemy_turn`` to be resilient to initiative ordering
+        (the enemy may or may not be the first combatant), with a
+        belt-and-braces step ceiling.
+        """
+        gs, _eids = _build_movement_fixture(
+            party_positions={"Alice": (5, 11)},  # 30 ft south
+            enemy_positions=(5, 5),
+        )
+        tracker = gs.initiative_tracker
+        assert tracker is not None
+        enemy = gs.active_enemies[0]
+
+        attack_seen = False
+        moved_before_attacking = 0
+        # Hard cap on initiative iterations: enough for a few rounds
+        # in a 2-combatant fight, well short of an infinite loop.
+        for _ in range(20):
+            current = tracker.get_current_combatant()
+            if current is not None and current.creature is enemy:
+                result = gs.process_enemy_turn()
+                assert result is not None
+                if result.action_taken == EnemyTurnAction.ATTACK:
+                    attack_seen = True
+                    moved_before_attacking = result.moved_squares
+                    break
+                # MOVED or NO_REACHABLE_TARGET: keep cycling
+                continue
+            # PC turn — skip past it.
+            tracker.next_turn()
+
+        assert attack_seen, (
+            "enemy never reached attack range — closing-distance "
+            "combat would never complete"
+        )
+        assert moved_before_attacking >= 5, (
+            f"enemy needed at least 5 steps to close 30 ft; "
+            f"got {moved_before_attacking}"
+        )

--- a/dnd-engine/tests/test_enemy_turn_movement.py
+++ b/dnd-engine/tests/test_enemy_turn_movement.py
@@ -281,3 +281,66 @@ class TestMonsterCannotMove:
         # Enemy position unchanged.
         assert gs.active_enemies[0].position.x == 5
         assert gs.active_enemies[0].position.y == 5
+
+
+class TestMonsterMovementDoesNotDeadlock:
+    """The anti-loop guard (two consecutive step failures) protects
+    against monster-vs-monster collisions and walls. Without it, a
+    monster blocked by another monster on every step would spin until
+    the hard step ceiling tripped.
+    """
+
+    def test_two_enemies_blocking_each_other_terminate_cleanly(self):
+        """Issue #641 acceptance criterion 5: enemy 1's path to the PC
+        is blocked by enemy 2; enemy 1's movement loop must exit
+        cleanly via the anti-loop guard rather than spin.
+
+        Layout (single shared south-bound axis):
+          enemy 1 at (5, 5), enemy 2 at (5, 6) directly blocking south.
+          PC at (5, 11) — south of both.
+
+        Enemy 1's greedy sign-step is always (0, +1). attempt_combat_step
+        rejects each step with reason ``"occupied by giant_rat_1"``.
+        After two consecutive failures the loop breaks; result is
+        NO_REACHABLE_TARGET with moved_squares=0 and the turn
+        advances.
+
+        We then call ``process_enemy_turn`` again for enemy 2's turn
+        as a smoke check: it should NOT hang and should make
+        meaningful progress (its south path is clear).
+        """
+        gs, _eids = _build_movement_fixture(
+            party_positions={"Alice": (5, 11)},
+            enemy_positions=[(5, 5), (5, 6)],
+        )
+        tracker = gs.initiative_tracker
+        assert tracker is not None
+        enemy_1 = gs.active_enemies[0]
+        enemy_2 = gs.active_enemies[1]
+
+        result_1 = gs.process_enemy_turn()
+
+        assert result_1 is not None
+        assert result_1.action_taken == EnemyTurnAction.NO_REACHABLE_TARGET
+        assert result_1.moved_squares == 0
+        assert result_1.turn_advanced is True
+        # Enemy 1 stayed at (5, 5).
+        assert (enemy_1.position.x, enemy_1.position.y) == (5, 5)
+
+        # Drive forward until enemy 2 acts (a PC may go between them
+        # depending on initiative). Cap the loop to prove no hang.
+        seen_enemy_2_turn = False
+        for _ in range(10):
+            current = tracker.get_current_combatant()
+            if current is not None and current.creature is enemy_2:
+                result_2 = gs.process_enemy_turn()
+                assert result_2 is not None
+                seen_enemy_2_turn = True
+                break
+            # Skip PC turns by advancing initiative manually.
+            tracker.next_turn()
+
+        assert seen_enemy_2_turn, (
+            "enemy 2 never got a turn within 10 initiative steps — "
+            "something is hanging combat"
+        )

--- a/dnd-engine/tests/test_enemy_turn_reach_targeting.py
+++ b/dnd-engine/tests/test_enemy_turn_reach_targeting.py
@@ -130,13 +130,18 @@ class TestRangeAwareTargeting:
             f"rat should have targeted in-reach Bob, picked {result.target_name!r}"
         )
 
-    def test_no_reachable_target_returns_dedicated_action_and_advances_turn(self):
-        """All PCs out of reach -> NO_REACHABLE_TARGET, turn advances.
+    def test_out_of_reach_pcs_trigger_layer3_movement_then_attack(self):
+        """All PCs out of bite reach -> Layer 3 closes distance & attacks.
 
-        Architect-flagged blocker: if the new "no in-reach" branch
-        forgets to advance the turn, the headless tick loop spins
-        forever and combat hangs. This test pins both the action enum
-        and the turn-advance contract so the regression is loud.
+        Before #641 (Layer 3) shipped, this branch returned
+        NO_REACHABLE_TARGET with no movement and the enemy stayed put.
+        Layer 3 wires ``attempt_combat_step`` into the loop so a
+        speed=30 enemy now closes a 30-ft gap and bites in the same
+        turn. The architectural invariant the original test guarded —
+        the turn advances so the headless tick loop never hangs — is
+        preserved here on the new ATTACK return path. Coverage for
+        the residual NO_REACHABLE_TARGET case (speed=0 / Grappled)
+        lives in tests/test_enemy_turn_movement.py::TestMonsterCannotMove.
         """
         gs, _enemy_eid = _build_targeting_fixture(
             party_positions={"Bob": (5, 11), "Abe": (5, 12)},  # both 30+ ft
@@ -149,16 +154,16 @@ class TestRangeAwareTargeting:
         result = gs.process_enemy_turn()
 
         assert result is not None
-        assert result.action_taken == EnemyTurnAction.NO_REACHABLE_TARGET
+        assert result.action_taken == EnemyTurnAction.ATTACK
+        assert result.moved_squares >= 5, (
+            "speed=30 enemy needs at least 5 steps to close 30 ft to "
+            f"bite reach; got {result.moved_squares}"
+        )
         assert result.turn_advanced is True
         assert tracker.current_turn_index != turn_index_before, (
             "initiative did not advance — combat would hang in the "
             "headless tick loop"
         )
-        assert result.attack_result is None
-        # No PC took damage.
-        for character in gs.party.characters:
-            assert character.current_hp == character.max_hp
 
     def test_combat_does_not_hang_when_all_enemies_stranded(self):
         """Multiple stranded enemies across rounds — initiative keeps moving.


### PR DESCRIPTION
## Summary

Closes the last gap in plan-03 (Movement, Terrain & Positioning) for live combat. Monsters now close distance toward the nearest PC when no one is in reach, then attack if they make it into range. Without this, the engine reach gate shipped by #634 left stranded enemies frozen — players could kite indefinitely from range.

## Changes

- **`dnd-engine/dnd_engine/core/game_state.py`** — wires `attempt_combat_step` into `process_enemy_turn`'s `NO_REACHABLE_TARGET` branch. Single 5-ft greedy `sign(dx, dy)` steps toward the nearest PC; loop breaks on (a) a PC entering reach (fall through to attack), (b) speed budget exhausted, (c) two consecutive step failures (anti-loop guard), or (d) the 12-step hard ceiling. Adds `EnemyTurnAction.MOVED` and `moved_squares` / `movement_end_position` fields on `EnemyTurnResult`.
- **`dnd-engine/tests/test_enemy_turn_movement.py`** *(new, 6 tests)* — covers all six acceptance criteria from the issue: close-and-attack, partial-movement MOVED, OA-on-monster-move, speed=0 stays put, monster-vs-monster anti-deadlock, full closing-distance round.
- **`dnd-engine/tests/test_enemy_turn_reach_targeting.py`** — refreshes the Layer 2 reach-targeting test that pinned the old "stay put" behavior, now expressing the Layer 3 ATTACK contract. Architectural invariant (turn-advance to prevent headless hang) preserved.

Opportunity attacks are inherited for free — `attempt_combat_step` already publishes `OPPORTUNITY_PROVOKED` for any mover (PC or monster).

## MVP limits (documented in code, deferred)

- Greedy sign-pathing only (no A*/flowfield) — will clump in doorways.
- No Dash action.
- No split movement around the attack (move-then-attack only).
- OA capture wrapper in `session.py:1405-1417` still mirrors PC moves only — UI follow-up, not a blocker.

## Testing

- [x] 6 new unit tests for the movement loop
- [x] Layer 2 test refreshed for Layer 3 semantics
- [x] Full dnd-engine suite: **3270 passed, 191 skipped** (no regressions)
- [x] Python code reviewer pass; feedback applied (hoisted `moved_squares` out of `locals()` introspection, fixed `movement_end_position` contract on the early-return path, added tiebreaker-comment)

## Related Issues

Closes #641. Completes Layer 3 of the #634 monster-combat series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)