### PR TITLE
Add #491: DC ladder IntEnum constants (plan-08 slice 6)

### DIFF
--- a/dnd-engine/dnd_engine/core/constants/__init__.py
+++ b/dnd-engine/dnd_engine/core/constants/__init__.py
@@ -1,0 +1,8 @@
+# ABOUTME: SRD-derived named constants used across the engine.
+# ABOUTME: Re-exports the Typical Difficulty Class ladder (`DC`).
+
+"""Engine-level named constants sourced from the SRD."""
+
+from dnd_engine.core.constants.dc_ladder import DC
+
+__all__ = ["DC"]

--- a/dnd-engine/dnd_engine/core/constants/dc_ladder.py
+++ b/dnd-engine/dnd_engine/core/constants/dc_ladder.py
@@ -1,0 +1,40 @@
+# ABOUTME: SRD-canonical Typical Difficulty Class ladder for D20 Tests.
+# ABOUTME: Defines DC.VERY_EASY..DC.NEARLY_IMPOSSIBLE as IntEnum members.
+
+"""Typical Difficulty Class ladder.
+
+Source: SRD § Playing the Game › D20 Tests › Typical Difficulty Classes
+(docs/srd/playing-the-game/d20-tests.md lines 731-865).
+
+| Difficulty        | DC |
+|-------------------|----|
+| Very easy         |  5 |
+| Easy              | 10 |
+| Medium            | 15 |
+| Hard              | 20 |
+| Very hard         | 25 |
+| Nearly impossible | 30 |
+
+Exposed as an ``IntEnum`` so members behave as integers in numeric
+comparisons (``total >= DC.MEDIUM``) and can be passed directly to call
+sites that accept an ``int`` DC (``make_skill_check(skill, dc=DC.HARD)``,
+``make_saving_throw(ability, dc=DC.EASY)``).
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class DC(IntEnum):
+    """SRD Typical Difficulty Class ladder."""
+
+    VERY_EASY = 5
+    EASY = 10
+    MEDIUM = 15
+    HARD = 20
+    VERY_HARD = 25
+    NEARLY_IMPOSSIBLE = 30
+
+
+__all__ = ["DC"]

--- a/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_d20_tests.py
@@ -385,14 +385,24 @@ class TestStep6_TargetNumber:
         assert hasattr(result, "attack_roll")
 
     def test_typical_difficulty_class_ladder_is_documented(self):
-        pytest.skip(
-            "GAP: the SRD's Typical Difficulty Classes ladder (Very "
-            "easy 5 / Easy 10 / Medium 15 / Hard 20 / Very hard 25 / "
-            "Nearly impossible 30) is not exposed as a named enum or "
-            "constant. DCs are scattered as integer literals in "
-            "conditions.json, scenario YAMLs, and spells.json. No "
-            "central reference exists. Tracked by issue #491."
-        )
+        """`DC` enum exposes the SRD's Typical Difficulty Classes ladder.
+
+        SRD § Playing the Game › D20 Tests › Typical Difficulty Classes
+        (docs/srd/playing-the-game/d20-tests.md lines 731-865) names
+        Very easy 5 / Easy 10 / Medium 15 / Hard 20 / Very hard 25 /
+        Nearly impossible 30. `dnd_engine.core.constants.DC` is the
+        importable enum that surfaces these values for callers.
+        """
+        from dnd_engine.core.constants import DC
+
+        assert DC.VERY_EASY == 5
+        assert DC.EASY == 10
+        assert DC.MEDIUM == 15
+        assert DC.HARD == 20
+        assert DC.VERY_HARD == 25
+        assert DC.NEARLY_IMPOSSIBLE == 30
+        # IntEnum: members usable wherever an int DC is expected.
+        assert int(DC.MEDIUM) == 15
 
 
 class TestKinds_AbilityCheckExamples:


### PR DESCRIPTION
## Summary

Plan-08 slice 6 — pure additive. Exposes the SRD's Typical Difficulty Class ladder as an importable `IntEnum` at `dnd_engine.core.constants.DC`.

| Difficulty        | DC |
|-------------------|----|
| Very easy         |  5 |
| Easy              | 10 |
| Medium            | 15 |
| Hard              | 20 |
| Very hard         | 25 |
| Nearly impossible | 30 |

Source: `docs/srd/playing-the-game/d20-tests.md` lines 731-865.

`IntEnum` was chosen (and sanctioned by the issue) so members behave as integers — callers can pass `DC.MEDIUM` directly anywhere an `int` DC is expected (`make_skill_check`, `make_saving_throw`, `make_ability_check`, `D20Test`) with no signature changes.

## Changes

- **`dnd-engine/dnd_engine/core/constants/__init__.py`** (new): re-exports `DC`.
- **`dnd-engine/dnd_engine/core/constants/dc_ladder.py`** (new): defines the `DC` IntEnum with module-level docstring citing the SRD source.
- **`dnd-engine/tests/srd/playing_the_game/test_d20_tests.py`**: unskips `TestStep6_TargetNumber::test_typical_difficulty_class_ladder_is_documented` (was a `pytest.skip("GAP: ... Tracked by issue #491.")`) and asserts each ladder value plus `IntEnum` semantics.

## Scope

Pure additive — no caller migrations. Existing JSON / YAML DC literals are untouched.

The optional follow-up in #491 ("lint scenario / condition DCs against the ladder and warn on off-ladder values") is **out of scope**: plan-08 explicitly tags this slice "Pure additive."

## Plan-08 context

This is the final non-deferred slice of plan-08. Heroic Inspiration (#489), voluntary save fail (#447), ability score caps (#486), tool+skill advantage (#483), initiative surprise/ties (#474), and save-ability lint (#450) remain `[DEFER]` per the plan.

## Testing

- [x] Red phase: confirmed `ImportError` before the new module landed.
- [x] Green phase: the rewritten test passes.
- [x] Regression: full SRD `playing_the_game` suite — **755 passed, 173 skipped** (one fewer skip than before; matches the unblocked GAP).
- [x] Smoke import: `from dnd_engine.core.constants import DC; int(DC.MEDIUM)` → `15`.
- [x] Ruff lint clean on changed files. (Pre-existing format drift in slice-5 lines of the same test file is out of scope.)

## Related Issues

Fixes #491
Plan-08 (#537) — slice 6 of 6 implemented slices

🤖 Generated with [Claude Code](https://claude.com/claude-code)