### PR TITLE
[plan-684 s2] GameState node-surface state + navigation API

### DIFF
--- a/client-terminal/tests/test_main_menu.py
+++ b/client-terminal/tests/test_main_menu.py
@@ -301,6 +301,8 @@ class TestShowCampaignSaveSlots:
         mock_game_state.party.characters = []
         mock_game_state.dungeon_name = "dungeon"
         mock_game_state.current_room_id = "room_1"
+        mock_game_state.current_node_id = None
+        mock_game_state.previous_node_id = None
         mock_game_state.dungeon = {"rooms": {}}
         mock_game_state.action_history = []
         mock_game_state.last_entry_direction = None
@@ -329,6 +331,8 @@ class TestShowCampaignSaveSlots:
         mock_game_state.party.characters = []
         mock_game_state.dungeon_name = "dungeon"
         mock_game_state.current_room_id = "room_1"
+        mock_game_state.current_node_id = None
+        mock_game_state.previous_node_id = None
         mock_game_state.dungeon = {"rooms": {}}
         mock_game_state.action_history = []
         mock_game_state.last_entry_direction = None

--- a/dnd-engine/dnd_engine/core/campaign_manager.py
+++ b/dnd-engine/dnd_engine/core/campaign_manager.py
@@ -186,7 +186,8 @@ class CampaignManager:
         campaign = self.load_campaign(campaign_name)
         campaign.last_played = datetime.now()
         campaign.current_dungeon = game_state.dungeon_name
-        campaign.current_room = game_state.current_room_id
+        # Node surfaces have no room; record the node id as the resume location
+        campaign.current_room = game_state.current_room_id or game_state.current_node_id
 
         # Update party character IDs
         campaign.party_character_ids = [char.name for char in game_state.party.characters]
@@ -353,10 +354,17 @@ class CampaignManager:
                     party_hp_parts.append(f"{name} {current_hp}/{max_hp}")
                 party_hp_summary = ", ".join(party_hp_parts)
 
-                # Get location description
-                current_room = game_state_data.get("current_room_id", "Unknown")
+                # Get location description (room id on grid surfaces,
+                # node id on node surfaces)
+                current_room = game_state_data.get("current_room_id")
+                current_node = game_state_data.get("current_node_id")
                 dungeon_name = game_state_data.get("dungeon_name", "Unknown")
