### PR TITLE
Add #537: D20Test primitive + migrate three callsites (plan-08 slice 1)

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -311,7 +311,6 @@ class Character(Creature):
         Raises:
             ValueError: If ability name is invalid
         """
-        from dnd_engine.core.dice import DiceRoller
         from dnd_engine.utils.events import Event, EventType
 
         # Normalize ability to short name
@@ -350,35 +349,28 @@ class Character(Creature):
         ):
             advantage = True
 
-        # SRD: advantage and disadvantage cancel. The dice roller
-        # raises on both-set, so cancel here before delegating.
-        if advantage and disadvantage:
-            advantage = False
-            disadvantage = False
-
-        # Roll the saving throw
-        roller = DiceRoller()
-        roll_result = roller.roll("d20", advantage=advantage, disadvantage=disadvantage)
-
-        # Get the saving throw modifier
         modifier = self.get_saving_throw_modifier(ability)
 
-        # Calculate total
-        total = roll_result.total + modifier
+        # Legacy `make_saving_throw` constructed a fresh `DiceRoller`
+        # rather than reusing `self._dice_roller`; omitting `roller`
+        # preserves that — the primitive defaults to a fresh roller.
+        # `Abilities` exposes modifier attrs by short name (`str_mod`,
+        # `dex_mod`, …), so look up by `ability_short`.
+        result = d20_test(
+            ability_mod=getattr(self.abilities, f"{ability_short}_mod"),
+            proficient=ability_short in self.saving_throw_proficiencies,
+            proficiency_bonus=self.proficiency_bonus,
+            advantage=advantage,
+            disadvantage=disadvantage,
+        )
 
-        # Determine success
-        success = total >= dc
+        success = result.succeeds_against(dc)
 
-        # Create result dict
-        result = {
+        result_dict = {
             "success": success,
-            "roll": roll_result.rolls[0]
-            if len(roll_result.rolls) == 1
-            else max(roll_result.rolls)
-            if advantage
-            else min(roll_result.rolls),
+            "roll": result.d20,
             "modifier": modifier,
-            "total": total,
+            "total": result.total,
             "dc": dc,
             "ability": ability_short,
         }
@@ -391,15 +383,15 @@ class Character(Creature):
                     "character": self.name,
                     "ability": ability_short,
                     "dc": dc,
-                    "roll": result["roll"],
+                    "roll": result.d20,
                     "modifier": modifier,
-                    "total": total,
+                    "total": result.total,
                     "success": success,
                 },
             )
             event_bus.emit(event)
 
-        return result
+        return result_dict
 
     @property
     def ranged_attack_bonus(self) -> int:

--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -7,6 +7,7 @@ from typing import Any
 from dnd_engine.core.creature import Abilities, Creature, Size
 from dnd_engine.core.dice import DiceRoller
 from dnd_engine.core.spell import Spell
+from dnd_engine.systems.d20 import d20_test
 from dnd_engine.systems.inventory import Inventory
 from dnd_engine.systems.resources import ResourcePool
 
@@ -857,7 +858,9 @@ class Character(Creature):
             raise KeyError(f"Unknown skill: {skill}")
 
         skill_info = skills_data[skill]
+        ability_key = skill_info["ability"]
         modifier = self.get_skill_modifier(skill, skills_data)
+        proficient = skill in self.skill_proficiencies
 
         # SRD § Actions › Help: a creature receiving Help rolls its
         # next ability check with Advantage; the one-shot grant is
@@ -866,28 +869,25 @@ class Character(Creature):
             advantage = True
             self.pending_help_from = None
 
-        # SRD: advantage and disadvantage cancel. The dice roller
-        # raises on both-set, so cancel here before delegating.
-        if advantage and disadvantage:
-            advantage = False
-            disadvantage = False
-
-        # Roll the d20
-        dice_roll = self._dice_roller.roll("1d20", advantage=advantage, disadvantage=disadvantage)
-
-        # Extract the d20 roll result (before modifier is added)
-        roll_result = dice_roll.total - dice_roll.modifier  # Get just the die result
-        total = roll_result + modifier
+        result = d20_test(
+            ability_mod=getattr(self.abilities, f"{ability_key}_mod"),
+            proficient=proficient,
+            proficiency_bonus=self.proficiency_bonus,
+            expertise=skill in self.expertise_skills,
+            advantage=advantage,
+            disadvantage=disadvantage,
+            roller=self._dice_roller,
+        )
 
         return {
             "skill": skill,
-            "ability": skill_info["ability"],
+            "ability": ability_key,
             "dc": dc,
-            "roll": roll_result,
+            "roll": result.d20,
             "modifier": modifier,
-            "total": total,
-            "success": total >= dc,
-            "proficient": skill in self.skill_proficiencies,
+            "total": result.total,
+            "success": result.succeeds_against(dc),
+            "proficient": proficient,
         }
 
     def get_sneak_attack_dice(self) -> str | None:

--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -9,6 +9,7 @@ from dnd_engine.core.creature import Creature
 from dnd_engine.core.dice import DiceRoller
 from dnd_engine.core.distance import distance_in_feet
 from dnd_engine.rules.damage import apply_damage_adjustments, apply_damage_modifiers
+from dnd_engine.systems.d20 import d20_test
 from dnd_engine.systems.perception import VisibilityRelation
 from dnd_engine.utils.events import Event, EventType
 
@@ -290,11 +291,18 @@ class CombatEngine:
             advantage = False
             disadvantage = False
 
-        # Roll attack (1d20 + bonus)
-        attack_roll_result = self.dice_roller.roll(
-            "1d20", advantage=advantage, disadvantage=disadvantage
+        # Roll attack via the unified D20Test primitive. `attack_bonus`
+        # is the bundled to-hit number (ability + PB + magic); slice 1
+        # passes the entire bundle as `ability_mod` to preserve the
+        # legacy `AttackResult.attack_bonus` semantics. The fine-grained
+        # PB-vs-magic split lands in plan-08 slice 2.
+        roll = d20_test(
+            ability_mod=attack_bonus,
+            advantage=advantage,
+            disadvantage=disadvantage,
+            roller=self.dice_roller,
         )
-        attack_roll = attack_roll_result.total  # The actual d20 result (without bonus)
+        attack_roll = roll.d20  # The natural d20 result (1-20)
 
         # Determine critical hit/miss
         critical_hit = attack_roll == 20

--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 from dnd_engine.core.position import Position
+from dnd_engine.systems.d20 import d20_test
 
 
 class Size(str, Enum):
@@ -744,8 +745,6 @@ class Creature:
         Raises:
             ValueError: If ability name is invalid
         """
