### PR TITLE
Add #483: Tool + skill proficiency grants Advantage (plan-08 slice 7)

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -577,6 +577,23 @@ class Character(Creature):
         armor_type = armor_data.get("armor_type", "")
         return armor_type in self.armor_proficiencies
 
+    def is_proficient_with_tool(self, tool_id: str) -> bool:
+        """
+        Check if character is proficient with a tool.
+
+        SRD § Proficiency › Equipment Proficiencies › Tools predicates
+        the Proficiency Bonus on this answer: "If you have proficiency
+        with a tool, you can add your Proficiency Bonus to any ability
+        check you make that uses the tool."
+
+        Args:
+            tool_id: Tool kit identifier (e.g., "thieves_tools").
+
+        Returns:
+            True iff ``tool_id`` is in ``self.tool_proficiencies``.
+        """
+        return tool_id in self.tool_proficiencies
+
     def gain_xp(self, amount: int) -> None:
         """
         Add experience points.
@@ -1048,6 +1065,169 @@ class Character(Creature):
             "total": result.total,
             "success": result.succeeds_against(dc),
             "proficient": proficient,
+            "circumstantial": circumstantial,
+        }
+
+    def make_tool_check(
+        self,
+        tool_id: str,
+        dc: int,
+        *,
+        skill: str | None = None,
+        ability: str | None = None,
+        skills_data: dict | None = None,
+        advantage: bool = False,
+        disadvantage: bool = False,
+        circumstantial: int = 0,
+    ) -> dict:
+        """
+        Roll an ability check that involves a tool.
+
+        SRD § Proficiency › Equipment Proficiencies › Tools:
+
+            If you have proficiency with a tool, you can add your
+            Proficiency Bonus to any ability check you make that uses
+            the tool. If you have proficiency in the skill that's also
+            used with that check, you have Advantage on the check too.
+
+        Behavioral matrix:
+
+        ===================  ==========================  =================
+        tool-proficient      skill named & proficient    Result
+        ===================  ==========================  =================
+        yes                  yes                         PB + Advantage
+        yes                  no                          PB only
+        no                   yes                         Delegate to skill
+        no                   no                          Plain ability
+        ===================  ==========================  =================
+
+        ``make_skill_check`` is invoked for the "no tool, skill only"
+        case so existing skill PB / Expertise wiring is reused. The
+        primitive ``d20_test`` enforces PB-applied-once when both
+        proficiencies are present.
+
+        Args:
+            tool_id: Tool kit identifier (e.g., "thieves_tools").
+            dc: Difficulty class to beat.
+            skill: Optional skill name. When provided, ``skills_data``
+                is required and the ability is derived from
+                ``skills_data[skill]["ability"]``. Tool + skill
+                proficiency together grant Advantage.
+            ability: Ability name (e.g., "dex"); required when
+                ``skill`` is None.
+            skills_data: Skills dictionary loaded from
+                ``data/srd/skills.json``; required when ``skill`` is
+                provided.
+            advantage: Caller-asserted advantage (stacks with the
+                tool+skill grant).
+            disadvantage: Cancels advantage per SRD.
+            circumstantial: Signed bonus/penalty (Bless / Bane /
+                Guidance / etc.).
+
+        Returns:
+            Dict with ``tool``, ``skill``, ``ability``, ``dc``,
+            ``roll``, ``modifier``, ``total``, ``success``,
+            ``tool_proficient``, ``skill_proficient``,
+            ``advantage_from_tool_skill``, ``circumstantial``.
+
+        Raises:
+            ValueError: If neither ``skill`` nor ``ability`` is given,
+                or if ``skill`` is given without ``skills_data``, or
+                if ``ability`` is not a valid ability name.
+            KeyError: If ``skill`` is not present in ``skills_data``.
+        """
+        if skill is None and ability is None:
+            raise ValueError(
+                "make_tool_check requires either 'skill' or 'ability'"
+            )
+
+        tool_proficient = self.is_proficient_with_tool(tool_id)
+        skill_proficient = (
+            skill is not None and skill in self.skill_proficiencies
+        )
+
+        # SRD: tool-only PB requires tool proficiency. When the caller
+        # has the skill but not the tool, defer to the skill path so
+        # skill PB / Expertise still applies — no regression for a
+        # skill-proficient character who happens to use a tool they
+        # aren't proficient with.
+        if not tool_proficient and skill_proficient:
+            result = self.make_skill_check(
+                skill, dc, skills_data,
+                advantage=advantage,
+                disadvantage=disadvantage,
+                circumstantial=circumstantial,
+            )
+            return {
+                "tool": tool_id,
+                "skill": skill,
+                "ability": result["ability"],
+                "dc": dc,
+                "roll": result["roll"],
+                "modifier": result["modifier"],
+                "total": result["total"],
+                "success": result["success"],
+                "tool_proficient": False,
+                "skill_proficient": True,
+                "advantage_from_tool_skill": False,
+                "circumstantial": circumstantial,
+            }
+
+        if skill is not None:
+            if skills_data is None:
+                raise ValueError(
+                    "make_tool_check requires 'skills_data' when 'skill' is given"
+                )
+            if skill not in skills_data:
+                raise KeyError(f"Unknown skill: {skill}")
+            ability_short = skills_data[skill]["ability"]
+        else:
+            short_to_full = {
+                "str": "strength",
+                "dex": "dexterity",
+                "con": "constitution",
+                "int": "intelligence",
+                "wis": "wisdom",
+                "cha": "charisma",
+            }
+            full_to_short = {v: k for k, v in short_to_full.items()}
+            ability_lower = ability.lower()
+            if ability_lower in short_to_full:
+                ability_short = ability_lower
+            elif ability_lower in full_to_short:
+                ability_short = full_to_short[ability_lower]
+            else:
+                raise ValueError(f"Invalid ability name: {ability}")
+
+        ability_mod = getattr(self.abilities, f"{ability_short}_mod")
+        auto_advantage = tool_proficient and skill_proficient
+
+        result = d20_test(
+            ability_mod=ability_mod,
+            proficient=tool_proficient,
+            proficiency_bonus=self.proficiency_bonus,
+            advantage=advantage or auto_advantage,
+            disadvantage=disadvantage,
+            circumstantial=circumstantial,
+            roller=self._dice_roller,
+        )
+
+        modifier = ability_mod + (
+            self.proficiency_bonus if tool_proficient else 0
+        )
+
+        return {
+            "tool": tool_id,
+            "skill": skill,
+            "ability": ability_short,
+            "dc": dc,
+            "roll": result.d20,
+            "modifier": modifier,
+            "total": result.total,
+            "success": result.succeeds_against(dc),
+            "tool_proficient": tool_proficient,
+            "skill_proficient": skill_proficient,
+            "advantage_from_tool_skill": auto_advantage,
             "circumstantial": circumstantial,
         }
 

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -2052,23 +2052,25 @@ class GameState:
         if "skill" in method:
             skill = method["skill"]
             dc = method["dc"]
-
-            # Check tool proficiency requirement
             tool_proficiency = method.get("tool_proficiency")
-            if tool_proficiency:
-                # Load proficiencies data to check if character has the tool
-                if (
-                    not hasattr(character, "tool_proficiencies")
-                    or tool_proficiency not in character.tool_proficiencies
-                ):
-                    # Character lacks required tool proficiency - they can still attempt but without proficiency bonus
-                    pass
-
-            # Load skills data
             skills_data = self.data_loader.load_skills()
 
-            # Make skill check
-            check_result = character.make_skill_check(skill, dc, skills_data)
+            # SRD § Proficiency › Equipment Proficiencies › Tools: when
+            # an unlock method declares a tool, route through
+            # `make_tool_check` so a tool-proficient character gains
+            # PB, and a character also proficient in the skill gains
+            # Advantage. The primitive handles the no-tool-proficiency
+            # fallback (delegates to `make_skill_check` when only the
+            # skill is proficient, plain ability check otherwise).
+            if tool_proficiency:
+                check_result = character.make_tool_check(
+                    tool_proficiency,
+                    dc,
+                    skill=skill,
+                    skills_data=skills_data,
+                )
+            else:
+                check_result = character.make_skill_check(skill, dc, skills_data)
 
             # Emit skill check event
             self.event_bus.emit(

--- a/dnd-engine/tests/srd/playing_the_game/test_exploration.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_exploration.py
@@ -298,8 +298,9 @@ class TestExploration_AdventuringEquipment_ThievesTools:
     def test_character_carries_tool_proficiencies(self) -> None:
         """`Character` exposes `tool_proficiencies` as a first-class field.
 
