### PR TITLE
Add #450: SRD save-ability lint vs Saving Throw Examples table (plan-08)

### DIFF
--- a/dnd-engine/dnd_engine/validation/__init__.py
+++ b/dnd-engine/dnd_engine/validation/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Validation package for data-quality lints over SRD JSON content.
+# ABOUTME: Hosts advisory checks that surface mistakes without failing the engine.

--- a/dnd-engine/dnd_engine/validation/save_ability_lint.py
+++ b/dnd-engine/dnd_engine/validation/save_ability_lint.py
@@ -1,0 +1,282 @@
+# ABOUTME: Advisory lint that compares declared saving-throw abilities in SRD
+# ABOUTME: spell and monster JSON against the SRD Saving Throw Examples table.
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+# Override field name: when an entry intentionally diverges from the SRD
+# Saving Throw Examples table, content authors annotate the source JSON
+# with this key (a non-empty string explaining why). The lint treats the
+# divergence as justified and excludes the entry from its report.
+OVERRIDE_KEY = "srd_save_override_reason"
+
+# SRD § Playing the Game › Saving Throws › Saving Throw Examples
+# Strength    -- Physically resist direct force
+# Dexterity   -- Dodge out of harm's way
+# Constitution-- Endure a toxic hazard
+# Intelligence-- Recognize an illusion as fake
+# Wisdom      -- Resist a mental assault
+# Charisma    -- Assert your identity
+_CATEGORY_TO_ABILITY = {
+    "force": "strength",
+    "dodge": "dexterity",
+    "endurance": "constitution",
+    "illusion": "intelligence",
+    "mental": "wisdom",
+    "identity": "charisma",
+}
+
+# Damage types that point at a specific ability via the SRD examples table.
+#   * poison / necrotic / acid  -> endurance (CON)
+#   * psychic                   -> mental (WIS)
+#   * thunder                   -> endurance (CON, shockwave)
+#   * fire / cold / lightning / radiant / force -> dodge (DEX)
+#   * bludgeoning / piercing / slashing         -> dodge (DEX) -- or
+#     force (STR) for a knock-prone style hit, which the keyword
+#     heuristic below handles separately.
+_DAMAGE_TYPE_CATEGORIES: dict[str, tuple[str, ...]] = {
+    "poison": ("endurance",),
+    "necrotic": ("endurance",),
+    "acid": ("endurance",),
+    "psychic": ("mental",),
+    "thunder": ("endurance", "dodge"),
+    "fire": ("dodge",),
+    "cold": ("dodge", "endurance"),
+    "lightning": ("dodge",),
+    "radiant": ("dodge",),
+    "force": ("dodge", "force"),
+    "bludgeoning": ("dodge", "force"),
+    "piercing": ("dodge",),
+    "slashing": ("dodge",),
+}
+
+# Magical schools that point at a specific ability category.
+_SCHOOL_CATEGORIES: dict[str, tuple[str, ...]] = {
+    "enchantment": ("mental",),
+    "illusion": ("mental", "illusion"),
+    "necromancy": ("endurance", "mental"),
+    "abjuration": ("identity",),
+}
+
+# Condition / status keywords that are commonly imposed by save effects.
+# These map to SRD examples-table categories. They are advisory: when
+# any plausible category from any signal matches the declared save, the
+# entry is considered consistent.
+_KEYWORD_CATEGORIES: list[tuple[str, str]] = [
+    ("charm", "mental"),
+    ("frighten", "mental"),
+    ("fear", "mental"),
+    ("dominate", "mental"),
+    ("possess", "identity"),
+    ("banish", "identity"),
+    ("illusion", "illusion"),
+    ("disbelieve", "illusion"),
+    ("poison", "endurance"),
+    ("disease", "endurance"),
+    ("paralyz", "endurance"),
+    ("stun", "endurance"),
+    ("petrif", "endurance"),
+    ("knock prone", "force"),
+    ("shoved", "force"),
+    ("grapple", "force"),
+    ("pushed", "force"),
+]
+
+
+@dataclass(frozen=True)
+class SaveAbilityDivergence:
+    """One advisory lint hit.
+
+    `entry` is a stable identifier (spell key, or
+    ``"<monster>.<action>"``). `declared` is the saving-throw ability
+    found in JSON. `expected` is one ability the SRD examples table
+    suggests for the inferred effect category. `reason` lists every
+    signal the lint observed and the resulting plausible categories.
+    """
+
+    entry: str
+    declared: str
+    expected: str
+    reason: str
+
+
+def _normalize_ability(value: str | None) -> str | None:
+    if not value:
+        return None
+    v = value.strip().lower()
+    short = {
+        "str": "strength",
+        "dex": "dexterity",
+        "con": "constitution",
+        "int": "intelligence",
+        "wis": "wisdom",
+        "cha": "charisma",
+    }
+    return short.get(v, v)
+
+
+def _classify_all(
+    *,
+    damage_type: str | None,
+    school: str | None,
+    tags: Iterable[str] | None,
+    text_blobs: Iterable[str | None],
+) -> tuple[set[str], list[str]]:
+    """Return (plausible category set, signal-trace list).
+
+    The lint flags a divergence only when the set is non-empty and the
+    declared save is *outside* it -- i.e. every signal we picked up
+    points elsewhere. Empty set means the lint stays silent.
+    """
+    categories: set[str] = set()
+    trace: list[str] = []
+
+    if school:
+        s = school.strip().lower()
+        if s in _SCHOOL_CATEGORIES:
+            for c in _SCHOOL_CATEGORIES[s]:
+                categories.add(c)
+            trace.append(f"school '{s}' -> {_SCHOOL_CATEGORIES[s]}")
+
+    if damage_type:
+        dt = damage_type.lower()
+        # Split compound damage like "bludgeoning and cold".
+        tokens = [t.strip() for t in dt.replace(" and ", ",").replace("/", ",").split(",")]
+        for token in tokens:
+            if token in _DAMAGE_TYPE_CATEGORIES:
+                for c in _DAMAGE_TYPE_CATEGORIES[token]:
+                    categories.add(c)
+                trace.append(f"damage '{token}' -> {_DAMAGE_TYPE_CATEGORIES[token]}")
+
+    haystack_parts: list[str] = []
+    for blob in text_blobs:
+        if blob:
+            haystack_parts.append(blob.lower())
+    if tags:
+        haystack_parts.extend(t.lower() for t in tags)
+    haystack = " ".join(haystack_parts)
+
+    for keyword, category in _KEYWORD_CATEGORIES:
+        if keyword in haystack:
+            categories.add(category)
+            trace.append(f"keyword '{keyword}' -> {category}")
+
+    return categories, trace
+
+
+def _check_entry(
+    *,
+    entry_id: str,
+    declared_ability: str | None,
+    override_reason: str | None,
+    damage_type: str | None,
+    school: str | None,
+    tags: Iterable[str] | None,
+    text_blobs: Iterable[str | None],
+) -> SaveAbilityDivergence | None:
+    if override_reason:
+        return None
+    declared = _normalize_ability(declared_ability)
+    if declared is None:
+        return None
+    categories, trace = _classify_all(
+        damage_type=damage_type,
+        school=school,
+        tags=tags,
+        text_blobs=text_blobs,
+    )
+    if not categories:
+        return None
+    plausible_abilities = {_CATEGORY_TO_ABILITY[c] for c in categories}
+    if declared in plausible_abilities:
+        return None
+    # Pick the first stable category for the suggested ability.
+    expected = sorted(plausible_abilities)[0]
+    return SaveAbilityDivergence(
+        entry=entry_id,
+        declared=declared,
+        expected=expected,
+        reason="; ".join(trace),
+    )
+
+
+def lint_spells(spells: dict) -> list[SaveAbilityDivergence]:
+    """Walk a spells.json-style mapping and return unjustified divergences."""
+    out: list[SaveAbilityDivergence] = []
+    for key, spell in spells.items():
+        if not isinstance(spell, dict):
+            continue
+        save = spell.get("saving_throw")
+        if not isinstance(save, dict):
+            continue
+        damage = spell.get("damage") or {}
+        damage_type = damage.get("damage_type") if isinstance(damage, dict) else None
+        hit = _check_entry(
+            entry_id=key,
+            declared_ability=save.get("ability"),
+            override_reason=spell.get(OVERRIDE_KEY) or save.get(OVERRIDE_KEY),
+            damage_type=damage_type,
+            school=spell.get("school"),
+            tags=spell.get("tags"),
+            text_blobs=[spell.get("description")],
+        )
+        if hit is not None:
+            out.append(hit)
+    return out
+
+
+def lint_monsters(monsters: dict) -> list[SaveAbilityDivergence]:
+    """Walk a monsters.json-style mapping and return unjustified divergences.
+
+    Saves on monsters live on individual actions (e.g. a Claws attack
+    that imposes paralysis), so the entry id is ``"<monster>.<action>"``.
+    """
+    out: list[SaveAbilityDivergence] = []
+    for mk, monster in monsters.items():
+        if not isinstance(monster, dict):
+            continue
+        for action in monster.get("actions") or []:
+            if not isinstance(action, dict):
+                continue
+            save = action.get("saving_throw")
+            if not isinstance(save, dict):
+                continue
+            entry_id = f"{mk}.{action.get('name', '?')}"
+            hit = _check_entry(
+                entry_id=entry_id,
+                declared_ability=save.get("ability"),
+                override_reason=action.get(OVERRIDE_KEY) or save.get(OVERRIDE_KEY),
+                damage_type=action.get("damage_type"),
+                school=None,
+                tags=None,
+                text_blobs=[action.get("special"), action.get("name")],
+            )
+            if hit is not None:
+                out.append(hit)
+    return out
+
+
+def _default_data_dir() -> Path:
+    # dnd_engine/validation/save_ability_lint.py -> dnd_engine/data/srd/
+    return Path(__file__).resolve().parent.parent / "data" / "srd"
+
+
+def lint_srd_save_abilities(
+    data_dir: Path | None = None,
+) -> list[SaveAbilityDivergence]:
+    """Load spells.json + monsters.json from `data_dir` and lint both.
+
+    Defaults to the package's bundled SRD data. Returns the merged list
+    of unjustified divergences; an empty list means the data is clean
+    (or every divergence has an explicit `srd_save_override_reason`).
+    """
+    base = data_dir or _default_data_dir()
+    spells_path = base / "spells.json"
+    monsters_path = base / "monsters.json"
+    spells = json.loads(spells_path.read_text())
+    monsters = json.loads(monsters_path.read_text())
+    return lint_spells(spells) + lint_monsters(monsters)