-        from dnd_engine.core.dice import DiceRoller
-
         # Normalize ability to short name
         short_to_full = {
             "str": "strength",
@@ -784,12 +783,6 @@ class Creature:
         ):
             advantage = True
 
-        # SRD: advantage and disadvantage cancel. The dice roller
-        # raises on both-set, so cancel here before delegating.
-        if advantage and disadvantage:
-            advantage = False
-            disadvantage = False
-
         # Get ability modifier
         if ability_full == "strength":
             modifier = self.abilities.str_mod
@@ -806,31 +799,24 @@ class Creature:
         else:
             raise ValueError(f"Invalid ability name: {ability}")
 
-        # Roll the saving throw
-        roller = DiceRoller()
-        roll_result = roller.roll("d20", advantage=advantage, disadvantage=disadvantage)
+        # Creatures have no proficient saves in the data model today
+        # (PB-from-CR derivation is plan-08 slice 2). The primitive's
+        # default roller (a fresh `DiceRoller`) matches the legacy
+        # behavior of this method.
+        result = d20_test(
+            ability_mod=modifier,
+            advantage=advantage,
+            disadvantage=disadvantage,
+        )
 
-        # Calculate total
-        total = roll_result.total + modifier
-
-        # Determine success
-        success = total >= dc
-
-        # Create result dict
-        result = {
-            "success": success,
-            "roll": roll_result.rolls[0]
-            if len(roll_result.rolls) == 1
-            else max(roll_result.rolls)
-            if advantage
-            else min(roll_result.rolls),
+        return {
+            "success": result.succeeds_against(dc),
+            "roll": result.d20,
             "modifier": modifier,
-            "total": total,
+            "total": result.total,
             "dc": dc,
             "ability": ability_short,
         }
-
-        return result
 
     def __str__(self) -> str:
         """String representation of the creature"""

--- a/dnd-engine/dnd_engine/systems/d20.py
+++ b/dnd-engine/dnd_engine/systems/d20.py
@@ -1,0 +1,160 @@
+# ABOUTME: SRD § Playing the Game › D20 Tests — unified primitive backing
+# ABOUTME: ability checks, saving throws, and attack rolls.
+
+"""Unified D20 Test primitive.
+
+The 2024 SRD treats ability checks, saving throws, and attack rolls as
+three flavors of the same mechanic — a "D20 Test". Each follows the
+same six-step procedure: declare the test, identify the relevant
+ability, decide proficiency, decide Advantage/Disadvantage, roll the
+d20 (with the higher/lower-of-two rule), add modifiers, and compare to
+a target number.
+
+This module implements that single procedure. Callers (skill checks,
+saving throws, attack rolls, and future surfaces like Heroic
+Inspiration rerolls or voluntary save failure) delegate the d20-roll +
+modifier-sum portion here and keep their own SRD-specific orchestration
+(reach gates, sneak attack, Dodge clauses, etc.) on the outside.
+
+Slice 1 of plan-08 introduces the primitive and migrates the three
+legacy surfaces to delegate. Later slices add rule guards on top —
+PB-from-CR, PB-once stacking, tool+skill advantage, circumstantial
+plumbing, voluntary fail, Heroic Inspiration — without further widening
+the primitive's signature.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from dnd_engine.core.dice import DiceRoller
+
+
+class AdvantageState(str, Enum):
+    """Resolved Advantage/Disadvantage state after SRD cancellation."""
+
+    NORMAL = "normal"
+    ADVANTAGE = "advantage"
+    DISADVANTAGE = "disadvantage"
+
+
+@dataclass(frozen=True)
+class D20Result:
+    """Result of a single D20 Test.
+
+    Attributes:
+        d20: The single die outcome actually consumed by the test —
+            ``max(rolls)`` under Advantage, ``min(rolls)`` under
+            Disadvantage, the sole roll otherwise. This is the natural
+            d20 value that determines critical hits / fumbles at the
+            callsite.
+        total: ``d20`` plus every additive channel in ``components``.
+            Compared directly to the target number (DC or AC) via
+            :meth:`succeeds_against`.
+        advantage_state: Resolved state after SRD's cancellation rule
+            (both Advantage and Disadvantage → neither).
+        components: Itemized additive channels for narration and
+            debugging. Always contains the keys ``ability_mod``,
+            ``proficiency``, and ``circumstantial``. Each value is a
+            signed int; the sum equals ``total - d20``.
+        rolls: Raw die outcomes — one die normally, two under
+            Advantage or Disadvantage.
+    """
+
+    d20: int
+    total: int
+    advantage_state: AdvantageState
+    components: dict[str, int]
+    rolls: tuple[int, ...]
+
+    def succeeds_against(self, target: int) -> bool:
+        """Return whether the total meets or beats the target number.
+
+        SRD step 6: "If the total of the d20 and its modifiers equals
+        or exceeds the target number, the D20 Test succeeds." The
+        target is a DC for ability checks and saving throws, an AC
+        for attack rolls.
+        """
+        return self.total >= target
+
+
+def d20_test(
+    *,
+    ability_mod: int = 0,
+    proficient: bool = False,
+    proficiency_bonus: int = 0,
+    expertise: bool = False,
+    advantage: bool = False,
+    disadvantage: bool = False,
+    circumstantial: int = 0,
+    roller: DiceRoller | None = None,
+) -> D20Result:
+    """Roll a single D20 Test per SRD § Playing the Game › D20 Tests.
+
+    Args:
+        ability_mod: Modifier from the test's relevant ability score.
+        proficient: True iff the character is proficient with the
+            relevant skill / save / weapon. Gates the proficiency
+            bonus.
+        proficiency_bonus: The character's Proficiency Bonus. Added
+            only when ``proficient`` is true; doubled when ``expertise``
+            is also true.
+        expertise: True iff the character has Expertise in the
+            relevant skill / tool. Has no effect when ``proficient``
+            is false.
+        advantage: Roll 2d20 and take the higher value.
+        disadvantage: Roll 2d20 and take the lower value.
+        circumstantial: Signed circumstantial bonus/penalty (Bless,
+            Bane, Guidance, cover, environment, etc.). Slice 1 plumbs
+            the channel; later slices wire callsite sources.
+        roller: Optional ``DiceRoller`` for determinism. Defaults to a
+            fresh, unseeded ``DiceRoller``.
+
+    Returns:
+        :class:`D20Result` carrying the resolved d20 outcome, modifier
+        breakdown, total, and advantage state.
+    """
+    # SRD: "If circumstances cause a roll to have both advantage and
+    # disadvantage, you're considered to have neither of them." Cancel
+    # before delegating to ``DiceRoller.roll``, which raises on both.
+    if advantage and disadvantage:
+        advantage = False
+        disadvantage = False
+
+    roller = roller or DiceRoller()
+    roll_result = roller.roll(
+        "1d20",
+        advantage=advantage,
+        disadvantage=disadvantage,
+    )
+
+    if advantage:
+        d20 = max(roll_result.rolls)
+        state = AdvantageState.ADVANTAGE
+    elif disadvantage:
+        d20 = min(roll_result.rolls)
+        state = AdvantageState.DISADVANTAGE
+    else:
+        d20 = roll_result.rolls[0]
+        state = AdvantageState.NORMAL
+
+    if proficient:
+        proficiency = proficiency_bonus * 2 if expertise else proficiency_bonus
+    else:
+        proficiency = 0
+
+    components: dict[str, int] = {
+        "ability_mod": ability_mod,
+        "proficiency": proficiency,
+        "circumstantial": circumstantial,
+    }
+    total = d20 + sum(components.values())
+
+    return D20Result(
+        d20=d20,
+        total=total,
+        advantage_state=state,
+        components=components,
+        rolls=tuple(roll_result.rolls),
+    )

--- a/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
@@ -92,18 +92,15 @@ class TestDefinition_ThreeKinds:
     def test_saving_throw_surface_exists(self):
         """Saving throws are exposed on both Character and Creature.
 
-        `Character.make_saving_throw`
-        (dnd-engine/dnd_engine/core/character.py:237) and
-        `Creature.make_saving_throw`
-        (dnd-engine/dnd_engine/core/creature.py:478) both roll 1d20 +
-        modifier vs DC, satisfying SRD step 4 + step 5 for the saving
-        throw kind.
+        `Character.make_saving_throw` and `Creature.make_saving_throw`
+        both delegate the d20 portion to the unified
+        `dnd_engine.systems.d20.d20_test` primitive (plan-08 slice 1).
         """
         assert hasattr(Character, "make_saving_throw")
         assert hasattr(Creature, "make_saving_throw")
         for func in (Character.make_saving_throw, Creature.make_saving_throw):
             src = inspect.getsource(func)
-            assert "d20" in src
+            assert "d20_test" in src
 
     def test_attack_roll_surface_exists(self):
         """Attack rolls are resolved by `CombatEngine.resolve_attack`.

--- a/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
@@ -105,13 +105,13 @@ class TestDefinition_ThreeKinds:
     def test_attack_roll_surface_exists(self):
         """Attack rolls are resolved by `CombatEngine.resolve_attack`.
 
-        `CombatEngine.resolve_attack`
-        (dnd-engine/dnd_engine/core/combat.py:91) rolls 1d20 + attack
-        bonus vs AC and is the third leg of the SRD's "three kinds" of
-        D20 tests.
+        Plan-08 slice 1 migrated the d20 portion to delegate to the
+        unified `dnd_engine.systems.d20.d20_test` primitive while
+        keeping the surrounding orchestration (reach, sneak attack,
+        unseen attacker/target, etc.) on the callsite.
         """
         src = inspect.getsource(CombatEngine.resolve_attack)
-        assert '"1d20"' in src or "'1d20'" in src
+        assert "d20_test" in src
 
     def test_general_ability_check_primitive_is_unified(self):
         pytest.skip(

--- a/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
@@ -73,21 +73,21 @@ class TestDefinition_ThreeKinds:
     """
 
     def test_ability_check_surface_exists(self):
-        """Skill checks are the only general ability-check surface today.
+        """The skill-check surface remains the engine's ability-check entry point.
 
-        The closest implementation of an ability check primitive is
-        `Character.make_skill_check`
-        (dnd-engine/dnd_engine/core/character.py:726), which couples
-        the d20 + ability modifier + (optional) proficiency bonus into
-        one call. There is no plain `make_ability_check(ability, dc)`
-        primitive — see GAP test below.
+        `Character.make_skill_check` couples ability modifier and
+        proficiency-if-relevant with a d20 roll. Plan-08 slice 1
+        migrated the d20 portion to delegate to the unified
+        `dnd_engine.systems.d20.d20_test` primitive, so the source no
+        longer carries the `"1d20"` literal directly — it now carries
+        a `d20_test(...)` call.
         """
         assert hasattr(Character, "make_skill_check"), (
             "Character must expose make_skill_check as its ability-check surface."
         )
         src = inspect.getsource(Character.make_skill_check)
         assert "advantage" in src and "disadvantage" in src
-        assert "1d20" in src
+        assert "d20_test" in src
 
     def test_saving_throw_surface_exists(self):
         """Saving throws are exposed on both Character and Creature.

--- a/dnd-engine/tests/srd/playing_the_game/test_d20_unified.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_d20_unified.py
@@ -1,0 +1,236 @@
+# ABOUTME: SRD conformance for the unified D20 Test primitive (plan-08 slice 1).
+# ABOUTME: Locks the contract for `dnd_engine.systems.d20.d20_test`.
+
+"""SRD conformance: unified D20 Test primitive.
+
+Companion to ``test_d20_tests.py`` (which audits the three legacy
+surfaces — ``Character.make_skill_check``, ``make_saving_throw``, and
+``CombatEngine.resolve_attack``). This file pins the single primitive
+that those surfaces will delegate to. Each parametrized case maps to a
+rule from ``docs/srd/playing-the-game/d20-tests.md``.
+
+The conformance "report" is ``pytest --collect-only -q tests/srd/``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dnd_engine.core.dice import DiceRoller
+from dnd_engine.systems.d20 import AdvantageState, D20Result, d20_test
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/d20-tests.md",
+    lines="731-865",
+)
+
+
+# ---------------------------------------------------------------------------
+# Structural contract
+# ---------------------------------------------------------------------------
+
+
+class TestResultShape:
+    """The primitive returns a ``D20Result`` with the contracted fields."""
+
+    def test_returns_d20result(self):
+        result = d20_test(roller=DiceRoller(seed=1))
+        assert isinstance(result, D20Result)
+
+    def test_components_dict_itemizes_all_channels(self):
+        """``components`` carries every additive channel by name.
+
+        SRD step 5 names three additive sources: ability modifier,
+        proficiency bonus (if relevant), and circumstantial
+        bonuses/penalties. Each gets a named key so callers (and
+        narration code) can render the breakdown.
+        """
+        result = d20_test(
+            ability_mod=3,
+            proficient=True,
+            proficiency_bonus=2,
+            circumstantial=1,
+            roller=DiceRoller(seed=1),
+        )
+        assert set(result.components.keys()) == {
+            "ability_mod",
+            "proficiency",
+            "circumstantial",
+        }
+
+
+# ---------------------------------------------------------------------------
+# SRD step 4 — Roll 1d20 (with optional Advantage/Disadvantage)
+# ---------------------------------------------------------------------------
+
+
+class TestRollD20:
+    """SRD § D20 Tests › Step 4."""
+
+    def test_normal_roll_uses_one_d20(self):
+        result = d20_test(roller=DiceRoller(seed=1))
+        assert result.advantage_state is AdvantageState.NORMAL
+        assert len(result.rolls) == 1
+        assert 1 <= result.d20 <= 20
+        assert result.d20 == result.rolls[0]
+
+    def test_advantage_takes_higher_of_two(self):
+        result = d20_test(advantage=True, roller=DiceRoller(seed=1))
+        assert result.advantage_state is AdvantageState.ADVANTAGE
+        assert len(result.rolls) == 2
+        assert result.d20 == max(result.rolls)
+
+    def test_disadvantage_takes_lower_of_two(self):
+        result = d20_test(disadvantage=True, roller=DiceRoller(seed=1))
+        assert result.advantage_state is AdvantageState.DISADVANTAGE
+        assert len(result.rolls) == 2
+        assert result.d20 == min(result.rolls)
+
+    def test_advantage_and_disadvantage_cancel(self):
+        """SRD: "If circumstances cause a roll to have both advantage and
+        disadvantage, you're considered to have neither of them." The
+        primitive cancels before delegating to ``DiceRoller.roll`` (which
+        raises if both are set)."""
+        result = d20_test(
+            advantage=True,
+            disadvantage=True,
+            roller=DiceRoller(seed=1),
+        )
+        assert result.advantage_state is AdvantageState.NORMAL
+        assert len(result.rolls) == 1
+
+
+# ---------------------------------------------------------------------------
+# SRD step 5 — Add modifiers (ability + proficiency-if-relevant + circumstantial)
+# ---------------------------------------------------------------------------
+
+
+class TestAddModifiers:
+    """SRD § D20 Tests › Step 5."""
+
+    def test_ability_modifier_added_to_total(self):
+        result = d20_test(ability_mod=4, roller=DiceRoller(seed=1))
+        assert result.components["ability_mod"] == 4
+        assert result.total == result.d20 + 4
+
+    def test_proficiency_bonus_added_when_proficient(self):
+        result = d20_test(
+            proficient=True,
+            proficiency_bonus=2,
+            roller=DiceRoller(seed=1),
+        )
+        assert result.components["proficiency"] == 2
+        assert result.total == result.d20 + 2
+
+    def test_proficiency_bonus_skipped_when_not_proficient(self):
+        """SRD step 5: PB applies "If Relevant" — i.e. only when proficient."""
+        result = d20_test(
+            proficient=False,
+            proficiency_bonus=2,
+            roller=DiceRoller(seed=1),
+        )
+        assert result.components["proficiency"] == 0
+        assert result.total == result.d20
+
+    def test_expertise_doubles_pb_when_proficient(self):
+        """SRD § Skills › Expertise: a character with Expertise doubles
+        their PB on a check using that skill."""
+        result = d20_test(
+            proficient=True,
+            proficiency_bonus=3,
+            expertise=True,
+            roller=DiceRoller(seed=1),
+        )
+        assert result.components["proficiency"] == 6
+        assert result.total == result.d20 + 6
+
+    def test_expertise_without_proficiency_is_a_noop(self):
+        """Defense: Expertise has no rules effect on a character who is
+        not proficient. The flag should be ignored, not silently
+        promoted to "double zero plus PB"."""
+        result = d20_test(
+            proficient=False,
+            proficiency_bonus=3,
+            expertise=True,
+            roller=DiceRoller(seed=1),
+        )
+        assert result.components["proficiency"] == 0
+        assert result.total == result.d20
+
+    def test_circumstantial_modifier_added(self):
+        """SRD step 5: "Circumstantial Bonuses and Penalties" — the third
+        additive channel. Caller passes a signed int; the primitive
+        sums it into the total."""
+        result = d20_test(circumstantial=-1, roller=DiceRoller(seed=1))
+        assert result.components["circumstantial"] == -1
+        assert result.total == result.d20 - 1
+
+    def test_all_channels_sum_into_total(self):
+        result = d20_test(
+            ability_mod=2,
+            proficient=True,
+            proficiency_bonus=2,
+            expertise=True,
+            circumstantial=1,
+            roller=DiceRoller(seed=1),
+        )
+        assert result.total == result.d20 + 2 + 4 + 1
+
+
+# ---------------------------------------------------------------------------
+# SRD step 6 — Compare total to a target number
+# ---------------------------------------------------------------------------
+
+
+class TestTargetNumber:
+    """SRD § D20 Tests › Step 6."""
+
+    def test_succeeds_against_uses_total_geq_dc(self):
+        """Same inequality for ability checks (DC), saving throws (DC),
+        and attack rolls (AC). The helper takes the target number and
+        returns ``total >= target``."""
+        result = d20_test(ability_mod=5, roller=DiceRoller(seed=42))
+        assert result.succeeds_against(result.total) is True
+        assert result.succeeds_against(result.total - 1) is True
+        assert result.succeeds_against(result.total + 1) is False
+
+
+# ---------------------------------------------------------------------------
+# Determinism — caller-supplied roller is honored verbatim
+# ---------------------------------------------------------------------------
+
+
+class TestRollerInjection:
+    """The primitive does not bypass a caller's seeded roller."""
+
+    def test_uses_caller_supplied_roller_for_normal_roll(self):
+        roller = DiceRoller(seed=12345)
+        expected = roller.roll("1d20").rolls[0]
+        # Re-seed and run through the primitive — should produce the
+        # same first die outcome.
+        result = d20_test(roller=DiceRoller(seed=12345))
+        assert result.d20 == expected
+
+    def test_uses_caller_supplied_roller_for_advantage(self):
+        roller = DiceRoller(seed=12345)
+        expected_rolls = roller.roll("1d20", advantage=True).rolls
+        result = d20_test(advantage=True, roller=DiceRoller(seed=12345))
+        assert tuple(expected_rolls) == result.rolls
+
+    def test_consumes_exactly_one_roller_call(self):
+        """Determinism guarantee for the migration: the primitive makes
+        a single ``roller.roll("1d20", ...)`` call so existing
+        sequence-sensitive tests don't drift after callsites migrate."""
+
+        class CountingRoller:
+            def __init__(self, inner: DiceRoller) -> None:
+                self.inner = inner
+                self.calls = 0
+
+            def roll(self, *args, **kwargs):
+                self.calls += 1
+                return self.inner.roll(*args, **kwargs)
+
+        counter = CountingRoller(DiceRoller(seed=1))
+        d20_test(advantage=True, roller=counter)
+        assert counter.calls == 1

--- a/dnd-engine/tests/srd/playing_the_game/test_saving_throws.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_saving_throws.py
@@ -19,6 +19,7 @@ import pytest
 
 from dnd_engine.core.character import Character, CharacterClass
 from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.systems.d20 import AdvantageState, D20Result
 
 pytestmark = pytest.mark.srd(
     "playing-the-game/saving-throws.md",
@@ -370,15 +371,28 @@ class TestDifficultyClass_SetByEffect:
         )
 
     def test_save_success_uses_total_meets_or_exceeds_dc(self):
-        """`success = total >= dc` — meeting the DC is a success.
+        """Meeting the DC is a success.
 
         SRD doesn't use "above the DC"; the standard reading and
         every official rules supplement treat ties as successes. This
         is the analogue of the `>= AC` rule on the attack side
-        (#attack-rolls.md). Source-level guard against a `>` regression.
+        (#attack-rolls.md). Plan-08 slice 1 moved the `>=` check into
+        :meth:`dnd_engine.systems.d20.D20Result.succeeds_against`, so
+        the source-level guard now lives there. Behavior is also
+        verified by a runtime check: a Character rolling exactly the
+        DC succeeds.
         """
-        src = inspect.getsource(Character.make_saving_throw)
-        assert "success = total >= dc" in src, (
-            "Save success must use `>=` so that a roll exactly equal "
-            "to the DC succeeds. Same convention as attack vs. AC."
+        src = inspect.getsource(D20Result.succeeds_against)
+        assert ">=" in src, (
+            "`D20Result.succeeds_against` must use `>=` so that a roll "
+            "exactly equal to the DC/AC succeeds."
         )
+        # Behavior: a roll exactly meeting the DC succeeds.
+        result = D20Result(
+            d20=10,
+            total=10,
+            advantage_state=AdvantageState.NORMAL,
+            components={"ability_mod": 0, "proficiency": 0, "circumstantial": 0},
+            rolls=(10,),
+        )
+        assert result.succeeds_against(10) is True

--- a/dnd-engine/tests/test_death_saves_integration.py
+++ b/dnd-engine/tests/test_death_saves_integration.py
@@ -449,7 +449,10 @@ class TestDeathSaveEvents:
         skills_data = data_loader.load_skills()
 
         with patch.object(rogue._dice_roller, "roll") as mock_roll:
-            mock_roll.return_value = Mock(total=15, modifier=0)  # High roll to ensure success
+            # `make_skill_check` delegates to `d20_test`, which reads
+            # `rolls[0]` from the DiceRoll. Provide both `rolls` and the
+            # legacy `total`/`modifier` so the mock fits either layer.
+            mock_roll.return_value = Mock(total=15, modifier=0, rolls=[15])
             check_result = rogue.make_skill_check("medicine", 10, skills_data)
 
         if check_result["success"]:


### PR DESCRIPTION
## Summary

Plan-08 slice 1 — foundation for unifying the SRD's D20 Test mechanic.

Introduces `dnd_engine.systems.d20.d20_test`, the single primitive backing every D20 Test (ability check, saving throw, attack roll), and migrates the three legacy callsites to delegate. **Behavior-preserving** — every public dict / `AttackResult` shape is unchanged. The full pytest suite stays green (3365 passed).

Follows the slicing precedent set by plan-01 (#530, shipped as 8 numbered slice PRs).

## Changes

- **`dnd-engine/dnd_engine/systems/d20.py`** *(new)* — `d20_test()`, `D20Result`, `AdvantageState`. Composes `DiceRoller`, handles adv/disadv cancellation, exposes ability mod / proficiency / expertise / circumstantial channels.
- **`dnd-engine/dnd_engine/core/character.py`** — `make_skill_check` and `make_saving_throw` delegate the d20 portion to the primitive. Help one-shot grant, Dodge clause, `SAVING_THROW` event emission, and the public dict shape all preserved on the callsite.
- **`dnd-engine/dnd_engine/core/creature.py`** — `make_saving_throw` delegates. Creatures still carry no proficient saves (monster PB-from-CR is slice 2 scope).
- **`dnd-engine/dnd_engine/core/combat.py`** — `resolve_attack` routes its d20 roll through the primitive. Reach gate, unseen attacker/target, sneak attack, damage pipeline, and `_process_saving_throw_effect` dispatch all untouched.
- **Tests:**
  - `tests/srd/playing_the_game/test_d20_unified.py` *(new)* — 17 parametrized SRD-marked tests pinning the primitive contract.
  - `tests/srd/playing_the_game/test_d20_tests.py` — three surface-exists audit assertions refreshed to check for `d20_test` delegation (the `"1d20"` literal moved off the callsites).
  - `tests/srd/playing_the_game/test_saving_throws.py` — `>=` source-level guard moved to `D20Result.succeeds_against`; runtime check added.
  - `tests/test_death_saves_integration.py` — one `DiceRoller.roll` mock widened to also expose `.rolls`, matching the seam contract.

## Out of scope (subsequent slices in plan-08)

- Step 3 — Monster PB-from-CR table, PB-once stacking guard (#480, #481)
- Step 4 — Tool + skill = Advantage (#483)
- Step 5 — Wire circumstantial mods from callsites (#487; param exists on the primitive but no callsite source feeds it yet)
- Step 6 — DC table constants (#491)
- Step 7 — Voluntary save fail (#447)
- Step 8 — Ability score caps (#486)
- Step 9 — Heroic Inspiration (#489)
- Step 10 — Saving-throw lint job (#450)
- Step 11 — Initiative surprise + ties (#474)

## Test plan

- [x] `uv run pytest dnd-engine/tests/srd/playing_the_game/test_d20_unified.py -v` — 17 new tests green
- [x] `uv run pytest dnd-engine/tests/` — 3365 passed, 191 skipped (full suite, no regressions)
- [x] `uv run ruff check` on changed files — clean
- [x] `python-code-reviewer` skill — no critical/high/medium findings

## Related issues

Part of #537 (plan-08 D20 Test Unification & Proficiency). Does **not** close #537 — subsequent slices in the plan-08 series will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)