### PR TITLE
Add #489: Heroic Inspiration (reroll any d20 + Human day-start grant)

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -174,6 +174,84 @@ class Character(Creature):
         # Darkvision range in feet (0 if no darkvision)
         self.darkvision_range: int = 0
 
+        # SRD § Playing the Game › Heroic Inspiration: a one-shot
+        # reroll any d20; capped at 1 instance per character. Humans
+        # start each day with it (granted on long rest).
+        self.heroic_inspiration: bool = False
+
+    @property
+    def has_heroic_inspiration(self) -> bool:
+        """Return whether the character currently holds Heroic Inspiration."""
+        return self.heroic_inspiration
+
+    def grant_heroic_inspiration(self) -> bool:
+        """
+        Grant Heroic Inspiration to this character.
+
+        SRD § Playing the Game › Heroic Inspiration: a character can
+        never have more than one instance. If something would grant
+        it while the character already has it, the caller is expected
+        to offer the instance to a teammate who lacks it.
+
+        Returns:
+            True if Heroic Inspiration was granted. False if the
+            character already had it (cap of one) — the caller may
+            offer it to another PC.
+        """
+        if self.heroic_inspiration:
+            return False
+        self.heroic_inspiration = True
+        return True
+
+    def spend_heroic_inspiration(self) -> bool:
+        """
+        Consume the held Heroic Inspiration.
+
+        Returns:
+            True if Heroic Inspiration was held and is now spent.
+            False if the character did not have any to spend.
+        """
+        if not self.heroic_inspiration:
+            return False
+        self.heroic_inspiration = False
+        return True
+
+    def _maybe_reroll_d20_for_heroic_inspiration(
+        self,
+        result,
+        use_heroic_inspiration: bool,
+        **d20_kwargs,
+    ):
+        """
+        Spend Heroic Inspiration to reroll the d20 immediately after
+        the initial roll, returning the new roll.
+
+        SRD: "If you have Heroic Inspiration, you can expend it to
+        reroll any die immediately after rolling it, and you must
+        use the new roll." Consumed only when the character actually
+        had Heroic Inspiration and the caller opted in.
+
+        Args:
+            result: The initial :class:`D20Result` to potentially replace.
+            use_heroic_inspiration: Caller intent to spend.
+            **d20_kwargs: Keyword args forwarded to a fresh
+                :func:`d20_test` invocation for the reroll. Must
+                match the original roll's conditions so the reroll
+                is mechanically identical (same ability mod,
+                proficiency, advantage state, circumstantial bonus).
+
+        Returns:
+            Tuple of ``(result, spent)`` where ``result`` is the new
+            :class:`D20Result` if a reroll occurred, otherwise the
+            original; ``spent`` is True iff the inspiration was
+            consumed.
+        """
+        if not use_heroic_inspiration or not self.heroic_inspiration:
+            return result, False
+        new_result = d20_test(roller=self._dice_roller, **d20_kwargs)
+        self.heroic_inspiration = False
+        return new_result, True
+
     @property
     def proficiency_bonus(self) -> int:
         """
@@ -289,6 +367,7 @@ class Character(Creature):
         advantage: bool = False,
         disadvantage: bool = False,
         circumstantial: int = 0,
+        use_heroic_inspiration: bool = False,
         event_bus=None,
     ) -> dict[str, Any]:
         """
@@ -365,13 +444,19 @@ class Character(Creature):
         # preserves that — the primitive defaults to a fresh roller.
         # `Abilities` exposes modifier attrs by short name (`str_mod`,
         # `dex_mod`, …), so look up by `ability_short`.
-        result = d20_test(
-            ability_mod=getattr(self.abilities, f"{ability_short}_mod"),
-            proficient=ability_short in self.saving_throw_proficiencies,
-            proficiency_bonus=self.proficiency_bonus,
-            advantage=advantage,
-            disadvantage=disadvantage,
-            circumstantial=circumstantial,
+        d20_kwargs = {
+            "ability_mod": getattr(self.abilities, f"{ability_short}_mod"),
+            "proficient": ability_short in self.saving_throw_proficiencies,
+            "proficiency_bonus": self.proficiency_bonus,
+            "advantage": advantage,
+            "disadvantage": disadvantage,
+            "circumstantial": circumstantial,
+        }
+        result = d20_test(**d20_kwargs)
+        result, heroic_inspiration_spent = (
+            self._maybe_reroll_d20_for_heroic_inspiration(
+                result, use_heroic_inspiration, **d20_kwargs
+            )
         )
 
         success = result.succeeds_against(dc)
@@ -384,6 +469,7 @@ class Character(Creature):
             "dc": dc,
             "ability": ability_short,
             "circumstantial": circumstantial,
+            "heroic_inspiration_spent": heroic_inspiration_spent,
         }
 
         # Emit event if event bus is provided
