### PR TITLE
Add #649: Skirmisher movement strategy + AttackStep/retreat pipeline execution

### DIFF
--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -5309,13 +5309,17 @@ class GameState:
                     )
             targeting_pool = in_reach
 
+        pipeline_target: Creature | None = None
         if pipeline_attack_outcome is not None and pipeline_attack_step is not None:
-            # Skirmisher path: pipeline already attacked. Reconstruct
-            # the post-attack state machinery from the pipeline outcome.
-            target = next(
+            pipeline_target = next(
                 (c for c in living_party if c.name == pipeline_attack_step.target_id),
                 None,
-            ) or living_party[0]
+            )
+
+        if pipeline_attack_outcome is not None and pipeline_target is not None:
+            # Skirmisher path: pipeline already attacked. Reconstruct
+            # the post-attack state machinery from the pipeline outcome.
+            target = pipeline_target
             attack_result = pipeline_attack_outcome
             # Conditions-before tracking is bypassed on the skirmisher
             # path; skirmisher attacks (goblin scimitar, kobold dagger)

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -1587,9 +1587,7 @@ class GameState:
         except (KeyError, AttributeError, TypeError):
             return False
 
-        obscurement = effective_obscurement(
-            self._ambient_light_level(), self.ambient_obscurement()
-        )
+        obscurement = effective_obscurement(self._ambient_light_level(), self.ambient_obscurement())
 
         cover_value = str(room.get("cover", "none")).lower()
         try:
@@ -1680,9 +1678,7 @@ class GameState:
         skills_data = self.data_loader.load_skills()
         check = creature.make_skill_check("stealth", dc, skills_data)
 
-        ok, reason = hide(
-            creature, turn_state, succeeded=check["success"], action_type=action_type
-        )
+        ok, reason = hide(creature, turn_state, succeeded=check["success"], action_type=action_type)
         if not ok:
             return HideAttemptResult(
                 attempted=False,
@@ -1727,9 +1723,7 @@ class GameState:
             # SRD § Actions › Hide is offered only when the current
             # combatant's surroundings permit it (the #496 gate).
             current = (
-                self.initiative_tracker.get_current_combatant()
-                if self.initiative_tracker
-                else None
+                self.initiative_tracker.get_current_combatant() if self.initiative_tracker else None
             )
             if current is not None and self.can_attempt_hide(current.creature):
                 actions.append("hide")
@@ -5187,18 +5181,19 @@ class GameState:
         # AttackStep outcome.
         pipeline_attack_outcome: AttackResult | None = None
         pipeline_attack_step: AttackStep | None = None
-        if (
-            enemy.position is not None
-            and not is_ranged_action(action)
-        ):
+        if enemy.position is not None and not is_ranged_action(action):
             reach_ft = attack_reach_for(action)
             in_reach = [
-                pc for pc in living_party
+                pc
+                for pc in living_party
                 if pc.position is not None
                 and distance_in_feet(
-                    enemy.position.x, enemy.position.y,
-                    pc.position.x, pc.position.y,
-                ) <= reach_ft
+                    enemy.position.x,
+                    enemy.position.y,
+                    pc.position.x,
+                    pc.position.y,
+                )
+                <= reach_ft
             ]
             if not in_reach:
                 # Layer 3 (#641): close distance toward the nearest PC,
@@ -5219,7 +5214,8 @@ class GameState:
                 # - No split movement around the attack (skirmisher
                 #   strategy lands separately).
                 ctx = TurnContext.build(
-                    self, enemy,
+                    self,
+                    enemy,
                     target_pool=living_party,
                     monster_data=monster_data,
                     action_data=action,
@@ -5239,8 +5235,7 @@ class GameState:
                     action_data: dict,
                 ) -> "AttackResult | None":
                     pipeline_target = next(
-                        (c for c in living_party
-                         if c.name == target_name and c.is_alive),
+                        (c for c in living_party if c.name == target_name and c.is_alive),
                         None,
                     )
                     if pipeline_target is None:
@@ -5261,7 +5256,9 @@ class GameState:
                     )
 
                 exec_result = ai_pipeline.execute(
-                    intent, self, enemy,
+                    intent,
+                    self,
+                    enemy,
                     reach_ft=reach_ft,
                     target_pool=living_party,
                     attack_resolver=_resolve_attack_step,
@@ -5286,15 +5283,15 @@ class GameState:
                     # enemy_eid).
                     self.initiative_tracker.next_turn()
                     action_taken = (
-                        EnemyTurnAction.MOVED if moved_squares > 0
+                        EnemyTurnAction.MOVED
+                        if moved_squares > 0
                         else EnemyTurnAction.NO_REACHABLE_TARGET
                     )
                     # Match the EnemyTurnResult contract (game_state.py
                     # comment above the field): movement_end_position
                     # is None when no movement happened.
                     end_position = (
-                        (enemy.position.x, enemy.position.y)
-                        if moved_squares > 0 else None
+                        (enemy.position.x, enemy.position.y) if moved_squares > 0 else None
                     )
                     return EnemyTurnResult(
                         enemy_name=enemy.name,
@@ -5449,8 +5446,7 @@ class GameState:
             # was already in reach.
             moved_squares=moved_squares,
             movement_end_position=(
-                (enemy.position.x, enemy.position.y)
-                if moved_squares > 0 else None
+                (enemy.position.x, enemy.position.y) if moved_squares > 0 else None
             ),
         )
 

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -28,6 +28,7 @@ from dnd_engine.systems.actions import hide
 from dnd_engine.systems.ai import EnemyAI
 from dnd_engine.systems.ai import pipeline as ai_pipeline
 from dnd_engine.systems.ai.context import TurnContext
+from dnd_engine.systems.ai.intent import AttackStep
 from dnd_engine.systems.condition_manager import ConditionManager
 from dnd_engine.systems.initiative import InitiativeTracker
 from dnd_engine.systems.inventory import EquipmentSlot
@@ -5181,6 +5182,11 @@ class GameState:
         # Stay 0/None on the ATTACK path when the enemy was already in
         # reach; updated by the movement loop below when it runs.
         moved_squares = 0
+        # Defaults for the skirmisher path (#649). Stay None unless the
+        # spatial branch below runs the pipeline and surfaces an
+        # AttackStep outcome.
+        pipeline_attack_outcome: AttackResult | None = None
+        pipeline_attack_step: AttackStep | None = None
         if (
             enemy.position is not None
             and not is_ranged_action(action)
@@ -5221,15 +5227,59 @@ class GameState:
                     is_ranged=False,
                 )
                 intent = ai_pipeline.decide(ctx)
+
+                # Skirmisher-style strategies need the AttackStep
+                # resolved mid-Intent so the retreat MoveStep can walk
+                # right after. The callback wraps combat_engine.resolve_attack
+                # against the live target pool; aggressive Intents
+                # carry no AttackStep, so the callback is never invoked.
+                def _resolve_attack_step(
+                    actor: Creature,
+                    target_name: str,
+                    action_data: dict,
+                ) -> "AttackResult | None":
+                    pipeline_target = next(
+                        (c for c in living_party
+                         if c.name == target_name and c.is_alive),
+                        None,
+                    )
+                    if pipeline_target is None:
+                        return None
+                    sees_def, sees_atk = self.attack_visibility(actor, pipeline_target)
+                    return self.combat_engine.resolve_attack(
+                        attacker=actor,
+                        defender=pipeline_target,
+                        attack_bonus=action_data["attack_bonus"],
+                        damage_dice=action_data["damage"],
+                        apply_damage=True,
+                        event_bus=self.event_bus,
+                        action=action_data,
+                        game_state=self,
+                        damage_type=action_data.get("damage_type"),
+                        attacker_sees_defender=sees_def,
+                        defender_sees_attacker=sees_atk,
+                    )
+
                 exec_result = ai_pipeline.execute(
                     intent, self, enemy,
                     reach_ft=reach_ft,
                     target_pool=living_party,
+                    attack_resolver=_resolve_attack_step,
                 )
                 moved_squares = exec_result.moved_squares
                 in_reach = exec_result.in_reach_targets
 
-                if not in_reach:
+                # Skirmisher path: the pipeline already drove the
+                # attack. Recover the AttackStep's target by name and
+                # bypass the smart-targeting + duplicate resolve_attack
+                # block below.
+                pipeline_attack_outcome = exec_result.attack_outcome
+                pipeline_attack_step = next(
+                    (s for s in intent.steps if isinstance(s, AttackStep)),
+                    None,
+                )
+
+                if not in_reach and pipeline_attack_outcome is None:
                     # Either moved without reaching (MOVED) or couldn't
                     # move at all (NO_REACHABLE_TARGET — speed 0,
                     # blocked from the start, or no resolvable
@@ -5259,35 +5309,50 @@ class GameState:
                     )
             targeting_pool = in_reach
 
-        # Use smart targeting based on enemy intelligence and combat
-        # history, scoped to the range-filtered candidate pool.
-        target = self.enemy_ai.select_target_smart(
-            available_targets=targeting_pool,
-            enemy_intelligence=enemy.abilities.intelligence,
-            combat_history=self.combat_history,
-            enemy_name=enemy.name,
-        )
+        if pipeline_attack_outcome is not None and pipeline_attack_step is not None:
+            # Skirmisher path: pipeline already attacked. Reconstruct
+            # the post-attack state machinery from the pipeline outcome.
+            target = next(
+                (c for c in living_party if c.name == pipeline_attack_step.target_id),
+                None,
+            ) or living_party[0]
+            attack_result = pipeline_attack_outcome
+            # Conditions-before tracking is bypassed on the skirmisher
+            # path; skirmisher attacks (goblin scimitar, kobold dagger)
+            # do not currently carry saving-throw payloads. The check
+            # below short-circuits via the `"saving_throw" in action`
+            # guard.
+            conditions_before: set[str] = set()
+        else:
+            # Use smart targeting based on enemy intelligence and combat
+            # history, scoped to the range-filtered candidate pool.
+            target = self.enemy_ai.select_target_smart(
+                available_targets=targeting_pool,
+                enemy_intelligence=enemy.abilities.intelligence,
+                combat_history=self.combat_history,
+                enemy_name=enemy.name,
+            )
 
-        # Track conditions before attack (for saving throw detection)
-        conditions_before = set()
-        if hasattr(target, "active_conditions"):
-            conditions_before = set(target.active_conditions.keys())
+            # Track conditions before attack (for saving throw detection)
+            conditions_before = set()
+            if hasattr(target, "active_conditions"):
+                conditions_before = set(target.active_conditions.keys())
 
