### PR TITLE
[plan-684 s1] Node-surface schema, loader validation, lab settlement fixture

### DIFF
--- a/client-terminal/terminal_client/ui/campaign_wizard.py
+++ b/client-terminal/terminal_client/ui/campaign_wizard.py
@@ -2,6 +2,9 @@
 # ABOUTME: Handles multi-step campaign creation with party building and dungeon selection
 
 
+import json
+from pathlib import Path
+
 import questionary
 from questionary import Choice
 from rich import box
@@ -341,6 +344,33 @@ class CampaignCreationWizard:
         except ValueError:
             print_error("Please enter a number")
 
+    def _list_adventure_files(self) -> list[Path]:
+        """
+        List dungeon files selectable as adventures.
+
+        Excludes generated dungeons (timestamped names) and node-surface
+        locations: this wizard starts the grid game loop, which requires
+        rooms/start_room. Files that fail to parse stay listed and fail at
+        load with a real error.
+
+        Returns:
+            Sorted list of selectable dungeon file paths
+        """
+        dungeons_dir = self.data_loader.data_path / "content" / "dungeons"
+        dungeon_files = sorted(dungeons_dir.glob("*.json"))
+
+        dungeon_files = [f for f in dungeon_files if not f.stem.startswith("generated_")]
+
+        def is_node_surface(path: Path) -> bool:
+            try:
+                with open(path) as f:
+                    data = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                return False
+            return isinstance(data, dict) and data.get("surface") == "node"
+
+        return [f for f in dungeon_files if not is_node_surface(f)]
+
     def _step_select_adventure(self) -> bool:
         """
         Step 4: Select adventure/dungeon.
@@ -352,12 +382,7 @@ class CampaignCreationWizard:
         print_section("Step 4: Select Adventure")
         console.print()
 
-        # List available dungeons
-        dungeons_dir = self.data_loader.data_path / "content" / "dungeons"
-        dungeon_files = sorted(dungeons_dir.glob("*.json"))
-
-        # Filter out generated dungeons (they have timestamps in name)
-        dungeon_files = [f for f in dungeon_files if not f.stem.startswith("generated_")]
+        dungeon_files = self._list_adventure_files()
 
         if not dungeon_files:
             print_error("No adventures found in dungeon directory")

--- a/client-terminal/tests/test_campaign_wizard_adventure_list.py
+++ b/client-terminal/tests/test_campaign_wizard_adventure_list.py
@@ -1,0 +1,70 @@
+# ABOUTME: Tests for the campaign wizard's adventure listing (issue #684 slice 1).
+# ABOUTME: Node-surface locations must not be selectable while the wizard drives the grid loop.
+
+import json
+
+import pytest
+
+from dnd_engine.rules.loader import DataLoader
+from terminal_client.ui.campaign_wizard import CampaignCreationWizard
+
+
+@pytest.fixture
+def wizard_with_mixed_content(tmp_path):
+    dungeon_dir = tmp_path / "content" / "dungeons"
+    dungeon_dir.mkdir(parents=True)
+
+    grid = {"id": "grid_dungeon", "name": "Grid Dungeon", "start_room": "a", "rooms": {"a": {}}}
+    (dungeon_dir / "grid_dungeon.json").write_text(json.dumps(grid))
+
+    node = {
+        "id": "node_settlement",
+        "name": "Node Settlement",
+        "surface": "node",
+        "start_node": "square",
+        "nodes": {
+            "square": {
+                "name": "Square",
+                "blurb": "A square.",
+                "description": "A quiet square.",
+            }
+        },
+    }
+    (dungeon_dir / "node_settlement.json").write_text(json.dumps(node))
+
+    generated = dict(grid, id="generated_123")
+    (dungeon_dir / "generated_123.json").write_text(json.dumps(generated))
+
+    loader = DataLoader()
+    loader.data_path = tmp_path
+    return CampaignCreationWizard(data_loader=loader)
+
+
+class TestAdventureListing:
+    def test_grid_dungeons_listed(self, wizard_with_mixed_content):
+        files = wizard_with_mixed_content._list_adventure_files()
+        assert [f.stem for f in files] == ["grid_dungeon"]
+
+    def test_node_surface_locations_excluded(self, wizard_with_mixed_content):
+        """A node-surface file must not be selectable: the wizard starts the
+        grid game loop, which requires rooms/start_room."""
+        files = wizard_with_mixed_content._list_adventure_files()
+        assert "node_settlement" not in [f.stem for f in files]
+
+    def test_generated_dungeons_excluded(self, wizard_with_mixed_content):
+        files = wizard_with_mixed_content._list_adventure_files()
+        assert "generated_123" not in [f.stem for f in files]
+
+    def test_unreadable_json_still_listed(self, tmp_path):
+        """Malformed JSON keeps its legacy behavior (listed; fails later),
+        rather than being silently hidden by the surface filter."""
+        dungeon_dir = tmp_path / "content" / "dungeons"
+        dungeon_dir.mkdir(parents=True)
+        (dungeon_dir / "broken.json").write_text("{not json")
+
+        loader = DataLoader()
+        loader.data_path = tmp_path
+        wizard = CampaignCreationWizard(data_loader=loader)
+
+        files = wizard._list_adventure_files()
+        assert [f.stem for f in files] == ["broken"]

--- a/dnd-engine/dnd_engine/core/room_registry.py
+++ b/dnd-engine/dnd_engine/core/room_registry.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from dnd_engine.rules.node_schema import validate_location_surface
+
 
 class RoomRegistry:
     """
@@ -124,10 +126,16 @@ class RoomRegistry:
         try:
             with open(dungeon_file) as f:
                 dungeon_data = json.load(f)
-            self._loaded_dungeons[dungeon_name] = dungeon_data
-            return dungeon_data
         except (json.JSONDecodeError, OSError):
             return None