-        The proficiency is read by `GameState._unlock_door`
-        (`game_state.py:1097-1099`) during the skill-based unlock path.
+        Read by `Character.is_proficient_with_tool` /
+        `Character.make_tool_check` during the skill-based unlock path
+        and any other tool-mediated ability check.
         """
         rogue = _make_rogue()
         assert hasattr(rogue, "tool_proficiencies"), (
@@ -309,21 +310,23 @@ class TestExploration_AdventuringEquipment_ThievesTools:
         assert "thieves_tools" in rogue.tool_proficiencies
 
     def test_unlock_door_path_inspects_thieves_tools_proficiency(self) -> None:
-        """`GameState.attempt_unlock` reads `character.tool_proficiencies`.
+        """`GameState.attempt_unlock` routes tool-flagged unlocks through
+        `make_tool_check`, which is the engine's single consumer of
+        `character.tool_proficiencies`.
 
         Source-level guard: the SRD's "bypass locked doors... with
         Thieves' Tools" promise has a real consumer at
-        `dnd-engine/dnd_engine/core/game_state.py:1093-1099`, where the
-        unlock path checks `method.get("tool_proficiency")` against
-        `character.tool_proficiencies` before resolving the skill
-        check.
+        `dnd-engine/dnd_engine/core/game_state.py` — the unlock path
+        reads `method.get("tool_proficiency")` and delegates to
+        `Character.make_tool_check(...)` so PB applies when the
+        character is tool-proficient and Advantage applies when they
+        are also skill-proficient (SRD § Proficiency › Equipment
+        Proficiencies › Tools).
 
-        The current implementation softens this to "still attempt but
-        without proficiency bonus" rather than blocking the attempt
-        outright — that softer behavior is by design (the SRD does
-        not actually require tool proficiency to make the check; it
-        only adds proficiency bonus). This test pins the
-        consultation, not the rejection.
+        The SRD does not actually require tool proficiency to attempt
+        the check; it only adds PB / Advantage. `make_tool_check`
+        handles the "lacks proficiency" case (delegates to
+        `make_skill_check` or a plain ability check).
         """
         unlock_src = inspect.getsource(GameState.attempt_unlock)
         assert "tool_proficiency" in unlock_src, (
@@ -331,9 +334,10 @@ class TestExploration_AdventuringEquipment_ThievesTools:
             "`tool_proficiency` requirement to honor the SRD's "
             "'bypass locked doors with Thieves' Tools' clause."
         )
