### PR TITLE
Refactor #647: decide/execute turn pipeline + event-driven visual sync

### DIFF
--- a/client-2d/src/client_2d/animation/__init__.py
+++ b/client-2d/src/client_2d/animation/__init__.py
@@ -1,0 +1,6 @@
+# ABOUTME: Animation utilities for the 2D client (sprite tweening, easing).
+# ABOUTME: Issue #647 — adds movement-tween queue for per-step monster sprite animation.
+
+from client_2d.animation.movement_tween import MovementTween, MovementTweenQueue
+
+__all__ = ["MovementTween", "MovementTweenQueue"]

--- a/client-2d/src/client_2d/animation/movement_tween.py
+++ b/client-2d/src/client_2d/animation/movement_tween.py
@@ -1,0 +1,149 @@
+# ABOUTME: Per-entity movement-tween queue for smooth per-step sprite animation (#647).
+# ABOUTME: Ease-out interpolation between (from, to) grid tiles; degrades to teleport under load.
+
+"""MovementTweenQueue — smooth sprite animation for engine-driven movement.
+
+When the engine publishes CREATURE_MOVED, the EntityManager (the
+event consumer) updates the entity's grid_x / grid_y and enqueues a
+tween in this queue. The render loop calls `tick(dt_ms)` per frame
+to advance active tweens, and reads `visual_offset(entity_id)` to
+get the current pixel offset to apply to the sprite at draw time.
+
+Tweens use ease-out for a quick "snap to destination" feel
+appropriate for tile-based movement (~120 ms per step). When the
+queue depth for an entity exceeds `TELEPORT_THRESHOLD`, the queue
+clears and snaps to the final position — a graceful degradation
+for fast turn sequences (multiple monsters resolving in one tick)
+that prevents the UI thread from being starved.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+
+DEFAULT_DURATION_MS = 120.0
+"""Default per-step tween duration. Calibrated for tile-based movement:
+fast enough to feel responsive, slow enough that the eye registers the
+step direction."""
+
+TELEPORT_THRESHOLD = 3
+"""Per-entity queue depth at which we collapse remaining tweens and
+teleport to the final tile. Keeps the visual layer responsive when
+the engine emits many CREATURE_MOVED events in one tick."""
+
+
+@dataclass
+class MovementTween:
+    """A single from→to tile tween with an ease-out time curve."""
+
+    from_x: int
+    from_y: int
+    to_x: int
+    to_y: int
+    duration_ms: float = DEFAULT_DURATION_MS
+    elapsed_ms: float = 0.0
+
+    @property
+    def progress(self) -> float:
+        """Linear time progress in [0, 1]."""
+        if self.duration_ms <= 0:
+            return 1.0
+        return max(0.0, min(1.0, self.elapsed_ms / self.duration_ms))
+
+    @property
+    def eased_progress(self) -> float:
+        """Ease-out cubic — quick start, gentle stop."""
+        t = self.progress
+        return 1.0 - (1.0 - t) ** 3
+
+    @property
+    def is_complete(self) -> bool:
+        return self.elapsed_ms >= self.duration_ms
+
+    def current_offset(self) -> tuple[float, float]:
+        """Return the (dx, dy) tile-space offset to add to `from_x/y`.
+
+        Returns an interpolated offset where the visible position is
+        `(from_x + dx, from_y + dy)` in tile units. At t=0 the offset
+        is (0,0); at t=1 it's `(to-from)`.
+        """
+        e = self.eased_progress
+        return ((self.to_x - self.from_x) * e, (self.to_y - self.from_y) * e)
+
+
+class MovementTweenQueue:
+    """Per-entity tween queue.
+
+    All operations are O(1) per entity. The render loop does one
+    `tick(dt_ms)` per frame and one `visual_offset(entity_id)` per
+    sprite per frame.
+    """
+
+    def __init__(self, *, teleport_threshold: int = TELEPORT_THRESHOLD) -> None:
+        self._queues: dict[str, deque[MovementTween]] = {}
+        self._teleport_threshold = teleport_threshold
+
+    def enqueue(
+        self,
+        entity_id: str,
+        from_tile: tuple[int, int],
+        to_tile: tuple[int, int],
+        *,
+        duration_ms: float = DEFAULT_DURATION_MS,
+    ) -> None:
+        """Add a from→to tween to the entity's queue.
+
+        If the queue depth would exceed the teleport threshold,
+        clear the queue and silently snap to the destination — the
+        visual layer cannot keep up with the engine, so a clean
+        teleport is preferable to a stuttering chain.
+        """
+        queue = self._queues.setdefault(entity_id, deque())
+        if len(queue) >= self._teleport_threshold:
+            queue.clear()
+            return
+        tween = MovementTween(
+            from_x=from_tile[0], from_y=from_tile[1],
+            to_x=to_tile[0], to_y=to_tile[1],
+            duration_ms=duration_ms,
+        )
+        queue.append(tween)
+
+    def tick(self, dt_ms: float) -> None:
+        """Advance all active tweens by `dt_ms` and pop completed ones."""
+        for queue in self._queues.values():
+            remaining = dt_ms
+            while queue and remaining > 0:
+                active = queue[0]
+                slot = active.duration_ms - active.elapsed_ms
+                if remaining < slot:
+                    active.elapsed_ms += remaining
+                    remaining = 0.0
+                else:
+                    active.elapsed_ms = active.duration_ms
+                    queue.popleft()
+                    remaining -= slot
+
+    def visual_offset(self, entity_id: str) -> tuple[float, float]:
+        """Return the current tile-space offset to apply to the sprite.
+
+        Returns `(0.0, 0.0)` when the entity has no active tween.
+        """
+        queue = self._queues.get(entity_id)
+        if not queue:
+            return (0.0, 0.0)
+        active = queue[0]
+        return active.current_offset()
+
+    def depth(self, entity_id: str) -> int:
+        """Return the queued tween count for an entity (testing aid)."""
+        queue = self._queues.get(entity_id)
+        return len(queue) if queue else 0
+
+    def clear(self, entity_id: str | None = None) -> None:
+        """Drop all queued tweens (per-entity or globally)."""
+        if entity_id is None:
+            self._queues.clear()
+        elif entity_id in self._queues:
+            self._queues[entity_id].clear()

--- a/client-2d/src/client_2d/entities/entity.py
+++ b/client-2d/src/client_2d/entities/entity.py
@@ -102,6 +102,14 @@ class Entity:
         engine Creature. This allows efficient rendering without
         constantly querying the engine.
 
+        Position is **not** synced here. The engine drives position via
+        explicit CREATURE_MOVED / CREATURE_PLACED events; the
+        EngineBridge subscribes to those events (#647) and writes
+        grid_x / grid_y directly so the visual layer sees per-step
+        movement without overwriting client-owned writes from legacy
+        combat (update_current_turn_position) or MCP tests that set
+        grid coordinates by hand.
+
         Returns:
             True if any state changed, False if unchanged.
             Use this to trigger animations on state changes.

--- a/client-2d/src/client_2d/entities/entity_manager.py
+++ b/client-2d/src/client_2d/entities/entity_manager.py
@@ -59,6 +59,11 @@ class EntityManager:
         self._monsters: dict[str, MonsterEntity] = {}
         self._party_members: dict[str, PartyMemberEntity] = {}
         self._items: dict[str, ItemEntity] = {}
+        # Engine event subscriptions (#647). Populated by
+        # subscribe_to_engine_events so we can unsubscribe and re-
+        # subscribe cleanly across load_scenario / reset_game cycles.
+        self._subscribed_event_bus = None
+        self._tween_queue = None
 
     def clear(self) -> None:
         """Remove all entities. Call on room transitions."""
@@ -175,6 +180,90 @@ class EntityManager:
                 changed.append(party_member)
 
         return changed
+
+
+    def subscribe_to_engine_events(
+        self,
+        event_bus,
+        *,
+        tween_queue=None,
+    ) -> None:
+        """Subscribe to engine position events so the visual layer stays current.
+
+        Issue #647: the engine publishes CREATURE_MOVED on every
+        successful 5-ft step (via attempt_combat_step) and
+        CREATURE_PLACED on every spatial placement (via set_position).
+        Subscribing here lets the EntityManager update grid_x / grid_y
+        on each entity in lockstep with the engine, so MCP ASCII output
+        and the 2D renderer both reflect intermediate tiles instead of
+        snapping to the final position only.
+
+        When ``tween_queue`` is provided, each step also enqueues a
+        sprite tween so windowed-mode rendering animates the move
+        smoothly. Headless mode passes ``None``.
+
+        The method is idempotent — calling it a second time first
+        unsubscribes from the previous bus. That matters because the
+        session re-creates the engine event bus on every
+        load_scenario / reset_game.
+        """
+        from dnd_engine.utils.events import EventType
+
+        if self._subscribed_event_bus is not None:
+            self._unsubscribe_from_engine_events()
+
+        self._subscribed_event_bus = event_bus
+        self._tween_queue = tween_queue
+        event_bus.subscribe(EventType.CREATURE_MOVED, self._on_creature_moved)
+        event_bus.subscribe(EventType.CREATURE_PLACED, self._on_creature_placed)
+
+    def _unsubscribe_from_engine_events(self) -> None:
+        """Detach from the currently-subscribed event bus."""
+        from dnd_engine.utils.events import EventType
+
+        if self._subscribed_event_bus is None:
+            return
+        try:
+            self._subscribed_event_bus.unsubscribe(
+                EventType.CREATURE_MOVED, self._on_creature_moved,
+            )
+            self._subscribed_event_bus.unsubscribe(
+                EventType.CREATURE_PLACED, self._on_creature_placed,
+            )
+        except (KeyError, ValueError):
+            # Old bus may have been torn down; tolerate.
+            pass
+        self._subscribed_event_bus = None
+        self._tween_queue = None
+
+    def _on_creature_moved(self, event) -> None:
+        """CREATURE_MOVED handler — update grid position + enqueue tween."""
+        data = event.data
+        entity_id = data.get("entity_id")
+        to = data.get("to")
+        if entity_id is None or to is None:
+            return
+        entity = self._entities.get(entity_id)
+        if entity is None:
+            return
+        from_tile = (entity.grid_x, entity.grid_y)
+        entity.grid_x = to.x
+        entity.grid_y = to.y
+        if self._tween_queue is not None:
+            self._tween_queue.enqueue(entity_id, from_tile, (to.x, to.y))
+
+    def _on_creature_placed(self, event) -> None:
+        """CREATURE_PLACED handler — snap grid position (no tween)."""
+        data = event.data
+        entity_id = data.get("entity_id")
+        position = data.get("position")
+        if entity_id is None or position is None:
+            return
+        entity = self._entities.get(entity_id)
+        if entity is None:
+            return
+        entity.grid_x = position.x
+        entity.grid_y = position.y
 
     def remove_dead_entities(self) -> list[Entity]:
         """Remove dead entities from the manager.

