### PR TITLE
Add #447: voluntary save-fail (auto_fail kwarg)

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -368,6 +368,7 @@ class Character(Creature):
         disadvantage: bool = False,
         circumstantial: int = 0,
         use_heroic_inspiration: bool = False,
+        auto_fail: bool = False,
         event_bus=None,
     ) -> dict[str, Any]:
         """
@@ -384,6 +385,12 @@ class Character(Creature):
                 once those spells are plumbed. Forwarded to the
                 d20-test primitive and surfaced on the returned dict
                 and emitted event for telemetry.
+            auto_fail: SRD § Playing the Game › Saving Throws › "If you
+                don't want to resist the effect, you can choose to fail
+                the save without rolling." When True, no d20 is rolled
+                and the result dict reports `success=False`, `roll=0`,
+                `total=modifier`. Used by willing targets opting into
+                friendly Charm/Polymorph and similar effects.
             event_bus: Optional EventBus instance to emit saving throw event
 
         Returns:
@@ -427,6 +434,45 @@ class Character(Creature):
         else:
             raise ValueError(f"Invalid ability name: {ability}")
 
+        modifier = self.get_saving_throw_modifier(ability)
+
+        # SRD § Playing the Game › Saving Throws › Choose to Fail:
+        # "If you don't want to resist the effect, you can choose to
+        # fail the save without rolling." Short-circuit before any
+        # d20 is rolled and return the same payload shape as the
+        # rolling path so downstream effect handlers don't need to
+        # special-case voluntary fails.
+        if auto_fail:
+            result_dict: dict[str, Any] = {
+                "success": False,
+                "roll": 0,
+                "modifier": modifier,
+                "total": modifier,
+                "dc": dc,
+                "ability": ability_short,
+                "circumstantial": circumstantial,
+                "heroic_inspiration_spent": False,
+            }
+            if event_bus is not None:
+                from dnd_engine.utils.events import Event, EventType
+
+                event = Event(
+                    type=EventType.SAVING_THROW,
+                    data={
+                        "character": self.name,
+                        "ability": ability_short,
+                        "dc": dc,
+                        "roll": 0,
+                        "modifier": modifier,
+                        "total": modifier,
+                        "success": False,
+                        "circumstantial": circumstantial,
+                        "auto_fail": True,
+                    },
+                )
+                event_bus.emit(event)
+            return result_dict
+
         # SRD § Actions › Dodge: a dodging creature rolls DEX saves with
         # Advantage, unless they are Incapacitated or their Speed is 0.
         if (
@@ -436,8 +482,6 @@ class Character(Creature):
             and self.speed > 0
         ):
             advantage = True
-
-        modifier = self.get_saving_throw_modifier(ability)
 
         # Legacy `make_saving_throw` constructed a fresh `DiceRoller`
         # rather than reusing `self._dice_roller`; omitting `roller`

--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -749,6 +749,7 @@ class Creature:
         advantage: bool = False,
         disadvantage: bool = False,
         circumstantial: int = 0,
+        auto_fail: bool = False,
         event_bus=None,
     ) -> dict:
         """
@@ -766,6 +767,11 @@ class Creature:
                 spells, or "another rule" per SRD § Playing the Game ›
                 D20 Tests › Step 5. Forwarded to the d20-test primitive
                 and surfaced on the returned dict for telemetry.
+            auto_fail: SRD § Playing the Game › Saving Throws › "If you
+                don't want to resist the effect, you can choose to fail
+                the save without rolling." When True, no d20 is rolled
+                and the result dict reports `success=False`, `roll=0`,
+                `total=modifier`.
             event_bus: Optional EventBus instance to emit saving throw event
 
         Returns:
@@ -834,6 +840,22 @@ class Creature:
             modifier = self.abilities.cha_mod
         else:
             raise ValueError(f"Invalid ability name: {ability}")
+
+        # SRD § Playing the Game › Saving Throws › Choose to Fail:
+        # "If you don't want to resist the effect, you can choose to
+        # fail the save without rolling." Short-circuit before any
+        # d20 is rolled and return the same payload shape as the
+        # rolling path.
+        if auto_fail:
+            return {
+                "success": False,
+                "roll": 0,
+                "modifier": modifier,
+                "total": modifier,
+                "dc": dc,
+                "ability": ability_short,
+                "circumstantial": circumstantial,
+            }
 
         # Creatures have no proficient saves in the data model today
         # (PB-from-CR derivation is plan-08 slice 2). The primitive's

