### PR TITLE
Add #487: Circumstantial modifier channel on D20-Test callers (plan-08 slice 5)

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -288,6 +288,7 @@ class Character(Creature):
         dc: int,
         advantage: bool = False,
         disadvantage: bool = False,
+        circumstantial: int = 0,
         event_bus=None,
     ) -> dict[str, Any]:
         """
@@ -298,16 +299,23 @@ class Character(Creature):
             dc: Difficulty class to beat
             advantage: Roll with advantage (roll twice, take higher)
             disadvantage: Roll with disadvantage (roll twice, take lower)
+            circumstantial: Signed bonus/penalty from class features,
+                spells, or "another rule" per SRD § Playing the Game ›
+                D20 Tests › Step 5. Used by Bless / Bane / Guidance
+                once those spells are plumbed. Forwarded to the
+                d20-test primitive and surfaced on the returned dict
+                and emitted event for telemetry.
             event_bus: Optional EventBus instance to emit saving throw event
 
         Returns:
             Dictionary with:
             - "success": bool (total >= dc)
             - "roll": int (the d20 roll before modifier)
-            - "modifier": int (saving throw modifier)
-            - "total": int (roll + modifier)
+            - "modifier": int (saving throw modifier — ability + PB)
+            - "total": int (roll + modifier + circumstantial)
             - "dc": int (the DC that was beaten)
             - "ability": str (the ability that was saved with, in short form)
+            - "circumstantial": int (the signed bonus/penalty applied)
 
         Raises:
             ValueError: If ability name is invalid
@@ -363,6 +371,7 @@ class Character(Creature):
             proficiency_bonus=self.proficiency_bonus,
             advantage=advantage,
             disadvantage=disadvantage,
+            circumstantial=circumstantial,
         )
 
         success = result.succeeds_against(dc)
@@ -374,6 +383,7 @@ class Character(Creature):
             "total": result.total,
             "dc": dc,
             "ability": ability_short,
+            "circumstantial": circumstantial,
         }
 
         # Emit event if event bus is provided
@@ -388,6 +398,7 @@ class Character(Creature):
                     "modifier": modifier,
                     "total": result.total,
                     "success": success,
+                    "circumstantial": circumstantial,
                 },
             )
             event_bus.emit(event)

--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -879,6 +879,7 @@ class Character(Creature):
         dc: int,
         advantage: bool = False,
         disadvantage: bool = False,
+        circumstantial: int = 0,
         event_bus=None,
     ) -> dict[str, Any]:
         """
@@ -897,10 +898,15 @@ class Character(Creature):
             dc: Difficulty class to beat.
             advantage: Roll with advantage (2d20, take higher).
             disadvantage: Roll with disadvantage (2d20, take lower).
+            circumstantial: Signed bonus/penalty from class features,
+                spells, or "another rule" per SRD § Playing the Game ›
+                D20 Tests › Step 5. Forwarded to the d20-test primitive
+                and surfaced on the returned dict for telemetry.
             event_bus: Optional EventBus to emit an ABILITY_CHECK event.
 
         Returns:
-            Dict with success / roll / modifier / total / dc / ability.
+            Dict with success / roll / modifier / total / dc / ability /
+            circumstantial.
 
         Raises:
             ValueError: If ability name is invalid.
@@ -931,6 +937,7 @@ class Character(Creature):
             ability_mod=ability_mod,
             advantage=advantage,
             disadvantage=disadvantage,
+            circumstantial=circumstantial,
             roller=self._dice_roller,
         )
 
@@ -942,6 +949,7 @@ class Character(Creature):
             "total": result.total,
             "dc": dc,
             "ability": ability_short,
+            "circumstantial": circumstantial,
         }
 
         if event_bus is not None:
@@ -961,6 +969,7 @@ class Character(Creature):
         skills_data: dict,
         advantage: bool = False,
         disadvantage: bool = False,