+
+        # Surface-declaring locations are validated on every load path, not
+        # only DataLoader's; a schema violation is an authoring bug and must
+        # surface loudly rather than degrade to a missing dungeon.
+        validate_location_surface(dungeon_data, source=str(dungeon_file))
+
+        self._loaded_dungeons[dungeon_name] = dungeon_data
+        return dungeon_data
 
     def get_room(self, room_id: str) -> dict[str, Any] | None:
         """

--- a/dnd-engine/dnd_engine/data/content/dungeons/lab_settlement.json
+++ b/dnd-engine/dnd_engine/data/content/dungeons/lab_settlement.json
@@ -1,0 +1,43 @@
+{
+  "id": "lab_settlement",
+  "name": "Lab Settlement",
+  "description": "A tiny test settlement exercising every node-surface schema shape. Used by automated tests and manual lab sessions; not part of any campaign.",
+  "surface": "node",
+  "start_node": "lab_square",
+  "nodes": {
+    "lab_square": {
+      "name": "Lab Square",
+      "blurb": "The heart of the lab settlement; a notice board stands by the well.",
+      "description": "You stand in a small square ringed by test buildings. A notice board leans beside a well, papered with parchments.",
+      "npcs": [],
+      "actions": ["gather_rumors", "read_job_board"]
+    },
+    "lab_tavern": {
+      "name": "The Testing Tankard",
+      "blurb": "A warm tavern for exercising talk, shop, and rest.",
+      "description": "Woodsmoke and spilled ale. The taproom is quiet; a fire crackles in the hearth.",
+      "npcs": [],
+      "actions": ["talk", "shop", "rest"]
+    },
+    "lab_gate": {
+      "name": "The Old Gate",
+      "blurb": "A sealed gate bearing a strange symbol.",
+      "description": "A rusted gate blocks a stairwell descending into darkness. A symbol is scratched into the lintel.",
+      "npcs": [],
+      "actions": [
+        {
+          "id": "examine_symbol",
+          "gate": {"skill": "religion", "dc": 12},
+          "on_success": "The symbol is a ward against the restless dead — someone sealed this gate on purpose.",
+          "on_failure": "The scratches look old and deliberate, but their meaning escapes you."
+        }
+      ],
+      "transition": {
+        "to": "test_dungeon",
+        "gate": {"skill": "athletics", "dc": 10},
+        "on_success": "The gate groans open, and stale air rolls up from the dark.",
+        "on_failure": "You heave at the gate, but it will not budge."
+      }
+    }
+  }
+}

--- a/dnd-engine/dnd_engine/rules/loader.py
+++ b/dnd-engine/dnd_engine/rules/loader.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from dnd_engine.core.creature import Abilities, Creature, MovementMode, Size
 from dnd_engine.core.dice import DiceRoller
+from dnd_engine.rules.node_schema import validate_node_location
 from dnd_engine.systems.perception import parse_senses
 
 
@@ -225,7 +226,14 @@ class DataLoader:
             raise FileNotFoundError(f"Dungeon file not found: {dungeon_file}")
 
         with open(dungeon_file) as f:
-            return json.load(f)
+            data = json.load(f)
+
+        # Node-surface locations are validated at load time; grid dungeons
+        # (no "surface" key) keep their historical unvalidated path.
+        if data.get("surface") == "node":
+            validate_node_location(data, source=str(dungeon_file))
+
+        return data
 
     def load_classes(self) -> dict[str, Any]:
         """

--- a/dnd-engine/dnd_engine/rules/loader.py
+++ b/dnd-engine/dnd_engine/rules/loader.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from dnd_engine.core.creature import Abilities, Creature, MovementMode, Size
 from dnd_engine.core.dice import DiceRoller
-from dnd_engine.rules.node_schema import validate_node_location
+from dnd_engine.rules.node_schema import validate_location_surface
 from dnd_engine.systems.perception import parse_senses
 
 
@@ -208,6 +208,8 @@ class DataLoader:
 
         Raises:
             FileNotFoundError: If dungeon file doesn't exist
