### PR TITLE
Add #484: make_ability_check primitive (plan-08 slice 4)

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -873,6 +873,87 @@ class Character(Creature):
 
         return modifier
 
+    def make_ability_check(
+        self,
+        ability: str,
+        dc: int,
+        advantage: bool = False,
+        disadvantage: bool = False,
+        event_bus=None,
+    ) -> dict[str, Any]:
+        """
+        Roll a raw ability check against a DC.
+
+        Unlike :meth:`make_skill_check`, this surface does not add a
+        proficiency bonus — raw ability checks (Strength to force open
+        a stuck door, Intelligence to recall lore, Constitution to
+        hold one's breath) are not gated by skill or tool proficiency
+        per SRD § Playing the Game › Ability Checks. Use
+        :meth:`make_skill_check` when a skill is named; the future
+        ``make_tool_check`` will cover tool-mediated checks (#483).
+
+        Args:
+            ability: Ability name (e.g., "str", "strength", "INT").
+            dc: Difficulty class to beat.
+            advantage: Roll with advantage (2d20, take higher).
+            disadvantage: Roll with disadvantage (2d20, take lower).
+            event_bus: Optional EventBus to emit an ABILITY_CHECK event.
+
+        Returns:
+            Dict with success / roll / modifier / total / dc / ability.
+
+        Raises:
+            ValueError: If ability name is invalid.
+        """
+        from dnd_engine.utils.events import Event, EventType
+
+        short_to_full = {
+            "str": "strength",
+            "dex": "dexterity",
+            "con": "constitution",
+            "int": "intelligence",
+            "wis": "wisdom",
+            "cha": "charisma",
+        }
+        full_to_short = {v: k for k, v in short_to_full.items()}
+
+        ability_lower = ability.lower()
+        if ability_lower in short_to_full:
+            ability_short = ability_lower
+        elif ability_lower in full_to_short:
+            ability_short = full_to_short[ability_lower]
+        else:
+            raise ValueError(f"Invalid ability name: {ability}")
+
+        ability_mod = getattr(self.abilities, f"{ability_short}_mod")
+
+        result = d20_test(
+            ability_mod=ability_mod,
+            advantage=advantage,
+            disadvantage=disadvantage,
+            roller=self._dice_roller,
+        )
+
+        success = result.succeeds_against(dc)
+        result_dict = {
+            "success": success,
+            "roll": result.d20,
+            "modifier": ability_mod,
+            "total": result.total,
+            "dc": dc,
+            "ability": ability_short,
+        }
+
+        if event_bus is not None:
+            event_bus.emit(
+                Event(
+                    type=EventType.ABILITY_CHECK,
+                    data={"character": self.name, **result_dict},
+                )
+            )
+
+        return result_dict
+
     def make_skill_check(
         self,
         skill: str,

--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -848,6 +848,84 @@ class Creature:
             "ability": ability_short,
         }
 
+    def make_ability_check(
+        self,
+        ability: str,
+        dc: int,
+        advantage: bool = False,
+        disadvantage: bool = False,
+        event_bus=None,
+    ) -> dict:
+        """
+        Roll a raw ability check against a DC.
+
+        Mirrors :meth:`Character.make_ability_check`. SRD § Playing
+        the Game › Ability Checks: a monster rolls ``d20 + ability
+        modifier`` for non-skill checks (escape a pit, push a boulder,
+        puzzle out a glyph). Creatures don't yet carry skill or tool
+        proficiencies, so the modifier here is just the ability mod.
+
+        Args:
+            ability: Ability name (short or full).
+            dc: Difficulty class to beat.
+            advantage: Roll 2d20, take higher.
+            disadvantage: Roll 2d20, take lower.
+            event_bus: Optional EventBus to emit an ABILITY_CHECK event.
+
+        Returns:
+            Dict with success / roll / modifier / total / dc / ability.
+
+        Raises:
+            ValueError: If ability name is invalid.
+        """
+        from dnd_engine.utils.events import Event, EventType
+
+        short_to_full = {
+            "str": "strength",
+            "dex": "dexterity",
+            "con": "constitution",
+            "int": "intelligence",
+            "wis": "wisdom",
+            "cha": "charisma",
+        }
+        full_to_short = {v: k for k, v in short_to_full.items()}
+
+        ability_lower = ability.lower()
+        if ability_lower in short_to_full:
+            ability_short = ability_lower
+        elif ability_lower in full_to_short:
+            ability_short = full_to_short[ability_lower]
+        else:
+            raise ValueError(f"Invalid ability name: {ability}")
+
+        ability_mod = getattr(self.abilities, f"{ability_short}_mod")
+
+        result = d20_test(
+            ability_mod=ability_mod,
+            advantage=advantage,
+            disadvantage=disadvantage,
+        )
+
+        success = result.succeeds_against(dc)
+        result_dict = {
+            "success": success,
+            "roll": result.d20,
+            "modifier": ability_mod,
+            "total": result.total,
+            "dc": dc,
+            "ability": ability_short,
+        }
+
+        if event_bus is not None:
+            event_bus.emit(
+                Event(
+                    type=EventType.ABILITY_CHECK,
+                    data={"creature": self.name, **result_dict},
+                )
+            )
+
+        return result_dict
+
     def __str__(self) -> str:
         """String representation of the creature"""
         status = "alive" if self.is_alive else "dead"