+        circumstantial: int = 0,
     ) -> dict:
         """
         Roll a skill check against a difficulty class (DC).
@@ -971,6 +980,12 @@ class Character(Creature):
             skills_data: Skills data dictionary loaded from skills.json
             advantage: Whether to roll with advantage (roll twice, take higher)
             disadvantage: Whether to roll with disadvantage (roll twice, take lower)
+            circumstantial: Signed bonus/penalty from class features,
+                spells, or "another rule" per SRD § Playing the Game ›
+                D20 Tests › Step 5. Used by Bless / Bane / Guidance /
+                Bardic Inspiration once those features are plumbed.
+                Forwarded to the d20-test primitive and surfaced on
+                the returned dict for telemetry.
 
         Returns:
             Dictionary containing:
@@ -979,9 +994,10 @@ class Character(Creature):
                 - "dc": difficulty class
                 - "roll": the d20 roll result (before modifier)
                 - "modifier": skill modifier applied
-                - "total": total result (roll + modifier)
+                - "total": total result (roll + modifier + circumstantial)
                 - "success": whether the check succeeded
                 - "proficient": whether the character is proficient in this skill
+                - "circumstantial": the signed bonus/penalty applied
 
         Raises:
             KeyError: If skill is not found in skills_data
@@ -1008,6 +1024,7 @@ class Character(Creature):
             expertise=skill in self.expertise_skills,
             advantage=advantage,
             disadvantage=disadvantage,
+            circumstantial=circumstantial,
             roller=self._dice_roller,
         )
 
@@ -1020,6 +1037,7 @@ class Character(Creature):
             "total": result.total,
             "success": result.succeeds_against(dc),
             "proficient": proficient,
+            "circumstantial": circumstantial,
         }
 
     def get_sneak_attack_dice(self) -> str | None:

--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -35,11 +35,15 @@ class AttackResult:
     disadvantage: bool
     sneak_attack_damage: int = 0  # Additional damage from sneak attack
     sneak_attack_dice: str | None = None  # Sneak attack dice notation (e.g., "2d6")
+    # SRD § Playing the Game › D20 Tests › Step 5: signed
+    # circumstantial bonus/penalty applied to the attack roll
+    # (Bless, Bane, cover, environment, class features, etc.).
+    circumstantial: int = 0
 
     @property
     def total_attack(self) -> int:
-        """Calculate total attack (roll + bonus)"""
-        return self.attack_roll + self.attack_bonus
+        """Calculate total attack (roll + bonus + circumstantial)"""
+        return self.attack_roll + self.attack_bonus + self.circumstantial
 
     @property
     def total_damage(self) -> int:
@@ -138,6 +142,7 @@ class CombatEngine:
         damage_type: str | None = None,
         attacker_sees_defender: VisibilityRelation | None = None,
         defender_sees_attacker: VisibilityRelation | None = None,
+        circumstantial: int = 0,
     ) -> AttackResult:
         """
         Resolve a complete attack.
@@ -187,6 +192,13 @@ class CombatEngine:
                 unmodified. When both an unseen attacker and an unseen
                 target apply, they cancel via the advantage/disadvantage
                 rule below.
+            circumstantial: Signed bonus/penalty from class features,
+                spells, or "another rule" per SRD § Playing the Game ›
+                D20 Tests › Step 5. Forwarded to the d20-test primitive
+                and surfaced on ``AttackResult.circumstantial`` for
+                telemetry. Hit determination uses
+                ``attack_roll + attack_bonus + circumstantial`` so a
+                Bless-like bonus can flip a borderline miss.
 
         Returns:
             AttackResult containing full attack details including sneak attack if applicable
@@ -241,6 +253,7 @@ class CombatEngine:
                         critical_hit=False,
                         advantage=advantage,
                         disadvantage=disadvantage,
+                        circumstantial=circumstantial,
                     )
 
         # SRD § Actions › Dodge: a dodging defender imposes Disadvantage
@@ -300,6 +313,7 @@ class CombatEngine:
             ability_mod=attack_bonus,
             advantage=advantage,
             disadvantage=disadvantage,
+            circumstantial=circumstantial,
             roller=self.dice_roller,
         )
         attack_roll = roll.d20  # The natural d20 result (1-20)
