### PR TITLE
Add #480: Monster Proficiency Bonus from CR (plan-08 slice 2)

### DIFF
--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -134,6 +134,7 @@ class Creature:
         size: Size = Size.MEDIUM,
         speeds: dict[MovementMode, int] | None = None,
         position: Position | None = None,
+        cr: str | int | float | None = None,
     ):
         """
         Initialize a creature.
@@ -144,6 +145,11 @@ class Creature:
             ac: Armor class (target number for attacks)
             abilities: Ability scores (STR, DEX, CON, INT, WIS, CHA)
             current_hp: Starting HP (defaults to max_hp if not specified)
+            cr: SRD Challenge Rating (monsters only). Drives
+                :attr:`proficiency_bonus` via the SRD CR-to-PB table.
+                Defaults to ``None`` for Characters and any creature
+                constructed without a CR; ``proficiency_bonus`` then
+                returns 0 and PC-side derivations remain authoritative.
             speed: Movement speed in feet per round (default 30 ft). The
                 legacy single-int `speed` kwarg is preserved so existing
                 callers and monsters.json (which carries a plain int)
@@ -224,6 +230,30 @@ class Creature:
         # or by ``InitiativeTracker.next_turn`` at the start of the
         # helper's own next turn.
         self.pending_help_from: Creature | None = None
+
+        # SRD § Playing the Game › Proficiency Bonus: a monster's PB is
+        # derived from its Challenge Rating via the SRD table (see
+        # ``dnd_engine.systems.proficiency``). Stored verbatim from the
+        # catalog so downstream consumers (XP awards, encounter
+        # balancing) can read the published CR without round-tripping
+        # through the PB band.
+        self.cr: str | int | float | None = cr
+
+    @property
+    def proficiency_bonus(self) -> int:
+        """SRD § Proficiency Bonus — derived from Challenge Rating.
+
+        Returns the SRD-table PB for ``self.cr`` (e.g., CR 1/4 → +2,
+        CR 5 → +3, CR 17 → +6). Returns ``0`` when no CR was supplied
+        — Characters override this via their own level-based property,
+        and any creature constructed without a CR has no Proficiency
+        Bonus to apply.
+        """
+        if self.cr is None:
+            return 0
+        from dnd_engine.systems.proficiency import proficiency_bonus_from_cr
+
+        return proficiency_bonus_from_cr(self.cr)
 
     @property
     def is_alive(self) -> bool:

--- a/dnd-engine/dnd_engine/data/srd/monsters.json
+++ b/dnd-engine/dnd_engine/data/srd/monsters.json
@@ -887,8 +887,8 @@
       "cha": 11
     },
     "skills": {
-      "arcana": 6,
-      "history": 6
+      "arcana": 5,
+      "history": 5
     },
     "senses": "passive Perception 11",
     "passive_perception": 11,

--- a/dnd-engine/dnd_engine/rules/loader.py
+++ b/dnd-engine/dnd_engine/rules/loader.py
@@ -107,7 +107,11 @@ class DataLoader:
         # forcing a JSON rewrite.
         size = Size(data.get("size", "medium").lower())
 
-        # Create the creature
+        # Create the creature. SRD § Proficiency Bonus: a monster's PB
+        # is derived from its Challenge Rating. The catalog ``cr`` field
+        # is passed through verbatim (e.g., ``"1/4"``) and the derived
+        # ``Creature.proficiency_bonus`` property handles the table
+        # lookup.
         creature = Creature(
             name=data["name"],
             max_hp=max_hp,
@@ -116,6 +120,7 @@ class DataLoader:
             speed=speed,
             size=size,
             speeds=speeds,
+            cr=data.get("cr"),
         )
 
         # Attach per-type damage modifier fields from the monster catalog.

--- a/dnd-engine/dnd_engine/systems/proficiency.py
+++ b/dnd-engine/dnd_engine/systems/proficiency.py
@@ -1,0 +1,94 @@
+# ABOUTME: SRD § Playing the Game › Proficiency Bonus — monster PB from CR.
+# ABOUTME: Plan-08 slice 2 — pure helper mapping a Challenge Rating to a PB.
+
+"""Monster Proficiency Bonus derived from Challenge Rating.
+
+The 2024 SRD pins a monster's Proficiency Bonus to its Challenge
+Rating via a single table (see ``docs/srd/playing-the-game/proficiency.md``):
+
+    | CR          | PB |
+    | ----------- | -- |
+    | Up to 4     | +2 |
+    | 5–8         | +3 |
+    | 9–12        | +4 |
+    | 13–16       | +5 |
+    | 17–20       | +6 |
+    | 21–24       | +7 |
+    | 25–28       | +8 |
+    | 29–30       | +9 |
+
+This module exposes a single pure helper —
+:func:`proficiency_bonus_from_cr` — that consumers (``Creature``,
+``DataLoader``, and future D20 surfaces in plan-08 slice 3) call to
+derive a monster's PB from the catalog ``cr`` string. Characters use
+their own level-based derivation (see ``Character.proficiency_bonus``);
+this helper is monster-side only.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# CR strings recognized by the catalog. Fractional CRs all map to +2
+# per the SRD table's "Up to 4" row.
+_FRACTIONAL_CR: Final[set[str]] = {"0", "1/8", "1/4", "1/2"}
+
+# Inclusive integer-CR ranges keyed by Proficiency Bonus.
+_CR_BANDS: Final[tuple[tuple[int, int, int], ...]] = (
+    (0, 4, 2),
+    (5, 8, 3),
+    (9, 12, 4),
+    (13, 16, 5),
+    (17, 20, 6),
+    (21, 24, 7),
+    (25, 28, 8),
+    (29, 30, 9),
+)
+
+
+def _normalize(cr: str | int | float) -> str:
+    """Return the canonical CR string for ``cr``.
+
+    Accepts the catalog's fractional strings (``"1/8"``, ``"1/4"``,
+    ``"1/2"``), integer-shaped strings, ``int``, and ``float`` (so a
+    caller may pass ``0.25`` interchangeably with ``"1/4"``).
+    """
+    if isinstance(cr, str):
+        return cr.strip()
+    if isinstance(cr, int):
+        return str(cr)
+    # float: map the three SRD fractionals; otherwise round to int.
+    fractionals = {0.0: "0", 0.125: "1/8", 0.25: "1/4", 0.5: "1/2"}
+    if cr in fractionals:
+        return fractionals[cr]
+    if cr == int(cr):
+        return str(int(cr))
+    raise ValueError(f"Unrecognized CR value: {cr!r}")
+
+
+def proficiency_bonus_from_cr(cr: str | int | float) -> int:
+    """Return the Proficiency Bonus for a monster with the given CR.
+
+    Args:
+        cr: Challenge Rating. May be a catalog string (``"0"``, ``"1/8"``,
+            ``"1/4"``, ``"1/2"``, or the integer CRs ``"1"`` through
+            ``"30"``), or the equivalent ``int``/``float``.
+
+    Returns:
+        The Proficiency Bonus per the SRD CR table.
+
+    Raises:
+        ValueError: If ``cr`` is not one of the SRD-defined values
+            (e.g., ``"31"``, ``"1/3"``, or arbitrary strings).
+    """
+    canonical = _normalize(cr)
+    if canonical in _FRACTIONAL_CR:
+        return 2
+    try:
+        cr_int = int(canonical)
+    except ValueError as exc:
+        raise ValueError(f"Unrecognized CR value: {cr!r}") from exc
+    for low, high, pb in _CR_BANDS:
+        if low <= cr_int <= high:
+            return pb
+    raise ValueError(f"CR {cr!r} is outside the SRD table (0–30)")