-                location = f"{dungeon_name} - Room {current_room}"
+                if current_room is not None:
+                    location = f"{dungeon_name} - Room {current_room}"
+                elif current_node is not None:
+                    location = f"{dungeon_name} - {current_node}"
+                else:
+                    location = f"{dungeon_name} - Unknown"
 
                 save_slot = SaveSlotMetadata(
                     slot_name=save_file.stem,
@@ -516,6 +524,8 @@ class CampaignManager:
             "game_state": {
                 "dungeon_name": game_state.dungeon_name,
                 "current_room_id": game_state.current_room_id,
+                "current_node_id": game_state.current_node_id,
+                "previous_node_id": game_state.previous_node_id,
                 "dungeon_state": self._serialize_dungeon_state(game_state.dungeon),
                 "in_combat": game_state.in_combat,
                 "action_history": game_state.action_history,
@@ -664,8 +674,10 @@ class CampaignManager:
                 game_state.dungeon["rooms"][room_id]["searched"] = room_state.get("searched", False)
                 game_state.dungeon["rooms"][room_id]["enemies"] = room_state.get("enemies", [])
 
-        # Restore current position
+        # Restore current position (room for grid surfaces, node for node surfaces)
         game_state.current_room_id = gs_data["current_room_id"]
+        game_state.current_node_id = gs_data.get("current_node_id")
+        game_state.previous_node_id = gs_data.get("previous_node_id")
 
         # Restore action history
         game_state.action_history = gs_data.get("action_history", [])

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -692,8 +692,13 @@ class GameState:
         except (AttributeError, TypeError):
             # data_path may not exist on mocked loaders
             pass
-        self.current_room_id = self.dungeon["start_room"]
+        # Surface discrimination (issue #684): a node surface tracks a
+        # current node and leaves the tile-grid room machinery dormant.
+        self.current_node_id: str | None = None
+        self.previous_node_id: str | None = None
+        self.current_room_id: str | None = None
         self.previous_room_id: str | None = None  # Track room transitions for narrative
+        self._set_start_location(self.dungeon)
 
         # Quest tracking system (optional, only if campaign_id is provided)
         self.quest_manager: QuestManager | None = None
@@ -708,12 +713,13 @@ class GameState:
                 # Emit initial room enter event to trigger quest auto-activation
                 # Skip if loading from save (save_slot_manager will emit at right time)
                 if not self._skip_initial_room_enter:
+                    location_id, location_name = self._current_location_identity()
                     self.event_bus.emit(
                         Event(
                             type=EventType.ROOM_ENTER,
                             data={
-                                "room_id": self.current_room_id,
-                                "room_name": self.get_current_room()["name"],
+                                "room_id": location_id,
+                                "room_name": location_name,
                                 "dungeon_id": self.dungeon_name,
                             },
                         )
@@ -1402,11 +1408,133 @@ class GameState:
         Called once after initialization to check the starting room
         for enemies and perform any other game start logic.
         """
+        if self.is_node_surface():
+            # Settlements have no room enemies or hidden features to sweep;
+            # play begins at the start node.
+            return
+
         # Check for passive perception features
         self._check_passive_perception()
 
         # Check for enemies
         self._check_for_enemies()
+
+    @property
+    def surface(self) -> str:
+        """Presentation surface of the current location ("grid" or "node")."""
+        return self.dungeon.get("surface", "grid")
+
+    def is_node_surface(self) -> bool:
+        """True when the current location presents as a node surface (settlement)."""
+        return self.surface == "node"
+
+    def _require_node_surface(self) -> None:
+        if not self.is_node_surface():
+            raise RuntimeError(f"{self.dungeon_name} is not a node surface; node API unavailable")
+
+    def _set_start_location(self, dungeon: dict[str, Any]) -> None:
+        """Point the current location at the dungeon's start, per surface."""
+        self.previous_node_id = None
+        self.previous_room_id = None
+        if dungeon.get("surface") == "node":
+            self.current_node_id = dungeon["start_node"]
+            self.current_room_id = None
+        else:
+            self.current_room_id = dungeon["start_room"]
+            self.current_node_id = None
+
+    def _current_location_identity(self) -> tuple[str, str]:
+        """Get the (id, display name) of the current node or room."""
+        if self.is_node_surface():
+            node = self.current_node()
+            return node["id"], node["name"]
+        return self.current_room_id, self.get_current_room()["name"]
+
+    def current_node(self) -> dict[str, Any]:
+        """
+        Get the current node's data (node surfaces only).
+
+        Returns:
+            Node dict with its "id" included.
+
+        Raises:
+            RuntimeError: If the current location is not a node surface.
+        """
+        self._require_node_surface()
+        return {"id": self.current_node_id, **self.dungeon["nodes"][self.current_node_id]}
+
+    def list_nodes(self) -> list[dict[str, Any]]:
+        """
+        List every node in the settlement for the flat-list menu.
+
+        Returns:
+            List of {"id", "name", "blurb"} in authored order.
+
+        Raises:
+            RuntimeError: If the current location is not a node surface.
+        """
+        self._require_node_surface()
+        return [
+            {"id": node_id, "name": node["name"], "blurb": node["blurb"]}
+            for node_id, node in self.dungeon["nodes"].items()
+        ]
+
+    def enter_node(self, node_id: str) -> dict[str, Any]:
+        """
+        Enter a node and return its display context.
+
+        Every node in a settlement is directly selectable (flat-list
+        navigation); there is no walked geometry between nodes.
+
+        Args:
+            node_id: The node to enter.
+
+        Returns:
+            {"id", "name", "description", "npcs", "actions", "transition"}
+            where npcs is a list of {"id", "name", "display_name"} for
+            NPCs currently at the node.
+
+        Raises:
+            RuntimeError: If the current location is not a node surface.
+            ValueError: If node_id is not a node in this settlement.
+        """
+        self._require_node_surface()
+        nodes = self.dungeon["nodes"]
+        if node_id not in nodes:
+            raise ValueError(f"Unknown node {node_id!r} in {self.dungeon_name}")
+
+        self.previous_node_id = self.current_node_id
+        self.current_node_id = node_id
+        node = nodes[node_id]
+
+        # Nodes unify with rooms at the event level so quest auto-activation
+        # and narrative listeners work unchanged on node surfaces.
+        self.event_bus.emit(
+            Event(
+                type=EventType.ROOM_ENTER,
+                data={
+                    "room_id": node_id,
+                    "room_name": node["name"],
+                    "dungeon_id": self.dungeon_name,
+                },
+            )
+        )
+
+        npcs = []
+        if self.npc_manager:
+            npcs = [
+                {"id": npc.id, "name": npc.name, "display_name": npc.display_name}
+                for npc in self.npc_manager.get_npcs_in_room(node_id)
+            ]
+
+        return {
+            "id": node_id,
+            "name": node["name"],
+            "description": node["description"],
+            "npcs": npcs,
+            "actions": list(node.get("actions", [])),
+            "transition": node.get("transition"),
+        }
 
     def get_current_room(self) -> dict[str, Any]:
         """
@@ -1414,7 +1542,15 @@ class GameState:
 
         Returns:
             Dictionary containing room information
+
+        Raises:
+            RuntimeError: If the current location is a node surface (nodes
+                have no tile rooms).
         """
+        if self.is_node_surface():
+            raise RuntimeError(
+                f"{self.dungeon_name} is a node surface; the tile-grid room API is unavailable"
+            )
         return self.dungeon["rooms"][self.current_room_id]
 
     def creature_environment(self, creature: "Creature") -> str | None:
@@ -1831,6 +1967,10 @@ class GameState:
             if current is not None and self.can_attempt_hide(current.creature):
                 actions.append("hide")
             return actions
+        elif self.is_node_surface():
+            # Node actions are authored per node and dispatched by the node
+            # surface API, not the grid action list.
+            return []
         else:
             actions = ["move"]
             room = self.get_current_room()
@@ -1851,6 +1991,9 @@ class GameState:
         """
         if self.in_combat:
             return False  # Cannot move during combat
+
+        if self.is_node_surface():
+            return False  # Node surfaces navigate via enter_node, not walked exits
 
         current_room = self.get_current_room()
         exits = current_room.get("exits", {})
@@ -2059,6 +2202,9 @@ class GameState:
         Returns:
             Dict of direction -> exit info for visible exits
         """
+        if self.is_node_surface():
+            return {}  # Node surfaces have no walked exits
+
         current_room = self.get_current_room()
         all_exits = current_room.get("exits", {})
 
@@ -5846,16 +5992,19 @@ class GameState:
             )
         )
 
-        # Load new dungeon if specified, otherwise reload current one
+        # Load new dungeon if specified, otherwise reload current one.
+        # Load before assigning any state so a failed load leaves the
+        # GameState fully on the old dungeon.
         if new_dungeon_name:
+            new_dungeon = self.data_loader.load_dungeon(new_dungeon_name, self.campaign_id)
             self.dungeon_name = new_dungeon_name
-            self.dungeon = self.data_loader.load_dungeon(new_dungeon_name, self.campaign_id)
+            self.dungeon = new_dungeon
         else:
             # Reload current dungeon from disk to reset state
             self.dungeon = self.data_loader.load_dungeon(self.dungeon_name, self.campaign_id)
 
-        # Reset to start room
-        self.current_room_id = self.dungeon["start_room"]
+        # Reset to the dungeon's start location (room or node, per surface)
+        self._set_start_location(self.dungeon)
 
         # Reset combat state
         self.in_combat = False

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -1,6 +1,7 @@
 # ABOUTME: Central game state manager coordinating all game systems
 # ABOUTME: Manages dungeon exploration, combat state, player actions, and game flow
 
+import copy
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
@@ -713,17 +714,7 @@ class GameState:
                 # Emit initial room enter event to trigger quest auto-activation
                 # Skip if loading from save (save_slot_manager will emit at right time)
                 if not self._skip_initial_room_enter:
-                    location_id, location_name = self._current_location_identity()
-                    self.event_bus.emit(
-                        Event(
-                            type=EventType.ROOM_ENTER,
-                            data={
-                                "room_id": location_id,
-                                "room_name": location_name,
-                                "dungeon_id": self.dungeon_name,
-                            },
-                        )
-                    )
+                    self._emit_room_enter(*self._current_location_identity())
             except FileNotFoundError:
                 logger.warning(f"No quest data found for campaign '{self.campaign_id}'")
 
@@ -1450,18 +1441,35 @@ class GameState:
             return node["id"], node["name"]
         return self.current_room_id, self.get_current_room()["name"]
 
+    def _emit_room_enter(self, location_id: str, location_name: str) -> None:
+        """Emit ROOM_ENTER for a room or node; nodes unify with rooms at the
+        event level so quest auto-activation and narrative listeners work
+        identically on both surfaces."""
+        self.event_bus.emit(
+            Event(
+                type=EventType.ROOM_ENTER,
+                data={
+                    "room_id": location_id,
+                    "room_name": location_name,
+                    "dungeon_id": self.dungeon_name,
+                },
+            )
+        )
+
     def current_node(self) -> dict[str, Any]:
         """
         Get the current node's data (node surfaces only).
 
         Returns:
-            Node dict with its "id" included.
+            Deep copy of the node dict with its "id" included; mutating it
+            never touches the authored dungeon content.
 
         Raises:
             RuntimeError: If the current location is not a node surface.
         """
         self._require_node_surface()
-        return {"id": self.current_node_id, **self.dungeon["nodes"][self.current_node_id]}
+        node = copy.deepcopy(self.dungeon["nodes"][self.current_node_id])
+        return {"id": self.current_node_id, **node}
 
     def list_nodes(self) -> list[dict[str, Any]]:
         """
@@ -1495,30 +1503,25 @@ class GameState:
             NPCs currently at the node.
 
         Raises:
-            RuntimeError: If the current location is not a node surface.
+            RuntimeError: If the current location is not a node surface, or
+                if combat is in progress.
             ValueError: If node_id is not a node in this settlement.
         """
         self._require_node_surface()
+        if self.in_combat:
+            raise RuntimeError("Cannot change nodes during combat")
         nodes = self.dungeon["nodes"]
         if node_id not in nodes:
             raise ValueError(f"Unknown node {node_id!r} in {self.dungeon_name}")
 
-        self.previous_node_id = self.current_node_id
-        self.current_node_id = node_id
-        node = nodes[node_id]
+        # Re-entering the current node re-renders without re-firing arrival:
+        # no ROOM_ENTER, and previous_node_id keeps the real "came from".
+        if node_id != self.current_node_id:
+            self.previous_node_id = self.current_node_id
+            self.current_node_id = node_id
+            self._emit_room_enter(node_id, nodes[node_id]["name"])
 
-        # Nodes unify with rooms at the event level so quest auto-activation
-        # and narrative listeners work unchanged on node surfaces.
-        self.event_bus.emit(
-            Event(
-                type=EventType.ROOM_ENTER,
-                data={
-                    "room_id": node_id,
-                    "room_name": node["name"],
-                    "dungeon_id": self.dungeon_name,
-                },
-            )
-        )
+        node = copy.deepcopy(nodes[node_id])
 
         npcs = []
         if self.npc_manager:
@@ -1532,7 +1535,7 @@ class GameState:
             "name": node["name"],
             "description": node["description"],
             "npcs": npcs,
-            "actions": list(node.get("actions", [])),
+            "actions": node.get("actions", []),
             "transition": node.get("transition"),
         }
 
