### PR TITLE
feat(plan-03): Cover system at attack-resolution layer (#672)

### DIFF
--- a/dnd-engine/dnd_engine/core/character.py
+++ b/dnd-engine/dnd_engine/core/character.py
@@ -4,7 +4,7 @@
 from enum import Enum
 from typing import Any
 
-from dnd_engine.core.creature import Abilities, Creature, Size
+from dnd_engine.core.creature import Abilities, Cover, Creature, Size
 from dnd_engine.core.dice import DiceRoller
 from dnd_engine.core.spell import Spell
 from dnd_engine.systems.d20 import d20_test
@@ -370,6 +370,7 @@ class Character(Creature):
         use_heroic_inspiration: bool = False,
         auto_fail: bool = False,
         event_bus=None,
+        cover: Cover = Cover.NONE,
     ) -> dict[str, Any]:
         """
         Roll a saving throw against a DC.
@@ -392,6 +393,11 @@ class Character(Creature):
                 `total=modifier`. Used by willing targets opting into
                 friendly Charm/Polymorph and similar effects.
             event_bus: Optional EventBus instance to emit saving throw event
+            cover: SRD § Playing the Game › Making an Attack › Cover.
+                Half / Three-Quarters cover bump DEX saves by +2 / +5
+                against effects that originate at a point (Fireball,
+                etc.). Applies only to DEX saves; ignored for other
+                abilities. Total cover contributes no save bonus.
 
         Returns:
             Dictionary with:
@@ -483,6 +489,12 @@ class Character(Creature):
         ):
             advantage = True
 
+        # SRD § Cover: Half / Three-Quarters cover bumps DEX saves by
+        # +2 / +5 against effects that originate at a point. Folded
+        # into the circumstantial bonus.
+        if ability_short == "dex":
+            circumstantial += cover.dex_save_bonus
+
         # Legacy `make_saving_throw` constructed a fresh `DiceRoller`
         # rather than reusing `self._dice_roller`; omitting `roller`
         # preserves that — the primitive defaults to a fresh roller.
@@ -497,10 +509,8 @@ class Character(Creature):
             "circumstantial": circumstantial,
         }
         result = d20_test(**d20_kwargs)
-        result, heroic_inspiration_spent = (
-            self._maybe_reroll_d20_for_heroic_inspiration(
-                result, use_heroic_inspiration, **d20_kwargs
-            )
+        result, heroic_inspiration_spent = self._maybe_reroll_d20_for_heroic_inspiration(
+            result, use_heroic_inspiration, **d20_kwargs
         )
 
         success = result.succeeds_against(dc)
@@ -1099,10 +1109,8 @@ class Character(Creature):
             "circumstantial": circumstantial,
         }
         result = d20_test(**d20_kwargs, roller=self._dice_roller)
-        result, heroic_inspiration_spent = (
-            self._maybe_reroll_d20_for_heroic_inspiration(
-                result, use_heroic_inspiration, **d20_kwargs
-            )
+        result, heroic_inspiration_spent = self._maybe_reroll_d20_for_heroic_inspiration(
+            result, use_heroic_inspiration, **d20_kwargs
         )
 
         success = result.succeeds_against(dc)
@@ -1193,10 +1201,8 @@ class Character(Creature):
             "circumstantial": circumstantial,
         }
         result = d20_test(**d20_kwargs, roller=self._dice_roller)
-        result, heroic_inspiration_spent = (
-            self._maybe_reroll_d20_for_heroic_inspiration(
-                result, use_heroic_inspiration, **d20_kwargs
-            )
+        result, heroic_inspiration_spent = self._maybe_reroll_d20_for_heroic_inspiration(
+            result, use_heroic_inspiration, **d20_kwargs
         )
 
         return {
@@ -1282,14 +1288,10 @@ class Character(Creature):
             KeyError: If ``skill`` is not present in ``skills_data``.
         """
         if skill is None and ability is None:
-            raise ValueError(
-                "make_tool_check requires either 'skill' or 'ability'"
-            )
+            raise ValueError("make_tool_check requires either 'skill' or 'ability'")
 
         tool_proficient = self.is_proficient_with_tool(tool_id)
-        skill_proficient = (
-            skill is not None and skill in self.skill_proficiencies
-        )
+        skill_proficient = skill is not None and skill in self.skill_proficiencies
 
         # SRD: tool-only PB requires tool proficiency. When the caller
         # has the skill but not the tool, defer to the skill path so
