### PR TITLE
feat(plan-03): diagonal movement cannot cross wall corners (#673)

### DIFF
--- a/dnd-engine/dnd_engine/core/distance.py
+++ b/dnd-engine/dnd_engine/core/distance.py
@@ -1,6 +1,15 @@
 # ABOUTME: Distance calculation utilities for grid-based tactical combat
 # ABOUTME: Implements Chebyshev distance (diagonal movement costs 1 square)
 
+from __future__ import annotations
+
+from collections import deque
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dnd_engine.core.map import Map
+    from dnd_engine.core.position import Position
+
 
 def chebyshev_distance(x1: int, y1: int, x2: int, y2: int) -> int:
     """
@@ -75,3 +84,76 @@ def distance_in_feet(x1: int, y1: int, x2: int, y2: int) -> int:
         15  # 3 squares * 5 ft
     """
     return chebyshev_distance(x1, y1, x2, y2) * 5
+
+
+def shortest_route_squares(grid_map: Map, start: Position, target: Position) -> int | None:
+    """
+    Count the shortest legal grid route from ``start`` to ``target`` in squares.
+
+    Implements the SRD § Playing on a Grid › Ranges rule ("Count by the
+    shortest route") with the corner-blocking constraint from § Corners
+    ("Diagonal movement can't cross the corner of a wall…"). Unlike
+    ``chebyshev_distance``, this consultation of map geometry rejects
+    diagonals whose cardinal neighbors are space-filling and rejects
+    paths through blocking tiles.
+
+    Performs a breadth-first search over 8-connected neighbors, treating
+    every step (orthogonal or diagonal) as one square — matching the
+    SRD's "diagonals cost the same as orthogonals" grid model. Stops
+    counting in the target's space (i.e., the count is the number of
+    steps to reach ``target``, not the number of tiles traversed).
+
+    Args:
+        grid_map: The map providing the ``is_blocking`` predicate.
+        start: Origin position. May coincide with ``target``.
+        target: Destination position.
+
+    Returns:
+        Number of grid squares along the shortest legal route, or
+        ``None`` if no such route exists. ``0`` when ``start == target``.
+
+    Example:
+        With walls at ``(1, 0)`` and ``(0, 1)`` on a 3×3 floor, the
+        diagonal ``(0, 0) → (1, 1)`` clips both walls' corners and is
+        illegal; the orthogonal neighbors are also walls, so
+        ``shortest_route_squares`` returns ``None`` (unreachable).
+    """
+    if start == target:
+        return 0
+
+    if grid_map.is_blocking(target.x, target.y):
+        # A blocking target is unreachable — you cannot stop counting
+        # inside a wall. Open-grid Chebyshev would silently return a
+        # number; the map-aware helper refuses the malformed query.
+        return None
+
+    # BFS over 8-connected steps. Each entry is (x, y, steps_so_far).
+    # ``visited`` keys are (x, y) tuples for cheap hashing.
+    queue: deque[tuple[int, int, int]] = deque()
+    queue.append((start.x, start.y, 0))
+    visited: set[tuple[int, int]] = {(start.x, start.y)}
+
+    while queue:
+        x, y, steps = queue.popleft()
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                if dx == 0 and dy == 0:
+                    continue
+                nx, ny = x + dx, y + dy
+                if (nx, ny) in visited:
+                    continue
+                if grid_map.is_blocking(nx, ny):
+                    continue
+                if (
+                    dx != 0
+                    and dy != 0
+                    and (grid_map.is_blocking(x + dx, y) or grid_map.is_blocking(x, y + dy))
+                ):
+                    # Diagonal clips a wall corner — illegal route.
+                    continue
+                if nx == target.x and ny == target.y:
+                    return steps + 1
+                visited.add((nx, ny))
+                queue.append((nx, ny, steps + 1))
+
+    return None

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -1154,6 +1154,27 @@ class GameState:
                 movement_remaining=budget,
             )
 
+        # SRD § Playing on a Grid › Corners: "Diagonal movement can't
+        # cross the corner of a wall, a large object, or other terrain
+        # feature that fills its space." A diagonal step is illegal
+        # when either cardinal neighbor between current and destination
+        # is space-filling — the diagonal segment clips that neighbor's
+        # corner even though the destination tile itself is clear.
+        if (
+            dx != 0
+            and dy != 0
+            and (
+                spatial_map.is_blocking(current.x + dx, current.y)
+                or spatial_map.is_blocking(current.x, current.y + dy)
+            )
+        ):
+            return MoveResult(
+                ok=False,
+                reason="diagonal blocked by wall corner",
+                position=current,
+                movement_remaining=budget,
+            )
+
         occupant = self.spatial.occupant_at(destination)
         allow_overlap = False
         if occupant is not None and occupant != entity_id:

--- a/dnd-engine/tests/srd/playing_the_game/test_the_order_of_combat.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_the_order_of_combat.py
@@ -255,9 +255,7 @@ class TestInitiative_GroupOfIdenticalCreatures:
         assert len(entries) == 3
         # All three share the same d20 result.
         rolls = {entry.initiative_roll for entry in entries}
-        assert len(rolls) == 1, (
-            f"identical-creatures group must share one roll; got {rolls}"
-        )
+        assert len(rolls) == 1, f"identical-creatures group must share one roll; got {rolls}"
         # And the same total (all have the same DEX modifier).
         totals = {entry.initiative_total for entry in entries}
         assert len(totals) == 1
@@ -288,9 +286,7 @@ class TestInitiative_Surprise:
         for seed in range(200):
             tracker = InitiativeTracker(DiceRoller(seed=seed))
             normal = tracker.add_combatant(_make_creature("Normal", dex=10))
-            surprised = tracker.add_combatant(
-                _make_creature("Ambushed", dex=10), surprised=True
-            )
+            surprised = tracker.add_combatant(_make_creature("Ambushed", dex=10), surprised=True)
             normal_totals.append(normal.initiative_roll)
             surprised_totals.append(surprised.initiative_roll)
 
@@ -426,10 +422,7 @@ class TestInitiative_Ties:
         tracker.dice_roller = DiceRoller(seed=1)
         tracker.add_combatant(monster)
 
-        if (
-            tracker.combatants[0].initiative_roll
-            == tracker.combatants[1].initiative_roll
-        ):
+        if tracker.combatants[0].initiative_roll == tracker.combatants[1].initiative_roll:
             # Tied counts: PC must come first.
             # (Their TOTALS differ — PC +0 vs monster +2 — but the
             # SRD 2024 wording considers the count after modifier;
@@ -437,15 +430,13 @@ class TestInitiative_Ties:
             # exactly opposite, the PC still wins on side.)
             tied_pairs = [
                 (a, b)
-                for a, b in zip(
-                    tracker.combatants, tracker.combatants[1:], strict=False
-                )
+                for a, b in zip(tracker.combatants, tracker.combatants[1:], strict=False)
                 if a.initiative_total == b.initiative_total
             ]
             for a, b in tied_pairs:
-                assert isinstance(a.creature, Character) or not isinstance(
-                    b.creature, Character
-                ), "On tied Initiative, a PC must precede a non-PC."
+                assert isinstance(a.creature, Character) or not isinstance(b.creature, Character), (
+                    "On tied Initiative, a PC must precede a non-PC."
+                )
 
         # Independent assertion that does not depend on the roll
         # coming out tied: feed two synthetic tied entries directly