@@ -315,8 +329,11 @@ class CombatEngine:
             # Fallback to base AC if no game_state (e.g., in unit tests)
             defender_ac = defender._base_ac
 
-        # Determine hit/miss
-        total_attack = attack_roll + attack_bonus
+        # Determine hit/miss. Circumstantial bonus/penalty is summed
+        # into the attack total per SRD § Playing the Game › D20 Tests
+        # › Step 5; the natural d20 outcome (`attack_roll`) is still
+        # the gate for critical hit / fumble below.
+        total_attack = attack_roll + attack_bonus + circumstantial
         hit = total_attack >= defender_ac
 
         # Natural 20 always hits, natural 1 always misses
@@ -423,6 +440,7 @@ class CombatEngine:
             disadvantage=disadvantage,
             sneak_attack_damage=sneak_attack_damage,
             sneak_attack_dice=sneak_attack_dice,
+            circumstantial=circumstantial,
         )
 
     def _calculate_damage(self, damage_dice: str, critical_hit: bool) -> int:

--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -748,6 +748,7 @@ class Creature:
         dc: int,
         advantage: bool = False,
         disadvantage: bool = False,
+        circumstantial: int = 0,
         event_bus=None,
     ) -> dict:
         """
@@ -761,6 +762,10 @@ class Creature:
             dc: Difficulty class to beat
             advantage: Roll with advantage (roll twice, take higher)
             disadvantage: Roll with disadvantage (roll twice, take lower)
+            circumstantial: Signed bonus/penalty from class features,
+                spells, or "another rule" per SRD § Playing the Game ›
+                D20 Tests › Step 5. Forwarded to the d20-test primitive
+                and surfaced on the returned dict for telemetry.
             event_bus: Optional EventBus instance to emit saving throw event
 
         Returns:
@@ -768,9 +773,10 @@ class Creature:
             - "success": bool (total >= dc)
             - "roll": int (the d20 roll before modifier)
             - "modifier": int (ability modifier)
-            - "total": int (roll + modifier)
+            - "total": int (roll + modifier + circumstantial)
             - "dc": int (the DC that was beaten)
             - "ability": str (the ability that was saved with, in short form)
+            - "circumstantial": int (the signed bonus/penalty applied)
 
         Raises:
             ValueError: If ability name is invalid
@@ -837,6 +843,7 @@ class Creature:
             ability_mod=modifier,
             advantage=advantage,
             disadvantage=disadvantage,
+            circumstantial=circumstantial,
         )
 
         return {
@@ -846,6 +853,7 @@ class Creature:
             "total": result.total,
             "dc": dc,
             "ability": ability_short,
+            "circumstantial": circumstantial,
         }
 
     def make_ability_check(

--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -854,6 +854,7 @@ class Creature:
         dc: int,
         advantage: bool = False,
         disadvantage: bool = False,
+        circumstantial: int = 0,
         event_bus=None,
     ) -> dict:
         """
@@ -870,10 +871,15 @@ class Creature:
             dc: Difficulty class to beat.
             advantage: Roll 2d20, take higher.
             disadvantage: Roll 2d20, take lower.
+            circumstantial: Signed bonus/penalty from class features,
+                spells, or "another rule" per SRD § Playing the Game ›
+                D20 Tests › Step 5. Forwarded to the d20-test primitive
+                and surfaced on the returned dict for telemetry.
             event_bus: Optional EventBus to emit an ABILITY_CHECK event.
 
         Returns:
-            Dict with success / roll / modifier / total / dc / ability.
+            Dict with success / roll / modifier / total / dc / ability /
+            circumstantial.
 
         Raises:
             ValueError: If ability name is invalid.
@@ -904,6 +910,7 @@ class Creature:
             ability_mod=ability_mod,
             advantage=advantage,
             disadvantage=disadvantage,
+            circumstantial=circumstantial,
         )
 
         success = result.succeeds_against(dc)
@@ -914,6 +921,7 @@ class Creature:
             "total": result.total,
             "dc": dc,
             "ability": ability_short,
