### PR TITLE
Fix #650: rebind combat attack from A to F

### DIFF
--- a/client-2d/src/client_2d/game.py
+++ b/client-2d/src/client_2d/game.py
@@ -1394,8 +1394,8 @@ class GameView(arcade.View):
                 name = self.selected_target.sub_type or self.selected_target.entity_id
                 self._add_combat_log(f"Selected: {name}")
 
-        # A or Enter to attack selected target
-        elif key in (arcade.key.A, arcade.key.ENTER):
+        # F (fight) or Enter to attack selected target
+        elif key in (arcade.key.F, arcade.key.ENTER):
             if self.selected_target:
                 self._attack_entity(self.selected_target)
             else:
@@ -1417,7 +1417,7 @@ class GameView(arcade.View):
             self._handle_combat_movement("south")
         elif key in (arcade.key.D, arcade.key.RIGHT):
             self._handle_combat_movement("east")
-        elif key == arcade.key.LEFT:  # A is attack, so only LEFT arrow for west
+        elif key in (arcade.key.A, arcade.key.LEFT):
             self._handle_combat_movement("west")
 
     def _handle_exploration_input(self, key: int) -> None:


### PR DESCRIPTION
## Summary
- `A` was bound to both move-west (exploration) and attack (combat), forcing players to reach for LEFT arrow to move west during combat — asymmetric with the other three directions that all accept WASD.
- Move attack to `F` (fight) so WASD stays consistent across modes. `Enter` still attacks the selected target.

## Changes
- **`client-2d/src/client_2d/game.py`** (`_handle_combat_input`):
  - `A` / `Enter` → attack  →  `F` / `Enter` → attack
  - `LEFT` only → move west  →  `A` / `LEFT` → move west (drops the load-bearing `# A is attack, so only LEFT arrow for west` comment)

## Testing
- [x] Manual: in combat, `A` moves west; `F` attacks selected target; `Enter` still attacks.
- [x] Exploration mode unchanged — `A`/`LEFT` already moved west there.
- No automated tests added — per project CLAUDE.md, UI keypress code is manually tested.

## Follow-ups (not in this PR)
- `InputHandler` class in `input/input_handler.py` isn't wired into combat input; both layers exist in parallel. Worth consolidating but is its own refactor.
- `InputHandler._is_action_valid` rejects movement actions in COMBAT mode; if we ever wire it up for combat, WASD will break. Same consolidation work.

## Related Issues
Fixes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)