@@ -806,16 +797,73 @@ class TestPlayingOnGrid_Corners:
     """
 
     def test_diagonal_move_cannot_cross_a_wall_corner(self) -> None:
-        pytest.skip(
-            "GAP: corner-blocking is not implemented. "
-            "`chebyshev_distance` (dnd_engine/core/distance.py:5-28) "
-            "treats every diagonal as a free 1-square step, with no "
-            "consultation of map / wall data. The client-2d combat-"
-            "move path (client-2d/src/client_2d/session.py:912) checks "
-            "only the destination tile for walls, never the two "
-            "orthogonal neighbors that form the corner. Tracked by "
-            "issue #476."
+        """`attempt_combat_step` rejects a diagonal that clips a wall corner.
+
+        Geometry: a wall at ``(1, 0)`` and a creature at ``(0, 0)``. The
+        diagonal step ``(dx=1, dy=1)`` would land on a floor tile
+        ``(1, 1)`` but its two cardinal neighbors are ``(1, 0)`` (wall)
+        and ``(0, 1)`` (floor). Per the SRD ("Diagonal movement can't
+        cross the corner of a wall…"), the step must fail because one
+        of those cardinal neighbors is space-filling — the diagonal
+        would clip the wall's corner. Pairs with
+        ``test_spatial_index.py::test_open_diagonal_corner_to_corner``
+        which pins the open-diagonal symmetry.
+        """
+        from dnd_engine.core.character import Character, CharacterClass
+        from dnd_engine.core.game_state import GameState
+        from dnd_engine.core.map import Map, TileType
+        from dnd_engine.core.party import Party
+        from dnd_engine.core.position import Position
+        from dnd_engine.rules.loader import DataLoader
+        from dnd_engine.utils.events import EventBus
+
+        tiles: dict[tuple[int, int], TileType] = {
+            (x, y): TileType.FLOOR for x in range(3) for y in range(3)
+        }
+        tiles[(1, 0)] = TileType.WALL
+        grid_map = Map(width=3, height=3, tiles=tiles)
+
+        abilities = Abilities(
+            strength=14,
+            dexterity=14,
+            constitution=14,
+            intelligence=10,
+            wisdom=10,
+            charisma=10,
         )
+        pc = Character(
+            name="Diag",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=abilities,
+            max_hp=12,
+            ac=12,
+            xp=0,
+        )
+        gs = GameState(
+            party=Party(characters=[pc]),
+            dungeon_name="test_dungeon",
+            event_bus=EventBus(),
+            data_loader=DataLoader(),
+            dice_roller=DiceRoller(),
+        )
+        gs.bootstrap_spatial(grid_map)
+        gs.initiative_tracker = InitiativeTracker(dice_roller=gs.dice_roller)
+        gs.initiative_tracker.add_combatant(pc)
+        for idx, entry in enumerate(gs.initiative_tracker.combatants):
+            if entry.creature is pc:
+                gs.initiative_tracker.current_turn_index = idx
+                break
+        gs.initiative_tracker.turn_states[pc].reset(speed=pc.speed)
+        entity_id = f"pc_{pc.name.lower()}"
+        gs.set_position(entity_id, 0, 0)
+
+        result = gs.attempt_combat_step(entity_id, 1, 1)
+
+        assert result.ok is False
+        assert result.reason is not None
+        assert "corner" in result.reason
+        assert result.position == Position(0, 0)
 
 
 class TestPlayingOnGrid_Ranges:
@@ -849,13 +897,46 @@ class TestPlayingOnGrid_Ranges:
         assert distance_in_feet(0, 0, 3, 3) == 15
 
     def test_range_count_honors_corner_blocking(self) -> None:
-        pytest.skip(
-            "GAP: 'count by the shortest route' implicitly excludes "
-            "routes that cross blocked corners, but the engine's "
-            "distance helpers don't take map context. Until corner-"
-            "blocking ships (issue #476), the shortest-route count "
-            "may pass through walls."
-        )
+        """`shortest_route_squares` rejects diagonals that clip wall corners.
+
+        The SRD says "count by the shortest route" but the route can't
+        cross a wall corner. ``chebyshev_distance`` doesn't take map
+        context — ``shortest_route_squares`` does. On an open grid the
+        diagonal route (0,0) → (1,1) is 1 square. With a wall at (1, 0)
+        AND a wall at (0, 1), the diagonal clips the corner of both,
+        so the only legal route runs through (1, 1) via a longer arc
+        that doesn't exist in this 2×2 carve-out — meaning the helper
+        either returns more than the Chebyshev count or reports the
+        target unreachable. The fixture leaves a corridor through
+        (2, 0) → (2, 1) → (1, 1), so the shortest route is 3 squares
+        (vs. Chebyshev's 1).
+        """
+        from dnd_engine.core.distance import shortest_route_squares
+        from dnd_engine.core.map import Map, TileType
+        from dnd_engine.core.position import Position
+
+        tiles: dict[tuple[int, int], TileType] = {
+            (x, y): TileType.FLOOR for x in range(3) for y in range(3)
+        }
+        tiles[(1, 0)] = TileType.WALL
+        tiles[(0, 1)] = TileType.WALL
+        grid_map = Map(width=3, height=3, tiles=tiles)
+
+        # Chebyshev (corner-blind) would say 1.
+        assert chebyshev_distance(0, 0, 1, 1) == 1
+        # Corner-aware shortest route walks (0,0)→(2,0)? No — (1,0) is a
+        # wall. The only legal path is (0,0)→(1,1) via cardinal-only
+        # steps that don't clip the corner: that's blocked too. The
+        # remaining route is (0,0) → ? The wall configuration makes
+        # (1, 1) unreachable from (0, 0) — the helper returns None.
+        assert shortest_route_squares(grid_map, Position(0, 0), Position(1, 1)) is None
+
+        # Sanity: with no walls, the helper agrees with Chebyshev.
+        open_tiles: dict[tuple[int, int], TileType] = {
+            (x, y): TileType.FLOOR for x in range(3) for y in range(3)
+        }
+        open_map = Map(width=3, height=3, tiles=open_tiles)
+        assert shortest_route_squares(open_map, Position(0, 0), Position(2, 2)) == 2
 
 
 class TestEndingCombat_OneSideDefeated:

--- a/dnd-engine/tests/srd/playing_the_game/test_the_order_of_combat.py
+++ b/dnd-engine/tests/srd/playing_the_game/test_the_order_of_combat.py
@@ -901,15 +901,13 @@ class TestPlayingOnGrid_Ranges:
 
         The SRD says "count by the shortest route" but the route can't
         cross a wall corner. ``chebyshev_distance`` doesn't take map
-        context — ``shortest_route_squares`` does. On an open grid the
-        diagonal route (0,0) → (1,1) is 1 square. With a wall at (1, 0)
-        AND a wall at (0, 1), the diagonal clips the corner of both,
-        so the only legal route runs through (1, 1) via a longer arc
-        that doesn't exist in this 2×2 carve-out — meaning the helper
-        either returns more than the Chebyshev count or reports the
-        target unreachable. The fixture leaves a corridor through
-        (2, 0) → (2, 1) → (1, 1), so the shortest route is 3 squares
-        (vs. Chebyshev's 1).
+        context — ``shortest_route_squares`` does. With walls at
+        ``(1, 0)`` and ``(0, 1)``, the mover at ``(0, 0)`` is boxed in:
+        both cardinal neighbors to ``(1, 1)`` are space-filling, so the
+        diagonal clips a corner and is illegal, and the only orthogonal
+        neighbors are themselves walls. ``(1, 1)`` is unreachable from
+        ``(0, 0)`` and the helper returns ``None`` — even though
+        Chebyshev (corner-blind) would report a distance of 1.
         """
         from dnd_engine.core.distance import shortest_route_squares
         from dnd_engine.core.map import Map, TileType
@@ -924,11 +922,9 @@ class TestPlayingOnGrid_Ranges:
 
         # Chebyshev (corner-blind) would say 1.
         assert chebyshev_distance(0, 0, 1, 1) == 1
-        # Corner-aware shortest route walks (0,0)→(2,0)? No — (1,0) is a
-        # wall. The only legal path is (0,0)→(1,1) via cardinal-only
-        # steps that don't clip the corner: that's blocked too. The
-        # remaining route is (0,0) → ? The wall configuration makes
-        # (1, 1) unreachable from (0, 0) — the helper returns None.
+        # Corner-aware: (0,0) has no legal exit toward (1,1). The
+        # diagonal clips both walls' corners; (1,0) and (0,1) are
+        # themselves walls. (1, 1) is unreachable.
         assert shortest_route_squares(grid_map, Position(0, 0), Position(1, 1)) is None
 
         # Sanity: with no walls, the helper agrees with Chebyshev.


### PR DESCRIPTION
## Summary

- Adds SRD corner-blocking to `GameState.attempt_combat_step`: a diagonal step is rejected when either cardinal neighbor between the current tile and the destination is space-filling, even if the destination itself is clear.
- Adds `shortest_route_squares` in `dnd_engine/core/distance.py` — a map-aware BFS that counts the shortest legal grid route honoring wall blocking and the corner rule.
- Lights up two previously skipped gating tests in `test_the_order_of_combat.py`:
  - `TestPlayingOnGrid_Corners::test_diagonal_move_cannot_cross_a_wall_corner`
  - `TestPlayingOnGrid_Ranges::test_range_count_honors_corner_blocking`
- Pairs with `test_spatial_index.py::test_open_diagonal_corner_to_corner` (unmodified) which pins the open-diagonal symmetry.

Closes #673. See plan: `plans/03-movement-terrain-positioning.md` (Slice 4).

## Test plan

- [x] `uv run pytest dnd-engine/tests/srd/playing_the_game/test_the_order_of_combat.py` — passes
- [x] `uv run pytest dnd-engine/tests/srd/playing_the_game/test_spatial_index.py` — passes
- [x] `uv run pytest dnd-engine/tests/` — only the 4 pre-existing failures (3 in `test_advantage_disadvantage`, 1 in `test_underwater_combat`) verified present on `main` before the branch
- [x] `uv run ruff check` and `ruff format --check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)