+            "circumstantial": circumstantial,
         }
 
         if event_bus is not None:

--- a/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
@@ -259,18 +259,64 @@ class TestStep5_AddModifiers:
         assert result["proficient"] is False
 
     def test_circumstantial_bonuses_can_be_added(self):
-        pytest.skip(
-            "GAP: the third additive channel from SRD step 5 — "
-            "Circumstantial Bonuses and Penalties from class features, "
-            "spells, or 'another rule' — has no caller-supplied "
-            "parameter on `make_skill_check`, `make_saving_throw`, or "
-            "`resolve_attack`. Bless / Bane / Guidance / Bardic "
-            "Inspiration cannot be plumbed without bolting onto each "
-            "call site. See `Character.make_skill_check` "
-            "(dnd-engine/dnd_engine/core/character.py:726) and "
-            "`make_saving_throw` (character.py:237) — both accept "
-            "only advantage/disadvantage flags. Tracked by issue #487."
+        """SRD step 5 third channel reaches every D20-Test caller.
+
+        Verifies the four caller surfaces (skill check, raw ability
+        check, saving throw, attack roll) all accept a caller-supplied
+        ``circumstantial`` modifier and route it through the unified
+        :func:`dnd_engine.systems.d20.d20_test` primitive — unlocking
+        Bless / Bane / Guidance / Bardic Inspiration plumbing without
+        per-callsite hacks.
+        """
+        fighter = _make_fighter()
+        skills = {"athletics": {"ability": "str"}}
+
+        # Skill check — same seed twice, +3 bonus reaches the total.
+        fighter._dice_roller = DiceRoller(seed=1)
+        skill_baseline = fighter.make_skill_check(
+            "athletics", dc=10, skills_data=skills
         )
+        fighter._dice_roller = DiceRoller(seed=1)
+        skill_boosted = fighter.make_skill_check(
+            "athletics", dc=10, skills_data=skills, circumstantial=3
+        )
+        assert skill_boosted["circumstantial"] == 3
+        assert skill_boosted["total"] == skill_baseline["total"] + 3
+
+        # Raw ability check — Guidance-like +2 reaches the total.
+        fighter._dice_roller = DiceRoller(seed=5)
+        ability_baseline = fighter.make_ability_check("str", dc=10)
+        fighter._dice_roller = DiceRoller(seed=5)
+        ability_boosted = fighter.make_ability_check(
+            "str", dc=10, circumstantial=2
+        )
+        assert ability_boosted["circumstantial"] == 2
+        assert ability_boosted["total"] == ability_baseline["total"] + 2
+
+        # Saving throw — Bless-like +1 surfaces on the result dict.
+        save_result = fighter.make_saving_throw("con", dc=10, circumstantial=1)
+        assert save_result["circumstantial"] == 1
+        assert save_result["total"] == (
+            save_result["roll"] + save_result["modifier"] + 1
+        )
+
+        # Attack roll — bonus surfaces on AttackResult and total_attack.
+        from dnd_engine.core.combat import CombatEngine
+
+        attacker = _make_creature()
+        defender = _make_creature()
+        engine = CombatEngine(dice_roller=DiceRoller(seed=1))
+        atk_baseline = engine.resolve_attack(
+            attacker=attacker, defender=defender,
+            attack_bonus=2, damage_dice="1d4",
+        )
+        engine = CombatEngine(dice_roller=DiceRoller(seed=1))
+        atk_boosted = engine.resolve_attack(
+            attacker=attacker, defender=defender,
+            attack_bonus=2, damage_dice="1d4", circumstantial=2,
+        )
+        assert atk_boosted.circumstantial == 2
+        assert atk_boosted.total_attack == atk_baseline.total_attack + 2
 
 
 class TestStep6_TargetNumber:

--- a/dnd-engine/tests/test_circumstantial_modifiers.py
+++ b/dnd-engine/tests/test_circumstantial_modifiers.py
@@ -1,0 +1,129 @@
+# ABOUTME: Verifies the `circumstantial` channel is plumbed through every
+# ABOUTME: D20-Test caller surface (skill / ability / save / attack).
+
+"""Circumstantial bonus/penalty plumbing (issue #487, plan-08 slice 5).
+
+SRD § Playing the Game › D20 Tests › Step 5 names three additive
+modifier categories that go on top of the d20: the relevant ability
+modifier, the proficiency bonus (if relevant), and **circumstantial
+bonuses and penalties** ("A class feature, a spell, or another rule
+might give a bonus or penalty to the die roll"). The unified
+:func:`dnd_engine.systems.d20.d20_test` primitive reserved the
+``circumstantial`` channel in slice 1 but no caller exposed it.
+
+This test module verifies each caller surface (skill check, raw ability
+check, saving throw, attack roll) accepts a caller-supplied
+``circumstantial`` value, forwards it to the primitive, and surfaces
+it on the returned result for telemetry — unblocking Bless / Bane /
+Guidance / Bardic Inspiration plumbing in later slices.
+"""
+
+from __future__ import annotations
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.dice import DiceRoller
+
+
+def _make_fighter() -> Character:
+    """Construct a minimal Fighter for caller-surface assertions."""
+    abilities = Abilities(
+        strength=16,
+        dexterity=14,
+        constitution=15,
+        intelligence=10,
+        wisdom=12,
+        charisma=8,
+    )
+    return Character(
+        name="Fighter",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=abilities,
+        max_hp=12,
+        ac=16,
+        saving_throw_proficiencies=["str", "con"],
+        skill_proficiencies=["athletics"],
+    )
+
+
+def _make_creature() -> Creature:
+    """Construct a vanilla creature without proficient saves."""
+    abilities = Abilities(
+        strength=10,
+        dexterity=14,
+        constitution=10,
+        intelligence=10,
+        wisdom=10,
+        charisma=10,
+    )
+    return Creature(name="Goblin", max_hp=7, ac=13, abilities=abilities)
+
+
+class TestSkillCheck:
+    """Skill checks expose the circumstantial channel."""
+
+    def test_skill_check_accepts_circumstantial(self):
+        """A `+3` Bless-like bonus reaches `total` and is itemized."""
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=1)
+        skills = {"athletics": {"ability": "str"}}
+
+        baseline = fighter.make_skill_check("athletics", dc=10, skills_data=skills)
+
+        fighter._dice_roller = DiceRoller(seed=1)
+        boosted = fighter.make_skill_check(
+            "athletics", dc=10, skills_data=skills, circumstantial=3
+        )
+
+        # Same seed → same natural d20 → boosted total is exactly +3.
+        assert boosted["roll"] == baseline["roll"]
+        assert boosted["total"] == baseline["total"] + 3
+        assert boosted["circumstantial"] == 3
+        # Baseline keeps the default zero channel for telemetry parity.
+        assert baseline["circumstantial"] == 0
+
+
+class TestAbilityCheck:
+    """Raw ability checks expose the circumstantial channel."""
+
+    def test_character_ability_check_accepts_circumstantial(self):
+        """A `+2` Guidance-like bonus stacks onto the raw STR check."""
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=5)
+
+        baseline = fighter.make_ability_check("str", dc=10)
+
+        fighter._dice_roller = DiceRoller(seed=5)
+        boosted = fighter.make_ability_check("str", dc=10, circumstantial=2)
+
+        assert boosted["roll"] == baseline["roll"]
+        assert boosted["total"] == baseline["total"] + 2
+        assert boosted["circumstantial"] == 2
+
+    def test_character_ability_check_accepts_negative_circumstantial(self):
+        """A `-1` Bane-like penalty subtracts from the total."""
+        fighter = _make_fighter()
+        fighter._dice_roller = DiceRoller(seed=5)
+
+        baseline = fighter.make_ability_check("int", dc=10)
+
+        fighter._dice_roller = DiceRoller(seed=5)
+        penalized = fighter.make_ability_check("int", dc=10, circumstantial=-1)
+
+        assert penalized["total"] == baseline["total"] - 1
+        assert penalized["circumstantial"] == -1
+
+    def test_creature_ability_check_accepts_circumstantial(self):
+        """`Creature.make_ability_check` mirrors the Character surface."""
+        goblin = _make_creature()
+
+        baseline = goblin.make_ability_check("dex", dc=10)
+        boosted = goblin.make_ability_check("dex", dc=10, circumstantial=1)
+
+        # Without a deterministic roller on Creature.make_ability_check
+        # (it constructs a fresh DiceRoller per call by primitive
+        # default), assert on the itemized channel only — the +1
+        # arithmetic is verified by the d20_test primitive's own tests.
+        assert baseline["circumstantial"] == 0
+        assert boosted["circumstantial"] == 1