--- a/client-2d/src/client_2d/session.py
+++ b/client-2d/src/client_2d/session.py
@@ -112,6 +112,12 @@ class GameSession:
         self.engine = EngineAdapter()
         self.layout_loader = LayoutLoader()
         self.entity_manager = EntityManager()
+        # Per-step monster sprite tween queue (#647). Wired to the
+        # engine event bus by _subscribe_entity_manager_to_engine
+        # after each engine-state setup (initialize / load_scenario /
+        # reset_game).
+        from client_2d.animation import MovementTweenQueue
+        self.movement_tween_queue = MovementTweenQueue()
 
         # Texture dicts - GameWindow populates these before initialize().
         # Empty dicts work fine for headless mode (entity_manager handles
@@ -198,6 +204,7 @@ class GameSession:
         )
         print(f"  Starting room: {game_info['room_name']}")
 
+        self._wire_entity_manager_to_engine_events()
         self._load_room_layout()
 
         print("\nStarting game...")
@@ -1982,9 +1989,30 @@ class GameSession:
         result = self.engine.set_seed(seed)
         return f"Dice roller reseeded with {result['seed']}."
 
+    def _wire_entity_manager_to_engine_events(self) -> None:
+        """Hook the EntityManager into the engine's event bus (#647).
+
+        Idempotent — calling it again after an engine state swap
+        (load_scenario, reset_game, initialize) cleanly transitions
+        the subscription to the fresh event bus. Headless mode passes
+        the same MovementTweenQueue; the queue's enqueue is a no-op
+        unless the renderer ticks and reads visual_offset, so headless
+        callers pay only the dict-update cost.
+        """
+        event_bus = getattr(self.engine, "event_bus", None)
+        if event_bus is None:
+            return
+        self.entity_manager.subscribe_to_engine_events(
+            event_bus, tween_queue=self.movement_tween_queue,
+        )
+
     def load_scenario(self, path: str) -> str:
         """Load a YAML scenario: swap engine state and rebuild visuals."""
         result = self.engine.load_scenario(path)
+        # The scenario load replaces game_state and event_bus, so re-
+        # attach the entity-manager subscription to the new bus before
+        # any entity-construction event handlers fire downstream.
+        self._wire_entity_manager_to_engine_events()
 
         # The new engine state has a new dungeon / room; reload the
         # layout (also resets fog + lighting).

--- a/client-2d/tests/test_entity.py
+++ b/client-2d/tests/test_entity.py
@@ -15,6 +15,14 @@ from client_2d.entities import (
 )
 
 
+class _MockPosition:
+    """Minimal stand-in for dnd_engine.core.position.Position."""
+
+    def __init__(self, x: int, y: int):
+        self.x = x
+        self.y = y
+
+
 class MockCreature:
     """Mock creature for testing entity sync without engine dependency."""
 
@@ -25,12 +33,14 @@ class MockCreature:
         max_hp: int = 10,
         is_alive: bool = True,
         active_conditions: dict | None = None,
+        position: _MockPosition | None = None,
     ):
         self.name = name
         self.current_hp = current_hp
         self.max_hp = max_hp
         self._is_alive = is_alive
         self.active_conditions = active_conditions or {}
+        self.position = position
 
     @property
     def is_alive(self) -> bool:
@@ -219,6 +229,34 @@ class TestEntity:
 
         assert changed is True
         assert "stunned" not in entity.conditions
+
+    def test_entity_sync_does_not_mirror_position(self):
+        """#647: sync_from_creature deliberately skips position.
+
+        The engine drives position via CREATURE_MOVED / CREATURE_PLACED
+        events; the EngineBridge subscription updates grid_x / grid_y
+        directly. Mirroring position from sync_from_creature would
+        clobber legacy client-owned writes (update_current_turn_position)
+        and the MCP test fixtures that assign grid coordinates by hand
+        before the engine knows about them.
+        """
+        creature = MockCreature(
+            current_hp=10, max_hp=10,
+            position=_MockPosition(7, 3),
+        )
+        entity = Entity(
+            entity_id="goblin_1",
+            grid_x=42,
+            grid_y=42,
+            entity_type=EntityType.MONSTER,
+        )
+        entity.creature = creature
+
+        # The visual grid_x/y stays at whatever the entity was
+        # constructed with — sync_from_creature only touches HP /
+        # alive / conditions.
+        assert entity.grid_x == 42
+        assert entity.grid_y == 42
 
 
 class TestMonsterEntity:

--- a/client-2d/tests/test_entity_manager_event_sync.py
+++ b/client-2d/tests/test_entity_manager_event_sync.py
@@ -1,0 +1,159 @@
+# ABOUTME: Integration tests — CREATURE_MOVED / CREATURE_PLACED events drive entity.grid_x/y (#647).
+# ABOUTME: Verifies EntityManager subscription, tween enqueue, and idempotent re-subscribe.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from client_2d.animation import MovementTweenQueue
+from client_2d.entities import (
+    Entity,
+    EntityManager,
+    EntityType,
+)
+
+
+@dataclass
+class _Pos:
+    x: int
+    y: int
+
+
+class _StubEvent:
+    def __init__(self, data: dict):
+        self.data = data
+
+
+class _StubBus:
+    """Minimal pub/sub stub matching dnd_engine.utils.events.EventBus surface."""
+
+    def __init__(self):
+        self._subs: dict = {}
+
+    def subscribe(self, event_type, handler):
+        self._subs.setdefault(event_type, []).append(handler)
+
+    def unsubscribe(self, event_type, handler):
+        if event_type in self._subs:
+            self._subs[event_type].remove(handler)
+
+    def publish(self, event_type, event):
+        for handler in self._subs.get(event_type, []):
+            handler(event)
+
+
+def _make_entity(eid: str, x: int, y: int) -> Entity:
+    return Entity(
+        entity_id=eid,
+        grid_x=x,
+        grid_y=y,
+        entity_type=EntityType.MONSTER,
+    )
+
+
+class TestEntityManagerEventSync:
+    def test_creature_moved_updates_grid_position(self):
+        from dnd_engine.utils.events import EventType
+
+        em = EntityManager()
+        bus = _StubBus()
+        em.subscribe_to_engine_events(bus)
+        ent = _make_entity("goblin_1", 5, 5)
+        em._add_entity(ent)
+
+        event = _StubEvent({
+            "entity_id": "goblin_1",
+            "origin": _Pos(5, 5),
+            "to": _Pos(6, 5),
+        })
+        bus.publish(EventType.CREATURE_MOVED, event)
+
+        assert ent.grid_x == 6
+        assert ent.grid_y == 5
+
+    def test_creature_placed_snaps_grid_position(self):
+        from dnd_engine.utils.events import EventType
+
+        em = EntityManager()
+        bus = _StubBus()
+        em.subscribe_to_engine_events(bus)
+        ent = _make_entity("pc_brick", 0, 0)
+        em._add_entity(ent)
+
+        event = _StubEvent({"entity_id": "pc_brick", "position": _Pos(7, 3)})
+        bus.publish(EventType.CREATURE_PLACED, event)
+
+        assert ent.grid_x == 7
+        assert ent.grid_y == 3
+
+    def test_unknown_entity_id_is_ignored(self):
+        from dnd_engine.utils.events import EventType
+
+        em = EntityManager()
+        bus = _StubBus()
+        em.subscribe_to_engine_events(bus)
+
+        event = _StubEvent({
+            "entity_id": "no_such_entity",
+            "origin": _Pos(0, 0),
+            "to": _Pos(1, 0),
+        })
+        # Should not raise.
+        bus.publish(EventType.CREATURE_MOVED, event)
+
+    def test_tween_queue_receives_enqueue_per_step(self):
+        from dnd_engine.utils.events import EventType
+
+        em = EntityManager()
+        bus = _StubBus()
+        tweens = MovementTweenQueue()
+        em.subscribe_to_engine_events(bus, tween_queue=tweens)
+        ent = _make_entity("goblin_1", 5, 5)
+        em._add_entity(ent)
+
+        event = _StubEvent({
+            "entity_id": "goblin_1",
+            "origin": _Pos(5, 5),
+            "to": _Pos(6, 5),
+        })
+        bus.publish(EventType.CREATURE_MOVED, event)
+
+        assert tweens.depth("goblin_1") == 1
+
+    def test_resubscribe_swaps_buses_cleanly(self):
+        from dnd_engine.utils.events import EventType
+
+        em = EntityManager()
+        bus_a = _StubBus()
+        bus_b = _StubBus()
+        em.subscribe_to_engine_events(bus_a)
+        em.subscribe_to_engine_events(bus_b)
+        ent = _make_entity("goblin_1", 0, 0)
+        em._add_entity(ent)
+
+        # Old bus is no longer wired.
+        bus_a.publish(EventType.CREATURE_MOVED, _StubEvent({
+            "entity_id": "goblin_1",
+            "origin": _Pos(0, 0),
+            "to": _Pos(9, 9),
+        }))
+        assert ent.grid_x == 0  # unchanged
+
+        # New bus is.
+        bus_b.publish(EventType.CREATURE_MOVED, _StubEvent({
+            "entity_id": "goblin_1",
+            "origin": _Pos(0, 0),
+            "to": _Pos(1, 0),
+        }))
+        assert ent.grid_x == 1
+
+    def test_malformed_event_data_is_tolerated(self):
+        from dnd_engine.utils.events import EventType
+
+        em = EntityManager()
+        bus = _StubBus()
+        em.subscribe_to_engine_events(bus)
+
+        # Missing required keys — handler should not raise.
+        bus.publish(EventType.CREATURE_MOVED, _StubEvent({}))
+        bus.publish(EventType.CREATURE_PLACED, _StubEvent({"entity_id": "g"}))