@@ -908,6 +994,7 @@ class Character(Creature):
         advantage: bool = False,
         disadvantage: bool = False,
         circumstantial: int = 0,
+        use_heroic_inspiration: bool = False,
         event_bus=None,
     ) -> dict[str, Any]:
         """
@@ -961,12 +1048,17 @@ class Character(Creature):
 
         ability_mod = getattr(self.abilities, f"{ability_short}_mod")
 
-        result = d20_test(
-            ability_mod=ability_mod,
-            advantage=advantage,
-            disadvantage=disadvantage,
-            circumstantial=circumstantial,
-            roller=self._dice_roller,
+        d20_kwargs = {
+            "ability_mod": ability_mod,
+            "advantage": advantage,
+            "disadvantage": disadvantage,
+            "circumstantial": circumstantial,
+        }
+        result = d20_test(**d20_kwargs, roller=self._dice_roller)
+        result, heroic_inspiration_spent = (
+            self._maybe_reroll_d20_for_heroic_inspiration(
+                result, use_heroic_inspiration, **d20_kwargs
+            )
         )
 
         success = result.succeeds_against(dc)
@@ -978,6 +1070,7 @@ class Character(Creature):
             "dc": dc,
             "ability": ability_short,
             "circumstantial": circumstantial,
+            "heroic_inspiration_spent": heroic_inspiration_spent,
         }
 
         if event_bus is not None:
@@ -998,6 +1091,7 @@ class Character(Creature):
         advantage: bool = False,
         disadvantage: bool = False,
         circumstantial: int = 0,
+        use_heroic_inspiration: bool = False,
     ) -> dict:
         """
         Roll a skill check against a difficulty class (DC).
@@ -1045,15 +1139,20 @@ class Character(Creature):
             advantage = True
             self.pending_help_from = None
 