+            NodeSchemaError: If the file declares a surface and violates
+                the node-surface schema
         """
         if campaign_id:
             dungeon_file = (
@@ -228,10 +230,9 @@ class DataLoader:
         with open(dungeon_file) as f:
             data = json.load(f)
 
-        # Node-surface locations are validated at load time; grid dungeons
-        # (no "surface" key) keep their historical unvalidated path.
-        if data.get("surface") == "node":
-            validate_node_location(data, source=str(dungeon_file))
+        # Locations that declare a surface are validated on load; grid
+        # dungeons without a "surface" key load as-is.
+        validate_location_surface(data, source=str(dungeon_file))
 
         return data
 

--- a/dnd-engine/dnd_engine/rules/node_schema.py
+++ b/dnd-engine/dnd_engine/rules/node_schema.py
@@ -1,0 +1,150 @@
+# ABOUTME: Schema validation for node-surface locations (settlements presented as theater-of-the-mind nodes).
+# ABOUTME: Enforces the fixed action vocabulary and the gated-action prose rules from issue #684.
+
+from typing import Any
+
+# Simple actions the engine dispatches without extra authoring. examine_* is
+# deliberately absent: it is skill-gated by definition, so it must be authored
+# in object form where the gate and both prose branches live.
+NODE_ACTION_VOCABULARY = frozenset(
+    {
+        "talk",
+        "shop",
+        "rest",
+        "gather_rumors",
+        "read_job_board",
+    }
+)
+
+EXAMINE_PREFIX = "examine_"
+
+VALID_SURFACES = frozenset({"grid", "node"})
+
+
+class NodeSchemaError(Exception):
+    """Raised when a node-surface location file violates the schema.
+
+    The message always includes the offending key path so an author can fix
+    the JSON without spelunking through tracebacks.
+    """
+
+
+def validate_node_location(data: dict[str, Any], source: str = "") -> None:
+    """
+    Validate a location dict that declares ``surface: "node"``.
+
+    Args:
+        data: Parsed location JSON.
+        source: Optional file path for error messages.
+
+    Raises:
+        NodeSchemaError: On any schema violation.
+    """
+    where = f" in {source}" if source else ""
+
+    surface = data.get("surface")
+    if surface not in VALID_SURFACES:
+        raise NodeSchemaError(
+            f"Unknown surface {surface!r}{where}; expected one of {sorted(VALID_SURFACES)}"
+        )
+
+    if "rooms" in data:
+        raise NodeSchemaError(
+            f"Node-surface location declares 'rooms'{where}; "
+            "'rooms' and 'nodes' are mutually exclusive"
+        )
+
+    nodes = data.get("nodes")
+    if not isinstance(nodes, dict) or not nodes:
+        raise NodeSchemaError(f"Node-surface location requires a non-empty 'nodes' mapping{where}")
+
+    start_node = data.get("start_node")
+    if not start_node:
+        raise NodeSchemaError(f"Node-surface location requires 'start_node'{where}")
+    if start_node not in nodes:
+        raise NodeSchemaError(f"start_node {start_node!r} is not a key in 'nodes'{where}")
+
+    for node_id, node in nodes.items():
+        _validate_node(node_id, node, where)
+
+
+def _validate_node(node_id: str, node: Any, where: str) -> None:
+    path = f"nodes.{node_id}"
+    if not isinstance(node, dict):
+        raise NodeSchemaError(f"{path} must be an object{where}")
+
+    for prose_field in ("name", "blurb", "description"):
+        value = node.get(prose_field)
+        if not isinstance(value, str) or not value.strip():
+            raise NodeSchemaError(f"{path} requires non-empty '{prose_field}'{where}")
+
+    npcs = node.get("npcs", [])
+    if not isinstance(npcs, list) or any(not isinstance(n, str) for n in npcs):
+        raise NodeSchemaError(f"{path}.npcs must be a list of NPC ids{where}")
+
+    for index, action in enumerate(node.get("actions", [])):
+        _validate_action(f"{path}.actions[{index}]", action, where)
+
+    if "transition" in node:
+        _validate_transition(f"{path}.transition", node["transition"], where)
+
+
+def _validate_action(path: str, action: Any, where: str) -> None:
+    if isinstance(action, str):
+        if action.startswith(EXAMINE_PREFIX):
+            raise NodeSchemaError(
+                f"{path}: {action!r} is skill-gated and must be authored in object "
+                f"form with 'gate', 'on_success', and 'on_failure'{where}"
+            )
+        if action not in NODE_ACTION_VOCABULARY:
+            raise NodeSchemaError(
+                f"{path}: unknown action {action!r}{where}; "
+                f"expected one of {sorted(NODE_ACTION_VOCABULARY)} or an object form"
+            )
+        return
+
+    if not isinstance(action, dict):
+        raise NodeSchemaError(f"{path} must be a string or object{where}")
+
+    action_id = action.get("id")
+    if not isinstance(action_id, str) or not (
+        action_id in NODE_ACTION_VOCABULARY or action_id.startswith(EXAMINE_PREFIX)
+    ):
+        raise NodeSchemaError(
+            f"{path}: unknown action id {action_id!r}{where}; "
+            f"expected one of {sorted(NODE_ACTION_VOCABULARY)} or '{EXAMINE_PREFIX}*'"
+        )
+
+    _validate_gate_and_prose(path, action, where)
+
+
+def _validate_transition(path: str, transition: Any, where: str) -> None:
+    if not isinstance(transition, dict):
+        raise NodeSchemaError(f"{path} must be an object{where}")
+
+    destination = transition.get("to")
+    if not isinstance(destination, str) or not destination.strip():
+        raise NodeSchemaError(f"{path} requires a non-empty 'to' destination{where}")
+
+    _validate_gate_and_prose(path, transition, where)
+
+
+def _validate_gate_and_prose(path: str, entry: dict[str, Any], where: str) -> None:
+    """A gate makes an entry a skill check; every check authors both outcomes."""
+    gate = entry.get("gate")
+    if gate is None:
+        return
+
+    if not isinstance(gate, dict):
+        raise NodeSchemaError(f"{path}.gate must be an object{where}")
+    if not isinstance(gate.get("skill"), str) or not gate.get("skill"):
+        raise NodeSchemaError(f"{path}.gate requires 'skill'{where}")
+    if not isinstance(gate.get("dc"), int):
+        raise NodeSchemaError(f"{path}.gate requires an integer 'dc'{where}")
+
+    for branch in ("on_success", "on_failure"):
+        value = entry.get(branch)
+        if not isinstance(value, str) or not value.strip():
+            raise NodeSchemaError(
+                f"{path}: gated entries require non-empty '{branch}' prose{where}"
+            )

--- a/dnd-engine/dnd_engine/rules/node_schema.py
+++ b/dnd-engine/dnd_engine/rules/node_schema.py
@@ -4,8 +4,8 @@
 from typing import Any
 
 # Simple actions the engine dispatches without extra authoring. examine_* is
-# deliberately absent: it is skill-gated by definition, so it must be authored
-# in object form where the gate and both prose branches live.
+# deliberately absent: it is a skill check, so it must be authored in object
+# form where the gate and both prose branches live.
 NODE_ACTION_VOCABULARY = frozenset(
     {
         "talk",
@@ -18,7 +18,19 @@ NODE_ACTION_VOCABULARY = frozenset(
 
 EXAMINE_PREFIX = "examine_"
 
-VALID_SURFACES = frozenset({"grid", "node"})
+# Every key a node may carry. Unknown keys fail at load so a typo like
+# "transtion" can't silently drop content.
+NODE_KEYS = frozenset(
+    {
+        "name",
+        "blurb",
+        "description",
+        "npcs",
+        "actions",
+        "transition",
+        "quest_hook",
+    }
+)
 
 
 class NodeSchemaError(Exception):
@@ -27,6 +39,36 @@ class NodeSchemaError(Exception):
     The message always includes the offending key path so an author can fix
     the JSON without spelunking through tracebacks.
     """
+
+
+def validate_location_surface(data: Any, source: str = "") -> None:
+    """
+    Validate any parsed location JSON according to its declared surface.
+
+    The single entry point for every load path (DataLoader, RoomRegistry).
+    Locations without a ``surface`` key are legacy grid dungeons and pass
+    through untouched, as do non-dict payloads.
+
+    Args:
+        data: Parsed location JSON.
+        source: Optional file path for error messages.
+
+    Raises:
+        NodeSchemaError: On an unknown surface value or any node-schema
+            violation.
+    """
+    if not isinstance(data, dict):
+        return
+
+    surface = data.get("surface")
+    if surface is None or surface == "grid":
+        return
+    if surface == "node":
+        validate_node_location(data, source=source)
+        return
+
+    where = f" in {source}" if source else ""
+    raise NodeSchemaError(f"Unknown surface {surface!r}{where}; expected 'grid' or 'node'")
 
 
 def validate_node_location(data: dict[str, Any], source: str = "") -> None:
@@ -42,10 +84,10 @@ def validate_node_location(data: dict[str, Any], source: str = "") -> None:
     """
     where = f" in {source}" if source else ""
 
-    surface = data.get("surface")
-    if surface not in VALID_SURFACES:
+    if data.get("surface") != "node":
         raise NodeSchemaError(
-            f"Unknown surface {surface!r}{where}; expected one of {sorted(VALID_SURFACES)}"
+            f"validate_node_location called for surface {data.get('surface')!r}{where}; "
+            "expected 'node'"
         )
 
     if "rooms" in data:
@@ -73,16 +115,24 @@ def _validate_node(node_id: str, node: Any, where: str) -> None:
     if not isinstance(node, dict):
         raise NodeSchemaError(f"{path} must be an object{where}")
 
+    unknown_keys = set(node) - NODE_KEYS
+    if unknown_keys:
+        raise NodeSchemaError(
+            f"{path} has unknown key(s) {sorted(unknown_keys)}{where}; "
+            f"expected only {sorted(NODE_KEYS)}"
+        )
+
     for prose_field in ("name", "blurb", "description"):
-        value = node.get(prose_field)
-        if not isinstance(value, str) or not value.strip():
-            raise NodeSchemaError(f"{path} requires non-empty '{prose_field}'{where}")
+        _require_nonempty_str(node, prose_field, path, where)
 
     npcs = node.get("npcs", [])
     if not isinstance(npcs, list) or any(not isinstance(n, str) for n in npcs):
         raise NodeSchemaError(f"{path}.npcs must be a list of NPC ids{where}")
 
-    for index, action in enumerate(node.get("actions", [])):
+    actions = node.get("actions", [])
+    if not isinstance(actions, list):
+        raise NodeSchemaError(f"{path}.actions must be a list{where}")
+    for index, action in enumerate(actions):
         _validate_action(f"{path}.actions[{index}]", action, where)
 
     if "transition" in node:
@@ -90,20 +140,10 @@ def _validate_node(node_id: str, node: Any, where: str) -> None:
 
 
 def _validate_action(path: str, action: Any, where: str) -> None:
+    # String actions are shorthand for {"id": <string>}; one branch validates both.
     if isinstance(action, str):
-        if action.startswith(EXAMINE_PREFIX):
-            raise NodeSchemaError(
-                f"{path}: {action!r} is skill-gated and must be authored in object "
-                f"form with 'gate', 'on_success', and 'on_failure'{where}"
-            )
-        if action not in NODE_ACTION_VOCABULARY:
-            raise NodeSchemaError(
-                f"{path}: unknown action {action!r}{where}; "
-                f"expected one of {sorted(NODE_ACTION_VOCABULARY)} or an object form"
-            )
-        return
-
-    if not isinstance(action, dict):
+        action = {"id": action}
+    elif not isinstance(action, dict):
         raise NodeSchemaError(f"{path} must be a string or object{where}")
 
     action_id = action.get("id")
@@ -111,8 +151,14 @@ def _validate_action(path: str, action: Any, where: str) -> None:
         action_id in NODE_ACTION_VOCABULARY or action_id.startswith(EXAMINE_PREFIX)
     ):
         raise NodeSchemaError(
-            f"{path}: unknown action id {action_id!r}{where}; "
+            f"{path}: unknown action {action_id!r}{where}; "
             f"expected one of {sorted(NODE_ACTION_VOCABULARY)} or '{EXAMINE_PREFIX}*'"
+        )
+
+    if action_id.startswith(EXAMINE_PREFIX) and "gate" not in action:
+        raise NodeSchemaError(
+            f"{path}: {action_id!r} is a skill check and must be authored in object "
+            f"form with 'gate', 'on_success', and 'on_failure'{where}"
         )
 
     _validate_gate_and_prose(path, action, where)
@@ -122,10 +168,7 @@ def _validate_transition(path: str, transition: Any, where: str) -> None:
     if not isinstance(transition, dict):
         raise NodeSchemaError(f"{path} must be an object{where}")
 
-    destination = transition.get("to")
-    if not isinstance(destination, str) or not destination.strip():
-        raise NodeSchemaError(f"{path} requires a non-empty 'to' destination{where}")
-
+    _require_nonempty_str(transition, "to", path, where)
     _validate_gate_and_prose(path, transition, where)
 
 
@@ -137,14 +180,16 @@ def _validate_gate_and_prose(path: str, entry: dict[str, Any], where: str) -> No
 
     if not isinstance(gate, dict):
         raise NodeSchemaError(f"{path}.gate must be an object{where}")
-    if not isinstance(gate.get("skill"), str) or not gate.get("skill"):
-        raise NodeSchemaError(f"{path}.gate requires 'skill'{where}")
-    if not isinstance(gate.get("dc"), int):
+    _require_nonempty_str(gate, "skill", f"{path}.gate", where)
+    dc = gate.get("dc")
+    if not isinstance(dc, int) or isinstance(dc, bool):
         raise NodeSchemaError(f"{path}.gate requires an integer 'dc'{where}")
 
     for branch in ("on_success", "on_failure"):
-        value = entry.get(branch)
-        if not isinstance(value, str) or not value.strip():
-            raise NodeSchemaError(
-                f"{path}: gated entries require non-empty '{branch}' prose{where}"
-            )
+        _require_nonempty_str(entry, branch, path, where)
+
+
+def _require_nonempty_str(container: dict[str, Any], field: str, path: str, where: str) -> None:
+    value = container.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise NodeSchemaError(f"{path} requires non-empty '{field}'{where}")

--- a/dnd-engine/tests/test_node_schema.py
+++ b/dnd-engine/tests/test_node_schema.py
@@ -2,13 +2,16 @@
 # ABOUTME: Covers surface discrimination, nodes validation, and gated-action prose rules.
 
 import copy
+import json
 
 import pytest
 
+from dnd_engine.core.room_registry import RoomRegistry
 from dnd_engine.rules.loader import DataLoader
 from dnd_engine.rules.node_schema import (
     NODE_ACTION_VOCABULARY,
     NodeSchemaError,
+    validate_location_surface,
     validate_node_location,
 )
 
@@ -35,6 +38,12 @@ def _minimal_settlement() -> dict:
             },
         },
     }
+
+
+def _write_dungeon(tmp_path, name: str, data: dict) -> None:
+    dungeon_dir = tmp_path / "content" / "dungeons"
+    dungeon_dir.mkdir(parents=True, exist_ok=True)
+    (dungeon_dir / f"{name}.json").write_text(json.dumps(data))
 
 
 class TestLabSettlementFixture:
@@ -75,6 +84,48 @@ class TestGridPathUnchanged:
     def test_campaign_grid_dungeon_loads(self, loader):
         data = loader.load_dungeon("crypt", campaign_id="the_unquiet_dead")
         assert "rooms" in data
+
+
+class TestSurfaceDispatch:
+    """validate_location_surface is the single entry point for surface handling."""
+
+    def test_missing_surface_passes(self):
+        validate_location_surface({"rooms": {}})  # legacy grid; should not raise
+
+    def test_explicit_grid_surface_passes(self):
+        validate_location_surface({"surface": "grid", "rooms": {}})  # should not raise
+
+    def test_node_surface_dispatches_to_node_validation(self):
+        data = _minimal_settlement()
+        del data["start_node"]
+        with pytest.raises(NodeSchemaError, match="start_node"):
+            validate_location_surface(data)
+
+    def test_unknown_surface_rejected(self):
+        with pytest.raises(NodeSchemaError, match="surface"):
+            validate_location_surface({"surface": "holodeck"})
+
+    def test_non_dict_passes_through(self):
+        validate_location_surface([])  # legacy tolerance; should not raise
+
+    def test_loader_rejects_typoed_surface(self, loader, tmp_path, monkeypatch):
+        """A typo like surface:"nodes" must fail loudly, not load as a grid."""
+        bad = _minimal_settlement()
+        bad["surface"] = "nodes"
+        _write_dungeon(tmp_path, "typo_settlement", bad)
+        monkeypatch.setattr(loader, "data_path", tmp_path)
+
+        with pytest.raises(NodeSchemaError, match="surface"):
+            loader.load_dungeon("typo_settlement")
+
+    def test_loader_tolerates_non_dict_top_level(self, loader, tmp_path, monkeypatch):
+        """Non-object top-level JSON keeps its legacy behavior: returned as-is."""
+        dungeon_dir = tmp_path / "content" / "dungeons"
+        dungeon_dir.mkdir(parents=True)
+        (dungeon_dir / "weird.json").write_text("[]")
+        monkeypatch.setattr(loader, "data_path", tmp_path)
+
+        assert loader.load_dungeon("weird") == []
 
 
 class TestSurfaceDiscrimination:
@@ -127,6 +178,21 @@ class TestNodeProse:
             validate_node_location(data)
 
 
+class TestNodeKeys:
+    """Unknown keys fail at load so typos can't silently drop content."""
+
+    def test_typoed_key_rejected(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["transtion"] = {"to": "test_dungeon"}
+        with pytest.raises(NodeSchemaError, match="transtion"):
+            validate_node_location(data)
+
+    def test_quest_hook_allowed(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["quest_hook"] = "investigate_crypt"
+        validate_node_location(data)  # should not raise
+
+
 class TestActionVocabulary:
     def test_vocabulary_contents(self):
         assert NODE_ACTION_VOCABULARY == {
@@ -149,8 +215,8 @@ class TestActionVocabulary:
             validate_node_location(data)
 
     def test_bare_examine_string_rejected(self):
-        """examine_* is skill-gated by definition; it must be object form
-        so the gate and both prose branches have somewhere to live."""
+        """examine_* is a skill check; without object form there is nowhere
+        for the gate and its two prose branches to live."""
         data = _minimal_settlement()
         data["nodes"]["square"]["actions"] = ["examine_door"]
         with pytest.raises(NodeSchemaError, match="examine_door"):
@@ -168,12 +234,33 @@ class TestActionVocabulary:
         ]
         validate_node_location(data)  # should not raise
 
+    def test_examine_object_without_gate_rejected(self):
+        """The examine invariant holds in object form too, not only string form."""
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = [{"id": "examine_door"}]
+        with pytest.raises(NodeSchemaError, match="gate"):
+            validate_node_location(data)
+
     def test_unknown_object_action_id_rejected(self):
         data = _minimal_settlement()
         data["nodes"]["square"]["actions"] = [
             {"id": "moonwalk", "on_success": "x", "on_failure": "y"}
         ]
         with pytest.raises(NodeSchemaError, match="moonwalk"):
+            validate_node_location(data)
+
+
+class TestActionsShape:
+    def test_actions_string_rejected(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = "talk"
+        with pytest.raises(NodeSchemaError, match="actions"):
+            validate_node_location(data)
+
+    def test_actions_non_iterable_rejected_as_schema_error(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = 5
+        with pytest.raises(NodeSchemaError, match="actions"):
             validate_node_location(data)
 
 
@@ -207,6 +294,32 @@ class TestGatedActionProse:
         with pytest.raises(NodeSchemaError, match="dc"):
             validate_node_location(data)
 
+    def test_boolean_dc_rejected(self):
+        """bool is a subclass of int; dc: true must not validate as DC 1."""
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = [
+            {
+                "id": "examine_door",
+                "gate": {"skill": "religion", "dc": True},
+                "on_success": "x",
+                "on_failure": "y",
+            }
+        ]
+        with pytest.raises(NodeSchemaError, match="dc"):
+            validate_node_location(data)
+
+    def test_zero_dc_accepted(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = [
+            {
+                "id": "examine_door",
+                "gate": {"skill": "religion", "dc": 0},
+                "on_success": "x",
+                "on_failure": "y",
+            }
+        ]
+        validate_node_location(data)  # should not raise
+
 
 class TestTransition:
     def test_transition_requires_destination(self):
@@ -239,14 +352,32 @@ class TestLoaderIntegration:
     """load_dungeon validates node-surface files at load time."""
 
     def test_invalid_node_file_raises_at_load(self, loader, tmp_path, monkeypatch):
-        import json
-
         bad = copy.deepcopy(_minimal_settlement())
         bad["start_node"] = "nowhere"
-        dungeon_dir = tmp_path / "content" / "dungeons"
-        dungeon_dir.mkdir(parents=True)
-        (dungeon_dir / "bad_settlement.json").write_text(json.dumps(bad))
+        _write_dungeon(tmp_path, "bad_settlement", bad)
         monkeypatch.setattr(loader, "data_path", tmp_path)
 
         with pytest.raises(NodeSchemaError, match="start_node"):
             loader.load_dungeon("bad_settlement")
+
+
+class TestRoomRegistryValidation:
+    """The registry load path enforces the same surface validation as DataLoader."""
+
+    def test_registry_rejects_invalid_node_file(self, tmp_path):
+        bad = _minimal_settlement()
+        bad["start_node"] = "nowhere"
+        (tmp_path / "bad_settlement.json").write_text(json.dumps(bad))
+        registry = RoomRegistry(dungeons_path=tmp_path)
+
+        with pytest.raises(NodeSchemaError, match="start_node"):
+            registry.load_dungeon("bad_settlement")
+
+    def test_registry_loads_valid_node_file(self, tmp_path):
+        good = _minimal_settlement()
+        (tmp_path / "good_settlement.json").write_text(json.dumps(good))
+        registry = RoomRegistry(dungeons_path=tmp_path)
+
+        data = registry.load_dungeon("good_settlement")
+        assert data is not None
+        assert data["surface"] == "node"

--- a/dnd-engine/tests/test_node_schema.py
+++ b/dnd-engine/tests/test_node_schema.py
@@ -1,0 +1,252 @@
+# ABOUTME: Tests for the node-surface location schema (issue #684 slice 1).
+# ABOUTME: Covers surface discrimination, nodes validation, and gated-action prose rules.
+
+import copy
+
+import pytest
+
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.rules.node_schema import (
+    NODE_ACTION_VOCABULARY,
+    NodeSchemaError,
+    validate_node_location,
+)
+
+
+@pytest.fixture
+def loader():
+    return DataLoader()
+
+
+def _minimal_settlement() -> dict:
+    """A minimal valid node-surface location for mutation in tests."""
+    return {
+        "id": "test_settlement",
+        "name": "Test Settlement",
+        "surface": "node",
+        "start_node": "square",
+        "nodes": {
+            "square": {
+                "name": "The Square",
+                "blurb": "A quiet square.",
+                "description": "You stand in a quiet square.",
+                "npcs": [],
+                "actions": ["gather_rumors"],
+            },
+        },
+    }
+
+
+class TestLabSettlementFixture:
+    """The lab settlement fixture loads and passes validation."""
+
+    def test_fixture_loads(self, loader):
+        data = loader.load_dungeon("lab_settlement")
+        assert data["surface"] == "node"
+        assert data["start_node"] in data["nodes"]
+
+    def test_fixture_has_prose_on_every_node(self, loader):
+        data = loader.load_dungeon("lab_settlement")
+        for node_id, node in data["nodes"].items():
+            assert node["name"], node_id
+            assert node["blurb"], node_id
+            assert node["description"], node_id
+
+    def test_fixture_exercises_gated_action_and_transition(self, loader):
+        """The lab fixture must cover the shapes later slices build on."""
+        data = loader.load_dungeon("lab_settlement")
+        nodes = data["nodes"].values()
+        gated = [
+            a for n in nodes for a in n.get("actions", []) if isinstance(a, dict) and a.get("gate")
+        ]
+        transitions = [n["transition"] for n in nodes if "transition" in n]
+        assert gated, "fixture needs at least one skill-gated action"
+        assert transitions, "fixture needs at least one transition"
+
+
+class TestGridPathUnchanged:
+    """Grid dungeons (no surface key) load exactly as before."""
+
+    def test_standalone_grid_dungeon_loads(self, loader):
+        data = loader.load_dungeon("test_dungeon")
+        assert "rooms" in data
+        assert "surface" not in data
+
+    def test_campaign_grid_dungeon_loads(self, loader):
+        data = loader.load_dungeon("crypt", campaign_id="the_unquiet_dead")
+        assert "rooms" in data
+
+
+class TestSurfaceDiscrimination:
+    def test_unknown_surface_value_rejected(self):
+        data = _minimal_settlement()
+        data["surface"] = "holodeck"
+        with pytest.raises(NodeSchemaError, match="surface"):
+            validate_node_location(data)
+
+    def test_rooms_and_nodes_are_mutually_exclusive(self):
+        data = _minimal_settlement()
+        data["rooms"] = {"square_room": {}}
+        with pytest.raises(NodeSchemaError, match="rooms"):
+            validate_node_location(data)
+
+    def test_node_surface_requires_nodes(self):
+        data = _minimal_settlement()
+        del data["nodes"]
+        with pytest.raises(NodeSchemaError, match="nodes"):
+            validate_node_location(data)
+
+
+class TestStartNode:
+    def test_start_node_required(self):
+        data = _minimal_settlement()
+        del data["start_node"]
+        with pytest.raises(NodeSchemaError, match="start_node"):
+            validate_node_location(data)
+
+    def test_start_node_must_exist(self):
+        data = _minimal_settlement()
+        data["start_node"] = "nowhere"
+        with pytest.raises(NodeSchemaError, match="start_node"):
+            validate_node_location(data)
+
+
+class TestNodeProse:
+    @pytest.mark.parametrize("missing", ["name", "blurb", "description"])
+    def test_prose_fields_required(self, missing):
+        data = _minimal_settlement()
+        del data["nodes"]["square"][missing]
+        with pytest.raises(NodeSchemaError, match=missing):
+            validate_node_location(data)
+
+    @pytest.mark.parametrize("missing", ["name", "blurb", "description"])
+    def test_prose_fields_must_be_nonempty(self, missing):
+        data = _minimal_settlement()
+        data["nodes"]["square"][missing] = ""
+        with pytest.raises(NodeSchemaError, match=missing):
+            validate_node_location(data)
+
+
+class TestActionVocabulary:
+    def test_vocabulary_contents(self):
+        assert NODE_ACTION_VOCABULARY == {
+            "talk",
+            "shop",
+            "rest",
+            "gather_rumors",
+            "read_job_board",
+        }
+
+    def test_simple_vocabulary_actions_accepted(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = sorted(NODE_ACTION_VOCABULARY)
+        validate_node_location(data)  # should not raise
+
+    def test_unknown_string_action_rejected(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = ["dance"]
+        with pytest.raises(NodeSchemaError, match="dance"):
+            validate_node_location(data)
+
+    def test_bare_examine_string_rejected(self):
+        """examine_* is skill-gated by definition; it must be object form
+        so the gate and both prose branches have somewhere to live."""
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = ["examine_door"]
+        with pytest.raises(NodeSchemaError, match="examine_door"):
+            validate_node_location(data)
+
+    def test_examine_object_with_gate_and_prose_accepted(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = [
+            {
+                "id": "examine_door",
+                "gate": {"skill": "religion", "dc": 12},
+                "on_success": "The symbol is a ward of Durgon.",
+                "on_failure": "The scratches mean nothing to you.",
+            }
+        ]
+        validate_node_location(data)  # should not raise
+
+    def test_unknown_object_action_id_rejected(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = [
+            {"id": "moonwalk", "on_success": "x", "on_failure": "y"}
+        ]
+        with pytest.raises(NodeSchemaError, match="moonwalk"):
+            validate_node_location(data)
+
+
+class TestGatedActionProse:
+    """AC: every skill-gated action authors success AND failure prose."""
+
+    @pytest.mark.parametrize("missing", ["on_success", "on_failure"])
+    def test_gated_action_requires_both_prose_branches(self, missing):
+        action = {
+            "id": "examine_door",
+            "gate": {"skill": "religion", "dc": 12},
+            "on_success": "You see it.",
+            "on_failure": "You see nothing.",
+        }
+        del action[missing]
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = [action]
+        with pytest.raises(NodeSchemaError, match=missing):
+            validate_node_location(data)
+
+    def test_gate_requires_skill_and_dc(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = [
+            {
+                "id": "examine_door",
+                "gate": {"skill": "religion"},
+                "on_success": "x",
+                "on_failure": "y",
+            }
+        ]
+        with pytest.raises(NodeSchemaError, match="dc"):
+            validate_node_location(data)
+
+
+class TestTransition:
+    def test_transition_requires_destination(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["transition"] = {}
+        with pytest.raises(NodeSchemaError, match="to"):
+            validate_node_location(data)
+
+    def test_ungated_transition_accepted(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["transition"] = {"to": "test_dungeon"}
+        validate_node_location(data)  # should not raise
+
+    @pytest.mark.parametrize("missing", ["on_success", "on_failure"])
+    def test_gated_transition_requires_both_prose_branches(self, missing):
+        transition = {
+            "to": "test_dungeon",
+            "gate": {"skill": "religion", "dc": 12},
+            "on_success": "The door opens.",
+            "on_failure": "The door resists.",
+        }
+        del transition[missing]
+        data = _minimal_settlement()
+        data["nodes"]["square"]["transition"] = transition
+        with pytest.raises(NodeSchemaError, match=missing):
+            validate_node_location(data)
+
+
+class TestLoaderIntegration:
+    """load_dungeon validates node-surface files at load time."""
+
+    def test_invalid_node_file_raises_at_load(self, loader, tmp_path, monkeypatch):
+        import json
+
+        bad = copy.deepcopy(_minimal_settlement())
+        bad["start_node"] = "nowhere"
+        dungeon_dir = tmp_path / "content" / "dungeons"
+        dungeon_dir.mkdir(parents=True)
+        (dungeon_dir / "bad_settlement.json").write_text(json.dumps(bad))
+        monkeypatch.setattr(loader, "data_path", tmp_path)
+
+        with pytest.raises(NodeSchemaError, match="start_node"):
+            loader.load_dungeon("bad_settlement")

--- a/plans/684-node-surface-slices.md
+++ b/plans/684-node-surface-slices.md
@@ -1,0 +1,193 @@
+# [#684] Node/social surface for settlements — slice plan
+
+## Status
+
+Drafted 2026-07-18. Supersedes the flat acceptance-criteria checklist in #684 with
+an ordered slice roster for **autonomous** implementation: every slice gates on a
+check that runs without a human (pytest, pexpect, or headless MCP playtest), and
+each slice is one PR.
+
+Parent design: `docs/PARTIAL_TOTM_DESIGN.md` (town node surface).
+Related epics: plan-07 #536 (pillars — NOT built here), plan-10 #539 (engine owns
+rules, clients thin — governing constraint).
+
+## Goal
+
+Settlements present as theater-of-the-mind: a flat list of **nodes** (pick a
+place), prose descriptions, and contextual actions — no walked `@`. The Arden
+opening beat of The Unquiet Dead (quest hook → shop → rest → rumors → depart to
+the crypt) is playable end-to-end in the terminal client.
+
+## Decisions on record
+
+- **Input model: hybrid (v1).** The prompt accepts **a number or prose**. The
+  numbered action list stays on screen as the DM's offered affordances; typed
+  prose ("ask marta about the lights", "head to the chapel") is the intended
+  primary mode. Prose routes through the existing **rule-based** `CommandParser`
+  (rapidfuzz — deterministic, no LLM), extended with node vocabulary. Deep
+  conversation remains the existing LLM chat loop inside `talk`. LLM-routed
+  freeform intent classification is **deferred** (slots in later as a
+  low-confidence parser fallback; pairs with plan-07's GM loop).
+- **NL lives in the client input layer only.** The engine API is typed intents
+  (`enter_node`, `talk`, `shop`, …). Plan-10 boundary: deepening NL later
+  requires zero engine churn.
+- **Main never breaks.** Slices 1–5 build against a **lab settlement fixture**
+  (`lab_settlement.json`, alongside the laboratory dungeon). Arden stays a tile
+  town until slice 6 cuts it over.
+- **Pillar dependency scoped down.** This plan adds a lightweight
+  surface-discrimination concept (grid vs node), NOT #536's full
+  explore/social/combat state machine.
+- **Save compatibility at cutover:** one-shot id remap (tile room → nearest
+  node) applied at load; old Arden tile-room ids resolve rather than invalidate
+  saves.
+- **Autonomy protocol per slice:** branch `feature/684-s<N>-<desc>` → TDD →
+  package suite green → review checkpoints (below) → PR → CI green → merge →
+  next slice.
+
+## Review protocol (lean — no multi-agent fan-out, per token-budget decision 2026-07-18)
+
+| Checkpoint | When | Mechanism |
+|---|---|---|
+| Design pass | Before slice 1; re-run if slice 2 changes the API shape | Inline single-pass review of the API shape against `PARTIAL_TOTM_DESIGN.md` + plan-10 boundaries (main context, no agents) |
+| Architecture check | Slices 2, 4, 7 | `architecture-guardian` skill before the PR |
+| Code review | Every slice | `/code-review` medium; **high** on slices 4 and 6 (seam + cutover). Confirmed findings fixed before PR |
+| QA gate | Slice 8 | `/playtester` free-form run of the Arden beat |
+
+Merge policy: CI green + clean review at the slice's checkpoint level = merge.
+
+## Slices
+
+Each slice is a single PR with its gating tests named up front. Sub-issues
+created per slice at slice start (plan-03 convention).
+
+### Slice 1 — Node schema, loader validation, lab fixture
+
+**Surface:** `dnd_engine/rules/loader.py` (+ a validation module);
+`data/content/dungeons/lab_settlement.json` (new fixture).
+
+Locations may declare `surface: "node"` with a `nodes` collection and
+`start_node` (grid `rooms` + `start_room` path untouched). Validation:
+`start_node` exists; nodes carry `name`/`blurb`/`description`; `actions` drawn
+from the fixed vocabulary (`talk`, `shop`, `rest`, `gather_rumors`,
+`read_job_board`, `examine_*`, `transition`); every skill-gated action authors
+`on_success` AND `on_failure` prose; `transition` targets declare a destination.
+
+**Gating tests:** new `tests/test_node_schema.py` — valid fixture loads; each
+validation rule has a failing-fixture case.
+
+### Slice 2 — Engine node-surface state + navigation API
+
+**Surface:** `dnd_engine/core/game_state.py` (+ new `core/node_surface.py` if
+warranted).
+
+`GameState` recognizes a node-surface location: `is_node_surface()`,
+`current_node()`, `list_nodes()` → (id, name, blurb), `enter_node(id)` → prose +
+present NPCs (existing `NPCManager.get_npcs_in_room` keyed by node id) +
+available actions. Tile machinery never instantiated on a node surface;
+grid-only methods (`move`, exits, search) degrade cleanly.
+
+**Gating tests:** integration vs lab fixture — enter settlement, list nodes,
+enter node, NPC presence, grid-method degradation.
+
+**Checkpoint:** architecture-guardian.
+
+### Slice 3 — Node actions: social routing + skill gates
+
+**Surface:** engine node action dispatch.
+
+`interactions()` merges node `actions` + present NPCs. `talk`/`shop`/`rest`
+route into existing NPC dialogue/shop/reputation systems; `gather_rumors` and
+`read_job_board` return prose gated by disposition; `examine_*` runs the skill
+check (seeded dice in tests) and returns authored success/failure prose.
+Disposition surfaces as a one-word text tag — never a number, never color.
+
+**Gating tests:** integration, seeded RNG; both branches of every skill gate
+asserted; disposition tag correctness at friendly/neutral/hostile thresholds.
+
+### Slice 4 — Transition seam, both directions
+
+**Surface:** `game_state.py` cross-dungeon move path, `room_registry`.
+
+Node `transition` action → loads the target grid dungeon at its start room
+(extends the existing cross-dungeon mechanism). Reverse: a grid exit whose
+destination is a node id re-enters the settlement's node surface at that node.
+This is the crypt ↔ town seam.
+
+**Gating tests:** round-trip integration — lab settlement → laboratory dungeon
+→ back to originating node; state preserved across the seam.
+
+**Checkpoints:** architecture-guardian + deep adversarial panel.
+
+### Slice 5 — Terminal three-zone rendering + hybrid input
+
+**Surface:** `client-terminal` — `ui/cli.py` node-surface branch in the run
+loop; `nlp/command_parser.py` + `GameContextProvider` node extensions.
+
+Three zones rendered as text: status strip (location · time · gold), scrolling
+prose log (DM voice, 2–4 short paragraphs per beat), numbered contextual action
+list. Node list hides behind `Go elsewhere ▸`. Prompt accepts **number or
+prose**: new `ACTION_PATTERNS` for node intents (`go/visit/head to <node>` →
+`enter_node`, etc.), context provider feeds node names + present NPCs.
+Mechanics bracketed (`[Religion DC 12]`); gated/locked cues are text/symbol,
+never color-only.
+
+**Gating tests:** parser unit tests (prose → intent mapping, fuzzy node names);
+pexpect e2e on the lab settlement — full keyboard playthrough via numbers AND
+via typed prose.
+
+### Slice 6 — Arden cutover + full-beat e2e
+
+**Surface:** campaign data + save-load remap.
+
+`town_of_arden.json` re-authored: 11 tile rooms → ~6 nodes (town_square,
+rusty_tankard, chapel, davos_manor, general_store, warrens_alley) with authored
+blurbs/descriptions. `npcs.json`: 5 `current_location`/`home_location` values →
+node ids (content otherwise untouched). `campaign.json` `starting_room` →
+node-aware. Return exits in `crypt.json` (`arden.town_road`) and
+`cult_hideout.json` (`arden.warrens_alley`) repointed at nodes. Save-load
+tile-room → node remap.
+
+**Gating tests:** data validation; save-migration unit tests; scripted pexpect
+run of the acceptance beat — quest hook, shop, rest, gather rumors, depart to
+crypt, return to town.
+
+**Checkpoint:** deep adversarial panel. Candidate for `/code-review ultra`
+(user-triggered).
+
+### Slice 7 — 2D client parity
+
+**Surface:** `client-2d` — `GameSession`, MCP tools.
+
+Render the same node model; MCP `game_state` exposes node list/actions so
+headless playtest can drive it. 2D adds decoration only — zero information the
+terminal lacks.
+
+**Risk flag:** scope-check at slice start — current campaign/town support in
+client-2d is unverified; slice may shrink (MCP-only) or split.
+
+**Gating tests:** client-2d unit tests + headless MCP playtest of the lab
+settlement and Arden.
+
+**Checkpoint:** architecture-guardian.
+
+### Slice 8 — Autonomous QA pass
+
+`/playtester` runs the Arden opening beat free-form (headless MCP + terminal
+pexpect), files issues for findings; blocking bugs fixed in-slice, non-blocking
+logged.
+
+## Deferred (new issues, out of #684)
+
+- Combat erupting *from* a node (tavern brawl) — needs plan-07 encounter
+  machinery; the seam built in slice 4 is the funnel it will use.
+- LLM intent-classification parser fallback.
+- Visual/clickable town map (TotM doc: later enhancement).
+- Travel montage / region map (plan-09).
+
+## Risks
+
+- **Slice 2 API shape is load-bearing** — errors propagate through 3–7; hence
+  the upfront adversarial design review re-runs if it shifts.
+- **client-2d campaign support unknown** (slice 7 flag).
+- **`campaign.json` starting_room semantics** change at cutover; campaign
+  start/save/load paths all touch it (slice 6 panel lens).


### PR DESCRIPTION
## Summary

Slice 1 of 8 for #684 (see `plans/684-node-surface-slices.md`, added in this PR): locations may declare `surface: "node"` with a `nodes` collection; every load path validates them; a lab settlement fixture exercises each schema shape as the test bed for slices 2–5. Arden stays a tile town until slice 6.

- `dnd_engine/rules/node_schema.py` — validator: fixed action vocabulary, gated actions must author both `on_success`/`on_failure` prose (AC), `examine_*` requires object form + gate, unknown node keys rejected, `dc` rejects booleans
- `validate_location_surface` is the single surface dispatcher, called by **both** load paths (`DataLoader.load_dungeon` and `RoomRegistry.load_dungeon`); unknown/typoed `surface` values fail loudly
- Campaign wizard excludes node-surface files from the adventure list (the grid loop can't start them)
- Grid dungeons (no `surface` key) load byte-for-byte as before

## Review

8-angle `/code-review` (medium) ran pre-PR; 9 confirmed findings fixed in the second commit (examine-gate gap, surface-typo bypass, registry bypass, wizard listing, bool DC, actions type, unknown keys, docstring contract, non-dict guard). Deferred to slice 2 with plan notes: node-aware `GameState` (`start_room` KeyError, `reset_dungeon` mutate-before-read).

## Tests

- `dnd-engine/tests/test_node_schema.py` — 46 tests (schema rules, loader integration, registry path)
- `client-terminal/tests/test_campaign_wizard_adventure_list.py` — 4 tests
- Full suites pristine: engine 3560 passed / 142 skipped (known GAP skips), terminal 424 passed

Part of #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKLEzfGNCC17h7C2nkMx2c