--- a/client-2d/tests/test_movement_tween.py
+++ b/client-2d/tests/test_movement_tween.py
@@ -1,0 +1,132 @@
+# ABOUTME: Unit tests for MovementTweenQueue — per-entity sprite tween smoothing (#647).
+# ABOUTME: Verifies ease-out interpolation, tick advancement, and teleport degradation.
+
+from __future__ import annotations
+
+from client_2d.animation.movement_tween import (
+    DEFAULT_DURATION_MS,
+    TELEPORT_THRESHOLD,
+    MovementTween,
+    MovementTweenQueue,
+)
+
+
+class TestMovementTween:
+    def test_progress_starts_at_zero(self):
+        tween = MovementTween(from_x=0, from_y=0, to_x=1, to_y=0)
+        assert tween.progress == 0.0
+        assert tween.is_complete is False
+
+    def test_progress_reaches_one_after_duration(self):
+        tween = MovementTween(from_x=0, from_y=0, to_x=1, to_y=0, duration_ms=100.0)
+        tween.elapsed_ms = 100.0
+        assert tween.progress == 1.0
+        assert tween.is_complete is True
+
+    def test_offset_zero_at_start(self):
+        tween = MovementTween(from_x=0, from_y=0, to_x=5, to_y=0)
+        dx, dy = tween.current_offset()
+        assert dx == 0.0
+        assert dy == 0.0
+
+    def test_offset_full_delta_at_end(self):
+        tween = MovementTween(from_x=0, from_y=0, to_x=5, to_y=3, duration_ms=100.0)
+        tween.elapsed_ms = 100.0
+        dx, dy = tween.current_offset()
+        assert dx == 5.0
+        assert dy == 3.0
+
+    def test_ease_out_progresses_faster_than_linear_early(self):
+        tween = MovementTween(from_x=0, from_y=0, to_x=1, to_y=0, duration_ms=100.0)
+        tween.elapsed_ms = 50.0  # halfway
+        # Linear would be 0.5; ease-out cubic at t=0.5 is 1 - 0.5^3 = 0.875.
+        assert tween.eased_progress > 0.7
+
+
+class TestMovementTweenQueue:
+    def test_initially_no_offset(self):
+        q = MovementTweenQueue()
+        assert q.visual_offset("goblin_1") == (0.0, 0.0)
+        assert q.depth("goblin_1") == 0
+
+    def test_enqueue_adds_tween(self):
+        q = MovementTweenQueue()
+        q.enqueue("goblin_1", (0, 0), (1, 0))
+        assert q.depth("goblin_1") == 1
+
+    def test_tick_advances_and_completes_tween(self):
+        q = MovementTweenQueue()
+        q.enqueue("goblin_1", (0, 0), (1, 0), duration_ms=100.0)
+        q.tick(100.0)
+        # Completed tweens pop out of the queue.
+        assert q.depth("goblin_1") == 0
+        assert q.visual_offset("goblin_1") == (0.0, 0.0)
+
+    def test_tick_partial_offset_in_progress(self):
+        q = MovementTweenQueue()
+        q.enqueue("goblin_1", (0, 0), (1, 0), duration_ms=100.0)
+        q.tick(50.0)  # halfway
+        dx, dy = q.visual_offset("goblin_1")
+        # Ease-out: progress > 0.5 at t=0.5.
+        assert 0.5 < dx < 1.0
+        assert dy == 0.0
+
+    def test_multiple_tweens_chain(self):
+        q = MovementTweenQueue()
+        q.enqueue("g", (0, 0), (1, 0), duration_ms=100.0)
+        q.enqueue("g", (1, 0), (2, 0), duration_ms=100.0)
+        assert q.depth("g") == 2
+        # Complete first tween.
+        q.tick(100.0)
+        assert q.depth("g") == 1
+        # Complete second tween.
+        q.tick(100.0)
+        assert q.depth("g") == 0
+
+    def test_tick_overflow_into_next_tween(self):
+        """When dt > remaining slot, the surplus advances the next tween."""
+        q = MovementTweenQueue()
+        q.enqueue("g", (0, 0), (1, 0), duration_ms=100.0)
+        q.enqueue("g", (1, 0), (2, 0), duration_ms=100.0)
+        q.tick(150.0)  # consumes the first (100ms) and 50ms into the second
+        assert q.depth("g") == 1
+        # The active second tween has 50ms elapsed → offset > 0.
+        dx, _ = q.visual_offset("g")
+        assert dx > 0.0
+
+    def test_teleport_threshold_drops_queue(self):
+        """At queue depth >= TELEPORT_THRESHOLD, new enqueues clear and snap."""
+        q = MovementTweenQueue()
+        for i in range(TELEPORT_THRESHOLD):
+            q.enqueue("g", (i, 0), (i + 1, 0))
+        assert q.depth("g") == TELEPORT_THRESHOLD
+        # Next enqueue triggers degradation: queue is cleared.
+        q.enqueue("g", (TELEPORT_THRESHOLD, 0), (TELEPORT_THRESHOLD + 1, 0))
+        assert q.depth("g") == 0
+        # Visual offset returns to neutral (sprite snaps).
+        assert q.visual_offset("g") == (0.0, 0.0)
+
+    def test_unknown_entity_has_zero_offset(self):
+        q = MovementTweenQueue()
+        q.enqueue("g", (0, 0), (1, 0))
+        assert q.visual_offset("other") == (0.0, 0.0)
+
+    def test_clear_per_entity(self):
+        q = MovementTweenQueue()
+        q.enqueue("a", (0, 0), (1, 0))
+        q.enqueue("b", (0, 0), (1, 0))
+        q.clear("a")
+        assert q.depth("a") == 0
+        assert q.depth("b") == 1
+
+    def test_clear_global(self):
+        q = MovementTweenQueue()
+        q.enqueue("a", (0, 0), (1, 0))
+        q.enqueue("b", (0, 0), (1, 0))
+        q.clear()
+        assert q.depth("a") == 0
+        assert q.depth("b") == 0
+
+    def test_default_duration_is_responsive(self):
+        """Sanity: default duration is in the responsive range for tile movement."""
+        assert 50.0 <= DEFAULT_DURATION_MS <= 300.0

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -5193,83 +5193,49 @@ class GameState:
                 ) <= reach_ft
             ]
             if not in_reach:
-                # Layer 3 (#641): close distance toward the nearest PC.
-                # Loop attempt_combat_step (single 5-ft tile per call);
-                # OAs publish automatically via that primitive. Break
-                # on: (a) a PC entering reach -> fall through to attack,
-                # (b) speed budget exhausted (no movement remaining),
-                # (c) two consecutive step failures (anti-loop guard
-                # for monster-vs-monster collisions and walls), or
-                # (d) the hard step ceiling as a paranoia backstop.
+                # Layer 3 (#641): close distance toward the nearest PC,
+                # now driven by the AI pipeline (#647). The greedy
+                # close-distance loop is the `AggressiveAdvance`
+                # MovementStrategy; per-monster strategies (skirmisher,
+                # etc.) plug in via the registry. `pipeline.decide`
+                # picks the strategy from `monsters.json` and asks it
+                # to plan a path; `pipeline.execute` walks it tile-by-
+                # tile through `attempt_combat_step`, so per-step
+                # CREATURE_MOVED publication, opportunity-attack
+                # provocation, and Difficult Terrain cost continue to
+                # flow through the existing primitive.
                 #
                 # MVP limits intentionally not addressed:
-                # - Greedy sign(dx, dy) pathing; will clump in doorways
-                #   and may provoke avoidable OAs.
+                # - Greedy sign(dx, dy) pathing in AggressiveAdvance.
                 # - No Dash. Targets beyond `speed` feet trigger MOVED.
-                # - No split movement around the attack.
-                # A* / flowfield deferred until friction shows up.
-                enemy_eid = self.spatial.occupant_at(enemy.position)
-                if enemy_eid is not None:
-                    consecutive_failures = 0
-                    max_steps = 12  # speed=30 only needs 6; hard ceiling
-                    while moved_squares < max_steps:
-                        candidates = [
-                            pc for pc in living_party
-                            if pc.position is not None
-                        ]
-                        if not candidates:
-                            break
-                        # Re-pick the nearest PC every iteration so a
-                        # mid-loop change (an OA killing a target,
-                        # plan-04 instant kill, etc.) is handled. The
-                        # ``pc.name`` tiebreaker is load-bearing: it
-                        # makes the pick stable when two PCs are
-                        # equidistant, so the enemy doesn't oscillate
-                        # between them step-to-step.
-                        target_pc = min(
-                            candidates,
-                            key=lambda pc: (
-                                distance_in_feet(
-                                    enemy.position.x, enemy.position.y,
-                                    pc.position.x, pc.position.y,
-                                ),
-                                pc.name,
-                            ),
-                        )
-                        dx = (
-                            1 if target_pc.position.x > enemy.position.x
-                            else -1 if target_pc.position.x < enemy.position.x
-                            else 0
-                        )
-                        dy = (
-                            1 if target_pc.position.y > enemy.position.y
-                            else -1 if target_pc.position.y < enemy.position.y
-                            else 0
-                        )
-                        if dx == 0 and dy == 0:
-                            break  # standing on the target tile (shouldn't happen)
-                        move_result = self.attempt_combat_step(
-                            enemy_eid, dx, dy,
-                        )
-                        if move_result.ok:
-                            moved_squares += 1
-                            consecutive_failures = 0
-                            in_reach = [
-                                pc for pc in living_party
-                                if pc.position is not None
-                                and distance_in_feet(
-                                    enemy.position.x, enemy.position.y,
-                                    pc.position.x, pc.position.y,
-                                ) <= reach_ft
-                            ]
-                            if in_reach:
-                                break  # fall through to attack
-                        else:
-                            consecutive_failures += 1
-                            if move_result.reason == "no movement remaining":
-                                break
-                            if consecutive_failures >= 2:
-                                break  # stuck (e.g., walls, other monster)
+                # - No split movement around the attack (skirmisher
+                #   strategy lands separately).
+                from dataclasses import replace
+
+                from dnd_engine.systems.ai import pipeline
+                from dnd_engine.systems.ai.context import TurnContext
+
+                ctx = TurnContext.build(
+                    self, enemy,
+                    target_pool=living_party,
+                    monster_data=monster_data,
+                )
+                # The local `action` is the resolved attack action for
+                # this turn; build ctx so decide() planning aligns.
+                ctx = replace(
+                    ctx,
+                    action_data=action,
+                    reach_ft=reach_ft,
+                    is_ranged=False,
+                )
+                intent = pipeline.decide(ctx)
+                exec_result = pipeline.execute(
+                    intent, self, enemy,
+                    reach_ft=reach_ft,
+                    target_pool=living_party,
+                )
+                moved_squares = exec_result.moved_squares
+                in_reach = exec_result.in_reach_targets
 
                 if not in_reach:
                     # Either moved without reaching (MOVED) or couldn't

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -26,6 +26,8 @@ from dnd_engine.rules.loader import DataLoader
 from dnd_engine.systems.action_economy import ActionType, Terrain, cost_for
 from dnd_engine.systems.actions import hide
 from dnd_engine.systems.ai import EnemyAI
+from dnd_engine.systems.ai import pipeline as ai_pipeline
+from dnd_engine.systems.ai.context import TurnContext
 from dnd_engine.systems.condition_manager import ConditionManager
 from dnd_engine.systems.initiative import InitiativeTracker
 from dnd_engine.systems.inventory import EquipmentSlot
@@ -5210,26 +5212,16 @@ class GameState:
                 # - No Dash. Targets beyond `speed` feet trigger MOVED.
                 # - No split movement around the attack (skirmisher
                 #   strategy lands separately).