--- a/dnd-engine/tests/srd/playing_the_game/test_ability_checks.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_ability_checks.py
@@ -312,15 +312,16 @@ class TestAbilityCheck_ProficiencyBonusOptional:
 
     def test_ability_check_with_tool_proficiency(self):
         pytest.skip(
-            "GAP: the SRD names *skill or tool* proficiency as "
-            "relevance gates. Skill proficiencies are honored "
-            "(dnd-engine/dnd_engine/core/character.py:715-722). Tool "
-            "proficiencies are stored on `Character` "
-            "(character.py:109, `tool_proficiencies`) but no ability-"
-            "check call site consults them. A 'Dexterity (thieves' "
-            "tools) check' adds proficiency only if Thieves' Tools is "
-            "in `tool_proficiencies` — that wiring doesn't exist. "
-            "Tracked by issue #484."
+            "GAP (narrowed): the raw ability-check surface now exists "
+            "(`Character.make_ability_check`, plan-08 slice 4 / "
+            "#484). What remains is the tool-proficiency wiring: a "
+            "'Dexterity (thieves' tools) check' should add the "
+            "proficiency bonus when Thieves' Tools is in "
+            "`Character.tool_proficiencies` (character.py:109), and "
+            "grant Advantage when the relevant skill is also "
+            "proficient. No `make_tool_check` / "
+            "`is_proficient_with_tool` API exists. Tracked by issue "
+            "#483."
         )
 
 

--- a/dnd-engine/tests/srd/playing_the_game/test_ability_checks.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_ability_checks.py
@@ -389,12 +389,31 @@ class TestAbilityCheck_CreatureParity:
         assert ">= dc" in src or "roll_total >= dc" in src
 
     def test_creature_has_general_purpose_ability_check_primitive(self):