-        assert "tool_proficiencies" in unlock_src, (
-            "GameState.attempt_unlock must check the character's "
-            "`tool_proficiencies` list, not just the requirement."
+        assert "make_tool_check" in unlock_src, (
+            "GameState.attempt_unlock must route tool-flagged unlocks "
+            "through `Character.make_tool_check` so PB and the tool+"
+            "skill Advantage are applied per SRD."
         )
 
 

--- a/dnd-engine/tests/srd/playing_the_game/test_proficiency.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_proficiency.py
@@ -20,6 +20,7 @@ import pytest
 
 from dnd_engine.core.character import Character, CharacterClass
 from dnd_engine.core.creature import Abilities
+from dnd_engine.core.dice import DiceRoller
 
 pytestmark = pytest.mark.srd(
     "playing-the-game/proficiency.md",
@@ -820,24 +821,136 @@ class TestProficiency_Tools:
         char.tool_proficiencies = ["thieves_tools"]
         assert "thieves_tools" in char.tool_proficiencies
 
+    def test_is_proficient_with_tool_helper(self) -> None:
+        """`Character.is_proficient_with_tool` answers SRD's tool gate.
+
+        SRD § Proficiency › Equipment Proficiencies › Tools predicates
+        PB on the question "do you have proficiency with the tool used
+        for this check?". A direct helper keeps callers tidy.
+        """
+        char = _make_fighter(level=1)
+        char.tool_proficiencies = ["thieves_tools"]
+        assert char.is_proficient_with_tool("thieves_tools") is True
+        assert char.is_proficient_with_tool("smiths_tools") is False
+
     def test_tool_check_adds_pb_when_proficient(self) -> None:
-        pytest.skip(
-            "GAP: `Character.tool_proficiencies` is stored (dnd-engine/"
-            "dnd_engine/core/character.py:109) but no `make_tool_check` "
-            "or `is_proficient_with_tool` API exists. No ability-check "
-            "surface adds PB based on the tool being used. Tracked by "
-            "issue #483."
+        """Tool proficiency adds PB to the ability check that uses it.
+
+        SRD: "If you have proficiency with a tool, you can add your
+        Proficiency Bonus to any ability check you make that uses the
+        tool." Verified by comparing a tool-proficient character to an
+        identical control without the proficiency, on the same seeded
+        d20.
+        """
+        proficient = _make_fighter(level=1)
+        proficient.tool_proficiencies = ["thieves_tools"]
+        proficient._dice_roller = DiceRoller(seed=7)
+
+        control = _make_fighter(level=1)
+        control.tool_proficiencies = []
+        control._dice_roller = DiceRoller(seed=7)
+
+        prof_result = proficient.make_tool_check(
+            "thieves_tools", dc=15, ability="dex"
+        )
+        ctrl_result = control.make_tool_check(
+            "thieves_tools", dc=15, ability="dex"
         )
 
+        assert prof_result["tool_proficient"] is True
+        assert ctrl_result["tool_proficient"] is False
+        # Same seed → same d20 → totals differ exactly by PB.
+        assert prof_result["roll"] == ctrl_result["roll"]
+        assert prof_result["total"] == ctrl_result["total"] + proficient.proficiency_bonus
+
     def test_tool_plus_skill_proficiency_grants_advantage(self) -> None:
-        pytest.skip(
-            "GAP: SRD: 'If you have proficiency in the skill that's "
-            "also used with that check, you have Advantage on the "
-            "check too.' `Character.make_skill_check` (dnd-engine/"
-            "dnd_engine/core/character.py:726) accepts advantage flags "
-            "but never auto-derives advantage from tool+skill overlap. "
-            "Tracked by issue #483."
+        """Tool + matching skill proficiency auto-grants Advantage.
+
+        SRD: "If you have proficiency in the skill that's also used
+        with that check, you have Advantage on the check too." A
+        seeded roller is shared between two runs: the both-proficient
+        rogue picks the higher of two d20s, so its d20 is >= the
+        tool-only rogue's single d20 (with equality only on
+        same-roll seeds).
+        """
+        skills_data = json.loads(SKILLS_JSON.read_text())
+
+        rogue_both = _make_fighter(level=1)
+        rogue_both.tool_proficiencies = ["thieves_tools"]
+        rogue_both.skill_proficiencies = ["sleight_of_hand", "athletics"]
+        rogue_both._dice_roller = DiceRoller(seed=3)
+
+        rogue_tool_only = _make_fighter(level=1)
+        rogue_tool_only.tool_proficiencies = ["thieves_tools"]
+        rogue_tool_only.skill_proficiencies = ["athletics"]
+        rogue_tool_only._dice_roller = DiceRoller(seed=3)
+
+        both = rogue_both.make_tool_check(
+            "thieves_tools", dc=12,
+            skill="sleight_of_hand", skills_data=skills_data,
         )
+        tool_only = rogue_tool_only.make_tool_check(
+            "thieves_tools", dc=12,
+            skill="sleight_of_hand", skills_data=skills_data,
+        )
+
+        assert both["advantage_from_tool_skill"] is True
+        assert tool_only["advantage_from_tool_skill"] is False
+        # Advantage takes max(d20, d20) — never lower than a single d20.
+        assert both["roll"] >= tool_only["roll"]
+        # PB applied once in both cases (SRD multiplier-once guard).
+        assert both["tool_proficient"] is True and tool_only["tool_proficient"] is True
+
+    def test_tool_check_falls_back_to_skill_when_no_tool_proficiency(self) -> None:
+        """No tool proficiency but skill-proficient → skill PB applies.
+
+        SRD only gates the *tool's* PB on tool proficiency. A
+        skill-proficient character still gets the skill's PB on a
+        plain skill check. `make_tool_check` therefore delegates to
+        `make_skill_check` when only the skill is proficient — no
+        advantage (that requires the tool too), but no regression.
+        """
+        skills_data = json.loads(SKILLS_JSON.read_text())
+
+        char = _make_fighter(level=1)
+        char.tool_proficiencies = []
+        char.skill_proficiencies = ["sleight_of_hand"]
+        char._dice_roller = DiceRoller(seed=11)
+
+        skill_check = char.make_skill_check(
+            "sleight_of_hand", dc=12, skills_data=skills_data,
+        )
+        char._dice_roller = DiceRoller(seed=11)
+        tool_check = char.make_tool_check(
+            "thieves_tools", dc=12,
+            skill="sleight_of_hand", skills_data=skills_data,
+        )
+
+        # Same seed, same path → identical roll and total.
+        assert tool_check["roll"] == skill_check["roll"]
+        assert tool_check["total"] == skill_check["total"]
+        assert tool_check["tool_proficient"] is False
+        assert tool_check["advantage_from_tool_skill"] is False
+
+    def test_tool_check_falls_back_to_plain_ability_check_when_neither(self) -> None:
+        """Neither tool nor skill proficient → plain ability check.
+
+        No PB, no advantage. Identical to `make_ability_check`.
+        """
+        char = _make_fighter(level=1)
+        char.tool_proficiencies = []
+        char.skill_proficiencies = []
+        char._dice_roller = DiceRoller(seed=5)
+
+        baseline = char.make_ability_check("dex", dc=15)
+        char._dice_roller = DiceRoller(seed=5)
+        tool_check = char.make_tool_check("thieves_tools", dc=15, ability="dex")
+
+        assert tool_check["roll"] == baseline["roll"]
+        assert tool_check["total"] == baseline["total"]
+        assert tool_check["tool_proficient"] is False
+        assert tool_check["skill_proficient"] is False
+        assert tool_check["advantage_from_tool_skill"] is False
 
 
 class TestProficiency_Expertise:

--- a/dnd-engine/tests/test_locked_doors.py
+++ b/dnd-engine/tests/test_locked_doors.py
@@ -429,6 +429,26 @@ class TestLockedDoors:
         fighter_result = game_state.attempt_unlock("west", 0, fighter)
         assert fighter_result["success"] is False
 
+    def test_tool_plus_skill_proficient_unlock_gets_advantage(
+        self, game_state_with_locked_doors
+    ):
+        """SRD §483: tool + skill proficient rogue gets Advantage on the unlock.
+
+        The crypt-style west door declares `skill=sleight_of_hand` +
+        `tool_proficiency=thieves_tools`. The rogue fixture has BOTH
+        proficiencies, so `make_tool_check` should auto-grant advantage
+        and the result dict should expose the flag for the event log.
+        """
+        game_state = game_state_with_locked_doors
+        rogue = game_state.party.characters[0]  # has thieves_tools + sleight_of_hand
+
+        result = game_state.attempt_unlock("west", 0, rogue)
+
+        skill_check = result["skill_check_result"]
+        assert skill_check["tool_proficient"] is True
+        assert skill_check["skill_proficient"] is True
+        assert skill_check["advantage_from_tool_skill"] is True
+
     def test_invalid_direction(self, game_state_with_locked_doors):
         """Test attempting to unlock a non-existent exit."""
         game_state = game_state_with_locked_doors


### PR DESCRIPTION
## Summary

Plan-08 slice 7 — closes the last non-deferred SRD gap in plan-08.

SRD § Proficiency › Equipment Proficiencies › Tools:

> If you have proficiency with a tool, you can add your Proficiency Bonus to any ability check you make that uses the tool. If you have proficiency in the skill that's also used with that check, you have Advantage on the check too.

The engine already stored `Character.tool_proficiencies` and the dungeon JSONs already declared `tool_proficiency` on `unlock_methods`, but no code path actually applied the PB or the Advantage. This PR wires the rule end-to-end:

- New `Character.is_proficient_with_tool(tool_id)` helper — the SRD's gate.
- New `Character.make_tool_check(...)` primitive with the SRD behavioral matrix.
- Lock-picking flow in `GameState.attempt_unlock` migrated to route through `make_tool_check` when JSON declares a `tool_proficiency`.

## Behavioral matrix

| tool-proficient | skill named & proficient | Result |
|---|---|---|
| ✅ | ✅ | PB + **Advantage** |
| ✅ | ❌ | PB only |
| ❌ | ✅ | Delegates to `make_skill_check` (skill PB, no advantage) |
| ❌ | ❌ | Plain ability check (no PB, no advantage) |

PB-once is enforced by the existing `d20_test` primitive.

## Changes

- **`dnd-engine/dnd_engine/core/character.py`** — `is_proficient_with_tool`, `make_tool_check`.
- **`dnd-engine/dnd_engine/core/game_state.py`** (`attempt_unlock` ~lines 2051-2090) — routes tool-flagged unlock methods through `make_tool_check`; removes the dead "lacks tool proficiency" `pass` branch.
- **`dnd-engine/tests/srd/playing_the_game/test_proficiency.py`** — lights up 2 GAP skips and adds 3 supporting tests:
  - `test_is_proficient_with_tool_helper` (new)
  - `test_tool_check_adds_pb_when_proficient` (was GAP `#483`)
  - `test_tool_plus_skill_proficiency_grants_advantage` (was GAP `#483`)
  - `test_tool_check_falls_back_to_skill_when_no_tool_proficiency` (new)
  - `test_tool_check_falls_back_to_plain_ability_check_when_neither` (new)
- **`dnd-engine/tests/srd/playing_the_game/test_exploration.py`** — updates source-level SRD guard `test_unlock_door_path_inspects_thieves_tools_proficiency` to track the new call-boundary idiom (`make_tool_check`) instead of the prior inline `tool_proficiencies` literal.
- **`dnd-engine/tests/test_locked_doors.py`** — new behavioral test confirming the rogue (tool + skill proficient) gets `advantage_from_tool_skill=True` on the crypt west-door unlock.

No data file or schema changes. No call-site behavior changes beyond the lock-picking flow.

## Plan-08 context

This is **plan-08 slice 7**. The full plan-08 implemented sequence is now:

| Slice | Issue | PR |
|---|---|---|
| 1 | #484 — D20Test primitive | #653 |
| 2 | #480 — Monster PB from CR | #654 |
| 3 | #481 — PB stacking guards | #655 |
| 4 | #484 — `make_ability_check` primitive | #656 |
| 5 | #487 — Circumstantial modifier channel | #658 |
| 6 | #491 — DC ladder IntEnum | #659 |
| 7 | #483 — Tool + skill advantage | **this PR** |

Remaining work in plan-08 is all `[DEFER]`: #447, #486, #489, #450, #474.

## Testing

- [x] Full test sweep: **3459 passed, 178 skipped** (down 2 from the GAP unskip).
- [x] Ruff lint clean on all changed files.
- [x] `TestProficiency_Tools`: 6 passed (was 1 passed + 2 GAP skips).
- [x] `test_locked_doors.py`: 17 passed (was 16) — existing `test_tool_proficiency_affects_skill_check` still green.
- [x] SRD source-level guard test (`test_unlock_door_path_inspects_thieves_tools_proficiency`) updated and passing.
- [ ] Smoke: pick the locked west door in the crypt with a rogue (manual; the behavioral test covers the rule).

## Related Issues

Fixes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)