--- a/dnd-engine/tests/srd/playing_the_game/test_monster_proficiency.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_monster_proficiency.py
@@ -1,0 +1,230 @@
+# ABOUTME: SRD conformance for monster Proficiency Bonus derived from CR.
+# ABOUTME: Plan-08 slice 2 — pins the CR-to-PB table and Creature wiring.
+
+"""SRD conformance: monster Proficiency Bonus from Challenge Rating.
+
+The 2024 SRD pins a monster's Proficiency Bonus to its Challenge
+Rating via a single table (CR up to 4 → +2, 5–8 → +3, … 29–30 → +9).
+Slice 1 of plan-08 left ``Creature.make_saving_throw`` with a marker
+comment deferring PB derivation to "slice 2"; this file is the
+conformance pin for that slice.
+
+Coverage:
+- ``proficiency_bonus_from_cr`` — pure helper, every SRD row,
+  fractional CR strings, numeric inputs, error on unknown CR.
+- ``Creature.proficiency_bonus`` — derived property; defaults to 0
+  when no CR was supplied (Characters / un-CR'd creatures).
+- ``DataLoader.create_monster`` — threads the JSON ``cr`` field
+  through to the constructed ``Creature``.
+- ``monsters.json`` data parity — every published save/skill total
+  is consistent with ``ability_mod + N·PB`` for N ∈ {1, 2}, the only
+  two options the SRD permits (proficient or expertise).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.systems.proficiency import proficiency_bonus_from_cr
+
+pytestmark = pytest.mark.srd(
+    "playing-the-game/proficiency.md",
+)
+
+
+# --- 1. Helper: CR → PB table ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cr, expected_pb",
+    [
+        # CR up to 4 → +2
+        ("0", 2),
+        ("1/8", 2),
+        ("1/4", 2),
+        ("1/2", 2),
+        ("1", 2),
+        ("2", 2),
+        ("3", 2),
+        ("4", 2),
+        # CR 5–8 → +3
+        ("5", 3),
+        ("6", 3),
+        ("8", 3),
+        # CR 9–12 → +4
+        ("9", 4),
+        ("12", 4),
+        # CR 13–16 → +5
+        ("13", 5),
+        ("16", 5),
+        # CR 17–20 → +6
+        ("17", 6),
+        ("20", 6),
+        # CR 21–24 → +7
+        ("21", 7),
+        ("24", 7),
+        # CR 25–28 → +8
+        ("25", 8),
+        ("28", 8),
+        # CR 29–30 → +9
+        ("29", 9),
+        ("30", 9),
+    ],
+)
+def test_pb_from_cr_table(cr, expected_pb):
+    assert proficiency_bonus_from_cr(cr) == expected_pb
+
+
+@pytest.mark.parametrize(
+    "cr, expected_pb",
+    [
+        (0, 2),
+        (0.125, 2),
+        (0.25, 2),
+        (0.5, 2),
+        (1, 2),
+        (5, 3),
+        (12, 4),
+        (30, 9),
+    ],
+)
+def test_pb_from_cr_accepts_numeric(cr, expected_pb):
+    assert proficiency_bonus_from_cr(cr) == expected_pb
+
+
+def test_pb_from_cr_raises_on_unknown():
+    with pytest.raises(ValueError):
+        proficiency_bonus_from_cr("31")
+    with pytest.raises(ValueError):
+        proficiency_bonus_from_cr("nonsense")
+
+
+# --- 2. Creature.proficiency_bonus property --------------------------------
+
+
+def _stub_abilities() -> Abilities:
+    return Abilities(
+        strength=10,
+        dexterity=10,
+        constitution=10,
+        intelligence=10,
+        wisdom=10,
+        charisma=10,
+    )
+
+
+def test_creature_proficiency_bonus_uses_cr():
+    creature = Creature(
+        name="Test Bear",
+        max_hp=10,
+        ac=12,
+        abilities=_stub_abilities(),
+        cr="5",
+    )
+    assert creature.cr == "5"
+    assert creature.proficiency_bonus == 3
+
+
+def test_creature_without_cr_returns_zero():
+    creature = Creature(
+        name="Test Blob",
+        max_hp=10,
+        ac=10,
+        abilities=_stub_abilities(),
+    )
+    assert creature.cr is None
+    assert creature.proficiency_bonus == 0
+
+
+def test_creature_fractional_cr_resolves_to_two():
+    creature = Creature(
+        name="Test Sprite",
+        max_hp=2,
+        ac=15,
+        abilities=_stub_abilities(),
+        cr="1/8",
+    )
+    assert creature.proficiency_bonus == 2
+
+
+# --- 3. DataLoader wiring ---------------------------------------------------
+
+
+def test_create_monster_threads_cr_from_json():
+    loader = DataLoader()
+    goblin = loader.create_monster("goblin")
+    assert goblin.cr == "1/4"
+    assert goblin.proficiency_bonus == 2
+
+
+# --- 4. monsters.json data parity ------------------------------------------
+
+
+_ABILITY_KEYS = ("str", "dex", "con", "int", "wis", "cha")
+
+
+def _ability_mod(score: int) -> int:
+    # SRD: floor((score - 10) / 2). Using math floor for negatives.
+    return (score - 10) // 2 if score >= 10 else -((10 - score + 1) // 2)
+
+
+def _skill_to_ability() -> dict[str, str]:
+    return DataLoader().load_skills()
+
+
+def test_monster_skill_save_totals_match_cr_derived_pb():
+    """Each non-null save/skill total in monsters.json equals
+    ``ability_mod + N·PB`` for N ∈ {1, 2} — the only two SRD-legal
+    options (proficient or expertise). Any mismatch indicates a bad
+    catalog entry, an incorrect CR, or an effect the data model does
+    not yet capture; surface the full mismatch list so it can be
+    triaged."""
+    loader = DataLoader()
+    monsters = loader.load_monsters()
+    skills_catalog = loader.load_skills()
+
+    mismatches: list[str] = []
+
+    for monster_id, data in monsters.items():
+        cr = data.get("cr")
+        if cr is None:
+            continue
+        pb = proficiency_bonus_from_cr(cr)
+        abilities = {k: data["abilities"][k] for k in _ABILITY_KEYS}
+        ability_mods = {k: _ability_mod(v) for k, v in abilities.items()}
+
+        # Saving throws: {"str": +3, ...} — keyed by ability short code.
+        saves = data.get("saving_throws") or {}
+        for ability_short, total in saves.items():
+            mod = ability_mods[ability_short]
+            if total not in (mod + pb, mod + 2 * pb):
+                mismatches.append(
+                    f"{monster_id} save {ability_short}={total} "
+                    f"(ability_mod={mod}, PB={pb}; "
+                    f"expected {mod + pb} or {mod + 2 * pb})"
+                )
+
+        # Skills: {"stealth": +6, ...} — keyed by skill name; resolve
+        # ability via the SRD skills catalog (skills.json).
+        skills = data.get("skills") or {}
+        for skill_name, total in skills.items():
+            skill_meta = skills_catalog.get(skill_name)
+            if skill_meta is None:
+                mismatches.append(
+                    f"{monster_id} skill {skill_name}: not found in skills catalog"
+                )
+                continue
+            ability_short = skill_meta["ability"]
+            mod = ability_mods[ability_short]
+            if total not in (mod + pb, mod + 2 * pb):
+                mismatches.append(
+                    f"{monster_id} skill {skill_name}={total} "
+                    f"(ability {ability_short} mod={mod}, PB={pb}; "
+                    f"expected {mod + pb} or {mod + 2 * pb})"
+                )
+
+    assert not mismatches, "monsters.json save/skill totals are not PB-consistent:\n" + "\n".join(
+        mismatches
+    )

--- a/dnd-engine/tests/srd/playing_the_game/test_monster_proficiency.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_monster_proficiency.py
@@ -166,12 +166,9 @@ _ABILITY_KEYS = ("str", "dex", "con", "int", "wis", "cha")
 
 
 def _ability_mod(score: int) -> int:
-    # SRD: floor((score - 10) / 2). Using math floor for negatives.
-    return (score - 10) // 2 if score >= 10 else -((10 - score + 1) // 2)
-
-
-def _skill_to_ability() -> dict[str, str]:
-    return DataLoader().load_skills()
+    # SRD: floor((score - 10) / 2). Python's // is floor division and
+    # handles negative scores correctly per the SRD rule.
+    return (score - 10) // 2
 
 
 def test_monster_skill_save_totals_match_cr_derived_pb():
@@ -212,9 +209,7 @@ def test_monster_skill_save_totals_match_cr_derived_pb():
         for skill_name, total in skills.items():
             skill_meta = skills_catalog.get(skill_name)
             if skill_meta is None:
-                mismatches.append(
-                    f"{monster_id} skill {skill_name}: not found in skills catalog"
-                )
+                mismatches.append(f"{monster_id} skill {skill_name}: not found in skills catalog")
                 continue
             ability_short = skill_meta["ability"]
             mod = ability_mods[ability_short]


### PR DESCRIPTION
## Summary

Plan-08 slice 2. Adds the SRD CR→PB derivation that slice 1 left as a marker comment in `Creature.make_saving_throw`. After this slice, `Creature.proficiency_bonus` works the same way `Character.proficiency_bonus` does — derived, not hardcoded — and the catalog can be lint-checked against the SRD math.

Out of scope (queued for slice 3 / #481): wiring `make_saving_throw` to actually *consume* the PB, the proficient-saves marker on `monsters.json`, the expertise marker on monster skills, and the PB-once stacking guard.

## Changes

- **`dnd_engine/systems/proficiency.py`** (new): `proficiency_bonus_from_cr(cr)` pure helper. Accepts the catalog's fractional strings (`"0"`, `"1/8"`, `"1/4"`, `"1/2"`), integer-shaped strings, `int`, and `float`. Raises `ValueError` for CR outside 0–30 or other non-SRD inputs.
- **`dnd_engine/core/creature.py`**: new `cr: str | int | float | None` kwarg on `Creature.__init__`; new `Creature.proficiency_bonus` `@property` returning the SRD-table PB when `cr` is set, `0` otherwise. `Character.proficiency_bonus` (level-based) still overrides as before.
- **`dnd_engine/rules/loader.py`**: `DataLoader.create_monster` threads `data.get("cr")` into the constructor.
- **`dnd_engine/data/srd/monsters.json`**: Mage (Weakened) arcana/history dropped from +6 to +5. The new data-parity test flagged the inconsistency — at CR 2 (PB +2) and INT 17 (+3), +6 was unreachable via either proficient (+5) or expertise (+7). The standard CR 6 Mage entry is untouched.
- **`tests/srd/playing_the_game/test_monster_proficiency.py`** (new): 37 tests covering the table (every SRD row, fractional strings, numeric inputs, error cases), the `Creature` property, the loader wiring, and a data-parity lint that walks `monsters.json` and asserts every save/skill total is consistent with `ability_mod + N·PB` for N ∈ {1, 2}.

## Testing

- [x] `uv run pytest tests/srd/playing_the_game/test_monster_proficiency.py` — 37 passed
- [x] `uv run pytest tests/srd/playing_the_game/` — 720 passed, 184 skipped (no regression in slice-1 D20 unification tests)
- [x] Ruff lint + format clean
- [x] Python code review pass (one dead-code helper and one overcomplicated mod calc removed in the last commit)

## Related Issues

Fixes #480. Part of plan-08 (#537).

🤖 Generated with [Claude Code](https://claude.com/claude-code)