-        result = d20_test(
-            ability_mod=getattr(self.abilities, f"{ability_key}_mod"),
-            proficient=proficient,
-            proficiency_bonus=self.proficiency_bonus,
-            expertise=skill in self.expertise_skills,
-            advantage=advantage,
-            disadvantage=disadvantage,
-            circumstantial=circumstantial,
-            roller=self._dice_roller,
+        d20_kwargs = {
+            "ability_mod": getattr(self.abilities, f"{ability_key}_mod"),
+            "proficient": proficient,
+            "proficiency_bonus": self.proficiency_bonus,
+            "expertise": skill in self.expertise_skills,
+            "advantage": advantage,
+            "disadvantage": disadvantage,
+            "circumstantial": circumstantial,
+        }
+        result = d20_test(**d20_kwargs, roller=self._dice_roller)
+        result, heroic_inspiration_spent = (
+            self._maybe_reroll_d20_for_heroic_inspiration(
+                result, use_heroic_inspiration, **d20_kwargs
+            )
         )
 
         return {
@@ -1066,6 +1165,7 @@ class Character(Creature):
             "success": result.succeeds_against(dc),
             "proficient": proficient,
             "circumstantial": circumstantial,
+            "heroic_inspiration_spent": heroic_inspiration_spent,
         }
 
     def make_tool_check(
@@ -1079,6 +1179,7 @@ class Character(Creature):
         advantage: bool = False,
         disadvantage: bool = False,
         circumstantial: int = 0,
+        use_heroic_inspiration: bool = False,
     ) -> dict:
         """
         Roll an ability check that involves a tool.
@@ -1157,6 +1258,7 @@ class Character(Creature):
                 advantage=advantage,
                 disadvantage=disadvantage,
                 circumstantial=circumstantial,
+                use_heroic_inspiration=use_heroic_inspiration,
             )
             return {
                 "tool": tool_id,
@@ -1171,6 +1273,9 @@ class Character(Creature):
                 "skill_proficient": True,
                 "advantage_from_tool_skill": False,
                 "circumstantial": circumstantial,
+                "heroic_inspiration_spent": result.get(
+                    "heroic_inspiration_spent", False
+                ),
             }
 
         if skill is not None:
@@ -1202,14 +1307,19 @@ class Character(Creature):
         ability_mod = getattr(self.abilities, f"{ability_short}_mod")
         auto_advantage = tool_proficient and skill_proficient
 
-        result = d20_test(
-            ability_mod=ability_mod,
-            proficient=tool_proficient,
-            proficiency_bonus=self.proficiency_bonus,
-            advantage=advantage or auto_advantage,
-            disadvantage=disadvantage,
-            circumstantial=circumstantial,
-            roller=self._dice_roller,
+        d20_kwargs = {
+            "ability_mod": ability_mod,
+            "proficient": tool_proficient,
+            "proficiency_bonus": self.proficiency_bonus,
+            "advantage": advantage or auto_advantage,
+            "disadvantage": disadvantage,
+            "circumstantial": circumstantial,
+        }
+        result = d20_test(**d20_kwargs, roller=self._dice_roller)
+        result, heroic_inspiration_spent = (
+            self._maybe_reroll_d20_for_heroic_inspiration(
+                result, use_heroic_inspiration, **d20_kwargs
+            )
         )
 
         modifier = ability_mod + (
@@ -1229,6 +1339,7 @@ class Character(Creature):
             "skill_proficient": skill_proficient,
             "advantage_from_tool_skill": auto_advantage,
             "circumstantial": circumstantial,
+            "heroic_inspiration_spent": heroic_inspiration_spent,
         }
 
     def get_sneak_attack_dice(self) -> str | None:
@@ -1815,6 +1926,13 @@ class Character(Creature):
         prepared_caster_classes = {CharacterClass.WIZARD, CharacterClass.CLERIC}
         can_prepare = self.character_class in prepared_caster_classes and not character_is_dead
 
+        # SRD § Heroic Inspiration: "Human characters start each day
+        # with Heroic Inspiration." Long Rest is the engine's proxy
+        # for the day boundary; dead characters do not benefit.
+        heroic_inspiration_granted = False
+        if not character_is_dead and self.race.lower() == "human":
+            heroic_inspiration_granted = self.grant_heroic_inspiration()
+
         return {
             "character": self.name,
             "rest_type": "long",
@@ -1822,6 +1940,7 @@ class Character(Creature):
             "resources_recovered": resources_recovered,
             "can_prepare_spells": can_prepare,
             "conditions_removed": conditions_removed,
+            "heroic_inspiration_granted": heroic_inspiration_granted,
         }
 
     @property

--- a/dnd-engine/tests/srd/playing_the_game/test_advantage_disadvantage.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_advantage_disadvantage.py
@@ -190,33 +190,119 @@ class TestHeroicInspiration:
     """
 
     def test_character_carries_heroic_inspiration_state(self):
-        pytest.skip(
-            "GAP: Heroic Inspiration is not implemented. No "
-            "`heroic_inspiration` field on `Character` "
-            "(dnd-engine/dnd_engine/core/character.py:35-127). "
-            "`dnd_engine/systems/resources.py` manages spell slots, "
-            "ki, rage uses, and bardic inspiration — Heroic "
-            "Inspiration is absent. Tracked by issue #489."
+        """`Character.heroic_inspiration` is a one-shot flag.
+
+        Fresh characters do not hold Heroic Inspiration. The
+        `grant_heroic_inspiration` / `spend_heroic_inspiration`
+        helpers (dnd-engine/dnd_engine/core/character.py) and the
+        `has_heroic_inspiration` property gate the reroll path.
+        """
+        fighter = _make_fighter()
+        assert fighter.has_heroic_inspiration is False
+        assert fighter.grant_heroic_inspiration() is True
+        assert fighter.has_heroic_inspiration is True
+        assert fighter.spend_heroic_inspiration() is True
+        assert fighter.has_heroic_inspiration is False
+
+    def test_heroic_inspiration_can_be_spent_to_reroll_d20(self, monkeypatch):
+        """The d20-test surface reroll uses the new roll, per SRD.
+
+        With Heroic Inspiration held, a `make_skill_check` opting in
+        via `use_heroic_inspiration=True` rerolls the d20 once and
+        keeps the new result (not the better of the two).
+        """
+        from dnd_engine.core import character as character_module
+        from dnd_engine.systems.d20 import AdvantageState, D20Result
+
+        fighter = _make_fighter()
+        fighter.grant_heroic_inspiration()
+
+        rolls = iter([
+            D20Result(
+                d20=3,
+                total=3 + fighter.proficiency_bonus + fighter.abilities.str_mod,
+                advantage_state=AdvantageState.NORMAL,
+                components={
+                    "ability_mod": fighter.abilities.str_mod,
+                    "proficiency": fighter.proficiency_bonus,
+                    "circumstantial": 0,
+                },
+                rolls=(3,),
+            ),
+            D20Result(
+                d20=18,
+                total=18 + fighter.proficiency_bonus + fighter.abilities.str_mod,
+                advantage_state=AdvantageState.NORMAL,
+                components={
+                    "ability_mod": fighter.abilities.str_mod,
+                    "proficiency": fighter.proficiency_bonus,
+                    "circumstantial": 0,
+                },
+                rolls=(18,),
+            ),
+        ])
+        monkeypatch.setattr(
+            character_module,
+            "d20_test",
+            lambda *a, **kw: next(rolls),
         )
 
-    def test_heroic_inspiration_can_be_spent_to_reroll_d20(self):
-        pytest.skip(
-            "GAP: no hook on `make_skill_check` / `make_saving_throw` "
-            "/ `resolve_attack` to spend Heroic Inspiration for a "
-            "reroll. The dice roller's advantage path "
-            "(dnd-engine/dnd_engine/core/dice.py:111-113) is the "
-            "closest mechanic but it picks max(d1,d2) — Heroic "
-            "Inspiration picks *either* die, which is different. "
-            "Tracked by issue #489."
+        skills_data = {"athletics": {"ability": "str"}}
+        result = fighter.make_skill_check(
+            "athletics", dc=15, skills_data=skills_data,
+            use_heroic_inspiration=True,
         )
 
-    def test_heroic_inspiration_is_consumed_on_use(self):
-        pytest.skip(
-            "GAP: depends on the field existing. The SRD rule is that "
-            "Heroic Inspiration is a one-shot per character — once "
-            "spent it's gone until granted again. Tracked by issue "
-            "#489."
+        # SRD: "must use the new roll" — second roll wins, not max.
+        assert result["roll"] == 18
+        assert result["heroic_inspiration_spent"] is True
+
+    def test_heroic_inspiration_is_consumed_on_use(self, monkeypatch):
+        """Spending Heroic Inspiration clears the flag.
+
+        A second check with `use_heroic_inspiration=True` after the
+        flag is consumed does not reroll and reports no spend.
+        """
+        from dnd_engine.core import character as character_module
+        from dnd_engine.systems.d20 import AdvantageState, D20Result
+
+        fighter = _make_fighter()
+        fighter.grant_heroic_inspiration()
+
+        def make_result(d20: int) -> D20Result:
+            return D20Result(
+                d20=d20,
+                total=d20 + fighter.proficiency_bonus + fighter.abilities.str_mod,
+                advantage_state=AdvantageState.NORMAL,
+                components={
+                    "ability_mod": fighter.abilities.str_mod,
+                    "proficiency": fighter.proficiency_bonus,
+                    "circumstantial": 0,
+                },
+                rolls=(d20,),
+            )
+
+        rolls = iter([make_result(1), make_result(20), make_result(5)])
+        monkeypatch.setattr(
+            character_module,
+            "d20_test",
+            lambda *a, **kw: next(rolls),
         )
+
+        skills_data = {"athletics": {"ability": "str"}}
+        first = fighter.make_skill_check(
+            "athletics", dc=15, skills_data=skills_data,
+            use_heroic_inspiration=True,
+        )
+        assert first["heroic_inspiration_spent"] is True
+        assert fighter.has_heroic_inspiration is False
+
+        second = fighter.make_skill_check(
+            "athletics", dc=15, skills_data=skills_data,
+            use_heroic_inspiration=True,
+        )
+        assert second["heroic_inspiration_spent"] is False
+        assert second["roll"] == 5
 
 
 class TestSurfaceParity_NotPropagatedOnCreature:

--- a/dnd-engine/tests/srd/playing_the_game/test_proficiency.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_proficiency.py
@@ -68,31 +68,80 @@ class TestProficiency_HeroicInspiration:
     > die immediately after rolling it, and you must use the new roll.
     """
 
-    def test_heroic_inspiration_lets_you_reroll_any_die(self) -> None:
-        pytest.skip(
-            "GAP: Heroic Inspiration is not implemented anywhere. No "
-            "`has_heroic_inspiration` flag on `Character` (dnd-engine/"
-            "dnd_engine/core/character.py:23), and `DiceRoller` "
-            "(dnd-engine/dnd_engine/core/dice.py) has no consume-to-"
-            "reroll API. Tracked by issue #478."
+    def test_heroic_inspiration_lets_you_reroll_any_die(
+        self, monkeypatch
+    ) -> None:
+        """A saving-throw reroll uses the new d20 result.
+
+        SRD: a character may expend Heroic Inspiration to reroll any
+        die and must use the new roll. Verified on
+        `Character.make_saving_throw` (issue #489).
+        """
+        from dnd_engine.core import character as character_module
+        from dnd_engine.systems.d20 import AdvantageState, D20Result
+
+        fighter = _make_fighter()
+        fighter.grant_heroic_inspiration()
+
+        def make_result(d20: int) -> D20Result:
+            return D20Result(
+                d20=d20,
+                total=d20 + fighter.proficiency_bonus + fighter.abilities.str_mod,
+                advantage_state=AdvantageState.NORMAL,
+                components={
+                    "ability_mod": fighter.abilities.str_mod,
+                    "proficiency": fighter.proficiency_bonus,
+                    "circumstantial": 0,
+                },
+                rolls=(d20,),
+            )
+
+        rolls = iter([make_result(2), make_result(17)])
+        monkeypatch.setattr(
+            character_module,
+            "d20_test",
+            lambda *a, **kw: next(rolls),
         )
+
+        result = fighter.make_saving_throw(
+            "str", dc=15, use_heroic_inspiration=True
+        )
+        assert result["roll"] == 17
+        assert result["heroic_inspiration_spent"] is True
+        assert fighter.has_heroic_inspiration is False
 
     def test_heroic_inspiration_cap_of_one_instance(self) -> None:
-        pytest.skip(
-            "GAP: SRD: 'You can never have more than one instance of "
-            "Heroic Inspiration. If something gives you Heroic "
-            "Inspiration and you already have it, you can give it to a "
-            "player character in your group who lacks it.' No cap-and-"
-            "transfer surface on `Character`. Tracked by issue #478."
-        )
+        """Cap of one instance; second grant signals transferable.
+
+        SRD: a character can never hold more than one instance. The
+        grant API returns False when the character already holds
+        Heroic Inspiration so the caller can offer it to another PC.
+        """
+        fighter = _make_fighter()
+        assert fighter.grant_heroic_inspiration() is True
+        assert fighter.has_heroic_inspiration is True
+        assert fighter.grant_heroic_inspiration() is False
+        assert fighter.has_heroic_inspiration is True
 
     def test_human_starts_each_day_with_heroic_inspiration(self) -> None:
-        pytest.skip(
-            "GAP: SRD: 'Human characters start each day with Heroic "
-            "Inspiration.' `races.json` defines a Human entry but no "
-            "engine code grants the flag at session start or after a "
-            "long rest. Tracked by issue #478."
-        )
+        """Long rest grants Heroic Inspiration to Humans only.
+
+        SRD: 'Human characters start each day with Heroic
+        Inspiration.' Long Rest is the engine's proxy for the day
+        boundary (issue #489). Non-human races do not get the grant.
+        """
+        human = _make_fighter()
+        human.race = "human"
+        assert human.has_heroic_inspiration is False
+        result = human.take_long_rest()
+        assert result["heroic_inspiration_granted"] is True
+        assert human.has_heroic_inspiration is True
+
+        elf = _make_fighter()
+        elf.race = "high_elf"
+        elf_result = elf.take_long_rest()
+        assert elf_result["heroic_inspiration_granted"] is False
+        assert elf.has_heroic_inspiration is False
 
 
 class TestProficiency_BonusByLevel:


### PR DESCRIPTION
## Summary

Implements SRD § Playing the Game › Heroic Inspiration — a one-shot flag a character may expend to reroll any d20, must use the new roll. Closes #489.

- `Character.heroic_inspiration: bool` field (capped at 1 instance)
- Grant / spend / has API on `Character`; second grant returns False so callers can offer transfer
- `use_heroic_inspiration` kwarg threaded into `make_ability_check`, `make_skill_check`, `make_saving_throw`, `make_tool_check`; reroll consumes the flag and reports `heroic_inspiration_spent` on the result dict
- `take_long_rest` grants Heroic Inspiration to `race == "human"` as the engine's day-boundary proxy; surfaces `heroic_inspiration_granted`
- 6 GAP-skipped tests replaced with real coverage across `test_advantage_disadvantage.py` and `test_proficiency.py`

`resolve_attack` reroll is intentionally deferred — the d20-check/save surface covers the issue's tracked tests; attacks can be a follow-up if desired.

## Test plan

- [x] `pytest tests/srd/playing_the_game/test_advantage_disadvantage.py::TestHeroicInspiration` — 3 pass
- [x] `pytest tests/srd/playing_the_game/test_proficiency.py::TestProficiency_HeroicInspiration` — 3 pass
- [x] Full suite: 3465 passed, 172 skipped (was 178 — 6 GAP skips removed)
- [ ] Manual sanity check that long rest for a human PC reports `heroic_inspiration_granted: True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)