--- a/dnd-engine/tests/test_circumstantial_modifiers.py
+++ b/dnd-engine/tests/test_circumstantial_modifiers.py
@@ -127,3 +127,39 @@ class TestAbilityCheck:
         # arithmetic is verified by the d20_test primitive's own tests.
         assert baseline["circumstantial"] == 0
         assert boosted["circumstantial"] == 1
+
+
+class TestSavingThrow:
+    """Saving throws expose the circumstantial channel."""
+
+    def test_character_saving_throw_accepts_circumstantial(self):
+        """A `+1` Bless-like bonus is surfaced on the result dict.
+
+        ``make_saving_throw`` constructs a fresh ``DiceRoller`` per
+        call rather than reusing ``self._dice_roller`` (see the
+        comment at character.py:354), so test the structural contract:
+        the bonus reaches the result. End-to-end arithmetic of the
+        ``circumstantial`` channel is verified by the d20-test
+        primitive's own tests in ``tests/srd/playing_the_game/
+        test_d20_unified.py``.
+        """
+        fighter = _make_fighter()
+
+        result = fighter.make_saving_throw("con", dc=10, circumstantial=1)
+
+        assert result["circumstantial"] == 1
+        # The "modifier" key carries the static save modifier
+        # (ability + PB), separate from the circumstantial channel.
+        # The total includes both: d20 + modifier + circumstantial.
+        assert result["total"] == result["roll"] + result["modifier"] + 1
+
+    def test_creature_saving_throw_accepts_circumstantial(self):
+        """A `-2` Bane-like penalty is surfaced on the Creature surface."""
+        goblin = _make_creature()
+
+        result = goblin.make_saving_throw("wis", dc=10, circumstantial=-2)
+
+        assert result["circumstantial"] == -2
+        # Creatures have no proficient saves today, so modifier ==
+        # ability mod, and total == d20 + ability_mod + circumstantial.
+        assert result["total"] == result["roll"] + result["modifier"] - 2