-        pytest.skip(
-            "GAP: `Creature` exposes `make_saving_throw` "
-            "(dnd-engine/dnd_engine/core/creature.py:478) but no "
-            "`make_ability_check` — a monster cannot roll a Strength "
-            "check to escape a pit, an Intelligence check to puzzle "
-            "out a glyph, etc. The condition-removal helper "
-            "(systems/condition_manager.py:220) is dedicated. Tracked "
-            "by issue #484."
+        """`Creature.make_ability_check(ability, dc)` rolls a raw check.
+
+        A monster can roll a Strength check to escape a pit or an
+        Intelligence check to puzzle out a glyph. Creatures don't yet
+        have skill proficiencies in the data model, so the surface
+        adds only the ability modifier.
+        """
+        goblin_abilities = Abilities(
+            strength=8,
+            dexterity=14,
+            constitution=10,
+            intelligence=10,
+            wisdom=8,
+            charisma=8,
         )
+        from dnd_engine.core.creature import Creature
+
+        goblin = Creature(
+            name="Goblin", max_hp=7, ac=13, abilities=goblin_abilities
+        )
+        result = goblin.make_ability_check("str", dc=10)
+        for key in ("success", "roll", "modifier", "total", "dc", "ability"):
+            assert key in result, f"missing field {key!r}"
+        # STR 8 → mod -1
+        assert result["modifier"] == -1
+        assert result["ability"] == "str"
+        assert result["dc"] == 10
+        assert result["total"] == result["roll"] - 1

--- a/dnd-engine/tests/srd/playing_the_game/test_ability_checks.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_ability_checks.py
@@ -192,16 +192,45 @@ class TestAbilityCheck_Primitive:
         assert result["ability"] == "dex"
 
     def test_ability_check_primitive_exists_for_non_skill_checks(self):
-        pytest.skip(
-            "GAP: there is no `make_ability_check(ability, dc)` "
-            "primitive. The SRD's canonical examples (Strength to "
-            "force open a door, Intelligence to recall lore) are not "
-            "skill checks. Only `make_skill_check` "
-            "(dnd-engine/dnd_engine/core/character.py:726) and "
-            "`ConditionManager.attempt_condition_removal` "
-            "(systems/condition_manager.py:220) roll an ability "
-            "check. Neither is general-purpose. Tracked by issue #484."
-        )
+        """`Character.make_ability_check(ability, dc)` rolls a raw ability check.
+
+        SRD: an ability check is `d20 + ability modifier` vs a DC. No
+        skill, no tool — just the ability. The fighter has STR 16
+        (+3); rolling against DC 10 produces ``total = roll + 3``.
+        """
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=1)
+        result = fighter.make_ability_check("str", dc=10)
+        # STR mod (+3), no proficiency
+        assert result["modifier"] == 3
+        assert result["total"] == result["roll"] + 3
+        assert result["ability"] == "str"
+        assert result["dc"] == 10
+        assert result["success"] == (result["total"] >= 10)
+
+    def test_ability_check_accepts_advantage_and_disadvantage(self):
+        """`make_ability_check` plumbs Advantage/Disadvantage through `d20_test`.
+
+        Advantage takes the higher of two d20s; the returned `roll`
+        field is the consumed die.
+        """
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=7)
+        adv = fighter.make_ability_check("str", dc=10, advantage=True)
+        fighter._dice_roller = DiceRoller(seed=7)
+        dis = fighter.make_ability_check("str", dc=10, disadvantage=True)
+        # Same seed but different selection rule — adv >= dis.
+        assert adv["roll"] >= dis["roll"]
+
+    def test_ability_check_accepts_full_and_short_ability_names(self):
+        """Both `"str"` and `"strength"` resolve to the STR modifier."""
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=3)
+        short = fighter.make_ability_check("str", dc=10)
+        fighter._dice_roller = DiceRoller(seed=3)
+        long = fighter.make_ability_check("strength", dc=10)
+        assert short["modifier"] == long["modifier"] == 3
+        assert short["ability"] == long["ability"] == "str"
 
 
 class TestAbilityCheck_ProficiencyBonusOptional:

--- a/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
@@ -114,22 +114,28 @@ class TestDefinition_ThreeKinds:
         assert "d20_test" in src
 
     def test_general_ability_check_primitive_is_unified(self):
-        pytest.skip(
-            "GAP: there is no general-purpose `make_ability_check` "
-            "primitive on Creature or Character. The d20 mechanic is "
-            "implemented three times in parallel: "
-            "`Character.make_skill_check` "
-            "(dnd-engine/dnd_engine/core/character.py:726), "
-            "`Character.make_saving_throw` (character.py:237), and "
-            "`CombatEngine.resolve_attack` "
-            "(dnd-engine/dnd_engine/core/combat.py:91). A Strength "
-            "check to force open a stuck door (the SRD's canonical "
-            "example) has no dedicated entry point — the only "
-            "ability-check-flavored helper, "
-            "`ConditionManager.attempt_condition_removal` "
-            "(systems/condition_manager.py:220), is hard-wired to "
-            "ending conditions. Tracked by issue #484."
+        """All four D20-test surfaces delegate to `d20_test`.
+
+        Source-level guard: `make_skill_check`, `make_saving_throw`,
+        `make_ability_check`, and `CombatEngine.resolve_attack` all
+        contain a `d20_test(...)` call. The unified primitive is the
+        sole d20 surface; plan-08 slice 4 closed out the raw
+        ability-check path that previously had no entry point.
+        """
+        assert hasattr(Character, "make_ability_check"), (
+            "Character must expose make_ability_check for raw "
+            "(non-skill, non-save) ability checks."
         )
+        for func in (
+            Character.make_skill_check,
+            Character.make_saving_throw,
+            Character.make_ability_check,
+            CombatEngine.resolve_attack,
+        ):
+            src = inspect.getsource(func)
+            assert "d20_test" in src, (
+                f"{func.__qualname__} does not delegate to d20_test"
+            )
 
 
 class TestStep4_RollD20:
@@ -371,22 +377,29 @@ class TestKinds_AbilityCheckExamples:
         assert result["dc"] == 10
 
     def test_strength_check_to_force_open_stuck_door(self):
-        pytest.skip(
-            "GAP: the SRD's canonical Strength check (force open a "
-            "stuck door) has no dedicated call site. The only paths "
-            "into an ability-check roll are `make_skill_check` "
-            "(athletics — narrows STR checks to climbing/jumping/"
-            "swimming/grappling) and "
-            "`ConditionManager.attempt_condition_removal` "
-            "(systems/condition_manager.py:220, condition-removal "
-            "only). A non-skill ability check requires the new "
-            "primitive. Tracked by issue #484."
-        )
+        """The SRD's canonical Strength check has a call site.
+
+        `Character.make_ability_check("str", dc)` is the dedicated
+        non-skill entry point. STR 16 (+3) vs DC 15.
+        """
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=1)
+        result = fighter.make_ability_check("str", dc=15)
+        for key in ("success", "roll", "modifier", "total", "dc", "ability"):
+            assert key in result, f"missing field {key!r}"
+        assert result["ability"] == "str"
+        assert result["modifier"] == 3
+        assert result["dc"] == 15
 
     def test_intelligence_check_to_remember_lore(self):