-        # Resolve attack
-        attacker_sees_defender, defender_sees_attacker = self.attack_visibility(enemy, target)
-        attack_result = self.combat_engine.resolve_attack(
-            attacker=enemy,
-            defender=target,
-            attack_bonus=action["attack_bonus"],
-            damage_dice=action["damage"],
-            apply_damage=True,
-            event_bus=self.event_bus,
-            action=action,
-            game_state=self,
-            damage_type=action.get("damage_type"),
-            attacker_sees_defender=attacker_sees_defender,
-            defender_sees_attacker=defender_sees_attacker,
-        )
+            # Resolve attack
+            attacker_sees_defender, defender_sees_attacker = self.attack_visibility(enemy, target)
+            attack_result = self.combat_engine.resolve_attack(
+                attacker=enemy,
+                defender=target,
+                attack_bonus=action["attack_bonus"],
+                damage_dice=action["damage"],
+                apply_damage=True,
+                event_bus=self.event_bus,
+                action=action,
+                game_state=self,
+                damage_type=action.get("damage_type"),
+                attacker_sees_defender=attacker_sees_defender,
+                defender_sees_attacker=defender_sees_attacker,
+            )
 
         # Check concentration if target was hit and took damage
         concentration_broken = None

--- a/dnd-engine/dnd_engine/data/srd/monsters.json
+++ b/dnd-engine/dnd_engine/data/srd/monsters.json
@@ -33,6 +33,9 @@
       "copper": 15,
       "silver": 3
     },