@@ -1583,6 +1586,8 @@ class GameState:
         # dungeon map have no current room, hence no environment context.
         # Treat an unresolvable room as "no environment" rather than
         # raising, since environment-granted carve-outs are optional.
+        if self.is_node_surface():
+            return None  # Node surfaces have no tile rooms, hence no environment
         try:
             room = self.get_current_room()
         except (KeyError, AttributeError, TypeError):

--- a/dnd-engine/dnd_engine/core/save_slot_manager.py
+++ b/dnd-engine/dnd_engine/core/save_slot_manager.py
@@ -343,6 +343,8 @@ class SaveSlotManager:
                 "dungeon_name": game_state.dungeon_name,
                 "campaign_id": game_state.campaign_id,
                 "current_room_id": game_state.current_room_id,
+                "current_node_id": game_state.current_node_id,
+                "previous_node_id": game_state.previous_node_id,
                 "dungeon_state": self._serialize_dungeon_state(game_state.dungeon),
                 "all_dungeon_states": self._serialize_all_dungeon_states(game_state),
                 "in_combat": game_state.in_combat,
@@ -581,8 +583,10 @@ class SaveSlotManager:
         all_dungeon_states = gs_data.get("all_dungeon_states", {})
         self._restore_all_dungeon_states(game_state, all_dungeon_states)
 