--- a/dnd-engine/tests/srd/playing_the_game/test_saving_throws.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_saving_throws.py
@@ -125,17 +125,48 @@ class TestDefinition_ChooseToFail:
     """
 
     def test_save_target_can_opt_to_fail_without_rolling(self):
-        pytest.skip(
-            "GAP: `Character.make_saving_throw` and "
-            "`Creature.make_saving_throw` always roll a d20 — there is "
-            "no `auto_fail`/`choose_to_fail` parameter and no call "
-            "site that lets a target voluntarily forgo the save. "
-            "See dnd_engine/core/character.py:237-339 and "
-            "dnd_engine/core/creature.py:475-578. A search for "
-            "'choose to fail' / 'auto fail' in the engine returns no "
-            "hits. Used in play when a willing target opts into a "
-            "friendly Charm or Polymorph. Tracked by issue #447."
+        """`auto_fail=True` short-circuits the save before any d20 roll.
+
+        SRD: "If you don't want to resist the effect, you can choose
+        to fail the save without rolling." Engine surface is an
+        `auto_fail` kwarg on `Character.make_saving_throw` and
+        `Creature.make_saving_throw`. When set, the methods return the
+        same SRD-shaped result dict as the rolling path but with
+        `success=False`, `roll=0`, and `total=modifier` — no d20 is
+        rolled.
+        """
+        fighter = _make_fighter()
+
+        result = fighter.make_saving_throw(
+            ability="con", dc=10, auto_fail=True
         )
+
+        assert result["success"] is False
+        assert result["roll"] == 0
+        assert result["ability"] == "con"
+        assert result["dc"] == 10
+        # All documented payload keys are still present so downstream
+        # effect handlers don't have to special-case voluntary fails.
+        for key in (
+            "success",
+            "roll",
+            "modifier",
+            "total",
+            "dc",
+            "ability",
+            "circumstantial",
+        ):
+            assert key in result, f"auto_fail result missing field {key!r}"
+
+        # Creatures (monsters) expose the same opt-in.
+        creature = _make_creature()
+        creature_result = creature.make_saving_throw(
+            ability="dex", dc=15, auto_fail=True
+        )
+        assert creature_result["success"] is False
+        assert creature_result["roll"] == 0
+        assert creature_result["ability"] == "dex"
+        assert creature_result["dc"] == 15
 
 
 class TestAbilityModifier_NamedForAbility:


### PR DESCRIPTION
Closes #447.

## Summary
- Adds `auto_fail: bool = False` to `Character.make_saving_throw` and `Creature.make_saving_throw`.
- When set, the save short-circuits before any d20 is rolled and returns the same SRD-shaped result dict with `success=False`, `roll=0`, `total=modifier` — so downstream effect handlers don't have to special-case voluntary fails.
- Promotes the SRD GAP-skipped test `TestDefinition_ChooseToFail::test_save_target_can_opt_to_fail_without_rolling` into a real behavioral test (covers both `Character` and `Creature`).

Skip count on `tests/srd/playing_the_game/test_saving_throws.py` drops from 2 to 1.

## SRD reference
> If you don't want to resist the effect, you can choose to fail the save without rolling.
— Playing the Game › Saving Throws › Choose to Fail

## Scope
Per the plan-08 slice pattern (#483 / #489), this lands the engine surface only. Threading `auto_fail` through specific call sites (friendly Charm / Polymorph targets and similar willing-target effects) is intentionally deferred to a follow-up — no current call site needs it yet, and no test demands it.

## Test plan
- [x] `uv run pytest dnd-engine/tests/srd/playing_the_game/test_saving_throws.py` — 13 passed, 1 skipped (was 12 passed, 2 skipped).
- [x] `uv run pytest dnd-engine/tests/test_saving_throws.py dnd-engine/tests/test_spell_saving_throws.py dnd-engine/tests/test_creature.py dnd-engine/tests/srd/playing_the_game/test_saving_throws_and_damage.py` — all green (107 passed, 1 skipped).
- [x] Full sweep: 3461 passed, 173 skipped. The 3 `test_advantage_disadvantage` source-text-introspection failures reproduce on `origin/main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)