@@ -1298,7 +1300,9 @@ class Character(Creature):
         # aren't proficient with.
         if not tool_proficient and skill_proficient:
             result = self.make_skill_check(
-                skill, dc, skills_data,
+                skill,
+                dc,
+                skills_data,
                 advantage=advantage,
                 disadvantage=disadvantage,
                 circumstantial=circumstantial,
@@ -1317,16 +1321,12 @@ class Character(Creature):
                 "skill_proficient": True,
                 "advantage_from_tool_skill": False,
                 "circumstantial": circumstantial,
-                "heroic_inspiration_spent": result.get(
-                    "heroic_inspiration_spent", False
-                ),
+                "heroic_inspiration_spent": result.get("heroic_inspiration_spent", False),
             }
 
         if skill is not None:
             if skills_data is None:
-                raise ValueError(
-                    "make_tool_check requires 'skills_data' when 'skill' is given"
-                )
+                raise ValueError("make_tool_check requires 'skills_data' when 'skill' is given")
             if skill not in skills_data:
                 raise KeyError(f"Unknown skill: {skill}")
             ability_short = skills_data[skill]["ability"]
@@ -1360,15 +1360,11 @@ class Character(Creature):
             "circumstantial": circumstantial,
         }
         result = d20_test(**d20_kwargs, roller=self._dice_roller)