-        # Restore current position
+        # Restore current position (room for grid surfaces, node for node surfaces)
         game_state.current_room_id = gs_data["current_room_id"]
+        game_state.current_node_id = gs_data.get("current_node_id")
+        game_state.previous_node_id = gs_data.get("previous_node_id")
 
         # Restore action history
         game_state.action_history = gs_data.get("action_history", [])
@@ -600,14 +604,15 @@ class SaveSlotManager:
                 slot_data["quest_objective_states"]
             )
 
-        # Fire ROOM_ENTER event for the loaded position
-        # This ensures discover objectives trigger for the restored room
+        # Fire ROOM_ENTER event for the loaded position (room or node)
+        # This ensures discover objectives trigger for the restored location
+        location_id, location_name = game_state._current_location_identity()
         game_state.event_bus.emit(
             Event(
                 type=EventType.ROOM_ENTER,
                 data={
-                    "room_id": game_state.current_room_id,
-                    "room_name": game_state.get_current_room().get("name", ""),
+                    "room_id": location_id,
+                    "room_name": location_name,
                     "dungeon_id": game_state.dungeon_name,
                 },
             )

--- a/dnd-engine/tests/test_node_surface_state.py
+++ b/dnd-engine/tests/test_node_surface_state.py
@@ -185,3 +185,78 @@ class TestResetDungeon:
         assert grid_game.is_node_surface()
         assert grid_game.current_node_id == "lab_square"
         assert grid_game.current_room_id is None
+
+
+class TestNodeSurfaceGuards:
+    def test_creature_environment_none_on_node_surface(self, node_game):
+        """Best-effort contract: no room means no environment, never an exception."""
+        creature = node_game.party.characters[0]
+        assert node_game.creature_environment(creature) is None
+
+    def test_enter_current_node_reenters_without_side_effects(self, node_game):
+        events = []
+        node_game.event_bus.subscribe(EventType.ROOM_ENTER, events.append)
+
+        context = node_game.enter_node("lab_square")
+
+        assert context["id"] == "lab_square"
+        assert events == []
+        assert node_game.previous_node_id is None
+
+    def test_enter_node_rejected_during_combat(self, node_game):
+        node_game.in_combat = True
+        with pytest.raises(RuntimeError, match="combat"):
+            node_game.enter_node("lab_tavern")
+        assert node_game.current_node_id == "lab_square"
+
+    def test_current_node_does_not_alias_dungeon_content(self, node_game):
+        node_game.current_node()["actions"].append("hacked")
+        assert "hacked" not in node_game.dungeon["nodes"]["lab_square"]["actions"]
+
+    def test_enter_node_context_does_not_alias_dungeon_content(self, node_game):
+        context = node_game.enter_node("lab_gate")
+        context["actions"][0]["gate"]["dc"] = 1
+        context["transition"]["gate"]["dc"] = 1
+        gate_node = node_game.dungeon["nodes"]["lab_gate"]
+        assert gate_node["actions"][0]["gate"]["dc"] == 12
+        assert gate_node["transition"]["gate"]["dc"] == 10
+
+
+class TestNodeSurfaceSaveLoad:
+    def test_slot_save_load_round_trips_node_position(self, node_game, tmp_path):
+        from dnd_engine.core.save_slot_manager import SaveSlotManager
+
+        node_game.enter_node("lab_gate")
+        manager = SaveSlotManager(saves_dir=tmp_path)
+        manager.save_game(1, node_game)
+
+        loaded, _ = manager.load_game(1)
+
+        assert loaded.current_node_id == "lab_gate"
+        assert loaded.previous_node_id == "lab_square"
+        assert loaded.current_room_id is None
+
+    def test_campaign_save_load_round_trips_node_position(self, node_game, tmp_path):
+        from dnd_engine.core.campaign_manager import CampaignManager
+
+        manager = CampaignManager(campaigns_dir=tmp_path)
+        manager.create_campaign("Lab Test", dungeon_name="lab_settlement")
+        node_game.enter_node("lab_tavern")
+        manager.save_campaign_state("Lab Test", node_game)
+
+        loaded = manager.load_campaign_state("Lab Test")
+
+        assert loaded.current_node_id == "lab_tavern"
+        assert loaded.current_room_id is None
+
+    def test_slot_metadata_shows_node_location(self, node_game, tmp_path):
+        from dnd_engine.core.campaign_manager import CampaignManager
+
+        manager = CampaignManager(campaigns_dir=tmp_path)
+        manager.create_campaign("Lab Test", dungeon_name="lab_settlement")
+        node_game.enter_node("lab_tavern")
+        manager.save_campaign_state("Lab Test", node_game)
+
+        slots = manager.list_save_slots("Lab Test")
+        assert slots, "expected at least one save slot"
+        assert "None" not in slots[0].location

--- a/dnd-engine/tests/test_node_surface_state.py
+++ b/dnd-engine/tests/test_node_surface_state.py
@@ -1,0 +1,187 @@
+# ABOUTME: Tests for GameState node-surface state and navigation API (issue #684 slice 2).
+# ABOUTME: Covers node init, list/enter/current node, grid-method degradation, and reset.
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.utils.events import EventBus, EventType
+
+
+@pytest.fixture
+def test_party():
+    abilities = Abilities(
+        strength=14,
+        dexterity=12,
+        constitution=13,
+        intelligence=10,
+        wisdom=11,
+        charisma=8,
+    )
+    character = Character(
+        name="Test Hero",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=abilities,
+        max_hp=12,
+        ac=16,
+    )
+    return Party([character])
+
+
+@pytest.fixture
+def node_game(test_party):
+    return GameState(
+        party=test_party,
+        dungeon_name="lab_settlement",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+    )
+
+
+@pytest.fixture
+def grid_game(test_party):
+    return GameState(
+        party=test_party,
+        dungeon_name="test_dungeon",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+    )
+
+
+class TestNodeSurfaceInit:
+    def test_starts_at_start_node(self, node_game):
+        assert node_game.is_node_surface()
+        assert node_game.surface == "node"
+        assert node_game.current_node_id == "lab_square"
+
+    def test_no_current_room_on_node_surface(self, node_game):
+        assert node_game.current_room_id is None
+
+    def test_grid_game_unaffected(self, grid_game):
+        assert not grid_game.is_node_surface()
+        assert grid_game.surface == "grid"
+        assert grid_game.current_node_id is None
+        assert grid_game.current_room_id == grid_game.dungeon["start_room"]
+
+
+class TestNodeNavigation:
+    def test_list_nodes_returns_id_name_blurb_in_authored_order(self, node_game):
+        nodes = node_game.list_nodes()
+        assert [n["id"] for n in nodes] == ["lab_square", "lab_tavern", "lab_gate"]
+        for node in nodes:
+            assert node["name"]
+            assert node["blurb"]
+            assert set(node) == {"id", "name", "blurb"}
+
+    def test_current_node_returns_node_with_id(self, node_game):
+        node = node_game.current_node()
+        assert node["id"] == "lab_square"
+        assert node["name"] == "Lab Square"
+        assert node["description"]
+
+    def test_enter_node_moves_and_returns_context(self, node_game):
+        context = node_game.enter_node("lab_tavern")
+        assert node_game.current_node_id == "lab_tavern"
+        assert node_game.previous_node_id == "lab_square"
+        assert context["id"] == "lab_tavern"
+        assert context["name"] == "The Testing Tankard"
+        assert context["description"]
+        assert context["actions"] == ["talk", "shop", "rest"]
+        assert context["npcs"] == []
+
+    def test_enter_node_unknown_id_raises(self, node_game):
+        with pytest.raises(ValueError, match="nowhere"):
+            node_game.enter_node("nowhere")
+        assert node_game.current_node_id == "lab_square"
+
+    def test_enter_node_emits_room_enter_event(self, node_game):
+        """Nodes unify with rooms at the event level so quest auto-activation
+        and narrative listeners work unchanged on node surfaces."""
+        events = []
+        node_game.event_bus.subscribe(EventType.ROOM_ENTER, events.append)
+
+        node_game.enter_node("lab_gate")
+
+        assert len(events) == 1
+        assert events[0].data["room_id"] == "lab_gate"
+        assert events[0].data["room_name"] == "The Old Gate"
+
+    def test_enter_node_includes_npcs_present(self, node_game):
+        class StubNPC:
+            def __init__(self):
+                self.id = "stub_npc"
+                self.name = "Stubby"
+                self.display_name = "Stubby the Stub"
+
+        class StubNPCManager:
+            def get_npcs_in_room(self, room_guid):
+                return [StubNPC()] if room_guid == "lab_tavern" else []
+
+        node_game.npc_manager = StubNPCManager()
+
+        context = node_game.enter_node("lab_tavern")
+        assert context["npcs"] == [
+            {"id": "stub_npc", "name": "Stubby", "display_name": "Stubby the Stub"}
+        ]
+
+    def test_node_api_raises_on_grid_surface(self, grid_game):
+        with pytest.raises(RuntimeError, match="node"):
+            grid_game.current_node()
+        with pytest.raises(RuntimeError, match="node"):
+            grid_game.list_nodes()
+        with pytest.raises(RuntimeError, match="node"):
+            grid_game.enter_node("anywhere")
+
+
+class TestGridMachineryDormant:
+    """On a node surface the tile-grid machinery must degrade cleanly."""
+
+    def test_move_returns_false(self, node_game):
+        assert node_game.move("north") is False
+        assert node_game.current_node_id == "lab_square"
+
+    def test_get_current_room_raises_clear_error(self, node_game):
+        with pytest.raises(RuntimeError, match="node surface"):
+            node_game.get_current_room()
+
+    def test_get_available_exits_empty(self, node_game):
+        assert node_game.get_available_exits() == {}
+
+    def test_get_available_actions_empty(self, node_game):
+        assert node_game.get_available_actions() == []
+
+    def test_start_does_not_crash(self, node_game):
+        node_game.start()  # no enemies, no perception sweep; should not raise
+        assert node_game.in_combat is False
+
+
+class TestResetDungeon:
+    def test_reset_on_node_surface_returns_to_start_node(self, node_game):
+        node_game.enter_node("lab_gate")
+        node_game.reset_dungeon()
+        assert node_game.current_node_id == "lab_square"
+        assert node_game.previous_node_id is None
+        assert node_game.current_room_id is None
+
+    def test_reset_to_missing_dungeon_leaves_state_intact(self, grid_game):
+        """A failed reset must not half-mutate: name and dungeon stay paired."""
+        old_name = grid_game.dungeon_name
+        old_dungeon = grid_game.dungeon
+        old_room = grid_game.current_room_id
+
+        with pytest.raises(FileNotFoundError):
+            grid_game.reset_dungeon("no_such_dungeon")
+
+        assert grid_game.dungeon_name == old_name
+        assert grid_game.dungeon is old_dungeon
+        assert grid_game.current_room_id == old_room
+
+    def test_reset_grid_to_node_dungeon_switches_surface(self, grid_game):
+        grid_game.reset_dungeon("lab_settlement")
+        assert grid_game.is_node_surface()
+        assert grid_game.current_node_id == "lab_square"
+        assert grid_game.current_room_id is None

--- a/plans/684-node-surface-slices.md
+++ b/plans/684-node-surface-slices.md
@@ -135,6 +135,14 @@ never color-only.
 pexpect e2e on the lab settlement — full keyboard playthrough via numbers AND
 via typed prose.
 
+**Carried findings from slice 2 review:** `CLI.display_room` →
+`get_room_display_context` → `get_current_room` raises on node surfaces — the
+node render branch this slice builds must be reached first; the CLI `reset`
+handler renders the room after reset and would mis-report "reset failed" when
+resetting into a settlement; if an event consumer ever needs to distinguish
+surfaces, add a `surface` field to ROOM_ENTER data rather than a new event
+type.
+
 ### Slice 6 — Arden cutover + full-beat e2e
 
 **Surface:** campaign data + save-load remap.
@@ -164,6 +172,13 @@ terminal lacks.
 
 **Risk flag:** scope-check at slice start — current campaign/town support in
 client-2d is unverified; slice may shrink (MCP-only) or split.
+
+**Carried finding from slice 2 review:** `EngineAdapter.new_game` sets
+`_initialized = True` before calling `get_current_room()`, so a node-surface
+dungeon leaves the adapter claiming initialized while every room-based call
+raises. Settlements never worked in client-2d (previously failed fast on
+`start_room`); make the adapter surface-aware or fail before flagging
+initialized.
 
 **Gating tests:** client-2d unit tests + headless MCP playtest of the lab
 settlement and Arden.


### PR DESCRIPTION
## Summary

Slice 2 of 8 for #684 (`plans/684-node-surface-slices.md`): the engine now has first-class node-surface state.

- `GameState` recognizes `surface: "node"`: `current_node()` / `list_nodes()` / `enter_node()` drive flat-list navigation; NPCs surface through the existing `NPCManager` keyed by node id
- `enter_node` emits `ROOM_ENTER` (nodes unify with rooms at the event level — quest auto-activation and narrative listeners work unchanged), guards against combat and no-op re-entry, and deep-copies returned content
- Tile-grid machinery stays dormant on node surfaces: `move`/exits/actions degrade cleanly; `get_current_room` raises a documented error
- Both save paths (`SaveSlotManager`, `CampaignManager`) persist and restore node position; loading a node-surface save no longer crashes; slot metadata shows the node id
- `creature_environment` keeps its best-effort contract on node surfaces (no room → `None`)

**Also included, advertised explicitly:** `reset_dungeon` now loads before assigning state, so a failed reset leaves the GameState fully on the old dungeon (grid games included). This closes a finding deferred from slice 1 review; it changes failure-path behavior for grid resets (previously half-mutated).

## Review

Architecture check (architecture-guardian): **APPROVED** — engine-only, event-driven, follows the `get_room_display_context` precedent; noted `core/node_surface.py` extraction as the slice-3 decision point.
`/code-review` medium (4 finder angles): 10 confirmed findings fixed in the second commit; 2 deferred to slices 5/7 with plan notes; 1 refuted.

## Tests

- `dnd-engine/tests/test_node_surface_state.py` — 26 tests (init, navigation, event emission, guards, aliasing, save/load round-trips both paths)
- Full suites pristine: engine 3586 passed / 142 known skips, terminal 424 passed

Part of #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKLEzfGNCC17h7C2nkMx2c