### PR TITLE
Add #486: Ability score caps and zero-reduction (plan-08 slice 8)

### DIFF
--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -69,13 +69,34 @@ class MovementMode(str, Enum):
     BURROW = "burrow"
 
 
+ABILITY_SCORE_FLOOR = 1
+ABILITY_SCORE_CEILING = 30
+ADVENTURER_SCORE_CAP = 20
+
+ABILITY_KEYS = (
+    "strength",
+    "dexterity",
+    "constitution",
+    "intelligence",
+    "wisdom",
+    "charisma",
+)
+
+
 @dataclass
 class Abilities:
     """
     D&D 5E ability scores (STR, DEX, CON, INT, WIS, CHA).
 
-    Ability scores typically range from 1-20 for player characters and monsters.
-    Each score provides a modifier calculated as: (score - 10) // 2
+    Per SRD § Playing the Game › The Six Abilities › Ability Scores, every
+    score is in the inclusive range ``[1, 30]``. Adventurers (player
+    characters) are additionally soft-capped at 20 unless a feature
+    explicitly permits exceeding it; use :meth:`for_adventurer` to enforce
+    that tighter ceiling at construction time. Scores of 0 are only
+    reachable transiently via :meth:`reduce_score`, which the SRD reserves
+    for named ability-score-reducing effects.
+
+    Each score provides a modifier calculated as: ``(score - 10) // 2``.
     """
 
     strength: int
@@ -84,6 +105,90 @@ class Abilities:
     intelligence: int
     wisdom: int
     charisma: int
+
+    def __post_init__(self) -> None:
+        """Validate every score is within the SRD's absolute ``[1, 30]`` range.
+
+        The SRD pins an absolute ceiling of 30 for any creature and a floor
+        of 1 (a score of 0 is only reachable transiently via ability-score
+        reduction effects -- see :meth:`reduce_score`). Out-of-range values
+        at construction time are bugs and raise ``ValueError``.
+        """
+        for key in ABILITY_KEYS:
+            value = getattr(self, key)
+            if not ABILITY_SCORE_FLOOR <= value <= ABILITY_SCORE_CEILING:
+                raise ValueError(
+                    f"Ability score {key}={value} is outside the SRD's "
+                    f"[{ABILITY_SCORE_FLOOR}, {ABILITY_SCORE_CEILING}] range."
+                )
+
+    @classmethod
+    def for_adventurer(
+        cls,
+        *,
+        strength: int,
+        dexterity: int,
+        constitution: int,
+        intelligence: int,
+        wisdom: int,
+        charisma: int,
+        features_allowing_above_20: tuple[str, ...] = (),
+    ) -> Abilities:
+        """Construct an :class:`Abilities` for a player character.
+
+        Adventurers are soft-capped at 20 (SRD § The Six Abilities ›
+        Ability Scores). Scores above 20 are only legal when a feature
+        explicitly permits exceeding the cap (e.g., a magic item or
+        epic-tier feature); pass the names of such features in
+        ``features_allowing_above_20`` to permit the higher value. The
+        absolute ``[1, 30]`` range from :meth:`__post_init__` still
+        applies.
+        """
+        scores = {
+            "strength": strength,
+            "dexterity": dexterity,
+            "constitution": constitution,
+            "intelligence": intelligence,
+            "wisdom": wisdom,
+            "charisma": charisma,
+        }
+        if not features_allowing_above_20:
+            for key, value in scores.items():
+                if value > ADVENTURER_SCORE_CAP:
+                    raise ValueError(
+                        f"Ability score {key}={value} exceeds the adventurer "
+                        f"cap of {ADVENTURER_SCORE_CAP}; supply "
+                        f"`features_allowing_above_20` to permit the higher "
+                        f"value."
+                    )
+        return cls(**scores)
+
+    def reduce_score(self, ability: str, amount: int, source: str) -> None:
+        """Reduce an ability score by ``amount`` from a named effect.
+
+        Implements SRD § The Six Abilities › Ability Scores › "If an effect
+        reduces a score to 0, that effect explains what happens." The
+        ``source`` parameter names that effect; it MUST be a non-empty
+        string so a score cannot be driven to (or below) 0 anonymously.
+        The score is floored at 0 -- ability-score reduction cannot drive
+        a score negative.
+        """
+        if ability not in ABILITY_KEYS:
+            raise ValueError(
+                f"Unknown ability {ability!r}; expected one of {ABILITY_KEYS}."
+            )
+        if amount < 0:
+            raise ValueError(
+                f"reduce_score amount must be non-negative; got {amount}."
+            )
+        if not source:
+            raise ValueError(
+                "reduce_score requires a non-empty `source` naming the "
+                "effect (SRD: the effect explains what reaching 0 means)."
+            )
+        current = getattr(self, ability)
+        new_value = max(0, current - amount)
+        setattr(self, ability, new_value)
 
     @property
     def str_mod(self) -> int:

--- a/dnd-engine/tests/srd/playing_the_game/test_the_six_abilities.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_the_six_abilities.py
@@ -213,32 +213,73 @@ class TestSixAbilities_ScoreRange:
     > have a score as high as 30.
     """
 
-    def test_score_floor_of_one_is_not_enforced_at_construction(self) -> None:
-        pytest.skip(
-            "GAP: `Abilities` (dnd-engine/dnd_engine/core/creature.py:"
-            "10-24) is a plain dataclass with no `__post_init__` "
-            "validation. Constructing `Abilities(strength=0, ...)` "
-            "succeeds, violating the SRD floor of 1. Tracked by "
-            "issue #486."
-        )
+    def test_score_floor_of_one_is_enforced_at_construction(self) -> None:
+        """`Abilities(strength=0, ...)` raises ``ValueError``.
 
-    def test_adventurer_score_cap_of_20_is_not_enforced(self) -> None:
-        pytest.skip(
-            "GAP: SRD pins a soft cap of 20 for adventurers (player "
-            "characters), with 21-30 reserved for extraordinary "
-            "creatures (typically monsters). `Character.__init__` "
-            "(dnd-engine/dnd_engine/core/character.py:35) accepts any "
-            "`Abilities` instance without checking whether a feature "
-            "permits exceeding 20. Tracked by issue #486."
-        )
+        SRD pins the floor at 1; a score of 0 is only reachable
+        transiently via :meth:`Abilities.reduce_score`, never at
+        construction. Source-level binding at
+        dnd-engine/dnd_engine/core/creature.py — `Abilities.__post_init__`.
+        """
+        with pytest.raises(ValueError, match="strength=0"):
+            Abilities(
+                strength=0,
+                dexterity=10,
+                constitution=10,
+                intelligence=10,
+                wisdom=10,
+                charisma=10,
+            )
 
-    def test_hard_score_cap_of_30_is_not_enforced(self) -> None:
-        pytest.skip(
-            "GAP: SRD pins an absolute ceiling of 30 for any creature. "
-            "`Abilities` (dnd-engine/dnd_engine/core/creature.py:10-24) "
-            "does not validate this — `Abilities(strength=99, ...)` "
-            "succeeds silently. Tracked by issue #486."
+    def test_adventurer_score_cap_of_20_is_enforced(self) -> None:
+        """`Abilities.for_adventurer(..., strength=21)` raises by default.
+
+        SRD pins a soft cap of 20 for adventurers (player characters),
+        with 21-30 reserved for extraordinary creatures or feature-gated
+        edge cases. :meth:`Abilities.for_adventurer` enforces the 20
+        ceiling unless the caller passes
+        ``features_allowing_above_20`` naming the feature that permits
+        the higher value.
+        """
+        with pytest.raises(ValueError, match="adventurer cap"):
+            Abilities.for_adventurer(
+                strength=21,
+                dexterity=10,
+                constitution=10,
+                intelligence=10,
+                wisdom=10,
+                charisma=10,
+            )
+
+        # Feature override permits exceeding 20 (still bounded by the
+        # absolute [1, 30] ceiling from __post_init__).
+        abilities = Abilities.for_adventurer(
+            strength=22,
+            dexterity=10,
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
+            features_allowing_above_20=("Manual of Gainful Exercise",),
         )
+        assert abilities.strength == 22
+
+    def test_hard_score_cap_of_30_is_enforced(self) -> None:
+        """`Abilities(strength=31, ...)` raises ``ValueError``.
+
+        SRD pins an absolute ceiling of 30 for any creature.
+        Source-level binding at
+        dnd-engine/dnd_engine/core/creature.py — `Abilities.__post_init__`.
+        """
+        with pytest.raises(ValueError, match="strength=31"):
+            Abilities(
+                strength=31,
+                dexterity=10,
+                constitution=10,
+                intelligence=10,
+                wisdom=10,
+                charisma=10,
+            )
 
     def test_monster_ability_scores_are_within_one_to_thirty(self) -> None:
         """Catalog parity: every monster's ability scores are in [1, 30].