-                from dataclasses import replace
-
-                from dnd_engine.systems.ai import pipeline
-                from dnd_engine.systems.ai.context import TurnContext
-
                 ctx = TurnContext.build(
                     self, enemy,
                     target_pool=living_party,
                     monster_data=monster_data,
-                )
-                # The local `action` is the resolved attack action for
-                # this turn; build ctx so decide() planning aligns.
-                ctx = replace(
-                    ctx,
                     action_data=action,
                     reach_ft=reach_ft,
                     is_ranged=False,
                 )
-                intent = pipeline.decide(ctx)
-                exec_result = pipeline.execute(
+                intent = ai_pipeline.decide(ctx)
+                exec_result = ai_pipeline.execute(
                     intent, self, enemy,
                     reach_ft=reach_ft,
                     target_pool=living_party,

--- a/dnd-engine/dnd_engine/systems/ai/__init__.py
+++ b/dnd-engine/dnd_engine/systems/ai/__init__.py
@@ -1,7 +1,21 @@
 # ABOUTME: AI system module for enemy behavior and decision-making.
 # ABOUTME: Provides targeting strategies and AI controllers for enemy creatures.
 
+from dnd_engine.systems.ai.context import TurnContext
 from dnd_engine.systems.ai.enemy_ai import EnemyAI
+from dnd_engine.systems.ai.intent import (
+    AttackStep,
+    ConditionRemovalStep,
+    Intent,
+    MoveStep,
+    TurnStep,
+    WaitStep,
+)
+from dnd_engine.systems.ai.movement_strategy import (
+    IntentPhase,
+    MovementStrategy,
+    MovePlan,
+)
 from dnd_engine.systems.ai.targeting import (
     LowestHPStrategy,
     RandomStrategy,
@@ -13,4 +27,14 @@ __all__ = [
     "LowestHPStrategy",
     "RandomStrategy",
     "EnemyAI",
+    "TurnContext",
+    "Intent",
+    "MoveStep",
+    "AttackStep",
+    "ConditionRemovalStep",
+    "WaitStep",
+    "TurnStep",
+    "MovementStrategy",
+    "MovePlan",
+    "IntentPhase",
 ]

--- a/dnd-engine/dnd_engine/systems/ai/context.py
+++ b/dnd-engine/dnd_engine/systems/ai/context.py
@@ -63,6 +63,9 @@ class TurnContext:
         *,
         target_pool: list[Creature] | None = None,
         monster_data: dict[str, Any] | None = None,
+        action_data: dict[str, Any] | None = None,
+        reach_ft: int | None = None,
+        is_ranged: bool | None = None,
     ) -> TurnContext:
         """Construct a TurnContext from a game state + enemy.
 
@@ -71,6 +74,12 @@ class TurnContext:
         action-selection contract). Falls back to None when the
         catalog or the action list is missing — callers handle that
         as "no valid attack".
+
+        Callers that already resolved the chosen attack action (e.g.
+        `process_enemy_turn`, which picks the first action carrying
+        both `attack_bonus` and `damage`) can pass `action_data` /
+        `reach_ft` / `is_ranged` explicitly so the context aligns
+        with the call site's action-selection rules.
 
         Args:
             state: The active game state.
@@ -81,6 +90,10 @@ class TurnContext:
             monster_data: Optional pre-resolved monster data dict.
                 When None, looks up `enemy.name.lower()` in the
                 catalog and returns an empty dict on miss.
+            action_data: Optional explicit override for the chosen
+                attack action. Skips the local lookup when provided.
+            reach_ft: Optional explicit override for reach.
+            is_ranged: Optional explicit override for ranged-ness.
 
         Returns:
             A frozen `TurnContext` ready to thread through `decide`.
@@ -88,21 +101,27 @@ class TurnContext:
         pool = target_pool if target_pool is not None else []
         m_data = monster_data if monster_data is not None else _lookup_monster_data(state, enemy)
 
-        action_data = _first_weapon_action(m_data)
-        reach_ft: int | None = None
-        is_ranged = False
         if action_data is not None:
-            reach_ft = attack_reach_for(action_data)
-            is_ranged = is_ranged_action(action_data)
+            resolved_action = action_data
+            resolved_reach = reach_ft if reach_ft is not None else attack_reach_for(action_data)
+            resolved_is_ranged = is_ranged if is_ranged is not None else is_ranged_action(action_data)
+        else:
+            resolved_action = _first_weapon_action(m_data)
+            if resolved_action is None:
+                resolved_reach = None
+                resolved_is_ranged = False
+            else:
+                resolved_reach = attack_reach_for(resolved_action)
+                resolved_is_ranged = is_ranged_action(resolved_action)
 
         return cls(
             state=state,
             actor=enemy,
             target_pool=pool,
             monster_data=m_data,
-            action_data=action_data,
-            reach_ft=reach_ft,
-            is_ranged=is_ranged,
+            action_data=resolved_action,
+            reach_ft=resolved_reach,
+            is_ranged=resolved_is_ranged,
         )
 
 

--- a/dnd-engine/dnd_engine/systems/ai/context.py
+++ b/dnd-engine/dnd_engine/systems/ai/context.py
@@ -1,0 +1,134 @@
+# ABOUTME: TurnContext snapshot passed to pipeline.decide and MovementStrategy.plan.
+# ABOUTME: Issue #647 — captures actor + action data + target pool for one enemy turn.
+
+"""Per-turn context bundle for the enemy-turn pipeline.
+
+`TurnContext` is the immutable read-side snapshot of everything
+`pipeline.decide` and any `MovementStrategy` needs to choose an
+`Intent`. It is built once at the start of an enemy turn and threaded
+through the strategy seam. State mutation happens later in
+`pipeline.execute`; strategies must not mutate `ctx`.
+
+The classmethod `build(state, enemy)` is the canonical constructor.
+It resolves the actor's first viable weapon action from the monster
+catalog (the existing `process_enemy_turn` behavior), reads `reach_ft`
+via `attack_reach_for`, and snapshots the living party.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from dnd_engine.core.combat_geometry import attack_reach_for, is_ranged_action
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+    from dnd_engine.core.game_state import GameState
+
+
+@dataclass(frozen=True)
+class TurnContext:
+    """Read-only snapshot of one enemy's turn-start situation.
+
+    Attributes:
+        state: The game state — passed through so strategies that
+            need to peek at terrain or spatial neighbors can, while
+            staying read-only by convention.
+        actor: The creature whose turn this is.
+        target_pool: Living party members (and any allied creatures
+            that count as targets). Caller filters dead targets.
+        monster_data: The actor's entry in the monsters catalog. May
+            be empty if the actor was not loaded from the catalog.
+        action_data: The chosen weapon action dict (e.g. the scimitar
+            entry). None if no viable action.
+        reach_ft: Effective reach in feet for `action_data`. None if
+            `action_data` is None.
+        is_ranged: True if `action_data` is a ranged attack.
+    """
+
+    state: GameState
+    actor: Creature
+    target_pool: list[Creature]
+    monster_data: dict[str, Any] = field(default_factory=dict)
+    action_data: dict[str, Any] | None = None
+    reach_ft: int | None = None
+    is_ranged: bool = False
+
+    @classmethod
+    def build(
+        cls,
+        state: GameState,
+        enemy: Creature,
+        *,
+        target_pool: list[Creature] | None = None,
+        monster_data: dict[str, Any] | None = None,
+    ) -> TurnContext:
+        """Construct a TurnContext from a game state + enemy.
+
+        Looks up the enemy's first non-Multiattack action from the
+        monsters catalog (preserving the current `process_enemy_turn`
+        action-selection contract). Falls back to None when the
+        catalog or the action list is missing — callers handle that
+        as "no valid attack".
+
+        Args:
+            state: The active game state.
+            enemy: The enemy whose turn is starting.
+            target_pool: Optional pre-resolved list of living party
+                members. When None, falls back to an empty list —
+                the pipeline resolves the pool separately.
+            monster_data: Optional pre-resolved monster data dict.
+                When None, looks up `enemy.name.lower()` in the
+                catalog and returns an empty dict on miss.
+
+        Returns:
+            A frozen `TurnContext` ready to thread through `decide`.
+        """
+        pool = target_pool if target_pool is not None else []
+        m_data = monster_data if monster_data is not None else _lookup_monster_data(state, enemy)
+
+        action_data = _first_weapon_action(m_data)
+        reach_ft: int | None = None
+        is_ranged = False
+        if action_data is not None:
+            reach_ft = attack_reach_for(action_data)
+            is_ranged = is_ranged_action(action_data)
+
+        return cls(
+            state=state,
+            actor=enemy,
+            target_pool=pool,
+            monster_data=m_data,
+            action_data=action_data,
+            reach_ft=reach_ft,
+            is_ranged=is_ranged,
+        )
+
+
+def _lookup_monster_data(state: GameState, enemy: Creature) -> dict[str, Any]:
+    """Look up an enemy's monsters.json entry on the data loader."""
+    loader = getattr(state, "data_loader", None)
+    if loader is None:
+        return {}
+    try:
+        monsters = loader.load_monsters()
+    except Exception:
+        return {}
+    key = enemy.name.lower().replace(" ", "_")
+    return monsters.get(key, {}) or {}
+
+
+def _first_weapon_action(monster_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the first non-Multiattack action from a monster entry.
+
+    Mirrors the current selection in `process_enemy_turn`: skip
+    Multiattack entries and take the first concrete weapon attack.
+    """
+    actions = monster_data.get("actions") or []
+    for action in actions:
+        name = (action.get("name") or "").lower()
+        if "multiattack" in name:
+            continue
+        return action
+    return None

--- a/dnd-engine/dnd_engine/systems/ai/intent.py
+++ b/dnd-engine/dnd_engine/systems/ai/intent.py
@@ -1,0 +1,77 @@
+# ABOUTME: Turn-intent dataclasses produced by pipeline.decide and consumed by pipeline.execute.
+# ABOUTME: Issue #647 — splits process_enemy_turn into a decide/execute pipeline.
+
+"""Intent value objects for the enemy-turn pipeline.
+
+`Intent` is the output of `pipeline.decide(ctx)` and the input to
+`pipeline.execute(intent, state)`. It carries an ordered list of
+discrete `TurnStep`s — typically `[MoveStep, AttackStep]`, but a
+skirmisher-style strategy emits `[MoveStep, AttackStep, MoveStep]`
+(close → attack → retreat). Holding the plan as data rather than as
+imperative control flow is what lets the AI become pluggable: a
+strategy's only job is to populate the step list; execution is uniform.
+
+All step types are frozen dataclasses so an Intent is value-equality
+comparable, hashable into test caches, and safe to log verbatim.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from dnd_engine.core.creature import MovementMode
+from dnd_engine.core.position import Position
+
+
+@dataclass(frozen=True)
+class MoveStep:
+    """A planned movement along a tile-by-tile path.
+
+    The path is the *sequence of destination tiles*, not including the
+    actor's starting tile. `execute` walks the path one tile at a time
+    via `GameState.attempt_combat_step`, so per-tile semantics
+    (CREATURE_MOVED publication, OA provocation, Difficult Terrain
+    cost) flow through unchanged from the existing primitive.
+    """
+
+    path: list[Position] = field(default_factory=list)
+    mode: MovementMode = MovementMode.WALK
+
+
+@dataclass(frozen=True)
+class AttackStep:
+    """A planned attack against a specific target with a chosen action."""
+
+    target_id: str
+    action: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ConditionRemovalStep:
+    """A planned attempt to remove a condition (e.g. on_fire) from the actor."""
+
+    condition_id: str
+
+
+@dataclass(frozen=True)
+class WaitStep:
+    """A planned wait — the actor takes no offensive or movement action this turn.
+
+    `reason` distinguishes the surface meaning so the result packager
+    can emit the correct `EnemyTurnAction` variant (NO_TARGETS,
+    NO_REACHABLE_TARGET, INCAPACITATED, etc.).
+    """
+
+    reason: str
+
+
+TurnStep = MoveStep | AttackStep | ConditionRemovalStep | WaitStep
+
+
+@dataclass(frozen=True)
+class Intent:
+    """The full ordered plan for one enemy turn."""
+
+    steps: list[TurnStep] = field(default_factory=list)
+    rationale: str = ""

--- a/dnd-engine/dnd_engine/systems/ai/movement_strategy.py
+++ b/dnd-engine/dnd_engine/systems/ai/movement_strategy.py
@@ -1,0 +1,83 @@
+# ABOUTME: MovementStrategy Protocol and MovePlan dataclass — pluggable monster movement AI.
+# ABOUTME: Issue #647 — lets monsters.json wire a per-monster strategy (aggressive, skirmisher, etc.).
+
+"""Pluggable movement strategy seam.
+
+A `MovementStrategy` is a stateless component that, given a
+`TurnContext` and a primary target, returns a `MovePlan` describing
+the tile path the actor should take this turn (plus optional
+mode/phase metadata). Strategies are pure planners — they do not
+mutate state and do not call `attempt_combat_step`. `pipeline.execute`
+consumes the plan and performs the actual stepping.
+
+`MovementStrategy` is a `typing.Protocol`, not an ABC, so strategies
+are duck-typed: any object with a `name: str` attribute and a `plan(...)`
+method satisfies the seam. This keeps content authors (likely just
+data + a small class) free of inheritance ceremony.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+
+from dnd_engine.core.creature import MovementMode
+from dnd_engine.core.position import Position
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+    from dnd_engine.systems.ai.context import TurnContext
+
+
+IntentPhase = Literal["close", "engage", "retreat"]
+
+
+@dataclass(frozen=True)
+class MovePlan:
+    """The path and metadata a `MovementStrategy` returns.
+
+    `path` is the ordered list of destination tiles excluding the
+    actor's starting tile. An empty path means the strategy chose
+    not to move (e.g. already in reach, no legal moves).
+
+    `intent_phase` lets the pipeline distinguish close-then-attack
+    plans from attack-then-retreat plans without inspecting paths.
+    """
+
+    path: list[Position] = field(default_factory=list)
+    mode: MovementMode = MovementMode.WALK
+    intent_phase: IntentPhase = "close"
+
+
+@runtime_checkable
+class MovementStrategy(Protocol):
+    """A pluggable per-monster movement planner.
+
+    Implementations live under `systems/ai/strategies/` and are
+    registered with `pipeline.STRATEGY_REGISTRY` so monsters.json
+    entries can opt in via `ai.movement_strategy`.
+    """
+
+    name: str
+
+    def plan(
+        self,
+        ctx: TurnContext,
+        primary_target: Creature,
+        reach_ft: int,
+    ) -> MovePlan:
+        """Return a `MovePlan` for this turn.
+
+        Args:
+            ctx: The turn context, including actor, target pool, and
+                monster-data dict (for content-driven knobs).
+            primary_target: The creature the actor is focused on this
+                turn — typically pre-selected by the targeting layer.
+            reach_ft: The actor's effective reach in feet for the
+                chosen action.
+
+        Returns:
+            A `MovePlan` whose `path` may be empty (no movement
+            planned) or non-empty (tile-by-tile destinations).
+        """
+        ...

--- a/dnd-engine/dnd_engine/systems/ai/pipeline.py
+++ b/dnd-engine/dnd_engine/systems/ai/pipeline.py
@@ -1,0 +1,254 @@
+# ABOUTME: decide / execute pipeline + strategy registry for the enemy-turn AI (#647).
+# ABOUTME: Wraps MovementStrategy lookup, Intent construction, and tile-by-tile execution.
+
+"""decide / execute pipeline for enemy turns.
+
+`pipeline.decide(ctx)` consults the actor's `monsters.json` entry
+for an `ai.movement_strategy` name, looks the strategy up in
+`STRATEGY_REGISTRY` (falling back to `"aggressive"` and logging a
+warning on miss), and asks it to plan a path. The output is an
+`Intent` carrying the resulting `MoveStep`s.
+
+`pipeline.execute(intent, state, enemy, ...)` walks each `MoveStep`
+path one tile at a time via `GameState.attempt_combat_step`, so the
+per-step CREATURE_MOVED event publication, opportunity-attack
+provocation, and Difficult Terrain cost continue to flow through the
+existing primitive. Execution stops on:
+
+* a living target entering reach (in_reach_targets populated);
+* no remaining movement budget;
+* two consecutive step failures (anti-stuck guard, matching the
+  original Layer 3 loop).
+
+This commit ships the seam wired only for the movement phase.
+Attack resolution remains in `process_enemy_turn` for now —
+`Intent` already models `AttackStep`, so a later commit can extend
+`execute` to drive attacks too.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from dnd_engine.core.distance import distance_in_feet
+from dnd_engine.core.position import Position
+from dnd_engine.systems.ai.intent import Intent, MoveStep, WaitStep
+from dnd_engine.systems.ai.strategies.aggressive import AggressiveAdvance
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+    from dnd_engine.core.game_state import GameState
+    from dnd_engine.systems.ai.context import TurnContext
+    from dnd_engine.systems.ai.movement_strategy import MovementStrategy
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STRATEGY = "aggressive"
+
+STRATEGY_REGISTRY: dict[str, MovementStrategy] = {
+    "aggressive": AggressiveAdvance(),
+}
+
+
+def get_strategy(name: str) -> MovementStrategy:
+    """Look up a movement strategy by name; fall back to the default.
+
+    Logs a warning when the name is missing from the registry — a
+    common drift mode for data-authored monsters.
+    """
+    strategy = STRATEGY_REGISTRY.get(name)
+    if strategy is None:
+        logger.warning(
+            "Unknown movement strategy '%s'; falling back to '%s'.",
+            name,
+            DEFAULT_STRATEGY,
+        )
+        strategy = STRATEGY_REGISTRY[DEFAULT_STRATEGY]
+    return strategy
+
+
+def _select_primary_target(ctx: TurnContext) -> Creature | None:
+    """Pick the nearest target by Chebyshev distance, tie-break by name.
+
+    Mirrors the existing Layer 3 loop's `pc.name` tiebreaker — load-
+    bearing so the actor doesn't oscillate between equidistant PCs.
+    """
+    actor = ctx.actor
+    if actor.position is None:
+        return None
+    candidates = [pc for pc in ctx.target_pool if pc.position is not None]
+    if not candidates:
+        return None
+    actor_pos = actor.position
+    return min(
+        candidates,
+        key=lambda pc: (
+            distance_in_feet(actor_pos.x, actor_pos.y, pc.position.x, pc.position.y),
+            pc.name,
+        ),
+    )
+
+
+def _in_reach(a: Position, b: Position, reach_ft: int) -> bool:
+    return distance_in_feet(a.x, a.y, b.x, b.y) <= reach_ft
+
+
+def decide(ctx: TurnContext) -> Intent:
+    """Build the turn's Intent from `ctx`.
+
+    Currently produces the movement phase only — attack and
+    condition-removal steps are still handled by `process_enemy_turn`.
+    Returns:
+
+    * `Intent(steps=[WaitStep("no_targets")])` — empty target pool.
+    * `Intent(steps=[])` — no actionable attack data or already in reach.
+    * `Intent(steps=[MoveStep(path=...)])` — movement planned.
+    """
+    if not ctx.target_pool:
+        return Intent(steps=[WaitStep(reason="no_targets")], rationale="no living targets")
+
+    if ctx.action_data is None or ctx.reach_ft is None or ctx.is_ranged:
+        return Intent(steps=[], rationale="no melee movement needed")
+
+    primary_target = _select_primary_target(ctx)
+    if primary_target is None:
+        return Intent(steps=[], rationale="no candidate with position")
+
+    actor_pos = ctx.actor.position
+    target_pos = primary_target.position
+    if actor_pos is None or target_pos is None:
+        return Intent(steps=[], rationale="no spatial context")
+
+    if _in_reach(actor_pos, target_pos, ctx.reach_ft):
+        return Intent(steps=[], rationale="already in reach")
+
+    strategy_name = ctx.monster_data.get("ai", {}).get("movement_strategy", DEFAULT_STRATEGY)
+    strategy = get_strategy(strategy_name)
+    plan = strategy.plan(ctx, primary_target, ctx.reach_ft)
+
+    if not plan.path:
+        return Intent(steps=[], rationale=f"{strategy.name} returned empty path")
+
+    return Intent(
+        steps=[MoveStep(path=list(plan.path), mode=plan.mode)],
+        rationale=f"close to {primary_target.name} via {strategy.name}",
+    )
+
+
+@dataclass
+class MovementExecution:
+    """Outcome of walking the MoveSteps in an Intent.
+
+    Surfaces enough state for `process_enemy_turn` to decide between
+    EnemyTurnAction.MOVED, NO_REACHABLE_TARGET, and falling through
+    to attack resolution.
+    """
+
+    moved_squares: int = 0
+    final_position: Position | None = None
+    in_reach_targets: list[Creature] = field(default_factory=list)
+    stopped_reason: str = ""
+
+
+def execute(
+    intent: Intent,
+    state: GameState,
+    enemy: Creature,
+    *,
+    reach_ft: int | None = None,
+    target_pool: list[Creature] | None = None,
+) -> MovementExecution:
+    """Walk the MoveSteps in `intent` via `GameState.attempt_combat_step`.
+
+    Args:
+        intent: The plan produced by `decide`.
+        state: The active game state.
+        enemy: The acting enemy.
+        reach_ft: Effective reach for the chosen action. When set
+            with `target_pool`, execution stops as soon as any
+            target enters reach.
+        target_pool: Living-target pool for the in-reach check.
+
+    Returns:
+        A `MovementExecution` capturing moved squares, final
+        position, in-reach targets at end of execution, and a
+        stop-reason string.
+    """
+    result = MovementExecution(final_position=enemy.position)
+    if enemy.position is None or not intent.steps:
+        return result
+    enemy_eid = state.spatial.occupant_at(enemy.position)
+    if enemy_eid is None:
+        result.stopped_reason = "no_entity_id"
+        return result
+
+    consecutive_failures = 0
+    pool = target_pool or []
+    for step in intent.steps:
+        if not isinstance(step, MoveStep):
+            continue
+        for target_tile in step.path:
+            # Check reach BEFORE moving — if a target is already in
+            # reach (e.g. a PC moved closer between turns), short-
+            # circuit so the actor can attack this turn.
+            if reach_ft is not None and pool:
+                in_reach_now = _filter_in_reach(enemy.position, pool, reach_ft)
+                if in_reach_now:
+                    result.in_reach_targets = in_reach_now
+                    result.stopped_reason = "in_reach"
+                    return _finalize(result, enemy)
+
+            dx = _sign(target_tile.x - enemy.position.x)
+            dy = _sign(target_tile.y - enemy.position.y)
+            if dx == 0 and dy == 0:
+                continue
+
+            move_result = state.attempt_combat_step(enemy_eid, dx, dy)
+            if move_result.ok:
+                result.moved_squares += 1
+                consecutive_failures = 0
+            else:
+                consecutive_failures += 1
+                if move_result.reason == "no movement remaining":
+                    result.stopped_reason = "no_movement_remaining"
+                    return _finalize(result, enemy)
+                if consecutive_failures >= 2:
+                    result.stopped_reason = "blocked"
+                    return _finalize(result, enemy)
+
+    # Final reach check after walking the full intent.
+    if reach_ft is not None and pool and enemy.position is not None:
+        result.in_reach_targets = _filter_in_reach(enemy.position, pool, reach_ft)
+    if result.in_reach_targets:
+        result.stopped_reason = "in_reach"
+    elif not result.stopped_reason:
+        result.stopped_reason = "exhausted"
+    return _finalize(result, enemy)
+
+
+def _filter_in_reach(
+    actor_pos: Position,
+    pool: list[Creature],
+    reach_ft: int,
+) -> list[Creature]:
+    return [
+        pc for pc in pool
+        if pc.position is not None
+        and distance_in_feet(actor_pos.x, actor_pos.y, pc.position.x, pc.position.y) <= reach_ft
+    ]
+
+
+def _finalize(result: MovementExecution, enemy: Creature) -> MovementExecution:
+    if enemy.position is not None:
+        result.final_position = enemy.position
+    return result
+
+
+def _sign(delta: int) -> int:
+    if delta > 0:
+        return 1
+    if delta < 0:
+        return -1
+    return 0

--- a/dnd-engine/dnd_engine/systems/ai/strategies/__init__.py
+++ b/dnd-engine/dnd_engine/systems/ai/strategies/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Strategy implementations registered with the pipeline registry.
+# ABOUTME: Issue #647 — concrete MovementStrategy variants live here.

--- a/dnd-engine/dnd_engine/systems/ai/strategies/aggressive.py
+++ b/dnd-engine/dnd_engine/systems/ai/strategies/aggressive.py
@@ -1,0 +1,95 @@
+# ABOUTME: AggressiveAdvance — verbatim port of the Layer 3 greedy close-distance loop (#641).
+# ABOUTME: Issue #647 — the default MovementStrategy. Plans a greedy path toward the primary target.
+
+"""AggressiveAdvance — close-distance via greedy stepping.
+
+This is the planner half of the Layer 3 loop in
+`game_state.py:5164–5302`. It produces a tile path that greedy-steps
+the actor toward the primary target until either the target enters
+reach or the step budget is exhausted. The execution-side concerns
+(blocked tiles, terrain cost, opportunity attacks, mid-loop kills)
+are handled by `pipeline.execute`, which walks the path one tile at
+a time via `GameState.attempt_combat_step`.
+
+Behavioral parity with the original loop:
+
+* Greedy king's-move: `dx, dy = sign(target.x - actor.x),
+  sign(target.y - actor.y)`.
+* Step budget: `min(actor.speed // 5, 12)`. The 12-tile hard ceiling
+  matches the original `max_steps = 12` guard.
+* Empty path when the actor is already in reach.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from dnd_engine.core.creature import MovementMode
+from dnd_engine.core.distance import distance_in_feet
+from dnd_engine.core.position import Position
+from dnd_engine.systems.ai.movement_strategy import MovePlan
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+    from dnd_engine.systems.ai.context import TurnContext
+
+
+HARD_STEP_CEILING = 12
+"""Anti-runaway cap on the planned path length. Speed 30 only needs 6
+steps to reach 30 ft; this ceiling fires only for very fast actors and
+matches the original `max_steps = 12` guard in the Layer 3 loop."""
+
+
+class AggressiveAdvance:
+    """Greedy close-distance planner — pluggable default strategy."""
+
+    name = "aggressive"
+
+    def plan(
+        self,
+        ctx: TurnContext,
+        primary_target: Creature,
+        reach_ft: int,
+    ) -> MovePlan:
+        """Return a greedy tile path toward `primary_target`.
+
+        Empty path means the actor is already within `reach_ft` or no
+        legal step is possible (no positions, zero step budget).
+        """
+        actor = ctx.actor
+        if actor.position is None or primary_target.position is None:
+            return MovePlan(path=[], mode=MovementMode.WALK, intent_phase="close")
+
+        if _in_reach(actor.position, primary_target.position, reach_ft):
+            return MovePlan(path=[], mode=MovementMode.WALK, intent_phase="close")
+
+        max_steps = min(actor.speed // 5, HARD_STEP_CEILING)
+        if max_steps <= 0:
+            return MovePlan(path=[], mode=MovementMode.WALK, intent_phase="close")
+
+        path: list[Position] = []
+        current = actor.position
+        target = primary_target.position
+        for _ in range(max_steps):
+            dx = _sign(target.x - current.x)
+            dy = _sign(target.y - current.y)
+            if dx == 0 and dy == 0:
+                break  # standing on the target tile (shouldn't happen)
+            current = Position(current.x + dx, current.y + dy)
+            path.append(current)
+            if _in_reach(current, target, reach_ft):
+                break
+
+        return MovePlan(path=path, mode=MovementMode.WALK, intent_phase="close")
+
+
+def _sign(delta: int) -> int:
+    if delta > 0:
+        return 1
+    if delta < 0:
+        return -1
+    return 0
+
+
+def _in_reach(a: Position, b: Position, reach_ft: int) -> bool:
+    return distance_in_feet(a.x, a.y, b.x, b.y) <= reach_ft

--- a/dnd-engine/tests/ai/test_aggressive_strategy.py
+++ b/dnd-engine/tests/ai/test_aggressive_strategy.py
@@ -1,0 +1,117 @@
+# ABOUTME: Unit tests for AggressiveAdvance — the verbatim port of the Layer 3 close-distance loop.
+# ABOUTME: Issue #647 commit 2 — covers the same scenarios as test_enemy_turn_movement.py at planner level.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from dnd_engine.core.creature import Abilities, Creature, MovementMode
+from dnd_engine.core.position import Position
+from dnd_engine.systems.ai.context import TurnContext
+from dnd_engine.systems.ai.strategies.aggressive import (
+    HARD_STEP_CEILING,
+    AggressiveAdvance,
+)
+
+
+@dataclass
+class _StubState:
+    data_loader: Any = None
+
+
+def _make_creature(name: str, x: int, y: int, speed: int = 30) -> Creature:
+    c = Creature(
+        name=name,
+        max_hp=20,
+        ac=15,
+        abilities=Abilities(
+            strength=10, dexterity=10, constitution=10,
+            intelligence=10, wisdom=10, charisma=10,
+        ),
+        speed=speed,
+    )
+    c.position = Position(x, y)
+    return c
+
+
+def _ctx(actor: Creature, *, target_pool: list[Creature] | None = None) -> TurnContext:
+    return TurnContext.build(
+        _StubState(),
+        actor,
+        target_pool=target_pool or [],
+        monster_data={},
+    )
+
+
+class TestAggressiveAdvancePlan:
+    def test_empty_path_when_already_in_reach(self):
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 1, 0)
+        plan = AggressiveAdvance().plan(_ctx(actor), target, reach_ft=5)
+        assert plan.path == []
+        assert plan.mode == MovementMode.WALK
+        assert plan.intent_phase == "close"
+
+    def test_straight_line_path_toward_distant_target(self):
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 5, 0)
+        plan = AggressiveAdvance().plan(_ctx(actor), target, reach_ft=5)
+        # speed 30 → 6 tile budget. Stops when within 5 ft (1 tile away).
+        # From (0,0) toward (5,0), stops at (4,0): distance to (5,0) is 5 ft.
+        assert plan.path == [Position(1, 0), Position(2, 0), Position(3, 0), Position(4, 0)]
+
+    def test_diagonal_path_uses_kings_move(self):
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 4, 4)
+        plan = AggressiveAdvance().plan(_ctx(actor), target, reach_ft=5)
+        # Greedy diagonal: (1,1), (2,2), (3,3). At (3,3), Chebyshev distance
+        # to (4,4) is max(|1|,|1|) = 1 tile = 5 ft → in reach.
+        assert plan.path == [Position(1, 1), Position(2, 2), Position(3, 3)]
+
+    def test_speed_bounded_truncation(self):
+        actor = _make_creature("Goblin", 0, 0, speed=10)
+        target = _make_creature("Brick", 20, 0)
+        plan = AggressiveAdvance().plan(_ctx(actor), target, reach_ft=5)
+        # speed 10 → 2 tile budget; target stays far away.
+        assert len(plan.path) == 2
+        assert plan.path == [Position(1, 0), Position(2, 0)]
+
+    def test_zero_speed_yields_empty_path(self):
+        actor = _make_creature("Goblin", 0, 0, speed=0)
+        target = _make_creature("Brick", 10, 0)
+        plan = AggressiveAdvance().plan(_ctx(actor), target, reach_ft=5)
+        assert plan.path == []
+
+    def test_hard_ceiling_caps_long_paths(self):
+        actor = _make_creature("FastGoblin", 0, 0, speed=120)
+        target = _make_creature("Brick", 100, 0)  # very far
+        plan = AggressiveAdvance().plan(_ctx(actor), target, reach_ft=5)
+        # speed 120 → 24 raw tile budget, but capped at HARD_STEP_CEILING=12.
+        assert len(plan.path) <= HARD_STEP_CEILING
+        assert len(plan.path) == HARD_STEP_CEILING
+
+    def test_actor_without_position_returns_empty(self):
+        actor = _make_creature("Goblin", 0, 0)
+        actor.position = None
+        target = _make_creature("Brick", 5, 0)
+        plan = AggressiveAdvance().plan(_ctx(actor), target, reach_ft=5)
+        assert plan.path == []
+
+    def test_target_without_position_returns_empty(self):
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 5, 0)
+        target.position = None
+        plan = AggressiveAdvance().plan(_ctx(actor), target, reach_ft=5)
+        assert plan.path == []
+
+    def test_path_stops_when_reach_window_entered(self):
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 3, 0)
+        plan = AggressiveAdvance().plan(_ctx(actor), target, reach_ft=5)
+        # From (0,0), step to (1,0): distance to (3,0) is 10 ft. Step to (2,0):
+        # distance is 5 ft → in reach. Path stops at (2,0).
+        assert plan.path == [Position(1, 0), Position(2, 0)]
+
+    def test_strategy_name(self):
+        assert AggressiveAdvance().name == "aggressive"

--- a/dnd-engine/tests/ai/test_intent.py
+++ b/dnd-engine/tests/ai/test_intent.py
@@ -1,0 +1,93 @@
+# ABOUTME: Unit tests for Intent and TurnStep variants (#647 commit 1).
+# ABOUTME: Verifies frozen-ness, default values, and constructor shape.
+
+from __future__ import annotations
+
+import pytest
+
+from dnd_engine.core.position import Position
+from dnd_engine.systems.ai.intent import (
+    AttackStep,
+    ConditionRemovalStep,
+    Intent,
+    MoveStep,
+    WaitStep,
+)
+
+
+class TestMoveStep:
+    def test_constructs_with_path(self):
+        step = MoveStep(path=[Position(1, 0), Position(2, 0)])
+        assert step.path == [Position(1, 0), Position(2, 0)]
+
+    def test_default_path_empty(self):
+        step = MoveStep()
+        assert step.path == []
+
+    def test_is_frozen(self):
+        step = MoveStep(path=[Position(0, 0)])
+        with pytest.raises((AttributeError, TypeError)):
+            step.path = []  # type: ignore[misc]
+
+
+class TestAttackStep:
+    def test_carries_target_and_action(self):
+        action = {"name": "Scimitar", "damage": "1d6+2"}
+        step = AttackStep(target_id="brick_pc", action=action)
+        assert step.target_id == "brick_pc"
+        assert step.action is action
+
+    def test_is_frozen(self):
+        step = AttackStep(target_id="t", action={})
+        with pytest.raises((AttributeError, TypeError)):
+            step.target_id = "other"  # type: ignore[misc]
+
+
+class TestConditionRemovalStep:
+    def test_carries_condition_id(self):
+        step = ConditionRemovalStep(condition_id="on_fire")
+        assert step.condition_id == "on_fire"
+
+    def test_is_frozen(self):
+        step = ConditionRemovalStep(condition_id="on_fire")
+        with pytest.raises((AttributeError, TypeError)):
+            step.condition_id = "stunned"  # type: ignore[misc]
+
+
+class TestWaitStep:
+    def test_carries_reason(self):
+        step = WaitStep(reason="no_targets")
+        assert step.reason == "no_targets"
+
+    def test_is_frozen(self):
+        step = WaitStep(reason="no_targets")
+        with pytest.raises((AttributeError, TypeError)):
+            step.reason = "other"  # type: ignore[misc]
+
+
+class TestIntent:
+    def test_default_steps_is_empty_list(self):
+        intent = Intent()
+        assert intent.steps == []
+        assert intent.rationale == ""
+
+    def test_carries_step_sequence(self):
+        steps = [
+            MoveStep(path=[Position(1, 0)]),
+            AttackStep(target_id="t", action={"name": "Bite"}),
+        ]
+        intent = Intent(steps=steps, rationale="close + attack")
+        assert intent.steps == steps
+        assert intent.rationale == "close + attack"
+
+    def test_supports_skirmisher_three_step_shape(self):
+        steps = [
+            MoveStep(path=[Position(1, 0)]),
+            AttackStep(target_id="t", action={}),
+            MoveStep(path=[Position(0, 0)]),
+        ]
+        intent = Intent(steps=steps)
+        assert len(intent.steps) == 3
+        assert isinstance(intent.steps[0], MoveStep)
+        assert isinstance(intent.steps[1], AttackStep)
+        assert isinstance(intent.steps[2], MoveStep)

--- a/dnd-engine/tests/ai/test_movement_strategy_protocol.py
+++ b/dnd-engine/tests/ai/test_movement_strategy_protocol.py
@@ -1,0 +1,64 @@
+# ABOUTME: Unit tests for the MovementStrategy Protocol seam and MovePlan dataclass (#647).
+# ABOUTME: Verifies runtime_checkable Protocol matches duck-typed stubs.
+
+from __future__ import annotations
+
+import pytest
+
+from dnd_engine.core.creature import MovementMode
+from dnd_engine.core.position import Position
+from dnd_engine.systems.ai.movement_strategy import MovementStrategy, MovePlan
+
+
+class TestMovePlan:
+    def test_default_path_empty(self):
+        plan = MovePlan()
+        assert plan.path == []
+        assert plan.mode == MovementMode.WALK
+        assert plan.intent_phase == "close"
+
+    def test_carries_path_and_mode(self):
+        plan = MovePlan(
+            path=[Position(1, 0), Position(2, 0)],
+            mode=MovementMode.FLY,
+            intent_phase="retreat",
+        )
+        assert plan.path == [Position(1, 0), Position(2, 0)]
+        assert plan.mode == MovementMode.FLY
+        assert plan.intent_phase == "retreat"
+
+    def test_is_frozen(self):
+        plan = MovePlan()
+        with pytest.raises((AttributeError, TypeError)):
+            plan.mode = MovementMode.FLY  # type: ignore[misc]
+
+
+class _StubStrategy:
+    """Duck-typed strategy stub — no inheritance, just the shape."""
+
+    name = "stub"
+
+    def plan(self, ctx, primary_target, reach_ft):  # noqa: ARG002
+        return MovePlan(path=[Position(1, 0)])
+
+
+class _MissingPlanMethod:
+    """A class that has `name` but not `plan`."""
+
+    name = "broken"
+
+
+class TestMovementStrategyProtocol:
+    def test_stub_satisfies_protocol(self):
+        stub = _StubStrategy()
+        assert isinstance(stub, MovementStrategy)
+
+    def test_missing_plan_method_fails_protocol(self):
+        broken = _MissingPlanMethod()
+        assert not isinstance(broken, MovementStrategy)
+
+    def test_stub_plan_returns_move_plan(self):
+        stub = _StubStrategy()
+        result = stub.plan(ctx=None, primary_target=None, reach_ft=5)
+        assert isinstance(result, MovePlan)
+        assert result.path == [Position(1, 0)]

--- a/dnd-engine/tests/ai/test_pipeline.py
+++ b/dnd-engine/tests/ai/test_pipeline.py
@@ -1,0 +1,172 @@
+# ABOUTME: Unit tests for the AI pipeline registry + decide() (#647 commit 3).
+# ABOUTME: Asserts strategy lookup fallback and Intent shape under varied contexts.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.position import Position
+from dnd_engine.systems.ai import pipeline
+from dnd_engine.systems.ai.context import TurnContext
+from dnd_engine.systems.ai.intent import MoveStep, WaitStep
+from dnd_engine.systems.ai.strategies.aggressive import AggressiveAdvance
+
+
+@dataclass
+class _StubState:
+    data_loader: Any = None
+
+
+def _make_creature(name: str, x: int, y: int, speed: int = 30) -> Creature:
+    c = Creature(
+        name=name,
+        max_hp=20,
+        ac=15,
+        abilities=Abilities(
+            strength=10, dexterity=10, constitution=10,
+            intelligence=10, wisdom=10, charisma=10,
+        ),
+        speed=speed,
+    )
+    c.position = Position(x, y)
+    return c
+
+
+SCIMITAR = {"name": "Scimitar", "reach": "5 ft.", "damage": "1d6", "attack_bonus": 4}
+
+
+class TestGetStrategy:
+    def test_returns_registered_strategy(self):
+        strategy = pipeline.get_strategy("aggressive")
+        assert isinstance(strategy, AggressiveAdvance)
+
+    def test_unknown_name_falls_back_to_default(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="dnd_engine.systems.ai.pipeline"):
+            strategy = pipeline.get_strategy("nonexistent")
+        assert isinstance(strategy, AggressiveAdvance)
+        assert any("nonexistent" in rec.message for rec in caplog.records)
+
+
+class TestDecide:
+    def test_no_targets_yields_wait_step(self):
+        actor = _make_creature("Goblin", 0, 0)
+        ctx = TurnContext.build(
+            _StubState(), actor,
+            target_pool=[],
+            monster_data={"actions": [SCIMITAR]},
+        )
+        intent = pipeline.decide(ctx)
+        assert len(intent.steps) == 1
+        assert isinstance(intent.steps[0], WaitStep)
+        assert intent.steps[0].reason == "no_targets"
+
+    def test_already_in_reach_yields_empty_intent(self):
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 1, 0)
+        ctx = TurnContext.build(
+            _StubState(), actor,
+            target_pool=[target],
+            monster_data={"actions": [SCIMITAR]},
+        )
+        intent = pipeline.decide(ctx)
+        assert intent.steps == []
+
+    def test_out_of_reach_yields_move_step(self):
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 5, 0)
+        ctx = TurnContext.build(
+            _StubState(), actor,
+            target_pool=[target],
+            monster_data={"actions": [SCIMITAR]},
+        )
+        intent = pipeline.decide(ctx)
+        assert len(intent.steps) == 1
+        assert isinstance(intent.steps[0], MoveStep)
+        assert intent.steps[0].path == [
+            Position(1, 0), Position(2, 0), Position(3, 0), Position(4, 0),
+        ]
+
+    def test_ranged_action_yields_no_movement(self):
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 5, 0)
+        ranged = {"name": "Shortbow", "range": "80/320 ft.", "damage": "1d6", "attack_bonus": 4}
+        ctx = TurnContext.build(
+            _StubState(), actor,
+            target_pool=[target],
+            monster_data={"actions": [ranged]},
+        )
+        intent = pipeline.decide(ctx)
+        assert intent.steps == []
+
+    def test_no_action_data_yields_empty_intent(self):
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 5, 0)
+        ctx = TurnContext.build(
+            _StubState(), actor,
+            target_pool=[target],
+            monster_data={},
+        )
+        intent = pipeline.decide(ctx)
+        assert intent.steps == []
+
+    def test_tie_break_by_name_when_two_equidistant(self):
+        actor = _make_creature("Goblin", 0, 0)
+        # "Alice" alphabetically precedes "Brick".
+        alice = _make_creature("Alice", 5, 0)
+        brick = _make_creature("Brick", 5, 0)
+        ctx = TurnContext.build(
+            _StubState(), actor,
+            target_pool=[brick, alice],
+            monster_data={"actions": [SCIMITAR]},
+        )
+        intent = pipeline.decide(ctx)
+        assert isinstance(intent.steps[0], MoveStep)
+        assert "Alice" in intent.rationale
+
+    def test_unknown_strategy_in_monster_data_falls_back(self, caplog):
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 5, 0)
+        ctx = TurnContext.build(
+            _StubState(), actor,
+            target_pool=[target],
+            monster_data={
+                "actions": [SCIMITAR],
+                "ai": {"movement_strategy": "nonexistent_strategy"},
+            },
+        )
+        with caplog.at_level(logging.WARNING, logger="dnd_engine.systems.ai.pipeline"):
+            intent = pipeline.decide(ctx)
+        # Still produces a movement path via the fallback strategy.
+        assert len(intent.steps) == 1
+        assert isinstance(intent.steps[0], MoveStep)
+        assert any("nonexistent_strategy" in rec.message for rec in caplog.records)
+
+
+class TestExecuteEmptyIntent:
+    """`execute` with an empty Intent is a no-op — sanity for the WaitStep / already-in-reach paths."""
+
+    def test_empty_intent_yields_zero_movement(self):
+        actor = _make_creature("Goblin", 0, 0)
+
+        @dataclass
+        class _StubSpatial:
+            def occupant_at(self, _pos):  # noqa: ANN001
+                return None
+
+        @dataclass
+        class _StubGameState:
+            spatial: Any = None
+
+        from dnd_engine.systems.ai.intent import Intent
+        result = pipeline.execute(
+            Intent(steps=[]),
+            _StubGameState(spatial=_StubSpatial()),
+            actor,
+            reach_ft=5,
+            target_pool=[],
+        )
+        assert result.moved_squares == 0
+        assert result.final_position == Position(0, 0)

--- a/dnd-engine/tests/ai/test_turn_context.py
+++ b/dnd-engine/tests/ai/test_turn_context.py
@@ -1,0 +1,128 @@
+# ABOUTME: Unit tests for TurnContext.build (#647 commit 1).
+# ABOUTME: Verifies action selection, reach parsing, and ranged detection.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.systems.ai.context import TurnContext
+
+
+@dataclass
+class _StubLoader:
+    """Minimal stand-in for DataLoader.load_monsters()."""
+
+    monsters: dict[str, Any]
+
+    def load_monsters(self) -> dict[str, Any]:
+        return self.monsters
+
+
+@dataclass
+class _StubState:
+    """Just enough GameState surface for TurnContext.build."""
+
+    data_loader: Any
+
+
+def _make_enemy(name: str = "Goblin") -> Creature:
+    return Creature(
+        name=name,
+        max_hp=7,
+        ac=15,
+        abilities=Abilities(
+            strength=8, dexterity=14, constitution=10,
+            intelligence=10, wisdom=8, charisma=8,
+        ),
+    )
+
+
+class TestTurnContextBuild:
+    def test_uses_provided_monster_data_when_passed(self):
+        enemy = _make_enemy()
+        state = _StubState(data_loader=None)
+        monster_data = {
+            "actions": [{"name": "Scimitar", "reach": "5 ft.", "damage": "1d6+2"}],
+        }
+        ctx = TurnContext.build(state, enemy, monster_data=monster_data)
+        assert ctx.actor is enemy
+        assert ctx.monster_data is monster_data
+        assert ctx.action_data is not None
+        assert ctx.action_data["name"] == "Scimitar"
+        assert ctx.reach_ft == 5
+        assert ctx.is_ranged is False
+
+    def test_resolves_monster_data_from_loader_by_lowercase_name(self):
+        enemy = _make_enemy("Goblin Boss")
+        catalog = {
+            "goblin_boss": {
+                "actions": [{"name": "Scimitar", "reach": "5 ft.", "damage": "1d6+2"}],
+            },
+        }
+        state = _StubState(data_loader=_StubLoader(monsters=catalog))
+        ctx = TurnContext.build(state, enemy)
+        assert ctx.action_data is not None
+        assert ctx.action_data["name"] == "Scimitar"
+
+    def test_skips_multiattack_picks_next_action(self):
+        enemy = _make_enemy()
+        state = _StubState(data_loader=None)
+        monster_data = {
+            "actions": [
+                {"name": "Multiattack", "description": "two attacks"},
+                {"name": "Scimitar", "reach": "5 ft.", "damage": "1d6+2"},
+            ],
+        }
+        ctx = TurnContext.build(state, enemy, monster_data=monster_data)
+        assert ctx.action_data is not None
+        assert ctx.action_data["name"] == "Scimitar"
+        assert ctx.reach_ft == 5
+
+    def test_detects_ranged_action(self):
+        enemy = _make_enemy()
+        state = _StubState(data_loader=None)
+        monster_data = {
+            "actions": [{"name": "Shortbow", "range": "80/320 ft.", "damage": "1d6+2"}],
+        }
+        ctx = TurnContext.build(state, enemy, monster_data=monster_data)
+        assert ctx.action_data is not None
+        assert ctx.is_ranged is True
+
+    def test_no_actions_yields_none_action_data(self):
+        enemy = _make_enemy()
+        state = _StubState(data_loader=None)
+        ctx = TurnContext.build(state, enemy, monster_data={})
+        assert ctx.action_data is None
+        assert ctx.reach_ft is None
+        assert ctx.is_ranged is False
+
+    def test_unknown_monster_in_catalog_falls_back_to_empty(self):
+        enemy = _make_enemy("Unknown Beast")
+        state = _StubState(data_loader=_StubLoader(monsters={}))
+        ctx = TurnContext.build(state, enemy)
+        assert ctx.monster_data == {}
+        assert ctx.action_data is None
+
+    def test_default_target_pool_is_empty_list(self):
+        enemy = _make_enemy()
+        state = _StubState(data_loader=None)
+        ctx = TurnContext.build(state, enemy, monster_data={})
+        assert ctx.target_pool == []
+
+    def test_provided_target_pool_passes_through(self):
+        enemy = _make_enemy()
+        state = _StubState(data_loader=None)
+        pc = _make_enemy("Brick")
+        ctx = TurnContext.build(state, enemy, target_pool=[pc], monster_data={})
+        assert ctx.target_pool == [pc]
+
+    def test_context_is_frozen(self):
+        enemy = _make_enemy()
+        state = _StubState(data_loader=None)
+        ctx = TurnContext.build(state, enemy, monster_data={})
+        with pytest.raises((AttributeError, TypeError)):
+            ctx.actor = None  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Closes #647 — partial. Lands the architectural seam and the user-visible behavior fix; defers two acceptance items as documented follow-up scope.

**What ships:**
- **dnd-engine:** A pluggable `decide/execute` enemy-turn pipeline. The Layer 3 close-distance loop in `process_enemy_turn` (~90 lines) is replaced by a call into `pipeline.decide(ctx) → Intent` + `pipeline.execute(intent, ...)`, which routes through a `MovementStrategy` registered in `STRATEGY_REGISTRY`. The default `AggressiveAdvance` strategy is a verbatim port of the prior greedy loop. Public `process_enemy_turn` contract unchanged; 3317 engine tests pass.
- **client-2d:** Engine-driven monster movement now reflects in the visual layer per-step instead of teleporting to the final tile. `EntityManager` subscribes to `CREATURE_MOVED` / `CREATURE_PLACED` and writes `entity.grid_x/y` directly. A new `MovementTweenQueue` (~120 ms ease-out per 5-ft step, teleport-degrades at depth ≥ 3) carries the sprite animation for windowed mode. 578 client tests pass.

**Total test impact:** 3895 tests green, no regressions.

## What's deferred (filed as follow-up scope, documented in plan)

- **Skirmisher strategy** + full god-method split — `pipeline.execute` would need to drive `AttackStep` (concentration, saves, visibility, narrative context), which is a substantial port. The seam supports it; the work is mechanical.
- **`Entity.grid_x/y` as `@property`** — the strict single-source-of-truth refactor conflicts with the legacy menu-driven combat path (`update_current_turn_position`) and the MCP-test fixtures that write `grid_x` by hand. Event-driven sync via `EntityManager.subscribe_to_engine_events` delivers the same visible behavior without the dataclass→property migration.
- **Skirmisher `ai.movement_strategy` in monsters.json** — the pipeline reads `ctx.monster_data.get("ai", {}).get("movement_strategy", "aggressive")` already; no monsters opt in yet because Skirmisher itself is deferred.

## Architecture

```
GameState.process_enemy_turn()  ← signature unchanged
  ├─ turn-start effects (unchanged)
  ├─ ctx = TurnContext.build(self, enemy, action_data=action, …)  ◄── NEW
  ├─ intent = ai_pipeline.decide(ctx)                              ◄── NEW
  ├─ exec_result = ai_pipeline.execute(intent, self, enemy, …)    ◄── NEW
  └─ attack resolution + turn-end effects (unchanged for now)

dnd_engine/systems/ai/
  ├─ intent.py             Intent, MoveStep, AttackStep, WaitStep, ConditionRemovalStep
  ├─ context.py            TurnContext.build()
  ├─ movement_strategy.py  MovementStrategy Protocol + MovePlan
  ├─ pipeline.py           STRATEGY_REGISTRY, decide(), execute()
  └─ strategies/
      └─ aggressive.py     AggressiveAdvance — verbatim port of Layer 3 loop

client_2d/animation/movement_tween.py
  └─ MovementTweenQueue    per-entity ease-out tween + teleport degradation
```

## Test plan
- [x] `dnd-engine` unit + integration suite (3317 passing)
- [x] `client-2d` unit + integration suite (578 passing)
- [x] New AI tests: 47 covering Intent shape, AggressiveAdvance behavior, TurnContext.build, pipeline decide/execute
- [x] New animation tests: 16 covering MovementTweenQueue tick / enqueue / teleport-at-depth-3
- [x] New integration tests: 6 covering EntityManager event subscription, tween enqueue per step, idempotent re-subscribe
- [ ] Manual MCP verification: `uv run dnd-2d --headless --mcp`, spawn a goblin out of reach, fire an enemy turn, confirm `game_state()` reports intermediate tiles between calls — recommended pre-merge

## Commits

1. AI core data types (Intent, TurnContext, MovementStrategy)
2. AggressiveAdvance strategy (port of Layer 3 close-distance loop)
3. decide/execute pipeline; route Layer 3 movement through it
4. EntityManager subscribes to CREATURE_MOVED + MovementTweenQueue
5. TurnContext.build accepts explicit action overrides (code-review follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)