-        pytest.skip(
-            "GAP: same root cause — no primitive for a non-skill "
-            "ability check. An INT check to recall lore would need "
-            "`Creature.make_ability_check('int', dc, skill=None)`. "
-            "Tracked by issue #484."
-        )
+        """A wizard's Intelligence check to recall lore uses the same surface.
+
+        Different ability, same primitive — `make_ability_check("int", dc)`.
+        Fighter has INT 10 (+0), so the total equals the d20 roll.
+        """
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=2)
+        result = fighter.make_ability_check("int", dc=12)
+        assert result["ability"] == "int"
+        assert result["modifier"] == 0
+        assert result["total"] == result["roll"]

--- a/dnd-engine/tests/srd/playing_the_game/test_proficiency.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_proficiency.py
@@ -174,24 +174,89 @@ class TestProficiency_BonusByCR:
     > A monster's Proficiency Bonus is based on its Challenge Rating.
     """
 
-    def test_creature_does_not_expose_proficiency_bonus_from_cr(self) -> None:
-        pytest.skip(
-            "GAP: `Creature` (dnd-engine/dnd_engine/core/creature.py:"
-            "57) has no `proficiency_bonus` property. Only `Character."
-            "proficiency_bonus` (character.py:130) exists, derived from "
-            "PC level. Nothing maps the `cr` field in monsters.json to "
-            "the SRD PB band. Tracked by issue #480."
+    @pytest.mark.parametrize(
+        "cr,expected_pb",
+        [
+            ("0", 2),
+            ("1/8", 2),
+            ("1/4", 2),
+            ("1/2", 2),
+            ("1", 2),
+            ("4", 2),
+            ("5", 3),
+            ("8", 3),
+            ("9", 4),
+            ("12", 4),
+            ("13", 5),
+            ("16", 5),
+            ("17", 6),
+            ("20", 6),
+        ],
+    )
+    def test_creature_proficiency_bonus_follows_cr_band(
+        self, cr: str, expected_pb: int
+    ) -> None:
+        """`Creature(cr=...).proficiency_bonus` follows the SRD CR→PB table.
+
+        SRD: CR 0-4 → +2, 5-8 → +3, 9-12 → +4, 13-16 → +5, 17-20 → +6.
+        Verified at band boundaries.
+        """
+        from dnd_engine.core.creature import Creature
+
+        creature = Creature(
+            name=f"creature_cr_{cr}",
+            max_hp=10,
+            ac=12,
+            abilities=Abilities(
+                strength=10,
+                dexterity=10,
+                constitution=10,
+                intelligence=10,
+                wisdom=10,
+                charisma=10,
+            ),
+            cr=cr,
+        )
+        assert creature.proficiency_bonus == expected_pb, (
+            f"CR {cr!r} expected PB {expected_pb}, got "
+            f"{creature.proficiency_bonus}"
         )
 
     def test_monster_save_totals_decompose_to_ability_mod_plus_pb(self) -> None:
-        pytest.skip(
-            "GAP: monsters.json stores `saving_throws` as raw final "
-            "totals (e.g., bearded_devil: str=5, con=4, wis=2 at "
-            "dnd_engine/data/srd/monsters.json:969). Without a "
-            "CR->PB mapping on `Creature`, the engine cannot validate "
-            "that those totals equal `ability_mod + PB` for the "
-            "proficient saves. Tracked by issue #480."
+        """Bearded devil's stored save totals = ability_mod + PB-from-CR.
+
+        SRD: a monster's proficient save modifier is its ability
+        modifier plus the Proficiency Bonus derived from its CR.
+        bearded_devil ships ``cr=3`` (PB +2) with abilities STR 16
+        (+3), CON 15 (+2), WIS 11 (+0). The stored ``saving_throws``
+        in monsters.json must equal ``ability_mod + PB`` for each
+        proficient save.
+        """
+        monsters_path = (
+            Path(__file__).resolve().parents[3]
+            / "dnd_engine"
+            / "data"
+            / "srd"
+            / "monsters.json"
         )
+        monsters = json.loads(monsters_path.read_text())
+        devil = monsters["bearded_devil"]
+
+        from dnd_engine.systems.proficiency import proficiency_bonus_from_cr
+
+        pb = proficiency_bonus_from_cr(devil["cr"])
+        assert pb == 2, f"CR {devil['cr']!r} should give PB +2, got {pb}"
+
+        # Compute the expected modifier for each proficient save.
+        for ability_short, stored_total in devil["saving_throws"].items():
+            ability_score = devil["abilities"][ability_short]
+            ability_mod = (ability_score - 10) // 2
+            expected = ability_mod + pb
+            assert stored_total == expected, (
+                f"bearded_devil {ability_short} save: stored "
+                f"{stored_total}, decomposes to {ability_mod} (ability) "
+                f"+ {pb} (PB) = {expected}"
+            )
 
 
 class TestProficiency_BonusApplication:


### PR DESCRIPTION
## Summary

Plan-08 slice 4 — closes out #484 by adding a `make_ability_check` surface for raw non-skill ability checks on both `Character` and `Creature`.

- `Character.make_ability_check(ability, dc, *, advantage, disadvantage, event_bus)` — thin shim over `d20_test`, no proficiency bonus (SRD: raw ability checks aren't gated by skill/tool proficiency).
- `Creature.make_ability_check(...)` — parity surface for monsters (escape a pit, puzzle out a glyph).
- Lights up **7 SRD GAP test skips** in `tests/srd/playing_the_game/`:
  - 5 cited #484 (general primitive, force-stuck-door, recall-lore, unified delegation, Creature parity)
  - 2 cited #480 but were vacuous skip-only bodies — rewritten as real CR-band parametrized test + bearded devil save decomposition
- Narrows the remaining tool-proficiency skip at `test_ability_checks.py:285` to cite #483 only (its ability-check half is now real; only the tool wiring remains a gap).

## Why

Slice 1 (PR #653) built the unified `d20_test` primitive and migrated `make_skill_check` / `make_saving_throw` / `resolve_attack` to delegate to it, but it did **not** add a surface for raw non-skill ability checks. The SRD's canonical examples — Strength to force open a stuck door, Intelligence to recall lore — had no entry point. `make_skill_check` narrows STR checks to athletics-only.

Issue #484 was closed COMPLETED on PR #653, but the underlying SRD gap remained. Today's triage (see `plans/08-d20-test-unification-proficiency.md`) reopened it.

## Test plan

- [x] `uv run pytest dnd-engine/tests/srd/` — 783 passed, 181 skipped (was 188 → -7)
- [x] `uv run pytest dnd-engine/` — 3444 passed, 182 skipped, 0 failures
- [x] All 4 surfaces (`make_skill_check`, `make_saving_throw`, `make_ability_check`, `resolve_attack`) source-asserted to delegate to `d20_test`

## Commits

- A — `Character.make_ability_check` + 5 unskipped tests (`d55236f`)
- B — `Creature.make_ability_check` parity + 1 unskipped test (`f6b44b9`)
- C — narrow tool-check skip to cite #483 only (`75e9094`)
- D — replace 2 vacuous #480 skips with real CR-PB decomposition tests (`428e8e3`)

Closes #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)