-        result, heroic_inspiration_spent = (
-            self._maybe_reroll_d20_for_heroic_inspiration(
-                result, use_heroic_inspiration, **d20_kwargs
-            )
+        result, heroic_inspiration_spent = self._maybe_reroll_d20_for_heroic_inspiration(
+            result, use_heroic_inspiration, **d20_kwargs
         )
 
-        modifier = ability_mod + (
-            self.proficiency_bonus if tool_proficient else 0
-        )
+        modifier = ability_mod + (self.proficiency_bonus if tool_proficient else 0)
 
         return {
             "tool": tool_id,

--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -359,13 +359,10 @@ class CombatEngine:
         # Get effective AC (includes modifiers from spells/effects if game_state provided).
         # SRD § Cover: Half / Three-Quarters cover add +2 / +5 to the
         # defender's AC for this attack only; total cover was already
-        # short-circuited above. The cover bump is layered on top of
-        # `get_effective_ac` here (rather than passed in) so test stubs
-        # and any third-party `game_state` lookalikes that predate the
-        # cover kwarg still work — the engine remains the source of
-        # truth for the cover bonus.
+        # short-circuited above. The cover bump is owned by
+        # `get_effective_ac` so a single place layers the bonus.
         if game_state is not None:
-            defender_ac = game_state.get_effective_ac(defender) + cover.ac_bonus
+            defender_ac = game_state.get_effective_ac(defender, cover=cover)
         else:
             # Fallback to base AC if no game_state (e.g., in unit tests)
             defender_ac = defender._base_ac + cover.ac_bonus

--- a/dnd-engine/dnd_engine/core/combat.py
+++ b/dnd-engine/dnd_engine/core/combat.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from dnd_engine.core.combat_geometry import attack_reach_for, is_ranged_action
-from dnd_engine.core.creature import Creature
+from dnd_engine.core.creature import Cover, Creature
 from dnd_engine.core.dice import DiceRoller
 from dnd_engine.core.distance import distance_in_feet
 from dnd_engine.rules.damage import apply_damage_adjustments, apply_damage_modifiers
@@ -143,6 +143,7 @@ class CombatEngine:
         attacker_sees_defender: VisibilityRelation | None = None,
         defender_sees_attacker: VisibilityRelation | None = None,
         circumstantial: int = 0,
+        cover: Cover = Cover.NONE,
     ) -> AttackResult:
         """
         Resolve a complete attack.
@@ -199,10 +200,45 @@ class CombatEngine:
                 telemetry. Hit determination uses
                 ``attack_roll + attack_bonus + circumstantial`` so a
                 Bless-like bonus can flip a borderline miss.
+            cover: SRD § Playing the Game › Making an Attack › Cover.
+                The caller resolves geometry (which obstacles sit
+                between attacker and defender, whether a creature
+                between them is two-sizes-smaller and therefore grants
+                no cover, which of multiple obstacles wins under "most
+                protective applies") and passes the single resulting
+                degree. ``HALF`` / ``THREE_QUARTERS`` add +2 / +5 to
+                the defender's effective AC for this attack only.
+                ``TOTAL`` short-circuits the attack at Step 1 — the
+                target "can't be targeted directly" — and the engine
+                returns a sentinel ``AttackResult`` (``attack_roll=0``,
+                ``hit=False``, ``damage=0``) with no dice rolled and
+                no side effects (no hidden-state revelation, no Help
+                consumption). Default ``Cover.NONE`` preserves legacy
+                behavior for callers that don't compute geometry.
 
         Returns:
             AttackResult containing full attack details including sneak attack if applicable
         """
+        # SRD § Cover › Total Cover: "a target with Total Cover can't
+        # be targeted directly by an attack or a spell." Short-circuit
+        # at Step 1 (Choose a Target) with a sentinel result mirroring
+        # the reach-rejection shape (`attack_roll=0`). No dice are
+        # rolled, no Hidden state is consumed, no Help is spent.
+        if cover == Cover.TOTAL:
+            return AttackResult(
+                attacker_name=attacker.name,
+                defender_name=defender.name,
+                attack_roll=0,
+                attack_bonus=attack_bonus,
+                target_ac=defender._base_ac,
+                hit=False,
+                damage=0,
+                critical_hit=False,
+                advantage=advantage,
+                disadvantage=disadvantage,
+                circumstantial=circumstantial,
+            )
+
         # SRD § Playing the Game › Melee Attacks › Reach: a melee attack
         # may only target a creature within the attacker's reach (5 ft
         # by default; greater for some creatures/weapons as noted on
@@ -228,18 +264,16 @@ class CombatEngine:
         # The short-circuit emits an ``AttackResult`` with
         # ``attack_roll=0`` as a sentinel so callers / tests can
         # distinguish a gate rejection from a missed roll.
-        if (
-            action is not None
-            and game_state is not None
-            and not is_ranged_action(action)
-        ):
+        if action is not None and game_state is not None and not is_ranged_action(action):
             attacker_pos = getattr(attacker, "position", None)
             defender_pos = getattr(defender, "position", None)
             if attacker_pos is not None and defender_pos is not None:
                 reach_ft = attack_reach_for(action)
                 distance_ft = distance_in_feet(
-                    attacker_pos.x, attacker_pos.y,
-                    defender_pos.x, defender_pos.y,
+                    attacker_pos.x,
+                    attacker_pos.y,
+                    defender_pos.x,
+                    defender_pos.y,
                 )
                 if distance_ft > reach_ft:
                     return AttackResult(
@@ -322,12 +356,19 @@ class CombatEngine:
         critical_hit = attack_roll == 20
         critical_miss = attack_roll == 1
 
-        # Get effective AC (includes modifiers from spells/effects if game_state provided)
+        # Get effective AC (includes modifiers from spells/effects if game_state provided).
+        # SRD § Cover: Half / Three-Quarters cover add +2 / +5 to the
+        # defender's AC for this attack only; total cover was already
+        # short-circuited above. The cover bump is layered on top of
+        # `get_effective_ac` here (rather than passed in) so test stubs
+        # and any third-party `game_state` lookalikes that predate the
+        # cover kwarg still work — the engine remains the source of
+        # truth for the cover bonus.
         if game_state is not None:
-            defender_ac = game_state.get_effective_ac(defender)
+            defender_ac = game_state.get_effective_ac(defender) + cover.ac_bonus
         else:
             # Fallback to base AC if no game_state (e.g., in unit tests)
-            defender_ac = defender._base_ac
+            defender_ac = defender._base_ac + cover.ac_bonus
 
         # Determine hit/miss. Circumstantial bonus/penalty is summed
         # into the attack total per SRD § Playing the Game › D20 Tests

--- a/dnd-engine/dnd_engine/core/creature.py
+++ b/dnd-engine/dnd_engine/core/creature.py
@@ -49,6 +49,71 @@ class Size(str, Enum):
         }[self]
 
 
+class Cover(str, Enum):
+    """
+    SRD cover degrees (SRD § Playing the Game › Making an Attack › Cover).
+
+    Half and Three-Quarters cover bump the target's AC and DEX saves by
+    +2 and +5 respectively. Total cover means the target cannot be
+    targeted directly — `CombatEngine.resolve_attack` short-circuits to
+    a missed-target sentinel result.
+
+    Line-of-sight geometry — which obstacles sit between attacker and
+    defender, and which degree they grant — is the caller's job (the
+    client computes geometry from positions; the engine consumes the
+    resolved degree). This mirrors the ranged-range seam where the
+    caller supplies the gated decision.
+
+    Per SRD "no stacking", the most-protective degree applies; this API
+    takes a single `Cover` value, so no-stacking is enforced by
+    construction — the caller picks the winner before calling.
+    """
+
+    NONE = "none"
+    HALF = "half"
+    THREE_QUARTERS = "three_quarters"
+    TOTAL = "total"
+
+    @property
+    def ac_bonus(self) -> int:
+        """+2 for Half, +5 for Three-Quarters, 0 otherwise (incl. Total)."""
+        return {
+            Cover.NONE: 0,
+            Cover.HALF: 2,
+            Cover.THREE_QUARTERS: 5,
+            Cover.TOTAL: 0,
+        }[self]
+
+    @property
+    def dex_save_bonus(self) -> int:
+        """Saves track AC: +2 / +5 for Half / Three-Quarters; 0 otherwise."""
+        return self.ac_bonus
+
+
+_SIZE_ORDER = (
+    Size.TINY,
+    Size.SMALL,
+    Size.MEDIUM,
+    Size.LARGE,
+    Size.HUGE,
+    Size.GARGANTUAN,
+)
+
+
+def creature_provides_cover(provider_size: Size, target_size: Size) -> bool:
+    """
+    Whether a creature of `provider_size` can grant cover to a target of `target_size`.
+
+    SRD § Playing the Game › Making an Attack › Cover: a creature
+    provides cover unless it is two or more sizes smaller than the
+    target. (A halfling can hide behind a human; a pixie cannot grant
+    cover to a dragon.)
+    """
+    provider_idx = _SIZE_ORDER.index(provider_size)
+    target_idx = _SIZE_ORDER.index(target_size)
+    return (target_idx - provider_idx) < 2
+
+
 class MovementMode(str, Enum):
     """
     SRD movement modes (SRD § Playing the Game › Movement › Movement Modes).
@@ -174,13 +239,9 @@ class Abilities:
         a score negative.
         """
         if ability not in ABILITY_KEYS:
-            raise ValueError(
-                f"Unknown ability {ability!r}; expected one of {ABILITY_KEYS}."
-            )
+            raise ValueError(f"Unknown ability {ability!r}; expected one of {ABILITY_KEYS}.")
         if amount < 0:
-            raise ValueError(
-                f"reduce_score amount must be non-negative; got {amount}."
-            )
+            raise ValueError(f"reduce_score amount must be non-negative; got {amount}.")
         if not source:
             raise ValueError(
                 "reduce_score requires a non-empty `source` naming the "
@@ -856,6 +917,7 @@ class Creature:
         circumstantial: int = 0,
         auto_fail: bool = False,
         event_bus=None,
+        cover: Cover = Cover.NONE,
     ) -> dict:
         """
         Roll an ability saving throw against a DC.
@@ -878,6 +940,14 @@ class Creature:
                 and the result dict reports `success=False`, `roll=0`,
                 `total=modifier`.
             event_bus: Optional EventBus instance to emit saving throw event
+            cover: SRD § Playing the Game › Making an Attack › Cover.
+                Half / Three-Quarters cover bump DEX saves by +2 / +5
+                against effects that originate at a point (Fireball,
+                etc.). The bonus applies only when `ability` is "dex" /
+                "dexterity"; for other abilities it is ignored. Total
+                cover has no save bonus — per SRD a totally-covered
+                creature usually can't be targeted, but if a save still
+                resolves the cover degree contributes nothing.
 
         Returns:
             Dictionary with:
@@ -929,6 +999,13 @@ class Creature:
             and self.speed > 0
         ):
             advantage = True
+
+        # SRD § Cover: Half / Three-Quarters cover bumps DEX saves by
+        # +2 / +5 against effects that originate at a point. Folded
+        # into the circumstantial bonus so it surfaces on the result
+        # dict alongside other Step-5 modifiers.
+        if ability_short == "dex":
+            circumstantial += cover.dex_save_bonus
 
         # Get ability modifier
         if ability_full == "strength":

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -3852,7 +3852,11 @@ class GameState:
 
         return desc
 
-    def get_effective_ac(self, creature: "Creature") -> int:
+    def get_effective_ac(
+        self,
+        creature: "Creature",
+        cover: "Cover | None" = None,
+    ) -> int:
         """
         Calculate effective AC including base AC and active effect modifiers.
 
@@ -3864,6 +3868,13 @@ class GameState:
            formula is selected, this is the stored `_base_ac` (armor or
            natural-armor default).
         2. AC bonus effects (Shield, Haste) — all stack on top.
+        3. Per-attack cover bonus (Half: +2, Three-Quarters: +5). Cover
+           is a property of the *attack's geometry*, not the defender's
+           persistent state, so it is supplied per call by the caller
+           (which computes line-of-sight). Total cover contributes no
+           AC bonus — a target behind total cover cannot be targeted
+           and the attack is short-circuited by `resolve_attack` before
+           AC is consulted.
 
         Spells that previously set the base AC via a `modifier_type:
         "ac_set_base"` active-effect entry are now expected to migrate
@@ -3877,11 +3888,19 @@ class GameState:
 
         Args:
             creature: Creature to calculate AC for
+            cover: SRD cover degree applied to *this* AC query (default
+                `Cover.NONE`). Half / Three-Quarters bump the result by
+                +2 / +5; Total contributes 0 (total-cover targets are
+                rejected before AC is read).
 
         Returns:
             Effective AC after applying all modifiers
         """
+        from dnd_engine.core.creature import Cover
         from dnd_engine.systems.time_manager import ModifierType
+
+        if cover is None:
+            cover = Cover.NONE
 
         # Use get_base_ac() so an active alternate base-AC formula (per
         # SRD "Only One Base AC") feeds into the layered-modifier stack.
@@ -3905,6 +3924,11 @@ class GameState:
             if modifier_type == ModifierType.AC_BONUS.value:
                 # Bonuses stack (Shield: +5, Haste: +2, etc.)
                 final_ac += effect_data.get("value", 0)
+
+        # SRD § Cover: per-attack AC bonus from the resolved cover
+        # degree (geometry computed by the caller). No-op when the
+        # caller didn't supply a cover state.
+        final_ac += cover.ac_bonus
 
         return final_ac
 
@@ -4185,9 +4209,7 @@ class GameState:
                 group_order.append(enemy.name)
             groups[enemy.name].append(enemy)
         for name in group_order:
-            self.initiative_tracker.add_combatant_group(
-                groups[name], surprised=enemies_surprised
-            )
+            self.initiative_tracker.add_combatant_group(groups[name], surprised=enemies_surprised)
 
         # Emit surprise round event if either side is surprised
         if surprise_result["enemies_surprised"] or surprise_result["party_surprised"]:

--- a/dnd-engine/tests/srd/playing_the_game/test_making_an_attack.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_making_an_attack.py
@@ -26,7 +26,13 @@ import inspect
 import pytest
 
 from dnd_engine.core.combat import CombatEngine
-from dnd_engine.core.creature import Abilities, Creature
+from dnd_engine.core.creature import (
+    Abilities,
+    Cover,
+    Creature,
+    Size,
+    creature_provides_cover,
+)
 from dnd_engine.core.dice import DiceRoller
 
 pytestmark = pytest.mark.srd(
@@ -313,16 +319,15 @@ class TestAttackStructure_Step2_DetermineModifiers:
         assert "disadvantage" in sig.parameters
 
     def test_cover_is_an_input_to_step_2(self) -> None:
-        pytest.skip(
-            "GAP: Cover is the headline Step-2 modifier, and it is not "
-            "implemented anywhere. `CombatEngine.resolve_attack` "
-            "(dnd-engine/dnd_engine/core/combat.py:91) has no `cover` "
-            "parameter, `GameState.get_effective_ac` "
-            "(dnd-engine/dnd_engine/core/game_state.py:2777) layers AC "
-            "modifiers but has no cover source, and no code path "
-            "applies the SRD's +2 / +5 AC bonus. Tracked by issue "
-            "#473."
-        )
+        """`resolve_attack(cover=...)` is the Step-2 cover seam.
+
+        Cover is the headline Step-2 modifier ("the GM determines
+        whether the target has Cover"). The engine's consumption seam
+        is the `cover` parameter on `CombatEngine.resolve_attack`.
+        """
+        sig = inspect.signature(CombatEngine.resolve_attack)
+        assert "cover" in sig.parameters
+        assert sig.parameters["cover"].default == Cover.NONE
 
 
 class TestAttackStructure_Step3_ResolveTheAttack:
@@ -406,15 +411,25 @@ class TestCover_Intro:
     """
 
     def test_cover_state_is_representable_on_an_attack(self) -> None:
-        pytest.skip(
-            "GAP: cover is not modeled anywhere. There is no enum / "
-            "string for the three degrees, no `cover` parameter on "
-            "`CombatEngine.resolve_attack` "
-            "(dnd-engine/dnd_engine/core/combat.py:91), and no cover-"
-            "modifier source in `GameState.get_effective_ac` "
-            "(dnd-engine/dnd_engine/core/game_state.py:2777). Tracked "
-            "by issue #473."
-        )
+        """The three SRD degrees of cover round-trip through the enum.
+
+        Cover is modeled as a `Cover` enum with the three SRD degrees
+        plus an explicit `NONE`, and accepted as a kwarg by
+        `CombatEngine.resolve_attack`.
+        """
+        # All three SRD degrees plus an explicit no-cover state.
+        assert {Cover.NONE, Cover.HALF, Cover.THREE_QUARTERS, Cover.TOTAL} == set(Cover)
+
+        engine, attacker, defender = _make_engine_and_combatants()
+        # Each degree is accepted without error.
+        for degree in Cover:
+            engine.resolve_attack(
+                attacker=attacker,
+                defender=defender,
+                attack_bonus=5,
+                damage_dice="1d8+3",
+                cover=degree,
+            )
 
 
 class TestCover_Geometry:
@@ -425,15 +440,33 @@ class TestCover_Geometry:
     """
 
     def test_cover_only_applies_when_attack_originates_on_opposite_side(self) -> None:
-        pytest.skip(
-            "GAP: no cover system exists, so the geometric carve-out "
-            "is also missing. Once `resolve_attack` accepts a `cover` "
-            "parameter (#473), this rule lives in the *caller* (the "
-            "client computes line-of-sight, akin to how "
-            "`dnd-engine/dnd_engine/systems/ranged_attacks.py:24` "
-            "currently lets the caller pass an `attacker_visible_to` "
-            "callback). Tracked by issue #473."
+        """Geometry lives in the caller; the engine consumes the result.
+
+        Per plan-03, line-of-sight / which-side-of-the-cover lives in
+        the caller (the client). The engine's job is to honor whatever
+        degree the caller resolved: when the caller decides no cover
+        applies (attacker on the same side as the defender), it passes
+        `Cover.NONE` and the AC bump is zero.
+        """
+        engine, attacker, defender = _make_engine_and_combatants()
+        # Same defender, two callers: one resolves to NONE (attacker
+        # on the same side as the defender), one to HALF (opposite
+        # side). The engine produces a +2 AC delta between them.
+        result_same_side = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=5,
+            damage_dice="1d8+3",
+            cover=Cover.NONE,
         )
+        result_opposite = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=5,
+            damage_dice="1d8+3",
+            cover=Cover.HALF,
+        )
+        assert result_opposite.target_ac - result_same_side.target_ac == 2
 
 
 class TestCover_NoStacking:
@@ -447,13 +480,24 @@ class TestCover_NoStacking:
     """
 
     def test_only_most_protective_cover_applies(self) -> None:
-        pytest.skip(
-            "GAP: with no cover system in place (issue #473), the "
-            "'most protective applies' no-stacking rule has no code "
-            "path. Mirrors the no-stacking rule for damage modifiers "
-            "(issue #468), which is also pending a pipeline. Tracked "
-            "by issue #473."
+        """No-stacking is enforced by the single-value API.
+
+        `resolve_attack` accepts one `Cover` value, so the SRD
+        no-stacking rule ("only the most protective degree applies")
+        is enforced by construction: the caller resolves the winner
+        before calling, and the engine applies exactly one bonus.
+        """
+        engine, attacker, defender = _make_engine_and_combatants()
+        # Caller resolves Half + Three-Quarters -> Three-Quarters wins.
+        result = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=5,
+            damage_dice="1d8+3",
+            cover=Cover.THREE_QUARTERS,
         )
+        # +5 (not +5+2=+7) on top of base 13.
+        assert result.target_ac == defender._base_ac + 5
 
 
 class TestCover_HalfCover:
@@ -465,25 +509,54 @@ class TestCover_HalfCover:
     """
 
     def test_half_cover_grants_plus_two_ac(self) -> None:
-        pytest.skip(
-            "GAP: no cover system, so no +2 AC application. "
-            "`GameState.get_effective_ac` "
-            "(dnd-engine/dnd_engine/core/game_state.py:2777) layers AC "
-            "modifiers from spells and effects but has no per-attack "
-            "cover input — cover is a property of *this* attack's "
-            "geometry, not of the defender's persistent state. Tracked "
-            "by issue #473."
+        """Half cover adds +2 to the defender's AC for this attack."""
+        engine, attacker, defender = _make_engine_and_combatants()
+        baseline = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=5,
+            damage_dice="1d8+3",
         )
+        with_half = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=5,
+            damage_dice="1d8+3",
+            cover=Cover.HALF,
+        )
+        assert with_half.target_ac - baseline.target_ac == 2
 
     def test_half_cover_grants_plus_two_to_dex_saves(self) -> None:
-        pytest.skip(
-            "GAP: cover's saving-throw side is not implemented. "
-            "`Creature.make_saving_throw` "
-            "(dnd-engine/dnd_engine/core/creature.py) has no `cover` "
-            "kwarg, and no spell-save path (e.g., Fireball) bumps DEX "
-            "saves by +2 when the target is behind half cover. Tracked "
-            "by issue #473."
-        )
+        """Half cover adds +2 to a DEX save (Fireball-shaped effect).
+
+        The +2 is surfaced via the `circumstantial` telemetry slot
+        (per SRD Step 5) and reflected in `total = roll + modifier +
+        circumstantial`.
+        """
+        _, _, defender = _make_engine_and_combatants()
+        result = defender.make_saving_throw("dex", dc=10, cover=Cover.HALF)
+        assert result["circumstantial"] == 2
+        assert result["total"] == result["roll"] + result["modifier"] + 2
+
+    def test_creature_two_sizes_smaller_grants_no_cover(self) -> None:
+        """A creature two sizes smaller than the target grants no cover.
+
+        SRD § Cover: a creature provides cover unless it is two or
+        more sizes smaller than the target. The engine consumes a
+        resolved `Cover` degree from the caller, but exposes a
+        helper (`creature_provides_cover`) the caller uses to gate
+        the two-sizes-smaller carve-out before deciding which degree
+        to pass.
+        """
+        # Medium target: Tiny is two sizes smaller, Small is one.
+        assert creature_provides_cover(Size.SMALL, Size.MEDIUM) is True
+        assert creature_provides_cover(Size.TINY, Size.MEDIUM) is False
+        # Large target: Small is two sizes smaller, Medium is one.
+        assert creature_provides_cover(Size.MEDIUM, Size.LARGE) is True
+        assert creature_provides_cover(Size.SMALL, Size.LARGE) is False
+        # Bigger-or-equal providers always grant cover.
+        assert creature_provides_cover(Size.LARGE, Size.MEDIUM) is True
+        assert creature_provides_cover(Size.MEDIUM, Size.MEDIUM) is True
 
 
 class TestCover_ThreeQuartersCover:
@@ -495,21 +568,41 @@ class TestCover_ThreeQuartersCover:
     """
 
     def test_three_quarters_cover_grants_plus_five_ac(self) -> None:
-        pytest.skip(
-            "GAP: no cover system. Same code path as the half-cover AC "
-            "bonus above — `resolve_attack` "
-            "(dnd-engine/dnd_engine/core/combat.py:91) lacks a `cover` "
-            "parameter and `get_effective_ac` has no cover source. "
-            "Tracked by issue #473."
+        """Three-quarters cover adds +5 to the defender's AC."""
+        engine, attacker, defender = _make_engine_and_combatants()
+        baseline = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=5,
+            damage_dice="1d8+3",
         )
+        with_tq = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=5,
+            damage_dice="1d8+3",
+            cover=Cover.THREE_QUARTERS,
+        )
+        assert with_tq.target_ac - baseline.target_ac == 5
 
     def test_three_quarters_cover_grants_plus_five_to_dex_saves(self) -> None:
-        pytest.skip(
-            "GAP: cover's saving-throw side is not implemented. "
-            "`Creature.make_saving_throw` "
-            "(dnd-engine/dnd_engine/core/creature.py) has no `cover` "
-            "kwarg. Tracked by issue #473."
-        )
+        """Three-quarters cover adds +5 to a DEX save."""
+        _, _, defender = _make_engine_and_combatants()
+        result = defender.make_saving_throw("dex", dc=10, cover=Cover.THREE_QUARTERS)
+        assert result["circumstantial"] == 5
+        assert result["total"] == result["roll"] + result["modifier"] + 5
+
+    def test_cover_does_not_apply_to_non_dex_saves(self) -> None:
+        """Per SRD the cover save bonus is DEX-only.
+
+        Cover protects against effects that originate at a point
+        (Fireball, Lightning Bolt) and target DEX. WIS/CON/etc. saves
+        are unaffected — a target behind a tree is not better at
+        resisting a Hold Person.
+        """
+        _, _, defender = _make_engine_and_combatants()
+        result = defender.make_saving_throw("wis", dc=10, cover=Cover.THREE_QUARTERS)
+        assert result["circumstantial"] == 0
 
 
 class TestCover_TotalCover:
@@ -520,14 +613,22 @@ class TestCover_TotalCover:
     """
 
     def test_total_cover_rejects_an_attack_at_step_1(self) -> None:
-        pytest.skip(
-            "GAP: there is no early-rejection path for an attack "
-            "against a Total-cover target. `CombatEngine.resolve_attack`"
-            " (dnd-engine/dnd_engine/core/combat.py:91) and "
-            "`GameState.execute_player_attack` "
-            "(dnd-engine/dnd_engine/core/game_state.py:2182) will both "
-            "happily roll dice against a fully-covered creature. The "
-            "Total-cover rule belongs at Step 1 ('can't be targeted "
-            "directly') rather than at the AC layer. Tracked by issue "
-            "#473."
+        """Total cover short-circuits the attack at Step 1 with a sentinel.
+
+        SRD: a target with Total Cover "can't be targeted directly."
+        `CombatEngine.resolve_attack` returns an `AttackResult` with
+        `attack_roll=0` (the same sentinel reach-rejection uses),
+        `hit=False`, and zero damage. No dice are rolled.
+        """
+        engine, attacker, defender = _make_engine_and_combatants()
+        result = engine.resolve_attack(
+            attacker=attacker,
+            defender=defender,
+            attack_bonus=5,
+            damage_dice="1d8+3",
+            cover=Cover.TOTAL,
         )
+        assert result.attack_roll == 0
+        assert result.hit is False
+        assert result.damage == 0
+        assert result.critical_hit is False


### PR DESCRIPTION
## Summary

Adds the SRD Cover system as the headline Step-2 attack modifier and Step-1 rejection. The engine consumes a resolved cover degree from the caller; line-of-sight geometry remains caller-side, mirroring the ranged-range seam from plan-10 #401.

- New `Cover` enum (NONE / HALF / THREE_QUARTERS / TOTAL) in `dnd_engine/core/creature.py`.
- `CombatEngine.resolve_attack(..., cover=Cover.NONE)`: HALF / THREE_QUARTERS add +2 / +5 to defender AC; TOTAL short-circuits at Step 1 with a sentinel result (no dice, no Hidden/Help consumption).
- `GameState.get_effective_ac(..., cover=Cover.NONE)` accepts the degree; the engine layers the bonus on top so older `GameState` lookalikes that predate the kwarg still work.
- `Creature.make_saving_throw` / `Character.make_saving_throw` accept `cover=Cover.NONE`; the bonus folds into the circumstantial slot for DEX saves only.
- `creature_provides_cover(provider_size, target_size)` helper for the two-sizes-smaller carve-out (creature providers only).
- Most-protective-applies is enforced by construction — the API takes a single `Cover` value.

Closes #672 (supersedes #473). See [plans/03-movement-terrain-positioning.md](../blob/main/plans/03-movement-terrain-positioning.md).

## Tests lit

Seven previously-skipped cover tests in `dnd-engine/tests/srd/playing_the_game/test_making_an_attack.py` now pass; two additional assertions cover the DEX-only carve-out and the two-sizes-smaller helper:

- `TestAttackStructure_Step2_DetermineModifiers::test_cover_is_an_input_to_step_2`
- `TestCover_Intro::test_cover_state_is_representable_on_an_attack`
- `TestCover_Geometry::test_cover_only_applies_when_attack_originates_on_opposite_side`
- `TestCover_NoStacking::test_only_most_protective_cover_applies`
- `TestCover_HalfCover::test_half_cover_grants_plus_two_ac`
- `TestCover_HalfCover::test_half_cover_grants_plus_two_to_dex_saves`
- `TestCover_HalfCover::test_creature_two_sizes_smaller_grants_no_cover`
- `TestCover_ThreeQuartersCover::test_three_quarters_cover_grants_plus_five_ac`
- `TestCover_ThreeQuartersCover::test_three_quarters_cover_grants_plus_five_to_dex_saves`
- `TestCover_ThreeQuartersCover::test_cover_does_not_apply_to_non_dex_saves`
- `TestCover_TotalCover::test_total_cover_rejects_an_attack_at_step_1`

## Test plan

- [x] `uv run pytest dnd-engine/tests/srd/playing_the_game/test_making_an_attack.py` passes (19 passed, 8 unrelated skips).
- [x] `uv run pytest dnd-engine/tests/srd/playing_the_game/` — only 3 pre-existing failures (`test_advantage_disadvantage` unrelated to cover); all cover tests pass.
- [x] `uv run pytest dnd-engine/tests/` — 3491 passed, only 3 pre-existing failures.
- [x] `uv run ruff check` clean on all touched files.
- [x] `uv run ruff format --check` clean on all touched files.