--- a/dnd-engine/tests/test_circumstantial_modifiers.py
+++ b/dnd-engine/tests/test_circumstantial_modifiers.py
@@ -21,6 +21,7 @@ Guidance / Bardic Inspiration plumbing in later slices.
 from __future__ import annotations
 
 from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.combat import CombatEngine
 from dnd_engine.core.creature import Abilities, Creature
 from dnd_engine.core.dice import DiceRoller
 
@@ -163,3 +164,44 @@ class TestSavingThrow:
         # Creatures have no proficient saves today, so modifier ==
         # ability mod, and total == d20 + ability_mod + circumstantial.
         assert result["total"] == result["roll"] + result["modifier"] - 2
+
+
+class TestAttackResolution:
+    """`CombatEngine.resolve_attack` exposes the circumstantial channel."""
+
+    def test_resolve_attack_accepts_circumstantial(self):
+        """A `+2` Bless-like bonus is surfaced on `AttackResult` and
+        flows into `total_attack` so a borderline roll connects.
+
+        Same-seeded roller; with `attack_bonus=2` against `AC=12`, the
+        seed-1 roll naturally totals to within one of AC. A +2
+        circumstantial bonus then comfortably crosses the threshold.
+        """
+        attacker = _make_creature()
+        defender = _make_creature()
+        defender._base_ac = 12
+        engine = CombatEngine(dice_roller=DiceRoller(seed=1))
+
+        baseline = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=2,
+            damage_dice="1d4",
+        )
+
+        engine = CombatEngine(dice_roller=DiceRoller(seed=1))
+        boosted = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=2,
+            damage_dice="1d4",
+            circumstantial=2,
+        )
+
+        # Same seed → same natural d20.
+        assert boosted.attack_roll == baseline.attack_roll
+        # The bonus is itemized on the result.
+        assert baseline.circumstantial == 0
+        assert boosted.circumstantial == 2
+        # `total_attack` includes the bonus.
+        assert boosted.total_attack == baseline.total_attack + 2