@@ -271,15 +312,42 @@ class TestSixAbilities_ScoreReducedToZero:
     > happens.
     """
 
-    def test_no_general_zero_reduction_pathway_exists(self) -> None:
-        pytest.skip(
-            "GAP: no engine code path lets an effect 'reduce a score "
-            "to 0' — `Abilities` (dnd-engine/dnd_engine/core/creature.py:"
-            "10-24) has no mutator API at all; scores are set once at "
-            "construction. The SRD requires that the *effect* explain "
-            "the consequences, which presupposes the mutator exists. "
-            "Tracked by issue #486."
+    def test_reduce_score_mutator_requires_a_named_source(self) -> None:
+        """`Abilities.reduce_score` requires a non-empty ``source``.
+
+        The SRD requires that any effect reducing a score to 0 *explain*
+        the consequences. :meth:`Abilities.reduce_score` enforces that by
+        refusing to mutate unless the caller names the effect, so a
+        score cannot be driven to 0 anonymously. The score floors at 0
+        rather than going negative.
+        """
+        abilities = Abilities(
+            strength=10,
+            dexterity=10,
+            constitution=10,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
         )
+
+        # Anonymous reduction is rejected.
+        with pytest.raises(ValueError, match="non-empty `source`"):
+            abilities.reduce_score("strength", 5, source="")
+        assert abilities.strength == 10  # unchanged
+
+        # Named reduction is allowed and floors at 0 (not negative).
+        abilities.reduce_score(
+            "strength", amount=15, source="Shadow strength drain"
+        )
+        assert abilities.strength == 0
+
+        # Reduction by 0 with a named source is a no-op (but still requires source).
+        abilities.reduce_score("dexterity", 0, source="Slow spell")
+        assert abilities.dexterity == 10
+
+        # Unknown ability names are rejected.
+        with pytest.raises(ValueError, match="Unknown ability"):
+            abilities.reduce_score("luck", 1, source="Anything")
 
 
 class TestSixAbilities_Modifiers:


### PR DESCRIPTION
## Summary

Enforces the SRD's ability-score guard rails on the `Abilities` dataclass — the last unimplemented child of plan-08 with code surface (besides voluntary save fail and initiative ties).

- `Abilities.__post_init__` validates every score is in `[1, 30]`. Out-of-range values at construction raise `ValueError`.
- `Abilities.for_adventurer(...)` constructor enforces the adventurer soft-cap of 20 unless `features_allowing_above_20=(...)` names a feature that permits the higher value.
- `Abilities.reduce_score(ability, amount, source)` mutator implements ability-score-reducing effects. Floors at 0 (never negative); requires a non-empty `source`, encoding the SRD rule that "if an effect reduces a score to 0, that effect explains what happens."

Closes #486.

## Test plan

- [x] 4 GAP `pytest.skip` stubs in `tests/srd/playing_the_game/test_the_six_abilities.py` rewritten as real RED tests, then turned GREEN
- [x] `uv run pytest dnd-engine/tests/` — 3464 passed, 170 skipped (the 3 pre-existing failures in `test_advantage_disadvantage.py` are unrelated to #486 and exist on main)
- [x] No existing `Abilities(...)` fixtures or data-loader callsites broke — every monster in `monsters.json` already satisfies `[1, 30]` (a pre-existing test asserts this catalog parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)