+    "ai": {
+      "movement_strategy": "skirmisher"
+    },
     "traits": [
       {
         "name": "Nimble Escape",

--- a/dnd-engine/dnd_engine/systems/ai/pipeline.py
+++ b/dnd-engine/dnd_engine/systems/ai/pipeline.py
@@ -29,6 +29,7 @@ Attack resolution remains in `process_enemy_turn` for now —
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -39,10 +40,13 @@ from dnd_engine.systems.ai.strategies.aggressive import AggressiveAdvance
 from dnd_engine.systems.ai.strategies.skirmisher import Skirmisher
 
 if TYPE_CHECKING:
+    from dnd_engine.core.combat import AttackResult
     from dnd_engine.core.creature import Creature
     from dnd_engine.core.game_state import GameState
     from dnd_engine.systems.ai.context import TurnContext
     from dnd_engine.systems.ai.movement_strategy import MovementStrategy
+
+AttackResolver = Callable[["Creature", str, dict], "AttackResult | None"]
 
 logger = logging.getLogger(__name__)
 
@@ -181,17 +185,21 @@ def decide(ctx: TurnContext) -> Intent:
 
 @dataclass
 class MovementExecution:
-    """Outcome of walking the MoveSteps in an Intent.
+    """Outcome of executing an Intent.
 
     Surfaces enough state for `process_enemy_turn` to decide between
     EnemyTurnAction.MOVED, NO_REACHABLE_TARGET, and falling through
-    to attack resolution.
+    to attack resolution. When the Intent included an AttackStep, the
+    resolver's `AttackResult` is captured on `attack_outcome` so the
+    caller can package the EnemyTurnResult directly without rerunning
+    `combat_engine.resolve_attack`.
     """
 
     moved_squares: int = 0
     final_position: Position | None = None
     in_reach_targets: list[Creature] = field(default_factory=list)
     stopped_reason: str = ""
+    attack_outcome: AttackResult | None = None
 
 
 def execute(
@@ -201,22 +209,38 @@ def execute(
     *,
     reach_ft: int | None = None,
     target_pool: list[Creature] | None = None,
+    attack_resolver: AttackResolver | None = None,
 ) -> MovementExecution:
-    """Walk the MoveSteps in `intent` via `GameState.attempt_combat_step`.
+    """Walk the Intent's steps against `state`.
+
+    MoveStep paths walk one tile at a time via
+    `GameState.attempt_combat_step` (preserving CREATURE_MOVED events,
+    opportunity-attack triggers, and Difficult Terrain costs). The
+    close phase short-circuits the per-tile loop as soon as a target
+    enters reach so the actor can attack this turn.
+
+    AttackStep is routed through `attack_resolver` when provided.
+    Skirmisher-style retreat is short-circuited if the attack killed
+    the target. Mid-retreat enemy death (e.g., via opportunity attack)
+    halts cleanly with `stopped_reason="enemy_died_mid_retreat"`.
 
     Args:
         intent: The plan produced by `decide`.
         state: The active game state.
         enemy: The acting enemy.
         reach_ft: Effective reach for the chosen action. When set
-            with `target_pool`, execution stops as soon as any
+            with `target_pool`, the close phase stops as soon as any
             target enters reach.
-        target_pool: Living-target pool for the in-reach check.
+        target_pool: Living-target pool for the in-reach check and
+            for resolving `AttackStep.target_id` to a `Creature`.
+        attack_resolver: Optional callback that resolves an
+            `AttackStep` against `state`. Signature:
+            `(actor, target_id, action) -> AttackResult | None`.
 
     Returns:
         A `MovementExecution` capturing moved squares, final
-        position, in-reach targets at end of execution, and a
-        stop-reason string.
+        position, in-reach targets, the attack outcome (if any), and
+        a stop-reason string.
     """
     result = MovementExecution(final_position=enemy.position)
     if enemy.position is None or not intent.steps:
@@ -226,21 +250,40 @@ def execute(
         result.stopped_reason = "no_entity_id"
         return result
 
-    consecutive_failures = 0
     pool = target_pool or []
+    consecutive_failures = 0
+    is_close_phase = True
+    retreat_walked = False
+
     for step in intent.steps:
+        if isinstance(step, AttackStep):
+            is_close_phase = False
+            if attack_resolver is None:
+                logger.warning(
+                    "Pipeline encountered AttackStep but no "
+                    "attack_resolver was provided; skipping.",
+                )
+                continue
+            result.attack_outcome = attack_resolver(enemy, step.target_id, step.action)
+            target = next(
+                (c for c in pool if c.name == step.target_id),
+                None,
+            )
+            if target is not None and not target.is_alive:
+                result.stopped_reason = "target_killed_no_retreat"
+                return _finalize(result, enemy)
+            if not enemy.is_alive:
+                result.stopped_reason = "enemy_died_mid_attack"
+                return _finalize(result, enemy)
+            continue
+
         if not isinstance(step, MoveStep):
             continue
+
         for target_tile in step.path:
-            # Check reach BEFORE moving — if a target is already in
-            # reach (e.g. a PC moved closer between turns), short-
-            # circuit so the actor can attack this turn.
-            if reach_ft is not None and pool:
-                in_reach_now = _filter_in_reach(enemy.position, pool, reach_ft)
-                if in_reach_now:
-                    result.in_reach_targets = in_reach_now
-                    result.stopped_reason = "in_reach"
-                    return _finalize(result, enemy)
+            if is_close_phase and reach_ft is not None and pool:
+                if _filter_in_reach(enemy.position, pool, reach_ft):
+                    break
 
             dx = _sign(target_tile.x - enemy.position.x)
             dy = _sign(target_tile.y - enemy.position.y)
@@ -251,6 +294,12 @@ def execute(
             if move_result.ok:
                 result.moved_squares += 1
                 consecutive_failures = 0
+                if not enemy.is_alive:
+                    result.stopped_reason = (
+                        "enemy_died_mid_retreat" if not is_close_phase
+                        else "enemy_died_mid_close"
+                    )
+                    return _finalize(result, enemy)
             else:
                 consecutive_failures += 1
                 if move_result.reason == "no movement remaining":
@@ -260,13 +309,18 @@ def execute(
                     result.stopped_reason = "blocked"
                     return _finalize(result, enemy)
 
-    # Final reach check after walking the full intent.
+        if not is_close_phase:
+            retreat_walked = True
+
     if reach_ft is not None and pool and enemy.position is not None:
         result.in_reach_targets = _filter_in_reach(enemy.position, pool, reach_ft)
-    if result.in_reach_targets:
-        result.stopped_reason = "in_reach"
-    elif not result.stopped_reason:
-        result.stopped_reason = "exhausted"
+    if not result.stopped_reason:
+        if retreat_walked:
+            result.stopped_reason = "retreated"
+        elif result.in_reach_targets:
+            result.stopped_reason = "in_reach"
+        else:
+            result.stopped_reason = "exhausted"
     return _finalize(result, enemy)
 
 

--- a/dnd-engine/dnd_engine/systems/ai/pipeline.py
+++ b/dnd-engine/dnd_engine/systems/ai/pipeline.py
@@ -169,7 +169,9 @@ def decide(ctx: TurnContext) -> Intent:
 
     post_close_position = close_path[-1] if close_path else actor_pos
     retreat_plan = retreat_fn(
-        ctx, primary_target, ctx.reach_ft,
+        ctx,
+        primary_target,
+        ctx.reach_ft,
         budget_used_ft=len(close_path) * 5,
         from_position=post_close_position,
     )
@@ -251,7 +253,6 @@ def execute(
         return result
 
     pool = target_pool or []
-    consecutive_failures = 0
     is_close_phase = True
     retreat_walked = False
 
@@ -280,6 +281,9 @@ def execute(
         if not isinstance(step, MoveStep):
             continue
 
+        # Anti-stuck guard is per-MoveStep — a failed step in the close
+        # phase must not poison the retreat phase's first tile.
+        consecutive_failures = 0
         for target_tile in step.path:
             if is_close_phase and reach_ft is not None and pool:
                 if _filter_in_reach(enemy.position, pool, reach_ft):
@@ -296,8 +300,7 @@ def execute(
                 consecutive_failures = 0
                 if not enemy.is_alive:
                     result.stopped_reason = (
-                        "enemy_died_mid_retreat" if not is_close_phase
-                        else "enemy_died_mid_close"
+                        "enemy_died_mid_retreat" if not is_close_phase else "enemy_died_mid_close"
                     )
                     return _finalize(result, enemy)
             else:
@@ -330,7 +333,8 @@ def _filter_in_reach(
     reach_ft: int,
 ) -> list[Creature]:
     return [
-        pc for pc in pool
+        pc
+        for pc in pool
         if pc.position is not None
         and distance_in_feet(actor_pos.x, actor_pos.y, pc.position.x, pc.position.y) <= reach_ft
     ]

--- a/dnd-engine/dnd_engine/systems/ai/pipeline.py
+++ b/dnd-engine/dnd_engine/systems/ai/pipeline.py
@@ -34,8 +34,9 @@ from typing import TYPE_CHECKING
 
 from dnd_engine.core.distance import distance_in_feet
 from dnd_engine.core.position import Position
-from dnd_engine.systems.ai.intent import Intent, MoveStep, WaitStep
+from dnd_engine.systems.ai.intent import AttackStep, Intent, MoveStep, WaitStep
 from dnd_engine.systems.ai.strategies.aggressive import AggressiveAdvance
+from dnd_engine.systems.ai.strategies.skirmisher import Skirmisher
 
 if TYPE_CHECKING:
     from dnd_engine.core.creature import Creature
@@ -49,6 +50,7 @@ DEFAULT_STRATEGY = "aggressive"
 
 STRATEGY_REGISTRY: dict[str, MovementStrategy] = {
     "aggressive": AggressiveAdvance(),
+    "skirmisher": Skirmisher(),
 }
 
 
@@ -98,13 +100,19 @@ def _in_reach(a: Position, b: Position, reach_ft: int) -> bool:
 def decide(ctx: TurnContext) -> Intent:
     """Build the turn's Intent from `ctx`.
 
-    Currently produces the movement phase only — attack and
-    condition-removal steps are still handled by `process_enemy_turn`.
-    Returns:
+    Returns one of:
 
     * `Intent(steps=[WaitStep("no_targets")])` — empty target pool.
-    * `Intent(steps=[])` — no actionable attack data or already in reach.
-    * `Intent(steps=[MoveStep(path=...)])` — movement planned.
+    * `Intent(steps=[])` — no actionable attack data, or aggressive
+      monster already in reach (process_enemy_turn handles attack).
+    * `Intent(steps=[MoveStep])` — aggressive close-distance plan.
+    * `Intent(steps=[MoveStep, AttackStep, MoveStep])` — skirmisher
+      close → attack → retreat (any element may be omitted when its
+      phase is empty: e.g. already-in-reach skirmisher emits
+      `[AttackStep, MoveStep(retreat)]`).
+
+    Attack and condition-removal steps for non-skirmisher monsters
+    still resolve inside `process_enemy_turn` for now.
     """
     if not ctx.target_pool:
         return Intent(steps=[WaitStep(reason="no_targets")], rationale="no living targets")
@@ -121,19 +129,53 @@ def decide(ctx: TurnContext) -> Intent:
     if actor_pos is None or target_pos is None:
         return Intent(steps=[], rationale="no spatial context")
 
-    if _in_reach(actor_pos, target_pos, ctx.reach_ft):
-        return Intent(steps=[], rationale="already in reach")
-
     strategy_name = ctx.monster_data.get("ai", {}).get("movement_strategy", DEFAULT_STRATEGY)
     strategy = get_strategy(strategy_name)
-    plan = strategy.plan(ctx, primary_target, ctx.reach_ft)
+    retreat_fn = getattr(strategy, "plan_retreat", None)
+    already_in_reach = _in_reach(actor_pos, target_pos, ctx.reach_ft)
 
-    if not plan.path:
-        return Intent(steps=[], rationale=f"{strategy.name} returned empty path")
+    # Aggressive monsters (and anything else without plan_retreat) keep
+    # the original contract: already-in-reach falls through to
+    # process_enemy_turn's attack flow with an empty Intent.
+    if retreat_fn is None and already_in_reach:
+        return Intent(steps=[], rationale="already in reach")
+
+    if already_in_reach:
+        close_path: list[Position] = []
+    else:
+        close_plan = strategy.plan(ctx, primary_target, ctx.reach_ft)
+        close_path = list(close_plan.path)
+        if not close_path:
+            return Intent(steps=[], rationale=f"{strategy.name} returned empty path")
+
+    steps: list = []
+    rationale_phases: list[str] = []
+    if close_path:
+        steps.append(MoveStep(path=close_path))
+        rationale_phases.append(f"close to {primary_target.name}")
+
+    if retreat_fn is None:
+        return Intent(
+            steps=steps,
+            rationale=f"close to {primary_target.name} via {strategy.name}",
+        )
+
+    steps.append(AttackStep(target_id=primary_target.name, action=ctx.action_data))
+    rationale_phases.append("attack")
+
+    post_close_position = close_path[-1] if close_path else actor_pos
+    retreat_plan = retreat_fn(
+        ctx, primary_target, ctx.reach_ft,
+        budget_used_ft=len(close_path) * 5,
+        from_position=post_close_position,
+    )
+    if retreat_plan is not None and retreat_plan.path:
+        steps.append(MoveStep(path=list(retreat_plan.path)))
+        rationale_phases.append("retreat")
 
     return Intent(
-        steps=[MoveStep(path=list(plan.path), mode=plan.mode)],
-        rationale=f"close to {primary_target.name} via {strategy.name}",
+        steps=steps,
+        rationale=f"skirmish ({strategy.name}): " + " → ".join(rationale_phases),
     )
 
 

--- a/dnd-engine/dnd_engine/systems/ai/strategies/skirmisher.py
+++ b/dnd-engine/dnd_engine/systems/ai/strategies/skirmisher.py
@@ -1,0 +1,126 @@
+# ABOUTME: Skirmisher — hit-and-run MovementStrategy that closes, attacks, then retreats.
+# ABOUTME: Issue #649. Provides both plan() (close) and plan_retreat() (withdraw out of reach).
+
+"""Skirmisher — the close-attack-retreat planner.
+
+Skirmisher monsters (e.g. goblins) follow a tactical loop: close on
+the primary target to deliver a single attack, then withdraw back
+out of melee reach the same turn. The withdrawal step provokes an
+opportunity attack, which is the price the skirmisher pays for the
+tactical advantage.
+
+The close phase (`plan`) is identical in shape to AggressiveAdvance:
+a greedy king's-move toward the primary target, bounded by step
+budget and `HARD_STEP_CEILING`.
+
+The retreat phase (`plan_retreat`) is the new surface this strategy
+introduces. It returns an opposite-direction path that stops as soon
+as the target is out of reach from the candidate tile (no point in
+over-running) while respecting the movement budget already consumed
+by the close phase. `pipeline.decide` discovers it via `getattr`, so
+AggressiveAdvance is unaffected.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from dnd_engine.core.creature import MovementMode
+from dnd_engine.core.position import Position
+from dnd_engine.systems.ai.movement_strategy import MovePlan
+from dnd_engine.systems.ai.strategies.aggressive import (
+    HARD_STEP_CEILING,
+    _in_reach,
+    _sign,
+)
+
+if TYPE_CHECKING:
+    from dnd_engine.core.creature import Creature
+    from dnd_engine.systems.ai.context import TurnContext
+
+
+class Skirmisher:
+    """Close-attack-retreat planner; goblins and similar nimble foes."""
+
+    name = "skirmisher"
+
+    def plan(
+        self,
+        ctx: TurnContext,
+        primary_target: Creature,
+        reach_ft: int,
+    ) -> MovePlan:
+        """Greedy king's-move close-to-reach path.
+
+        Mirrors AggressiveAdvance: an empty path means the actor is
+        already in reach or no legal step is possible.
+        """
+        actor = ctx.actor
+        if actor.position is None or primary_target.position is None:
+            return MovePlan(path=[], mode=MovementMode.WALK, intent_phase="close")
+
+        if _in_reach(actor.position, primary_target.position, reach_ft):
+            return MovePlan(path=[], mode=MovementMode.WALK, intent_phase="close")
+
+        max_steps = min(actor.speed // 5, HARD_STEP_CEILING)
+        if max_steps <= 0:
+            return MovePlan(path=[], mode=MovementMode.WALK, intent_phase="close")
+
+        path: list[Position] = []
+        current = actor.position
+        target = primary_target.position
+        for _ in range(max_steps):
+            dx = _sign(target.x - current.x)
+            dy = _sign(target.y - current.y)
+            if dx == 0 and dy == 0:
+                break
+            current = Position(current.x + dx, current.y + dy)
+            path.append(current)
+            if _in_reach(current, target, reach_ft):
+                break
+
+        return MovePlan(path=path, mode=MovementMode.WALK, intent_phase="close")
+
+    def plan_retreat(
+        self,
+        ctx: TurnContext,
+        primary_target: Creature,
+        reach_ft: int,
+        budget_used_ft: int,
+    ) -> MovePlan | None:
+        """Plan an opposite-direction path that breaks the target's reach.
+
+        Returns None when planning is impossible — no remaining budget,
+        no spatial context. Returns a `MovePlan` with `path == []` when
+        the actor is already disengaged (no retreat needed but the
+        caller can still see the intent phase).
+        """
+        actor = ctx.actor
+        if actor.position is None or primary_target.position is None:
+            return None
+
+        remaining_ft = actor.speed - budget_used_ft
+        if remaining_ft < 5:
+            return None
+
+        max_steps = min(remaining_ft // 5, HARD_STEP_CEILING)
+        if max_steps <= 0:
+            return None
+
+        if not _in_reach(actor.position, primary_target.position, reach_ft):
+            return MovePlan(path=[], mode=MovementMode.WALK, intent_phase="retreat")
+
+        path: list[Position] = []
+        current = actor.position
+        target = primary_target.position
+        for _ in range(max_steps):
+            dx = -_sign(target.x - current.x)
+            dy = -_sign(target.y - current.y)
+            if dx == 0 and dy == 0:
+                break
+            current = Position(current.x + dx, current.y + dy)
+            path.append(current)
+            if not _in_reach(current, target, reach_ft):
+                break
+
+        return MovePlan(path=path, mode=MovementMode.WALK, intent_phase="retreat")

--- a/dnd-engine/dnd_engine/systems/ai/strategies/skirmisher.py
+++ b/dnd-engine/dnd_engine/systems/ai/strategies/skirmisher.py
@@ -87,16 +87,24 @@ class Skirmisher:
         primary_target: Creature,
         reach_ft: int,
         budget_used_ft: int,
+        *,
+        from_position: Position | None = None,
     ) -> MovePlan | None:
         """Plan an opposite-direction path that breaks the target's reach.
 
+        `from_position` is the post-close position the retreat starts
+        from. When omitted, falls back to `ctx.actor.position` — which
+        is correct only when the actor hasn't closed yet (unit tests
+        and already-in-reach skirmishers).
+
         Returns None when planning is impossible — no remaining budget,
         no spatial context. Returns a `MovePlan` with `path == []` when
-        the actor is already disengaged (no retreat needed but the
-        caller can still see the intent phase).
+        the actor is already disengaged so the caller can still see the
+        intent phase.
         """
         actor = ctx.actor
-        if actor.position is None or primary_target.position is None:
+        origin = from_position if from_position is not None else actor.position
+        if origin is None or primary_target.position is None:
             return None
 
         remaining_ft = actor.speed - budget_used_ft
@@ -107,11 +115,11 @@ class Skirmisher:
         if max_steps <= 0:
             return None
 
-        if not _in_reach(actor.position, primary_target.position, reach_ft):
+        if not _in_reach(origin, primary_target.position, reach_ft):
             return MovePlan(path=[], mode=MovementMode.WALK, intent_phase="retreat")
 
         path: list[Position] = []
-        current = actor.position
+        current = origin
         target = primary_target.position
         for _ in range(max_steps):
             dx = -_sign(target.x - current.x)

--- a/dnd-engine/tests/ai/test_pipeline_skirmisher.py
+++ b/dnd-engine/tests/ai/test_pipeline_skirmisher.py
@@ -3,14 +3,18 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import logging
+from dataclasses import dataclass, field
 from typing import Any
+from unittest.mock import MagicMock
 
+from dnd_engine.core.combat import AttackResult
 from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.move_result import MoveResult
 from dnd_engine.core.position import Position
 from dnd_engine.systems.ai import pipeline
 from dnd_engine.systems.ai.context import TurnContext
-from dnd_engine.systems.ai.intent import AttackStep, MoveStep
+from dnd_engine.systems.ai.intent import AttackStep, Intent, MoveStep
 from dnd_engine.systems.ai.strategies.skirmisher import Skirmisher
 
 
@@ -132,3 +136,225 @@ class TestDecideAggressiveStillWorks:
         )
         intent = pipeline.decide(ctx)
         assert intent.steps == []
+
+
+# ---------- execute() tests ----------
+
+
+@dataclass
+class _StubSpatial:
+    occupants: dict[Position, str] = field(default_factory=dict)
+
+    def occupant_at(self, pos: Position) -> str | None:
+        return self.occupants.get(pos)
+
+
+@dataclass
+class _StubGameState:
+    """Stub state that scripts attempt_combat_step results in order."""
+
+    spatial: _StubSpatial = field(default_factory=_StubSpatial)
+    step_results: list[MoveResult] = field(default_factory=list)
+    enemy: Creature | None = None
+    on_each_step: Any = None  # callable hook, e.g., flip enemy.is_alive
+
+    def attempt_combat_step(self, entity_id: str, dx: int, dy: int) -> MoveResult:
+        result = self.step_results.pop(0)
+        if result.ok and result.position is not None and self.enemy is not None:
+            self.enemy.position = result.position
+        if self.on_each_step is not None:
+            self.on_each_step(entity_id, dx, dy)
+        return result
+
+
+def _ok_step(pos: Position) -> MoveResult:
+    return MoveResult(ok=True, reason=None, position=pos, movement_remaining=25)
+
+
+def _attack_outcome(hit: bool = True, damage: int = 5) -> AttackResult:
+    return AttackResult(
+        attacker_name="Goblin",
+        defender_name="Brick",
+        attack_roll=15,
+        attack_bonus=4,
+        target_ac=15,
+        hit=hit,
+        damage=damage,
+        critical_hit=False,
+        advantage=False,
+        disadvantage=False,
+    )
+
+
+class TestExecuteAttackStep:
+    """execute() routes AttackStep through the supplied attack_resolver."""
+
+    def test_resolver_called_with_actor_target_id_and_action(self):
+        actor = _make_creature("Goblin", 5, 9)
+        target = _make_creature("Brick", 5, 10)
+        spatial = _StubSpatial(occupants={Position(5, 9): "goblin_0"})
+        state = _StubGameState(spatial=spatial, enemy=actor)
+        resolver = MagicMock(return_value=_attack_outcome())
+
+        intent = Intent(steps=[AttackStep(target_id="Brick", action=SCIMITAR)])
+        result = pipeline.execute(
+            intent, state, actor,
+            reach_ft=5,
+            target_pool=[target],
+            attack_resolver=resolver,
+        )
+
+        resolver.assert_called_once_with(actor, "Brick", SCIMITAR)
+        assert result.attack_outcome is not None
+        assert result.attack_outcome.hit is True
+
+    def test_skips_retreat_when_attack_kills_target(self):
+        actor = _make_creature("Goblin", 5, 9)
+        target = _make_creature("Brick", 5, 10)
+        spatial = _StubSpatial(occupants={Position(5, 9): "goblin_0"})
+        state = _StubGameState(spatial=spatial, enemy=actor)
+
+        def killer(_actor: Creature, _tid: str, _action: dict) -> AttackResult:
+            target.current_hp = 0  # kill the target
+            return _attack_outcome(damage=20)
+
+        intent = Intent(steps=[
+            AttackStep(target_id="Brick", action=SCIMITAR),
+            MoveStep(path=[Position(5, 8)]),
+        ])
+        result = pipeline.execute(
+            intent, state, actor,
+            reach_ft=5,
+            target_pool=[target],
+            attack_resolver=killer,
+        )
+
+        assert result.stopped_reason == "target_killed_no_retreat"
+        assert result.moved_squares == 0
+        assert result.attack_outcome is not None
+
+    def test_attackstep_without_resolver_logs_warning_and_continues(self, caplog):
+        actor = _make_creature("Goblin", 5, 9)
+        target = _make_creature("Brick", 5, 10)
+        spatial = _StubSpatial(occupants={Position(5, 9): "goblin_0"})
+        state = _StubGameState(
+            spatial=spatial,
+            enemy=actor,
+            step_results=[_ok_step(Position(5, 8))],
+        )
+
+        intent = Intent(steps=[
+            AttackStep(target_id="Brick", action=SCIMITAR),
+            MoveStep(path=[Position(5, 8)]),
+        ])
+        with caplog.at_level(logging.WARNING, logger="dnd_engine.systems.ai.pipeline"):
+            result = pipeline.execute(
+                intent, state, actor,
+                reach_ft=5,
+                target_pool=[target],
+                attack_resolver=None,
+            )
+
+        assert result.attack_outcome is None
+        # Retreat still walked despite missing resolver.
+        assert result.moved_squares == 1
+        assert any("attack_resolver" in rec.message for rec in caplog.records)
+
+
+class TestExecuteFullSkirmish:
+    """A complete close → attack → retreat sequence."""
+
+    def test_completes_all_phases(self):
+        actor = _make_creature("Goblin", 5, 5)
+        target = _make_creature("Brick", 5, 10)
+        spatial = _StubSpatial(occupants={Position(5, 5): "goblin_0"})
+        state = _StubGameState(
+            spatial=spatial,
+            enemy=actor,
+            step_results=[
+                # Close phase: 4 tiles to (5, 9).
+                _ok_step(Position(5, 6)),
+                _ok_step(Position(5, 7)),
+                _ok_step(Position(5, 8)),
+                _ok_step(Position(5, 9)),
+                # Retreat phase: 1 tile back to (5, 8).
+                _ok_step(Position(5, 8)),
+            ],
+        )
+        resolver = MagicMock(return_value=_attack_outcome())
+
+        intent = Intent(steps=[
+            MoveStep(path=[
+                Position(5, 6), Position(5, 7), Position(5, 8), Position(5, 9),
+            ]),
+            AttackStep(target_id="Brick", action=SCIMITAR),
+            MoveStep(path=[Position(5, 8)]),
+        ])
+        result = pipeline.execute(
+            intent, state, actor,
+            reach_ft=5,
+            target_pool=[target],
+            attack_resolver=resolver,
+        )
+
+        assert result.moved_squares == 5
+        assert result.attack_outcome is not None
+        assert result.stopped_reason == "retreated"
+        assert state.step_results == []  # all scripted steps consumed
+        resolver.assert_called_once()
+
+    def test_stops_when_enemy_dies_during_retreat(self):
+        actor = _make_creature("Goblin", 5, 9)
+        target = _make_creature("Brick", 5, 10)
+        spatial = _StubSpatial(occupants={Position(5, 9): "goblin_0"})
+
+        def kill_after_first_retreat(_eid: str, _dx: int, _dy: int) -> None:
+            actor.current_hp = 0
+
+        state = _StubGameState(
+            spatial=spatial,
+            enemy=actor,
+            step_results=[
+                _ok_step(Position(5, 8)),  # first retreat step (OA kills)
+                _ok_step(Position(5, 7)),  # would be 2nd step (should not run)
+            ],
+            on_each_step=kill_after_first_retreat,
+        )
+        resolver = MagicMock(return_value=_attack_outcome())
+
+        intent = Intent(steps=[
+            AttackStep(target_id="Brick", action=SCIMITAR),
+            MoveStep(path=[Position(5, 8), Position(5, 7)]),
+        ])
+        result = pipeline.execute(
+            intent, state, actor,
+            reach_ft=5,
+            target_pool=[target],
+            attack_resolver=resolver,
+        )
+
+        assert result.stopped_reason == "enemy_died_mid_retreat"
+        assert result.moved_squares == 1
+        # Second tile MUST NOT be walked.
+        assert len(state.step_results) == 1
+
+
+class TestExecuteAggressivePathUnchanged:
+    """Sanity: existing single-MoveStep contract is byte-identical."""
+
+    def test_aggressive_in_reach_short_circuits_as_before(self):
+        actor = _make_creature("Bandit", 5, 5)
+        target = _make_creature("Brick", 5, 6)
+        spatial = _StubSpatial(occupants={Position(5, 5): "bandit_0"})
+        state = _StubGameState(spatial=spatial, enemy=actor)
+
+        intent = Intent(steps=[MoveStep(path=[Position(5, 6)])])
+        result = pipeline.execute(
+            intent, state, actor,
+            reach_ft=5,
+            target_pool=[target],
+        )
+        # Already in reach before stepping → in_reach short-circuit.
+        assert result.stopped_reason == "in_reach"
+        assert result.moved_squares == 0
+        assert result.attack_outcome is None

--- a/dnd-engine/tests/ai/test_pipeline_skirmisher.py
+++ b/dnd-engine/tests/ai/test_pipeline_skirmisher.py
@@ -29,8 +29,12 @@ def _make_creature(name: str, x: int, y: int, speed: int = 30) -> Creature:
         max_hp=20,
         ac=15,
         abilities=Abilities(
-            strength=10, dexterity=10, constitution=10,
-            intelligence=10, wisdom=10, charisma=10,
+            strength=10,
+            dexterity=10,
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
         ),
         speed=speed,
     )
@@ -55,7 +59,8 @@ class TestDecideSkirmisher:
         actor = _make_creature("Goblin", 5, 5)
         target = _make_creature("Brick", 5, 10)
         ctx = TurnContext.build(
-            _StubState(), actor,
+            _StubState(),
+            actor,
             target_pool=[target],
             monster_data=SKIRMISHER_DATA,
         )
@@ -63,7 +68,10 @@ class TestDecideSkirmisher:
         assert len(intent.steps) == 3
         assert isinstance(intent.steps[0], MoveStep)
         assert intent.steps[0].path == [
-            Position(5, 6), Position(5, 7), Position(5, 8), Position(5, 9),
+            Position(5, 6),
+            Position(5, 7),
+            Position(5, 8),
+            Position(5, 9),
         ]
         assert isinstance(intent.steps[1], AttackStep)
         assert intent.steps[1].target_id == "Brick"
@@ -80,7 +88,8 @@ class TestDecideSkirmisher:
         actor = _make_creature("Goblin", 0, 0, speed=30)
         target = _make_creature("Brick", 7, 0)
         ctx = TurnContext.build(
-            _StubState(), actor,
+            _StubState(),
+            actor,
             target_pool=[target],
             monster_data=SKIRMISHER_DATA,
         )
@@ -88,8 +97,12 @@ class TestDecideSkirmisher:
         assert len(intent.steps) == 2
         assert isinstance(intent.steps[0], MoveStep)
         assert intent.steps[0].path == [
-            Position(1, 0), Position(2, 0), Position(3, 0),
-            Position(4, 0), Position(5, 0), Position(6, 0),
+            Position(1, 0),
+            Position(2, 0),
+            Position(3, 0),
+            Position(4, 0),
+            Position(5, 0),
+            Position(6, 0),
         ]
         assert isinstance(intent.steps[1], AttackStep)
 
@@ -99,7 +112,8 @@ class TestDecideSkirmisher:
         actor = _make_creature("Goblin", 5, 9)
         target = _make_creature("Brick", 5, 10)
         ctx = TurnContext.build(
-            _StubState(), actor,
+            _StubState(),
+            actor,
             target_pool=[target],
             monster_data=SKIRMISHER_DATA,
         )
@@ -118,7 +132,8 @@ class TestDecideAggressiveStillWorks:
         actor = _make_creature("Bandit", 0, 0)
         target = _make_creature("Brick", 5, 0)
         ctx = TurnContext.build(
-            _StubState(), actor,
+            _StubState(),
+            actor,
             target_pool=[target],
             monster_data={"actions": [SCIMITAR]},
         )
@@ -130,7 +145,8 @@ class TestDecideAggressiveStillWorks:
         actor = _make_creature("Bandit", 0, 0)
         target = _make_creature("Brick", 1, 0)
         ctx = TurnContext.build(
-            _StubState(), actor,
+            _StubState(),
+            actor,
             target_pool=[target],
             monster_data={"actions": [SCIMITAR]},
         )
@@ -198,7 +214,9 @@ class TestExecuteAttackStep:
 
         intent = Intent(steps=[AttackStep(target_id="Brick", action=SCIMITAR)])
         result = pipeline.execute(
-            intent, state, actor,
+            intent,
+            state,
+            actor,
             reach_ft=5,
             target_pool=[target],
             attack_resolver=resolver,
@@ -218,12 +236,16 @@ class TestExecuteAttackStep:
             target.current_hp = 0  # kill the target
             return _attack_outcome(damage=20)
 
-        intent = Intent(steps=[
-            AttackStep(target_id="Brick", action=SCIMITAR),
-            MoveStep(path=[Position(5, 8)]),
-        ])
+        intent = Intent(
+            steps=[
+                AttackStep(target_id="Brick", action=SCIMITAR),
+                MoveStep(path=[Position(5, 8)]),
+            ]
+        )
         result = pipeline.execute(
-            intent, state, actor,
+            intent,
+            state,
+            actor,
             reach_ft=5,
             target_pool=[target],
             attack_resolver=killer,
@@ -243,13 +265,17 @@ class TestExecuteAttackStep:
             step_results=[_ok_step(Position(5, 8))],
         )
 
-        intent = Intent(steps=[
-            AttackStep(target_id="Brick", action=SCIMITAR),
-            MoveStep(path=[Position(5, 8)]),
-        ])
+        intent = Intent(
+            steps=[
+                AttackStep(target_id="Brick", action=SCIMITAR),
+                MoveStep(path=[Position(5, 8)]),
+            ]
+        )
         with caplog.at_level(logging.WARNING, logger="dnd_engine.systems.ai.pipeline"):
             result = pipeline.execute(
-                intent, state, actor,
+                intent,
+                state,
+                actor,
                 reach_ft=5,
                 target_pool=[target],
                 attack_resolver=None,
@@ -283,15 +309,24 @@ class TestExecuteFullSkirmish:
         )
         resolver = MagicMock(return_value=_attack_outcome())
 
-        intent = Intent(steps=[
-            MoveStep(path=[
-                Position(5, 6), Position(5, 7), Position(5, 8), Position(5, 9),
-            ]),
-            AttackStep(target_id="Brick", action=SCIMITAR),
-            MoveStep(path=[Position(5, 8)]),
-        ])
+        intent = Intent(
+            steps=[
+                MoveStep(
+                    path=[
+                        Position(5, 6),
+                        Position(5, 7),
+                        Position(5, 8),
+                        Position(5, 9),
+                    ]
+                ),
+                AttackStep(target_id="Brick", action=SCIMITAR),
+                MoveStep(path=[Position(5, 8)]),
+            ]
+        )
         result = pipeline.execute(
-            intent, state, actor,
+            intent,
+            state,
+            actor,
             reach_ft=5,
             target_pool=[target],
             attack_resolver=resolver,
@@ -322,12 +357,16 @@ class TestExecuteFullSkirmish:
         )
         resolver = MagicMock(return_value=_attack_outcome())
 
-        intent = Intent(steps=[
-            AttackStep(target_id="Brick", action=SCIMITAR),
-            MoveStep(path=[Position(5, 8), Position(5, 7)]),
-        ])
+        intent = Intent(
+            steps=[
+                AttackStep(target_id="Brick", action=SCIMITAR),
+                MoveStep(path=[Position(5, 8), Position(5, 7)]),
+            ]
+        )
         result = pipeline.execute(
-            intent, state, actor,
+            intent,
+            state,
+            actor,
             reach_ft=5,
             target_pool=[target],
             attack_resolver=resolver,
@@ -337,6 +376,55 @@ class TestExecuteFullSkirmish:
         assert result.moved_squares == 1
         # Second tile MUST NOT be walked.
         assert len(state.step_results) == 1
+
+
+class TestExecuteAntiStuckGuardScope:
+    """The 2-consecutive-failures guard is per-MoveStep, not lifetime.
+
+    Regression for a bug where a failed step in the close phase poisoned
+    the retreat phase: one more failed retreat step would trip the guard
+    and exit with `stopped_reason="blocked"` even though the failures
+    were in unrelated phases separated by an attack.
+    """
+
+    def test_close_phase_failure_does_not_poison_retreat(self):
+        actor = _make_creature("Goblin", 5, 8)
+        target = _make_creature("Brick", 5, 10)
+        spatial = _StubSpatial(occupants={Position(5, 8): "goblin_0"})
+
+        # Close: one failed step (e.g., transient block). Retreat: first
+        # tile succeeds. With the bug, counter carries into retreat and
+        # the next failed tile (if any) would trip "blocked" early.
+        state = _StubGameState(
+            spatial=spatial,
+            enemy=actor,
+            step_results=[
+                MoveResult(ok=False, reason="blocked", position=None, movement_remaining=25),
+                _ok_step(Position(5, 9)),  # close succeeds after retry-ish
+                _ok_step(Position(5, 8)),  # retreat first tile
+            ],
+        )
+        resolver = MagicMock(return_value=_attack_outcome())
+
+        intent = Intent(
+            steps=[
+                MoveStep(path=[Position(5, 9), Position(5, 9)]),  # one fail, one ok
+                AttackStep(target_id="Brick", action=SCIMITAR),
+                MoveStep(path=[Position(5, 8)]),
+            ]
+        )
+        result = pipeline.execute(
+            intent,
+            state,
+            actor,
+            reach_ft=5,
+            target_pool=[target],
+            attack_resolver=resolver,
+        )
+
+        # Retreat completed; guard did not fire across phases.
+        assert result.stopped_reason == "retreated"
+        assert result.moved_squares == 2
 
 
 class TestExecuteAggressivePathUnchanged:
@@ -350,7 +438,9 @@ class TestExecuteAggressivePathUnchanged:
 
         intent = Intent(steps=[MoveStep(path=[Position(5, 6)])])
         result = pipeline.execute(
-            intent, state, actor,
+            intent,
+            state,
+            actor,
             reach_ft=5,
             target_pool=[target],
         )

--- a/dnd-engine/tests/ai/test_pipeline_skirmisher.py
+++ b/dnd-engine/tests/ai/test_pipeline_skirmisher.py
@@ -1,0 +1,134 @@
+# ABOUTME: Pipeline tests for the Skirmisher strategy (#649).
+# ABOUTME: Covers decide() Intent shape and execute() AttackStep/retreat orchestration.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.position import Position
+from dnd_engine.systems.ai import pipeline
+from dnd_engine.systems.ai.context import TurnContext
+from dnd_engine.systems.ai.intent import AttackStep, MoveStep
+from dnd_engine.systems.ai.strategies.skirmisher import Skirmisher
+
+
+@dataclass
+class _StubState:
+    data_loader: Any = None
+
+
+def _make_creature(name: str, x: int, y: int, speed: int = 30) -> Creature:
+    c = Creature(
+        name=name,
+        max_hp=20,
+        ac=15,
+        abilities=Abilities(
+            strength=10, dexterity=10, constitution=10,
+            intelligence=10, wisdom=10, charisma=10,
+        ),
+        speed=speed,
+    )
+    c.position = Position(x, y)
+    return c
+
+
+SCIMITAR = {"name": "Scimitar", "reach": "5 ft.", "damage": "1d6", "attack_bonus": 4}
+SKIRMISHER_DATA = {"actions": [SCIMITAR], "ai": {"movement_strategy": "skirmisher"}}
+
+
+class TestSkirmisherRegistered:
+    def test_registry_has_skirmisher(self):
+        strategy = pipeline.get_strategy("skirmisher")
+        assert isinstance(strategy, Skirmisher)
+
+
+class TestDecideSkirmisher:
+    """When monster_data names skirmisher, decide() emits the 3-step Intent."""
+
+    def test_close_attack_retreat_when_out_of_reach(self):
+        actor = _make_creature("Goblin", 5, 5)
+        target = _make_creature("Brick", 5, 10)
+        ctx = TurnContext.build(
+            _StubState(), actor,
+            target_pool=[target],
+            monster_data=SKIRMISHER_DATA,
+        )
+        intent = pipeline.decide(ctx)
+        assert len(intent.steps) == 3
+        assert isinstance(intent.steps[0], MoveStep)
+        assert intent.steps[0].path == [
+            Position(5, 6), Position(5, 7), Position(5, 8), Position(5, 9),
+        ]
+        assert isinstance(intent.steps[1], AttackStep)
+        assert intent.steps[1].target_id == "Brick"
+        assert intent.steps[1].action == SCIMITAR
+        assert isinstance(intent.steps[2], MoveStep)
+        # Greedy retreat away from (5,10): one tile (5,8) breaks reach 5.
+        assert intent.steps[2].path == [Position(5, 8)]
+        assert "skirmish" in intent.rationale.lower()
+
+    def test_two_steps_when_close_budget_exhausts_speed(self):
+        # Speed 30 → 6-tile budget. Target at (7,0) = 35 ft away. Close
+        # walks the full 6 tiles to (6,0) (5 ft from target → in reach),
+        # leaving zero budget for retreat.
+        actor = _make_creature("Goblin", 0, 0, speed=30)
+        target = _make_creature("Brick", 7, 0)
+        ctx = TurnContext.build(
+            _StubState(), actor,
+            target_pool=[target],
+            monster_data=SKIRMISHER_DATA,
+        )
+        intent = pipeline.decide(ctx)
+        assert len(intent.steps) == 2
+        assert isinstance(intent.steps[0], MoveStep)
+        assert intent.steps[0].path == [
+            Position(1, 0), Position(2, 0), Position(3, 0),
+            Position(4, 0), Position(5, 0), Position(6, 0),
+        ]
+        assert isinstance(intent.steps[1], AttackStep)
+
+    def test_attack_then_retreat_when_already_in_reach(self):
+        # Goblin starts adjacent — no close phase needed, but it should
+        # still attack and retreat.
+        actor = _make_creature("Goblin", 5, 9)
+        target = _make_creature("Brick", 5, 10)
+        ctx = TurnContext.build(
+            _StubState(), actor,
+            target_pool=[target],
+            monster_data=SKIRMISHER_DATA,
+        )
+        intent = pipeline.decide(ctx)
+        assert len(intent.steps) == 2
+        assert isinstance(intent.steps[0], AttackStep)
+        assert intent.steps[0].target_id == "Brick"
+        assert isinstance(intent.steps[1], MoveStep)
+        assert intent.steps[1].path == [Position(5, 8)]
+
+
+class TestDecideAggressiveStillWorks:
+    """Backstop: aggressive monsters get the same single-MoveStep Intent."""
+
+    def test_aggressive_out_of_reach_emits_single_move(self):
+        actor = _make_creature("Bandit", 0, 0)
+        target = _make_creature("Brick", 5, 0)
+        ctx = TurnContext.build(
+            _StubState(), actor,
+            target_pool=[target],
+            monster_data={"actions": [SCIMITAR]},
+        )
+        intent = pipeline.decide(ctx)
+        assert len(intent.steps) == 1
+        assert isinstance(intent.steps[0], MoveStep)
+
+    def test_aggressive_already_in_reach_emits_empty(self):
+        actor = _make_creature("Bandit", 0, 0)
+        target = _make_creature("Brick", 1, 0)
+        ctx = TurnContext.build(
+            _StubState(), actor,
+            target_pool=[target],
+            monster_data={"actions": [SCIMITAR]},
+        )
+        intent = pipeline.decide(ctx)
+        assert intent.steps == []

--- a/dnd-engine/tests/ai/test_skirmisher_integration.py
+++ b/dnd-engine/tests/ai/test_skirmisher_integration.py
@@ -32,8 +32,12 @@ def _make_skirmish_state() -> tuple[GameState, Character, Creature, str]:
     rather than dice rolls.
     """
     abilities = Abilities(
-        strength=15, dexterity=14, constitution=13,
-        intelligence=10, wisdom=12, charisma=8,
+        strength=15,
+        dexterity=14,
+        constitution=13,
+        intelligence=10,
+        wisdom=12,
+        charisma=8,
     )
     fighter = Character(
         name="Fighter 1",
@@ -65,8 +69,7 @@ def _make_skirmish_state() -> tuple[GameState, Character, Creature, str]:
     gs._start_combat()
 
     goblin_idx = next(
-        i for i, entry in enumerate(gs.initiative_tracker.combatants)
-        if entry.creature is goblin
+        i for i, entry in enumerate(gs.initiative_tracker.combatants) if entry.creature is goblin
     )
     gs.initiative_tracker.current_turn_index = goblin_idx
     gs.initiative_tracker.turn_states[goblin].reset(speed=goblin.speed)
@@ -111,19 +114,14 @@ class TestGoblinSkirmishesEndToEnd:
 
         gs.process_enemy_turn()
 
-        positions = [
-            e.data["to"]
-            for e in moves if e.data.get("entity_id") == goblin_id
-        ]
+        positions = [e.data["to"] for e in moves if e.data.get("entity_id") == goblin_id]
         assert len(positions) == 6
         # Close phase: 5 tiles heading south toward (3,9).
         expected_close = [(3, 4), (3, 5), (3, 6), (3, 7), (3, 8)]
         for i, expected in enumerate(expected_close):
             assert (positions[i].x, positions[i].y) == expected, (
-                f"close step {i}: expected {expected}, "
-                f"got ({positions[i].x},{positions[i].y})"
+                f"close step {i}: expected {expected}, got ({positions[i].x},{positions[i].y})"
             )
         # Retreat phase: one tile heading back north — direction reverses,
         # which is the load-bearing assertion for "attack happened between".
         assert (positions[5].x, positions[5].y) == (3, 7)
-

--- a/dnd-engine/tests/ai/test_skirmisher_integration.py
+++ b/dnd-engine/tests/ai/test_skirmisher_integration.py
@@ -10,7 +10,7 @@ from dnd_engine.core.game_state import EnemyTurnAction, GameState
 from dnd_engine.core.map import Map, TileType
 from dnd_engine.core.party import Party
 from dnd_engine.rules.loader import DataLoader
-from dnd_engine.utils.events import EventBus
+from dnd_engine.utils.events import Event, EventBus, EventType
 
 
 def _floor_map(size: int = 12) -> Map:
@@ -93,4 +93,37 @@ class TestGoblinSkirmishesEndToEnd:
         assert result.movement_end_position == (3, 7)
         # The actual goblin object's position mirrors the spatial index.
         assert goblin.position == end_position
+
+    def test_creature_moved_events_fire_in_close_then_retreat_order(self):
+        """The engine's contract for UI consumers: CREATURE_MOVED events
+        arrive in temporal order — five close-phase moves heading toward
+        the PC followed by one retreat-phase move heading away. A
+        renderer can pair this stream with the EnemyTurnResult.attack_result
+        to emit three discrete log lines (close → attack → retreat).
+
+        Melee weapon attacks do not currently emit a discrete attack
+        event through the bus (only spells do); the attack is surfaced
+        via `EnemyTurnResult.attack_result` instead.
+        """
+        gs, _fighter, _goblin, goblin_id = _make_skirmish_state()
+        moves: list[Event] = []
+        gs.event_bus.subscribe(EventType.CREATURE_MOVED, moves.append)
+
+        gs.process_enemy_turn()
+
+        positions = [
+            e.data["to"]
+            for e in moves if e.data.get("entity_id") == goblin_id
+        ]
+        assert len(positions) == 6
+        # Close phase: 5 tiles heading south toward (3,9).
+        expected_close = [(3, 4), (3, 5), (3, 6), (3, 7), (3, 8)]
+        for i, expected in enumerate(expected_close):
+            assert (positions[i].x, positions[i].y) == expected, (
+                f"close step {i}: expected {expected}, "
+                f"got ({positions[i].x},{positions[i].y})"
+            )
+        # Retreat phase: one tile heading back north — direction reverses,
+        # which is the load-bearing assertion for "attack happened between".
+        assert (positions[5].x, positions[5].y) == (3, 7)
 

--- a/dnd-engine/tests/ai/test_skirmisher_integration.py
+++ b/dnd-engine/tests/ai/test_skirmisher_integration.py
@@ -1,0 +1,96 @@
+# ABOUTME: Integration test — goblin tagged "skirmisher" closes, attacks, then retreats.
+# ABOUTME: Verifies the full process_enemy_turn → pipeline → attempt_combat_step flow.
+
+from __future__ import annotations
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.core.game_state import EnemyTurnAction, GameState
+from dnd_engine.core.map import Map, TileType
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.utils.events import EventBus
+
+
+def _floor_map(size: int = 12) -> Map:
+    tiles = {(x, y): TileType.FLOOR for x in range(size) for y in range(size)}
+    return Map(width=size, height=size, tiles=tiles)
+
+
+def _pc_id(name: str) -> str:
+    return f"pc_{name.lower().replace(' ', '_')}"
+
+
+def _make_skirmish_state() -> tuple[GameState, Character, Creature, str]:
+    """A 12×12 floor, one PC at (3,9), one goblin at (3,3).
+
+    The goblin's speed is 30 ft (6 tiles). From (3,3) to (3,9) is six
+    tiles → the goblin can close to (3,8) (5 ft from the PC, in reach),
+    spend 5 tiles of budget on the close, and retain 5 ft for one
+    retreat step back to (3,7). All assertions key off engine state
+    rather than dice rolls.
+    """
+    abilities = Abilities(
+        strength=15, dexterity=14, constitution=13,
+        intelligence=10, wisdom=12, charisma=8,
+    )
+    fighter = Character(
+        name="Fighter 1",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=abilities,
+        max_hp=30,
+        ac=30,  # high AC so the goblin's attack misses, keeping the PC alive
+        xp=0,
+    )
+    party = Party(characters=[fighter])
+    gs = GameState(
+        party=party,
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+        dice_roller=DiceRoller(seed=1),
+    )
+    gs.bootstrap_spatial(_floor_map())
+
+    goblin = gs.data_loader.create_monster("goblin")
+    gs.active_enemies.append(goblin)
+
+    pc_id = _pc_id(fighter.name)
+    goblin_id = "goblin_0"
+    gs.set_position(goblin_id, 3, 3)
+    gs.set_position(pc_id, 3, 9)
+
+    gs._start_combat()
+
+    goblin_idx = next(
+        i for i, entry in enumerate(gs.initiative_tracker.combatants)
+        if entry.creature is goblin
+    )
+    gs.initiative_tracker.current_turn_index = goblin_idx
+    gs.initiative_tracker.turn_states[goblin].reset(speed=goblin.speed)
+    # _start_combat surprises monsters on round 1; clear it so the
+    # goblin can act on its forced turn.
+    if "surprised" in goblin.conditions:
+        goblin.remove_condition("surprised")
+    return gs, fighter, goblin, goblin_id
+
+
+class TestGoblinSkirmishesEndToEnd:
+    def test_goblin_closes_attacks_then_retreats(self):
+        gs, _fighter, goblin, goblin_id = _make_skirmish_state()
+
+        result = gs.process_enemy_turn()
+        assert result is not None
+        assert result.action_taken == EnemyTurnAction.ATTACK
+        # Close was 5 tiles, retreat was 1 tile.
+        assert result.moved_squares == 6
+        # Goblin ended at (3, 7) — one tile back from the attack position.
+        end_position = gs.spatial.position_of(goblin_id)
+        assert end_position is not None
+        assert (end_position.x, end_position.y) == (3, 7)
+        assert result.movement_end_position == (3, 7)
+        # The actual goblin object's position mirrors the spatial index.
+        assert goblin.position == end_position
+

--- a/dnd-engine/tests/ai/test_skirmisher_strategy.py
+++ b/dnd-engine/tests/ai/test_skirmisher_strategy.py
@@ -24,8 +24,12 @@ def _make_creature(name: str, x: int, y: int, speed: int = 30) -> Creature:
         max_hp=20,
         ac=15,
         abilities=Abilities(
-            strength=10, dexterity=10, constitution=10,
-            intelligence=10, wisdom=10, charisma=10,
+            strength=10,
+            dexterity=10,
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
         ),
         speed=speed,
     )
@@ -61,7 +65,10 @@ class TestSkirmisherClosePhase:
         target = _make_creature("Brick", 5, 0)
         plan = Skirmisher().plan(_ctx(actor), target, reach_ft=5)
         assert plan.path == [
-            Position(1, 0), Position(2, 0), Position(3, 0), Position(4, 0),
+            Position(1, 0),
+            Position(2, 0),
+            Position(3, 0),
+            Position(4, 0),
         ]
 
     def test_zero_speed_yields_empty_path(self):
@@ -99,7 +106,10 @@ class TestSkirmisherRetreat:
         actor = _make_creature("Goblin", 5, 9)
         target = _make_creature("Brick", 5, 10)
         retreat = Skirmisher().plan_retreat(
-            _ctx(actor), target, reach_ft=5, budget_used_ft=20,
+            _ctx(actor),
+            target,
+            reach_ft=5,
+            budget_used_ft=20,
         )
         assert retreat is not None
         assert retreat.path == [Position(5, 8)]
@@ -112,7 +122,10 @@ class TestSkirmisherRetreat:
         actor = _make_creature("Goblin", 4, 4, speed=30)
         target = _make_creature("Brick", 5, 5)
         retreat = Skirmisher().plan_retreat(
-            _ctx(actor), target, reach_ft=10, budget_used_ft=5,
+            _ctx(actor),
+            target,
+            reach_ft=10,
+            budget_used_ft=5,
         )
         assert retreat is not None
         # (3,3) → distance 10 ft (still in reach). (2,2) → 15 ft (out).
@@ -124,7 +137,10 @@ class TestSkirmisherRetreat:
         actor = _make_creature("Goblin", 4, 4, speed=30)
         target = _make_creature("Brick", 5, 5)
         retreat = Skirmisher().plan_retreat(
-            _ctx(actor), target, reach_ft=10, budget_used_ft=25,
+            _ctx(actor),
+            target,
+            reach_ft=10,
+            budget_used_ft=25,
         )
         assert retreat is not None
         assert retreat.path == [Position(3, 3)]  # one tile only
@@ -133,7 +149,10 @@ class TestSkirmisherRetreat:
         actor = _make_creature("Goblin", 5, 9, speed=30)
         target = _make_creature("Brick", 5, 10)
         retreat = Skirmisher().plan_retreat(
-            _ctx(actor), target, reach_ft=5, budget_used_ft=30,
+            _ctx(actor),
+            target,
+            reach_ft=5,
+            budget_used_ft=30,
         )
         assert retreat is None
 
@@ -141,7 +160,10 @@ class TestSkirmisherRetreat:
         actor = _make_creature("Goblin", 5, 9, speed=30)
         target = _make_creature("Brick", 5, 10)
         retreat = Skirmisher().plan_retreat(
-            _ctx(actor), target, reach_ft=5, budget_used_ft=26,  # 4 ft remaining
+            _ctx(actor),
+            target,
+            reach_ft=5,
+            budget_used_ft=26,  # 4 ft remaining
         )
         assert retreat is None
 
@@ -150,7 +172,10 @@ class TestSkirmisherRetreat:
         actor.position = None
         target = _make_creature("Brick", 5, 10)
         retreat = Skirmisher().plan_retreat(
-            _ctx(actor), target, reach_ft=5, budget_used_ft=0,
+            _ctx(actor),
+            target,
+            reach_ft=5,
+            budget_used_ft=0,
         )
         assert retreat is None
 
@@ -159,7 +184,10 @@ class TestSkirmisherRetreat:
         target = _make_creature("Brick", 5, 10)
         target.position = None
         retreat = Skirmisher().plan_retreat(
-            _ctx(actor), target, reach_ft=5, budget_used_ft=0,
+            _ctx(actor),
+            target,
+            reach_ft=5,
+            budget_used_ft=0,
         )
         assert retreat is None
 
@@ -170,7 +198,10 @@ class TestSkirmisherRetreat:
         actor = _make_creature("Goblin", 0, 0)
         target = _make_creature("Brick", 10, 10)  # Chebyshev 50 ft
         retreat = Skirmisher().plan_retreat(
-            _ctx(actor), target, reach_ft=5, budget_used_ft=0,
+            _ctx(actor),
+            target,
+            reach_ft=5,
+            budget_used_ft=0,
         )
         assert retreat is not None
         assert retreat.path == []
@@ -182,7 +213,9 @@ class TestSkirmisherRetreat:
         actor = _make_creature("FastGoblin", 5, 9, speed=200)
         target = _make_creature("Brick", 5, 10)
         retreat = Skirmisher().plan_retreat(
-            _ctx(actor), target, reach_ft=100,  # never out of reach
+            _ctx(actor),
+            target,
+            reach_ft=100,  # never out of reach
             budget_used_ft=0,
         )
         assert retreat is not None
@@ -193,7 +226,10 @@ class TestSkirmisherRetreat:
         actor = _make_creature("Goblin", 5, 5)
         target = _make_creature("Brick", 6, 6)
         retreat = Skirmisher().plan_retreat(
-            _ctx(actor), target, reach_ft=5, budget_used_ft=20,
+            _ctx(actor),
+            target,
+            reach_ft=5,
+            budget_used_ft=20,
         )
         assert retreat is not None
         # (4,4) → Chebyshev 10 ft from (6,6) → out of reach.

--- a/dnd-engine/tests/ai/test_skirmisher_strategy.py
+++ b/dnd-engine/tests/ai/test_skirmisher_strategy.py
@@ -1,0 +1,200 @@
+# ABOUTME: Unit tests for Skirmisher — the close-attack-retreat MovementStrategy (#649).
+# ABOUTME: Covers both plan() (close phase) and plan_retreat() (hit-and-run withdrawal).
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from dnd_engine.core.creature import Abilities, Creature, MovementMode
+from dnd_engine.core.position import Position
+from dnd_engine.systems.ai.context import TurnContext
+from dnd_engine.systems.ai.strategies.aggressive import HARD_STEP_CEILING
+from dnd_engine.systems.ai.strategies.skirmisher import Skirmisher
+
+
+@dataclass
+class _StubState:
+    data_loader: Any = None
+
+
+def _make_creature(name: str, x: int, y: int, speed: int = 30) -> Creature:
+    c = Creature(
+        name=name,
+        max_hp=20,
+        ac=15,
+        abilities=Abilities(
+            strength=10, dexterity=10, constitution=10,
+            intelligence=10, wisdom=10, charisma=10,
+        ),
+        speed=speed,
+    )
+    c.position = Position(x, y)
+    return c
+
+
+def _ctx(actor: Creature, *, target_pool: list[Creature] | None = None) -> TurnContext:
+    return TurnContext.build(
+        _StubState(),
+        actor,
+        target_pool=target_pool or [],
+        monster_data={},
+    )
+
+
+class TestSkirmisherClosePhase:
+    """plan() mirrors AggressiveAdvance: greedy king's-move to reach."""
+
+    def test_strategy_name(self):
+        assert Skirmisher().name == "skirmisher"
+
+    def test_empty_path_when_already_in_reach(self):
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 1, 0)
+        plan = Skirmisher().plan(_ctx(actor), target, reach_ft=5)
+        assert plan.path == []
+        assert plan.mode == MovementMode.WALK
+        assert plan.intent_phase == "close"
+
+    def test_straight_line_path_toward_distant_target(self):
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 5, 0)
+        plan = Skirmisher().plan(_ctx(actor), target, reach_ft=5)
+        assert plan.path == [
+            Position(1, 0), Position(2, 0), Position(3, 0), Position(4, 0),
+        ]
+
+    def test_zero_speed_yields_empty_path(self):
+        actor = _make_creature("Goblin", 0, 0, speed=0)
+        target = _make_creature("Brick", 10, 0)
+        plan = Skirmisher().plan(_ctx(actor), target, reach_ft=5)
+        assert plan.path == []
+
+    def test_hard_ceiling_caps_long_paths(self):
+        actor = _make_creature("FastGoblin", 0, 0, speed=120)
+        target = _make_creature("Brick", 100, 0)
+        plan = Skirmisher().plan(_ctx(actor), target, reach_ft=5)
+        assert len(plan.path) == HARD_STEP_CEILING
+
+    def test_actor_without_position_returns_empty(self):
+        actor = _make_creature("Goblin", 0, 0)
+        actor.position = None
+        target = _make_creature("Brick", 5, 0)
+        plan = Skirmisher().plan(_ctx(actor), target, reach_ft=5)
+        assert plan.path == []
+
+
+class TestSkirmisherRetreat:
+    """plan_retreat() is the new surface: greedy opposite-king's-move away.
+
+    Stops adding tiles as soon as the target is out of reach from the
+    candidate tile (no point in over-running), and respects the
+    remaining movement budget.
+    """
+
+    def test_retreat_stops_at_first_out_of_reach_tile(self):
+        # Actor adjacent to target (just landed the attack). Speed 30,
+        # already used 20 ft closing → 10 ft (2 tiles) remaining.
+        # One step south escapes the 5 ft reach.
+        actor = _make_creature("Goblin", 5, 9)
+        target = _make_creature("Brick", 5, 10)
+        retreat = Skirmisher().plan_retreat(
+            _ctx(actor), target, reach_ft=5, budget_used_ft=20,
+        )
+        assert retreat is not None
+        assert retreat.path == [Position(5, 8)]
+        assert retreat.mode == MovementMode.WALK
+        assert retreat.intent_phase == "retreat"
+
+    def test_retreat_extends_when_first_step_still_in_reach(self):
+        # Reach 10 ft: one diagonal step away (Chebyshev 10 ft) is still
+        # in reach, so the path keeps going until truly out.
+        actor = _make_creature("Goblin", 4, 4, speed=30)
+        target = _make_creature("Brick", 5, 5)
+        retreat = Skirmisher().plan_retreat(
+            _ctx(actor), target, reach_ft=10, budget_used_ft=5,
+        )
+        assert retreat is not None
+        # (3,3) → distance 10 ft (still in reach). (2,2) → 15 ft (out).
+        assert retreat.path == [Position(3, 3), Position(2, 2)]
+
+    def test_retreat_respects_remaining_budget(self):
+        # Long reach + tight budget: would need 2 tiles to escape but
+        # only 1 tile of movement remains.
+        actor = _make_creature("Goblin", 4, 4, speed=30)
+        target = _make_creature("Brick", 5, 5)
+        retreat = Skirmisher().plan_retreat(
+            _ctx(actor), target, reach_ft=10, budget_used_ft=25,
+        )
+        assert retreat is not None
+        assert retreat.path == [Position(3, 3)]  # one tile only
+
+    def test_retreat_returns_none_when_budget_exhausted(self):
+        actor = _make_creature("Goblin", 5, 9, speed=30)
+        target = _make_creature("Brick", 5, 10)
+        retreat = Skirmisher().plan_retreat(
+            _ctx(actor), target, reach_ft=5, budget_used_ft=30,
+        )
+        assert retreat is None
+
+    def test_retreat_returns_none_when_budget_below_one_tile(self):
+        actor = _make_creature("Goblin", 5, 9, speed=30)
+        target = _make_creature("Brick", 5, 10)
+        retreat = Skirmisher().plan_retreat(
+            _ctx(actor), target, reach_ft=5, budget_used_ft=26,  # 4 ft remaining
+        )
+        assert retreat is None
+
+    def test_retreat_returns_none_when_actor_has_no_position(self):
+        actor = _make_creature("Goblin", 5, 9)
+        actor.position = None
+        target = _make_creature("Brick", 5, 10)
+        retreat = Skirmisher().plan_retreat(
+            _ctx(actor), target, reach_ft=5, budget_used_ft=0,
+        )
+        assert retreat is None
+
+    def test_retreat_returns_none_when_target_has_no_position(self):
+        actor = _make_creature("Goblin", 5, 9)
+        target = _make_creature("Brick", 5, 10)
+        target.position = None
+        retreat = Skirmisher().plan_retreat(
+            _ctx(actor), target, reach_ft=5, budget_used_ft=0,
+        )
+        assert retreat is None
+
+    def test_retreat_empty_when_already_out_of_reach(self):
+        # Actor at long range — no retreat planning needed. Returns
+        # an empty MovePlan rather than None so the caller can still
+        # log "already disengaged" without special-casing.
+        actor = _make_creature("Goblin", 0, 0)
+        target = _make_creature("Brick", 10, 10)  # Chebyshev 50 ft
+        retreat = Skirmisher().plan_retreat(
+            _ctx(actor), target, reach_ft=5, budget_used_ft=0,
+        )
+        assert retreat is not None
+        assert retreat.path == []
+        assert retreat.intent_phase == "retreat"
+
+    def test_retreat_caps_at_hard_step_ceiling(self):
+        # Pathological speed; retreat should never plan more than 12
+        # tiles even with abundant budget.
+        actor = _make_creature("FastGoblin", 5, 9, speed=200)
+        target = _make_creature("Brick", 5, 10)
+        retreat = Skirmisher().plan_retreat(
+            _ctx(actor), target, reach_ft=100,  # never out of reach
+            budget_used_ft=0,
+        )
+        assert retreat is not None
+        assert len(retreat.path) == HARD_STEP_CEILING
+
+    def test_retreat_diagonal_away_from_target(self):
+        # Actor northwest of target; retreat goes further NW.
+        actor = _make_creature("Goblin", 5, 5)
+        target = _make_creature("Brick", 6, 6)
+        retreat = Skirmisher().plan_retreat(
+            _ctx(actor), target, reach_ft=5, budget_used_ft=20,
+        )
+        assert retreat is not None
+        # (4,4) → Chebyshev 10 ft from (6,6) → out of reach.
+        assert retreat.path == [Position(4, 4)]


### PR DESCRIPTION
## Summary

Implements the Skirmisher MovementStrategy and extends \`pipeline.execute\` to drive AttackStep + a trailing retreat MoveStep via an injected callback. Goblins now close → attack → retreat in one turn, provoking opportunity attacks on the way out. First real demonstration that #647's pluggable AI pipeline pays off.

Closes #649.

## Changes

- **\`dnd-engine/dnd_engine/systems/ai/strategies/skirmisher.py\`** (new): \`Skirmisher\` with \`plan()\` (close to reach) and \`plan_retreat()\` (greedy opposite-king's-move out of reach). \`plan_retreat\` takes a \`from_position\` kwarg so the pipeline can compute the retreat from the post-close tile, not the actor's pre-turn position.
- **\`dnd-engine/dnd_engine/systems/ai/pipeline.py\`**: Registered \`"skirmisher"\` in \`STRATEGY_REGISTRY\`. Refactored \`decide()\` to emit \`[MoveStep(close)?, AttackStep, MoveStep(retreat)?]\` Intents for strategies that expose \`plan_retreat\` (discovered via \`getattr\`). Already-in-reach skirmishers emit \`[AttackStep, MoveStep(retreat)]\`; close-budget-exhausted skirmishers emit \`[MoveStep(close), AttackStep]\`. Aggressive monsters keep their existing single-MoveStep contract byte-identically.
- **\`dnd-engine/dnd_engine/systems/ai/pipeline.py\`** (\`execute()\`): Added \`attack_resolver\` kwarg and \`attack_outcome\` field on \`MovementExecution\`. Step loop now distinguishes the close phase (in-reach short-circuits the per-tile walk) from the post-attack retreat phase (in-reach check disabled — we're trying to *leave* reach). Mid-Intent death short-circuits cleanly:
  - target dies → \`stopped_reason="target_killed_no_retreat"\`
  - enemy dies during attack → \`"enemy_died_mid_attack"\`
  - enemy dies during retreat → \`"enemy_died_mid_retreat"\`
  - full skirmish completes → \`"retreated"\`
- **\`dnd-engine/dnd_engine/core/game_state.py\`** (\`process_enemy_turn\`): Threads an inner \`_resolve_attack_step\` callback to \`ai_pipeline.execute\`. When the pipeline drove an attack, post-processing consumes \`exec_result.attack_outcome\` directly — bypassing the smart-targeting + duplicate \`resolve_attack\` block. The \`MOVED\`/\`NO_REACHABLE_TARGET\` short-circuit is gated on the absence of a pipeline attack so the skirmisher's post-retreat empty in-reach pool is not misread as "monster failed to engage".
- **\`dnd-engine/dnd_engine/data/srd/monsters.json\`**: Goblin tagged \`"ai": {"movement_strategy": "skirmisher"}\`. Kobold not tagged (no kobold entry in catalog yet; deferred).

## Architecture Notes

- The \`MovementStrategy\` Protocol gains \`plan_retreat\` as a duck-typed optional method (no Protocol breakage; AggressiveAdvance needs zero changes).
- The \`attack_resolver\` callback shape (\`Creature, str, dict -> AttackResult | None\`) keeps the pipeline from importing \`combat_engine\`.
- **Out of scope** (future tickets): cover-aware retreat, ranged-skirmisher (Kite) variant, multiattack with movement between attacks, moving condition-removal + dash into the pipeline, kobold tagging.
- **Documented limitation**: saving-throw detection is bypassed on the skirmisher path. Current skirmisher monsters (goblin scimitar) carry no saving-throw weapon attacks, and the \`"saving_throw" in action\` guard short-circuits cleanly. Future skirmishers with save-payload weapons need a follow-up.

## Testing

- [x] Unit: \`test_skirmisher_strategy.py\` (16 tests, plan + plan_retreat coverage)
- [x] Pipeline: \`test_pipeline_skirmisher.py\` (12 tests, decide() Intent shapes + execute() AttackStep/retreat orchestration + short-circuits)
- [x] Integration: \`test_skirmisher_integration.py\` (2 tests, goblin closes-attacks-retreats end-to-end via process_enemy_turn + CREATURE_MOVED event-order contract)
- [x] Full engine suite: 3347 passed, 191 skipped
- [x] Full client-2d suite: 578 passed, 2 skipped
- [x] Manual playtest: spawned goblin out of reach, observed close → attack → retreat in one turn via MCP

## Commits (TDD-sequenced)

1. \`Add #649: Skirmisher MovementStrategy with plan() and plan_retreat()\` — strategy + unit tests
2. \`Add #649: pipeline.decide emits 3-step Intent for skirmishers\` — registry + decide() refactor
3. \`Add #649: pipeline.execute consumes AttackStep + retreat\` — execute() state machine + attack_resolver
4. \`Add #649: wire process_enemy_turn skirmisher delegation + tag goblin\` — game_state callback + monsters.json
5. \`Test #649: lock the skirmisher event-sequence engine contract\` — CREATURE_MOVED order assertions
6. \`Fix #649: drop silent target-misattribution fallback in skirmisher path\` — code-review fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)