### PR DESCRIPTION
## Summary

Plan-08 slice 5 — plumbs the third additive D20-Test modifier channel (SRD § Playing the Game › D20 Tests › Step 5: *Circumstantial Bonuses and Penalties*) through every caller surface. The unified `d20_test()` primitive reserved the `circumstantial` channel in slice 1; this PR exposes it on the 4 caller methods so Bless / Bane / Guidance / Bardic Inspiration can be plumbed without per-callsite hacks.

Closes #487. SRD GAP skip count drops by 1.

> Replaces #657 (auto-closed when its base branch `feature/484-ability-check-primitive` was deleted by the squash-merge of slice-4 PR #656). Rebased onto current `main` — slice-4 commits dropped as already-upstream.

## Changes

- **`dnd_engine/core/character.py`**: Add `circumstantial: int = 0` to `make_skill_check`, `make_ability_check`, `make_saving_throw`. Forwards to `d20_test()`; surfaces on returned dict + `SAVING_THROW` event for telemetry.
- **`dnd_engine/core/creature.py`**: Same pattern for `make_ability_check` and `make_saving_throw`.
- **`dnd_engine/core/combat.py`**: Add `circumstantial: int = 0` to `CombatEngine.resolve_attack`; add `circumstantial: int = 0` field to `AttackResult` dataclass; update `total_attack` property to include the channel; hit determination uses `attack_roll + attack_bonus + circumstantial` so a Bless-like bonus can flip a borderline miss.
- **`tests/test_circumstantial_modifiers.py`** (new): 7 tests covering every surface — baseline vs boosted comparisons with seeded `DiceRoller` for deterministic arithmetic; structural assertion for the save methods (which intentionally use fresh unseeded rollers).
- **`tests/srd/playing_the_game/test_d20_tests.py`**: Replace the `pytest.skip("GAP: ...#487")` at `test_circumstantial_bonuses_can_be_added` with a real multi-caller SRD conformance assertion.

## Backward compatibility

All new parameters default to `0`; `AttackResult.circumstantial` defaults to `0` (follows the existing `sneak_attack_damage: int = 0` precedent). Existing keyword-arg callers in `game_state.py`, `combat.py`, `creature.py`, `actions.py` are unaffected.

## Testing

- [x] New unit tests pass: 7/7 in `tests/test_circumstantial_modifiers.py`
- [x] SRD GAP unskip passes: `test_circumstantial_bonuses_can_be_added` now green
- [x] SRD playing-the-game suite: 753 passed, 175 skipped, 0 failed
- [x] Full dnd-engine suite (post-rebase): **3452 passed, 181 skipped, 0 failed**
- [x] Ruff lint clean on changed files (pre-commit hook enforced on every commit)
- [x] TDD discipline: every commit pairs implementation with test

## Out of scope (documented in `plans/08-d20-test-unification-proficiency.md`)

- Named-bonus list for per-source telemetry — defer until a caller needs it.
- Wiring Bless / Bane / Guidance / Bardic Inspiration themselves — consumers of this plumbing.
- Tool-proficiency advantage (#483, the other slice-5 item per the plan) — handled in a follow-up sub-slice.

## Observation (not blocking)

`CombatEngine.resolve_attack` now has 16 parameters (was 15) — a pre-existing smell worth a follow-up issue (group contextual modifiers into an `AttackContext` dataclass). Refactor is out of scope here.

## Related Issues

Closes #487. Supersedes #657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)