--- a/dnd-engine/tests/srd/playing_the_game/test_saving_throws.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_saving_throws.py
@@ -248,18 +248,38 @@ class TestAbilityModifier_SaveExamplesTable:
     """
 
     def test_effects_default_to_srd_recommended_save_ability(self):
-        pytest.skip(
-            "GAP: The engine has no central mapping from effect "
-            "category (force / dodge / poison / illusion / mental / "
-            "identity) to its recommended save ability. Each spell "
-            "and monster trait hardcodes its save in JSON "
-            "(`dnd_engine/data/srd/spells.json`, "
-            "`dnd_engine/data/srd/monsters.json`), so a content "
-            "author can — and sometimes does — pick a save that "
-            "doesn't match the SRD examples table. No validator "
-            "checks this. The examples table is advisory, not "
-            "normative, so this gap is low-severity but worth a "
-            "lint-style audit. Tracked by issue #450."
+        """Advisory lint: declared saves match the examples table.
+
+        `dnd_engine.validation.save_ability_lint` walks
+        `data/srd/spells.json` and `data/srd/monsters.json`, classifies
+        each save-bearing effect by category (force/dodge/poison/
+        illusion/mental/identity) from damage type, school, tags, and
+        description keywords, and reports entries whose declared save
+        ability sits outside every plausible category. Content authors
+        can opt out of any specific entry by adding an
+        `srd_save_override_reason` string to the entry (or to its
+        `saving_throw` block) explaining the intentional divergence.
+
+        The check is advisory -- the SRD examples table is guidance, not
+        a hard rule -- but every divergence in shipped data must be
+        either fixed or explicitly justified so the lint stays useful.
+        Tracked by issue #450.
+        """
+        from dnd_engine.validation.save_ability_lint import (
+            lint_srd_save_abilities,
+        )
+
+        divergences = lint_srd_save_abilities()
+
+        assert divergences == [], (
+            "Unjustified save-ability divergences from the SRD examples "
+            "table. Either correct the JSON or add an "
+            "`srd_save_override_reason` to the entry:\n"
+            + "\n".join(
+                f"  {d.entry}: declared={d.declared}, "
+                f"expected={d.expected} ({d.reason})"
+                for d in divergences
+            )
         )
 
 

--- a/dnd-engine/tests/test_save_ability_lint.py
+++ b/dnd-engine/tests/test_save_ability_lint.py
@@ -1,0 +1,140 @@
+# ABOUTME: Unit tests for the advisory save-ability lint that compares declared
+# ABOUTME: saving throws in spell/monster JSON against the SRD examples table.
+
+from __future__ import annotations
+
+from dnd_engine.validation.save_ability_lint import (
+    OVERRIDE_KEY,
+    SaveAbilityDivergence,
+    lint_monsters,
+    lint_spells,
+    lint_srd_save_abilities,
+)
+
+
+def test_clean_dodge_spell_produces_no_divergence():
+    """Fireball-shaped entry: DEX save, fire damage, evocation -> clean."""
+    spells = {
+        "fireball": {
+            "saving_throw": {"ability": "dexterity"},
+            "damage": {"damage_type": "fire"},
+            "school": "evocation",
+            "tags": ["damage", "aoe"],
+            "description": "A bright streak flashes...",
+        }
+    }
+    assert lint_spells(spells) == []
+
+
+def test_poison_damage_with_strength_save_is_flagged():
+    """Poison damage points at CON (endure); declared STR should flag."""
+    spells = {
+        "fake_poison_spell": {
+            "saving_throw": {"ability": "strength"},
+            "damage": {"damage_type": "poison"},
+            "school": "necromancy",
+            "description": "Toxic green mist.",
+        }
+    }
+    divs = lint_spells(spells)
+    assert len(divs) == 1
+    assert divs[0].entry == "fake_poison_spell"
+    assert divs[0].declared == "strength"
+    assert divs[0].expected == "constitution"
+
+
+def test_override_reason_suppresses_divergence():
+    """An explicit `srd_save_override_reason` justifies a divergence."""
+    spells = {
+        "fake_poison_spell": {
+            "saving_throw": {"ability": "strength"},
+            "damage": {"damage_type": "poison"},
+            "school": "necromancy",
+            "description": "Toxic green mist.",
+            OVERRIDE_KEY: ("GM ruling: target braces against gut-cramp via STR."),
+        }
+    }
+    assert lint_spells(spells) == []
+
+
+def test_override_on_saving_throw_block_also_suppresses():
+    """Override may live on the saving_throw sub-object as well."""
+    spells = {
+        "fake_poison_spell": {
+            "saving_throw": {
+                "ability": "strength",
+                OVERRIDE_KEY: "deliberate SRD divergence",
+            },
+            "damage": {"damage_type": "poison"},
+            "school": "necromancy",
+            "description": "Toxic green mist.",
+        }
+    }
+    assert lint_spells(spells) == []
+
+
+def test_short_ability_codes_are_normalized():
+    """`dex` and `dexterity` are treated as the same declared save."""
+    spells = {
+        "x": {
+            "saving_throw": {"ability": "dex"},
+            "damage": {"damage_type": "fire"},
+            "school": "evocation",
+        }
+    }
+    assert lint_spells(spells) == []
+
+
+def test_monster_action_save_is_flagged_by_paralysis_keyword():
+    """A monster action that paralyzes points at CON; CHA save flags."""
+    monsters = {
+        "fake_thing": {
+            "actions": [
+                {
+                    "name": "Touch",
+                    "saving_throw": {"ability": "charisma"},
+                    "damage_type": "slashing",
+                    "special": "Target must save or be paralyzed.",
+                }
+            ]
+        }
+    }
+    divs = lint_monsters(monsters)
+    assert len(divs) == 1
+    assert divs[0].entry == "fake_thing.Touch"
+    assert divs[0].declared == "charisma"
+
+
+def test_spell_with_no_save_is_ignored():
+    """Spells without a `saving_throw` block are skipped silently."""
+    spells = {"magic_missile": {"damage": {"damage_type": "force"}}}
+    assert lint_spells(spells) == []
+
+
+def test_weak_signal_does_not_produce_false_positive():
+    """When no signal fires, the lint stays silent rather than guess."""
+    spells = {
+        "obscure_thing": {
+            "saving_throw": {"ability": "wisdom"},
+            "school": "transmutation",
+            "description": "Something happens.",
+        }
+    }
+    assert lint_spells(spells) == []
+
+
+def test_srd_data_lint_is_clean():
+    """Shipped SRD data ships clean (no unjustified divergences)."""
+    divs = lint_srd_save_abilities()
+    assert divs == [], "Unjustified save-ability divergences in shipped SRD data:\n" + "\n".join(
+        f"  {d.entry}: declared={d.declared}, expected={d.expected} ({d.reason})" for d in divs
+    )
+
+
+def test_divergence_is_a_dataclass_with_expected_fields():
+    """Public dataclass contract: entry/declared/expected/reason."""
+    d = SaveAbilityDivergence(entry="x", declared="strength", expected="constitution", reason="r")
+    assert d.entry == "x"
+    assert d.declared == "strength"
+    assert d.expected == "constitution"
+    assert d.reason == "r"


### PR DESCRIPTION
## Summary

Closes #450. Plan-08 lint-style data-quality slice.

Adds an **advisory** lint that walks `data/srd/spells.json` and `data/srd/monsters.json` and compares each declared saving-throw ability against the SRD § Playing the Game › Saving Throws "Saving Throw Examples" table (STR-force / DEX-dodge / CON-endure / INT-illusion / WIS-mental / CHA-identity).

- New module: `dnd-engine/dnd_engine/validation/save_ability_lint.py`
  - Public surface: `SaveAbilityDivergence` dataclass + `lint_spells(...)`, `lint_monsters(...)`, `lint_srd_save_abilities(...)`.
  - Classifies each effect into a *set* of plausible categories from damage type, school, and a keyword scan over tags/description/special text. Only flags when the declared save is outside every plausible category, so dual-flavour effects (e.g. enchantment that also deals fire damage) don't false-positive.
  - Authors can opt out by adding `srd_save_override_reason: "<why>"` either to the entry or to its `saving_throw` block.
- Unskips `TestAbilityModifier_SaveExamplesTable::test_effects_default_to_srd_recommended_save_ability` -- now asserts zero unjustified divergences. Skip count on `test_saving_throws.py`: **13p+1s -> 14p**.
- Adds `dnd-engine/tests/test_save_ability_lint.py` with unit coverage of the classifier, both override paths, monster-action handling, ability-code normalization, and silent-on-weak-signal behaviour.

## Lint results on shipped SRD data

**0 divergences. 0 overrides applied. 0 JSON fixes.** All 11 save-bearing spells (`sacred_flame`, `burning_hands`, `hold_person`, `fireball`, `lightning_bolt`, `thunderwave`, `shatter`, `fear`, `stinking_cloud`, `ice_storm`, `blight`) and 3 save-bearing monster actions (`ghast.Claws`, `ghoul.Claws`, `bearded_devil.Beard`) already align with the SRD examples table.

## Test plan

- [x] `uv run pytest dnd-engine/tests/test_save_ability_lint.py dnd-engine/tests/srd/playing_the_game/test_saving_throws.py` -- 24 pass
- [x] Confirm the gating skip drops: 13p+1s -> 14p on `test_saving_throws.py`
- [x] Ruff check + format clean
- [ ] Full `uv run pytest dnd-engine/tests/` (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)