### PR TITLE
[plan-684 s3] Node action dispatch — social routing + skill gates

### DIFF
--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -18,6 +18,7 @@ from dnd_engine.core.entity_ids import pc_entity_id
 from dnd_engine.core.map import Map
 from dnd_engine.core.move_result import MoveResult
 from dnd_engine.core.node_surface import NodeSurfaceActions
+from dnd_engine.core.node_surface import npc_view as node_surface_npc_view
 from dnd_engine.core.npc_manager import NPCManager
 from dnd_engine.core.party import Party
 from dnd_engine.core.position import Position
@@ -1535,8 +1536,7 @@ class GameState:
         npcs = []
         if self.npc_manager:
             npcs = [
-                {"id": npc.id, "name": npc.name, "display_name": npc.display_name}
-                for npc in self.npc_manager.get_npcs_in_room(node_id)
+                node_surface_npc_view(npc) for npc in self.npc_manager.get_npcs_in_room(node_id)
             ]
 
         return {

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -17,6 +17,7 @@ from dnd_engine.core.distance import distance_in_feet
 from dnd_engine.core.entity_ids import pc_entity_id
 from dnd_engine.core.map import Map
 from dnd_engine.core.move_result import MoveResult
+from dnd_engine.core.node_surface import NodeSurfaceActions
 from dnd_engine.core.npc_manager import NPCManager
 from dnd_engine.core.party import Party
 from dnd_engine.core.position import Position
@@ -695,6 +696,7 @@ class GameState:
             pass
         # Surface discrimination (issue #684): a node surface tracks a
         # current node and leaves the tile-grid room machinery dormant.
+        self._node_actions: NodeSurfaceActions | None = None
         self.current_node_id: str | None = None
         self.previous_node_id: str | None = None
         self.current_room_id: str | None = None
@@ -1418,6 +1420,13 @@ class GameState:
     def is_node_surface(self) -> bool:
         """True when the current location presents as a node surface (settlement)."""
         return self.surface == "node"
+
+    @property
+    def node_actions(self) -> NodeSurfaceActions:
+        """Action dispatch for the current node (talk/shop/rest/rumors/examine)."""
+        if self._node_actions is None:
+            self._node_actions = NodeSurfaceActions(self)
+        return self._node_actions
 
     def _require_node_surface(self) -> None:
         if not self.is_node_surface():

--- a/dnd-engine/dnd_engine/core/node_surface.py
+++ b/dnd-engine/dnd_engine/core/node_surface.py
@@ -19,6 +19,20 @@ class NodeActionError(Exception):
     """
 
 
+def npc_view(npc: NPC) -> dict[str, Any]:
+    """Client-facing NPC data; disposition is a word, never a number.
+
+    The single NPC shape shared by enter_node and interactions so the two
+    payloads cannot drift.
+    """
+    return {
+        "id": npc.id,
+        "name": npc.name,
+        "display_name": npc.display_name,
+        "disposition": npc.get_disposition().value,
+    }
+
+
 class NodeSurfaceActions:
     """
     Dispatches the fixed node-action vocabulary for the current node.
@@ -181,21 +195,20 @@ class NodeSurfaceActions:
         Returns:
             {"success": bool, "prose": authored branch, "check": check dict}
         """
-        node = self.game_state.current_node()
-        action = next(
-            (
-                a
-                for a in self._normalized_actions(node)
-                if a["id"] == action_id and a["id"].startswith("examine_")
-            ),
-            None,
-        )
+        action = self._find_action(action_id)
         if action is None:
-            raise NodeActionError(f"No action {action_id!r} at {node['id']}")
+            raise NodeActionError(f"No action {action_id!r} at {self.game_state.current_node_id}")
+        if not action["id"].startswith("examine_"):
+            raise NodeActionError(f"{action_id!r} is not an examinable action")
 
         gate = action["gate"]
         skills_data = self.game_state.data_loader.load_skills()
-        check = character.make_skill_check(gate["skill"], gate["dc"], skills_data)
+        try:
+            check = character.make_skill_check(gate["skill"], gate["dc"], skills_data)
+        except KeyError as exc:
+            raise NodeActionError(
+                f"Unknown skill {gate['skill']!r} authored on {action_id!r}"
+            ) from exc
         success = check["success"]
         return {
             "success": success,
@@ -213,11 +226,25 @@ class NodeSurfaceActions:
             for action in node.get("actions", [])
         ]
 
+    def _live_node(self) -> dict[str, Any]:
+        """The current node's live dict, for internal read-only lookups.
+
+        Avoids current_node()'s defensive deep copy; never returned to
+        callers and never mutated.
+        """
+        self.game_state._require_node_surface()
+        return self.game_state.dungeon["nodes"][self.game_state.current_node_id]
+
+    def _find_action(self, action_id: str) -> dict[str, Any] | None:
+        """Look up an authored action by id on the current node."""
+        for action in self._normalized_actions(self._live_node()):
+            if action["id"] == action_id:
+                return action
+        return None
+
     def _require_action(self, action_id: str) -> None:
-        node = self.game_state.current_node()
-        authored = [a["id"] for a in self._normalized_actions(node)]
-        if action_id not in authored:
-            raise NodeActionError(f"No action {action_id!r} at {node['id']}")
+        if self._find_action(action_id) is None:
+            raise NodeActionError(f"No action {action_id!r} at {self.game_state.current_node_id}")
 
     def _npcs_present(self) -> list[NPC]:
         npc_manager = self.game_state.npc_manager
@@ -232,13 +259,8 @@ class NodeSurfaceActions:
         raise NodeActionError(f"{npc_id!r} is not here")
 
     def _npc_view(self, npc: NPC) -> dict[str, Any]:
-        """Client-facing NPC data; disposition is a word, never a number."""
-        return {
-            "id": npc.id,
-            "name": npc.name,
-            "display_name": npc.display_name,
-            "disposition": npc.get_disposition().value,
-        }
+        """See module-level npc_view — one shape for all NPC payloads."""
+        return npc_view(npc)
 
     def _disposition_effects(self, npc: NPC) -> dict[str, Any]:
         if not npc.reputation_modifiers:
@@ -247,15 +269,19 @@ class NodeSurfaceActions:
         return effects.get(npc.get_disposition().value, {})
 
     def _quest_hook_texts(self, npc: NPC) -> list[str]:
+        """Hook lines for available quests this NPC knows, voiced with the
+        authored per-NPC npc_hints wording when present (the same mechanism
+        the LLM chat path uses), falling back to the quest description."""
         quest_manager = self.game_state.quest_manager
         if not quest_manager:
             return []
-        available = {quest.id: quest for quest in quest_manager.get_available_quests()}
-        return [
-            available[quest_id].description
-            for quest_id in npc.knowledge.quest_hooks
-            if quest_id in available
-        ]
+        texts = []
+        for quest in quest_manager.get_available_quests():
+            if quest.id not in npc.knowledge.quest_hooks:
+                continue
+            hint = quest.hint_for("available", npc.id)
+            texts.append(hint or quest.description)
+        return texts
 
     @staticmethod
     def _adjusted_price(price: int, modifier: float) -> int:

--- a/dnd-engine/dnd_engine/core/node_surface.py
+++ b/dnd-engine/dnd_engine/core/node_surface.py
@@ -1,0 +1,263 @@
+# ABOUTME: Node-surface action dispatch — talk/shop/rest/rumors/job-board/examine on settlement nodes.
+# ABOUTME: Routes the fixed action vocabulary into the NPC, rest, quest, and skill-check systems.
+
+from typing import TYPE_CHECKING, Any
+
+from dnd_engine.core.npc import NPC, NPCDisposition
+
+if TYPE_CHECKING:
+    from dnd_engine.core.character import Character
+    from dnd_engine.core.game_state import GameState
+
+
+class NodeActionError(Exception):
+    """Raised when a node action cannot be dispatched.
+
+    Covers actions not authored on the current node, absent NPCs, and
+    NPCs that lack the capability an action needs (e.g. no shop). The
+    message names the offending action or NPC.
+    """
+
+
+class NodeSurfaceActions:
+    """
+    Dispatches the fixed node-action vocabulary for the current node.
+
+    Pure routing layer: every action resolves through an existing engine
+    system (NPCManager/NPC data, party_rest, QuestManager,
+    Character.make_skill_check). Results are plain dicts for clients to
+    render; disposition is always surfaced as a word, never a number.
+    """
+
+    def __init__(self, game_state: "GameState"):
+        self.game_state = game_state
+
+    # ------------------------------------------------------------------
+    # View
+
+    def interactions(self) -> dict[str, Any]:
+        """
+        Get the current node's available actions, NPCs, and transition.
+
+        Returns:
+            {"actions": [normalized action objects], "npcs": [npc views],
+             "transition": transition dict or None}
+        """
+        node = self.game_state.current_node()
+        return {
+            "actions": self._normalized_actions(node),
+            "npcs": [self._npc_view(npc) for npc in self._npcs_present()],
+            "transition": node.get("transition"),
+        }
+
+    # ------------------------------------------------------------------
+    # Social actions
+
+    def talk(self, npc_id: str) -> dict[str, Any]:
+        """
+        Open conversation with an NPC at the current node.
+
+        Returns:
+            {"npc": npc view, "greeting": disposition-appropriate line}
+        """
+        self._require_action("talk")
+        npc = self._require_npc(npc_id)
+        return {"npc": self._npc_view(npc), "greeting": npc.get_greeting()}
+
+    def shop(self, npc_id: str) -> dict[str, Any]:
+        """
+        Open an NPC's shop with disposition-adjusted prices.
+
+        Returns:
+            {"refused": False, "npc": view, "inventory": [...], "buy_rate": x}
+            or {"refused": True, "npc": view, "dialogue": refusal line} when
+            a hostile shopkeeper refuses service.
+        """
+        self._require_action("shop")
+        npc = self._require_npc(npc_id)
+        if not npc.shop or not npc.shop.enabled:
+            raise NodeActionError(f"{npc.display_name} has no shop")
+
+        effects = self._disposition_effects(npc)
+        if effects.get("refuses_service"):
+            return {
+                "refused": True,
+                "npc": self._npc_view(npc),
+                "dialogue": npc.get_greeting(),
+            }
+
+        price_modifier = effects.get("price_modifier", 1.0)
+        inventory = [
+            {
+                "item_id": item.item_id,
+                "price": self._adjusted_price(item.price, price_modifier),
+                "stock": item.stock,
+            }
+            for item in npc.shop.inventory
+        ]
+        return {
+            "refused": False,
+            "npc": self._npc_view(npc),
+            "inventory": inventory,
+            "buy_rate": npc.shop.buy_rate,
+        }
+
+    def rest(self, rest_type: str = "long") -> Any:
+        """
+        Rest at the current node (routes to the engine's party rest).
+
+        Returns:
+            PartyRestResult from GameState.party_rest.
+        """
+        self._require_action("rest")
+        return self.game_state.party_rest(rest_type)
+
+    def gather_rumors(self) -> dict[str, Any]:
+        """
+        Collect rumors from NPCs at the current node.
+
+        Non-hostile NPCs share their general knowledge and local lore.
+        NPCs whose disposition grants extra_hints also share the hooks of
+        quests currently available. Hostile NPCs refuse.
+
+        Returns:
+            {"rumors": [{"npc_id", "npc_name", "disposition", "text"}],
+             "refusals": [{"npc_id", "npc_name", "prose"}]}
+        """
+        self._require_action("gather_rumors")
+        rumors: list[dict[str, Any]] = []
+        refusals: list[dict[str, Any]] = []
+
+        for npc in self._npcs_present():
+            disposition = npc.get_disposition()
+            if disposition == NPCDisposition.HOSTILE:
+                refusals.append(
+                    {"npc_id": npc.id, "npc_name": npc.name, "prose": npc.get_greeting()}
+                )
+                continue
+
+            texts = list(npc.knowledge.general) + list(npc.knowledge.local_lore)
+            if self._disposition_effects(npc).get("extra_hints"):
+                texts.extend(self._quest_hook_texts(npc))
+
+            rumors.extend(
+                {
+                    "npc_id": npc.id,
+                    "npc_name": npc.name,
+                    "disposition": disposition.value,
+                    "text": text,
+                }
+                for text in texts
+            )
+
+        return {"rumors": rumors, "refusals": refusals}
+
+    def read_job_board(self) -> dict[str, Any]:
+        """
+        Read the job board: hooks for quests currently available.
+
+        Returns:
+            {"postings": [{"quest_id", "name", "description"}]}
+        """
+        self._require_action("read_job_board")
+        quest_manager = self.game_state.quest_manager
+        if not quest_manager:
+            return {"postings": []}
+        return {
+            "postings": [
+                {"quest_id": quest.id, "name": quest.name, "description": quest.description}
+                for quest in quest_manager.get_available_quests()
+            ]
+        }
+
+    def examine(self, action_id: str, character: "Character") -> dict[str, Any]:
+        """
+        Resolve a skill-gated examine action with the given character.
+
+        The gate resolves through Character.make_skill_check (the d20-test
+        primitive); the authored on_success/on_failure prose is returned so
+        a failed roll is still a narrative beat.
+
+        Returns:
+            {"success": bool, "prose": authored branch, "check": check dict}
+        """
+        node = self.game_state.current_node()
+        action = next(
+            (
+                a
+                for a in self._normalized_actions(node)
+                if a["id"] == action_id and a["id"].startswith("examine_")
+            ),
+            None,
+        )
+        if action is None:
+            raise NodeActionError(f"No action {action_id!r} at {node['id']}")
+
+        gate = action["gate"]
+        skills_data = self.game_state.data_loader.load_skills()
+        check = character.make_skill_check(gate["skill"], gate["dc"], skills_data)
+        success = check["success"]
+        return {
+            "success": success,
+            "prose": action["on_success"] if success else action["on_failure"],
+            "check": check,
+        }
+
+    # ------------------------------------------------------------------
+    # Internals
+
+    def _normalized_actions(self, node: dict[str, Any]) -> list[dict[str, Any]]:
+        """String actions become {"id": <string>}; objects pass through."""
+        return [
+            {"id": action} if isinstance(action, str) else action
+            for action in node.get("actions", [])
+        ]
+
+    def _require_action(self, action_id: str) -> None:
+        node = self.game_state.current_node()
+        authored = [a["id"] for a in self._normalized_actions(node)]
+        if action_id not in authored:
+            raise NodeActionError(f"No action {action_id!r} at {node['id']}")
+
+    def _npcs_present(self) -> list[NPC]:
+        npc_manager = self.game_state.npc_manager
+        if not npc_manager:
+            return []
+        return npc_manager.get_npcs_in_room(self.game_state.current_node_id)
+
+    def _require_npc(self, npc_id: str) -> NPC:
+        for npc in self._npcs_present():
+            if npc.id == npc_id:
+                return npc
+        raise NodeActionError(f"{npc_id!r} is not here")
+
+    def _npc_view(self, npc: NPC) -> dict[str, Any]:
+        """Client-facing NPC data; disposition is a word, never a number."""
+        return {
+            "id": npc.id,
+            "name": npc.name,
+            "display_name": npc.display_name,
+            "disposition": npc.get_disposition().value,
+        }
+
+    def _disposition_effects(self, npc: NPC) -> dict[str, Any]:
+        if not npc.reputation_modifiers:
+            return {}
+        effects = npc.reputation_modifiers.get("disposition_effects", {})
+        return effects.get(npc.get_disposition().value, {})
+
+    def _quest_hook_texts(self, npc: NPC) -> list[str]:
+        quest_manager = self.game_state.quest_manager
+        if not quest_manager:
+            return []
+        available = {quest.id: quest for quest in quest_manager.get_available_quests()}
+        return [
+            available[quest_id].description
+            for quest_id in npc.knowledge.quest_hooks
+            if quest_id in available
+        ]
+
+    @staticmethod
+    def _adjusted_price(price: int, modifier: float) -> int:
+        """Disposition-adjusted price, rounded half-up, never below 1."""
+        return max(1, int(price * modifier + 0.5))

--- a/dnd-engine/dnd_engine/core/quest.py
+++ b/dnd-engine/dnd_engine/core/quest.py
@@ -151,6 +151,35 @@ class Quest:
         if self.turn_in_npc is None and self.quest_giver is not None:
             self.turn_in_npc = self.quest_giver
 
+    def hint_for(self, state_value: str, npc_id: str) -> str:
+        """
+        Get the authored NPC-specific hint for this quest in a given state.
+
+        npc_hints[state] may be a string (same wording for every NPC) or a
+        dict keyed by NPC id or by role suffix (e.g. "innkeeper" from
+        "marta_innkeeper"). Returns "" when nothing is authored — callers
+        choose their own fallback.
+
+        Args:
+            state_value: Quest state value ("available", "active", ...)
+            npc_id: The NPC voicing the hint
+
+        Returns:
+            The authored hint line, or "" if none applies.
+        """
+        if not self.npc_hints:
+            return ""
+        state_hints = self.npc_hints.get(state_value, {})
+        if isinstance(state_hints, str):
+            return state_hints
+        if isinstance(state_hints, dict):
+            if npc_id in state_hints:
+                return state_hints[npc_id]
+            role = npc_id.split("_")[-1]
+            if role in state_hints:
+                return state_hints[role]
+        return ""
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Quest":
         """

--- a/dnd-engine/dnd_engine/llm/npc_chat.py
+++ b/dnd-engine/dnd_engine/llm/npc_chat.py
@@ -610,28 +610,12 @@ class NPCChatManager:
         return {"quests": available}
 
     def _get_quest_hint(self, quest_id: str, npc_id: str) -> str:
-        """Get NPC-specific hint for a quest."""
-        # Try to get hint from quest data
+        """Get NPC-specific hint for a quest (delegates to Quest.hint_for)."""
         if self.game_state.quest_manager:
             quest = self.game_state.quest_manager.quests.get(quest_id)
-            if quest and quest.npc_hints:
+            if quest:
                 state = self.game_state.quest_manager.get_quest_state(quest_id)
-                state_hints = quest.npc_hints.get(state.value, {})
-
-                # state_hints can be a string (same for all NPCs) or dict (NPC-specific)
-                if isinstance(state_hints, str):
-                    return state_hints
-
-                if isinstance(state_hints, dict):
-                    if npc_id in state_hints:
-                        return state_hints[npc_id]
-                    # Try by NPC role
-                    npc = self._current_conversation.npc if self._current_conversation else None
-                    if npc:
-                        role = npc.id.split("_")[-1]  # e.g., "innkeeper" from "marta_innkeeper"
-                        if role in state_hints:
-                            return state_hints[role]
-
+                return quest.hint_for(state.value, npc_id)
         return ""
 
     def _handle_open_shop(self) -> dict[str, Any]:

--- a/dnd-engine/dnd_engine/rules/node_schema.py
+++ b/dnd-engine/dnd_engine/rules/node_schema.py
@@ -161,6 +161,15 @@ def _validate_action(path: str, action: Any, where: str) -> None:
             f"form with 'gate', 'on_success', and 'on_failure'{where}"
         )
 
+    # Only examine_* actions (and transitions) may be skill-gated: the
+    # dispatch layer does not roll gates on vocabulary actions, so a gate
+    # authored there would be silently ignored at play time.
+    if not action_id.startswith(EXAMINE_PREFIX) and "gate" in action:
+        raise NodeSchemaError(
+            f"{path}: {action_id!r} cannot carry a 'gate'; only "
+            f"'{EXAMINE_PREFIX}*' actions and transitions are skill-gated"
+        )
+
     _validate_gate_and_prose(path, action, where)
 
 

--- a/dnd-engine/tests/test_node_actions.py
+++ b/dnd-engine/tests/test_node_actions.py
@@ -1,0 +1,349 @@
+# ABOUTME: Tests for node-surface action dispatch (issue #684 slice 3).
+# ABOUTME: Covers interactions, talk/shop/rest routing, rumors, job board, and skill-gated examine.
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.node_surface import NodeActionError
+from dnd_engine.core.npc import NPC
+from dnd_engine.core.party import Party
+from dnd_engine.core.quest import QuestManager
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.utils.events import EventBus
+
+
+def _npc(npc_id: str, location: str, reputation: int = 0, **overrides) -> NPC:
+    data = {
+        "id": npc_id,
+        "name": npc_id.title(),
+        "display_name": f"{npc_id.title()} the Tester",
+        "home_location": location,
+        "current_location": location,
+        "personality": {"traits": ["testy"], "speech_style": "terse"},
+        "knowledge": {
+            "general": [f"{npc_id} general rumor"],
+            "quest_hooks": ["investigate_crypt"],
+            "local_lore": [f"{npc_id} local lore"],
+        },
+        "shop": {
+            "enabled": True,
+            "shop_type": "tavern",
+            "inventory": [
+                {"item_id": "ale", "price": 10, "stock": -1},
+                {"item_id": "room_night", "price": 20, "stock": 3},
+            ],
+            "buy_rate": 0.5,
+        },
+        "dialogue": {
+            "greeting": f"Welcome, says {npc_id}.",
+            "farewell": "Bye.",
+            "hostile_greeting": f"Get out, says {npc_id}.",
+        },
+        "reputation_modifiers": {
+            "friendly_threshold": 10,
+            "hostile_threshold": -20,
+            "disposition_effects": {
+                "friendly": {"price_modifier": 0.9, "extra_hints": True},
+                "hostile": {"refuses_service": True},
+            },
+        },
+    }
+    data.update(overrides)
+    npc = NPC.from_dict(data)
+    npc.player_reputation = reputation
+    return npc
+
+
+class StubNPCManager:
+    def __init__(self, npcs):
+        self.npcs = {npc.id: npc for npc in npcs}
+
+    def get_npcs_in_room(self, room_guid):
+        return [npc for npc in self.npcs.values() if npc.current_location == room_guid]
+
+    def get_npc(self, npc_id):
+        return self.npcs.get(npc_id)
+
+
+@pytest.fixture
+def test_party():
+    abilities = Abilities(
+        strength=14,
+        dexterity=12,
+        constitution=13,
+        intelligence=10,
+        wisdom=11,
+        charisma=8,
+    )
+    character = Character(
+        name="Test Hero",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=abilities,
+        max_hp=12,
+        ac=16,
+    )
+    return Party([character])
+
+
+@pytest.fixture
+def node_game(test_party):
+    game = GameState(
+        party=test_party,
+        dungeon_name="lab_settlement",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+    )
+    game.npc_manager = StubNPCManager(
+        [
+            _npc("tavernkeep", "lab_tavern", reputation=0),
+            _npc("friendly", "lab_tavern", reputation=15),
+            _npc("grump", "lab_tavern", reputation=-30),
+        ]
+    )
+    return game
+
+
+@pytest.fixture
+def tavern_game(node_game):
+    node_game.enter_node("lab_tavern")
+    return node_game
+
+
+class TestInteractions:
+    def test_interactions_merge_actions_and_npcs(self, tavern_game):
+        view = tavern_game.node_actions.interactions()
+        assert [a["id"] for a in view["actions"]] == ["talk", "shop", "rest"]
+        npc_ids = [npc["id"] for npc in view["npcs"]]
+        assert npc_ids == ["tavernkeep", "friendly", "grump"]
+
+    def test_npcs_carry_disposition_word_never_number(self, tavern_game):
+        view = tavern_game.node_actions.interactions()
+        by_id = {npc["id"]: npc for npc in view["npcs"]}
+        assert by_id["tavernkeep"]["disposition"] == "neutral"
+        assert by_id["friendly"]["disposition"] == "friendly"
+        assert by_id["grump"]["disposition"] == "hostile"
+        for npc in view["npcs"]:
+            assert "reputation" not in npc
+
+    def test_actions_normalized_to_objects(self, node_game):
+        node_game.enter_node("lab_gate")
+        view = node_game.node_actions.interactions()
+        examine = view["actions"][0]
+        assert examine["id"] == "examine_symbol"
+        assert examine["gate"] == {"skill": "religion", "dc": 12}
+
+    def test_transition_surfaces_in_view(self, node_game):
+        node_game.enter_node("lab_gate")
+        view = node_game.node_actions.interactions()
+        assert view["transition"]["to"] == "test_dungeon"
+
+
+class TestTalk:
+    def test_talk_returns_disposition_greeting(self, tavern_game):
+        result = tavern_game.node_actions.talk("tavernkeep")
+        assert result["greeting"] == "Welcome, says tavernkeep."
+        assert result["npc"]["disposition"] == "neutral"
+
+    def test_talk_hostile_npc_uses_hostile_greeting(self, tavern_game):
+        result = tavern_game.node_actions.talk("grump")
+        assert result["greeting"] == "Get out, says grump."
+        assert result["npc"]["disposition"] == "hostile"
+
+    def test_talk_to_absent_npc_raises(self, tavern_game):
+        with pytest.raises(NodeActionError, match="nobody"):
+            tavern_game.node_actions.talk("nobody")
+
+    def test_talk_requires_authored_action(self, node_game):
+        # lab_square authors gather_rumors/read_job_board but not talk
+        with pytest.raises(NodeActionError, match="talk"):
+            node_game.node_actions.talk("tavernkeep")
+
+
+class TestShop:
+    def test_shop_returns_inventory_at_listed_prices(self, tavern_game):
+        result = tavern_game.node_actions.shop("tavernkeep")
+        assert result["refused"] is False
+        prices = {item["item_id"]: item["price"] for item in result["inventory"]}
+        assert prices == {"ale": 10, "room_night": 20}
+
+    def test_friendly_disposition_discounts_prices(self, tavern_game):
+        result = tavern_game.node_actions.shop("friendly")
+        prices = {item["item_id"]: item["price"] for item in result["inventory"]}
+        assert prices == {"ale": 9, "room_night": 18}
+
+    def test_hostile_npc_refuses_service(self, tavern_game):
+        result = tavern_game.node_actions.shop("grump")
+        assert result["refused"] is True
+        assert result["dialogue"] == "Get out, says grump."
+        assert "inventory" not in result
+
+    def test_shop_with_shopless_npc_raises(self, tavern_game):
+        npc = tavern_game.npc_manager.get_npc("tavernkeep")
+        npc.shop = None
+        with pytest.raises(NodeActionError, match="shop"):
+            tavern_game.node_actions.shop("tavernkeep")
+
+
+class TestRest:
+    def test_rest_routes_to_party_rest(self, tavern_game):
+        hero = tavern_game.party.characters[0]
+        hero.current_hp = 1
+
+        result = tavern_game.node_actions.rest("long")
+
+        assert hero.current_hp == hero.max_hp
+        assert result.rest_type == "long"
+
+    def test_rest_requires_authored_action(self, node_game):
+        with pytest.raises(NodeActionError, match="rest"):
+            node_game.node_actions.rest("long")
+
+
+class TestGatherRumors:
+    def test_rumors_from_npcs_present(self, tavern_game):
+        # gather_rumors is authored on lab_square, not lab_tavern; author it
+        # here to exercise NPC-sourced rumors.
+        tavern_game.dungeon["nodes"]["lab_tavern"]["actions"].append("gather_rumors")
+
+        result = tavern_game.node_actions.gather_rumors()
+
+        texts = [r["text"] for r in result["rumors"]]
+        assert "tavernkeep general rumor" in texts
+        assert "tavernkeep local lore" in texts
+
+    def test_hostile_npc_refuses_rumors(self, tavern_game):
+        tavern_game.dungeon["nodes"]["lab_tavern"]["actions"].append("gather_rumors")
+
+        result = tavern_game.node_actions.gather_rumors()
+
+        refusing = [r["npc_id"] for r in result["refusals"]]
+        assert "grump" in refusing
+        sharing = {r["npc_id"] for r in result["rumors"]}
+        assert "grump" not in sharing
+
+    def test_friendly_npc_with_extra_hints_shares_quest_hooks(self, tavern_game):
+        tavern_game.dungeon["nodes"]["lab_tavern"]["actions"].append("gather_rumors")
+        quest_manager = QuestManager()
+        quest_manager.load_quests_from_dict(
+            {
+                "quests": [
+                    {
+                        "id": "investigate_crypt",
+                        "name": "The Crypt Problem",
+                        "description": "Strange lights at the crypt.",
+                        "unlocked_by_default": True,
+                    }
+                ]
+            }
+        )
+        tavern_game.quest_manager = quest_manager
+
+        result = tavern_game.node_actions.gather_rumors()
+
+        hook_texts = [r["text"] for r in result["rumors"] if r["npc_id"] == "friendly"]
+        assert "Strange lights at the crypt." in hook_texts
+        neutral_texts = [r["text"] for r in result["rumors"] if r["npc_id"] == "tavernkeep"]
+        assert "Strange lights at the crypt." not in neutral_texts
+
+    def test_no_npcs_yields_empty_rumors(self, node_game):
+        # lab_square authors gather_rumors and has no NPCs
+        result = node_game.node_actions.gather_rumors()
+        assert result["rumors"] == []
+        assert result["refusals"] == []
+
+
+class TestReadJobBoard:
+    def test_postings_from_available_quests(self, node_game):
+        quest_manager = QuestManager()
+        quest_manager.load_quests_from_dict(
+            {
+                "quests": [
+                    {
+                        "id": "investigate_crypt",
+                        "name": "The Crypt Problem",
+                        "description": "Strange lights at the crypt.",
+                        "unlocked_by_default": True,
+                    },
+                    {
+                        "id": "locked_quest",
+                        "name": "Locked",
+                        "description": "Not yet.",
+                        "unlocked_by_default": False,
+                    },
+                ]
+            }
+        )
+        node_game.quest_manager = quest_manager
+
+        result = node_game.node_actions.read_job_board()
+
+        assert result["postings"] == [
+            {
+                "quest_id": "investigate_crypt",
+                "name": "The Crypt Problem",
+                "description": "Strange lights at the crypt.",
+            }
+        ]
+
+    def test_no_quest_manager_yields_empty_postings(self, node_game):
+        node_game.quest_manager = None
+        result = node_game.node_actions.read_job_board()
+        assert result["postings"] == []
+
+    def test_requires_authored_action(self, tavern_game):
+        with pytest.raises(NodeActionError, match="read_job_board"):
+            tavern_game.node_actions.read_job_board()
+
+
+class TestExamine:
+    def test_examine_success_returns_success_prose(self, node_game):
+        node_game.enter_node("lab_gate")
+        # DC 1 with a non-negative modifier cannot fail (d20 minimum is 1)
+        node_game.dungeon["nodes"]["lab_gate"]["actions"][0]["gate"]["dc"] = 1
+        hero = node_game.party.characters[0]
+
+        result = node_game.node_actions.examine("examine_symbol", hero)
+
+        assert result["success"] is True
+        assert result["prose"].startswith("The symbol is a ward")
+        assert result["check"]["skill"] == "religion"
+        assert result["check"]["dc"] == 1
+
+    def test_examine_failure_returns_failure_prose(self, node_game):
+        node_game.enter_node("lab_gate")
+        # DC 40 cannot be reached by d20 + a level-1 modifier
+        node_game.dungeon["nodes"]["lab_gate"]["actions"][0]["gate"]["dc"] = 40
+        hero = node_game.party.characters[0]
+
+        result = node_game.node_actions.examine("examine_symbol", hero)
+
+        assert result["success"] is False
+        assert result["prose"].startswith("The scratches look old")
+
+    def test_examine_unknown_action_raises(self, node_game):
+        node_game.enter_node("lab_gate")
+        hero = node_game.party.characters[0]
+        with pytest.raises(NodeActionError, match="examine_wall"):
+            node_game.node_actions.examine("examine_wall", hero)
+
+    def test_examine_emits_skill_check_via_engine(self, node_game):
+        """The check must go through Character.make_skill_check (the d20-test
+        primitive), not a private dice path."""
+        node_game.enter_node("lab_gate")
+        hero = node_game.party.characters[0]
+        calls = {}
+        original = hero.make_skill_check
+
+        def spy(skill, dc, skills_data, **kwargs):
+            calls["skill"] = skill
+            calls["dc"] = dc
+            return original(skill, dc, skills_data, **kwargs)
+
+        hero.make_skill_check = spy
+
+        node_game.node_actions.examine("examine_symbol", hero)
+
+        assert calls == {"skill": "religion", "dc": 12}

--- a/dnd-engine/tests/test_node_actions.py
+++ b/dnd-engine/tests/test_node_actions.py
@@ -347,3 +347,60 @@ class TestExamine:
         node_game.node_actions.examine("examine_symbol", hero)
 
         assert calls == {"skill": "religion", "dc": 12}
+
+
+class TestExamineErrorContract:
+    def test_examine_non_examine_action_names_the_problem(self, tavern_game):
+        """'talk' exists at the tavern; the error must say it isn't examinable,
+        not falsely claim the action doesn't exist."""
+        hero = tavern_game.party.characters[0]
+        with pytest.raises(NodeActionError, match="examin"):
+            tavern_game.node_actions.examine("talk", hero)
+
+    def test_examine_unknown_gate_skill_raises_node_action_error(self, node_game):
+        """A typoed authored skill fails inside the NodeActionError contract,
+        not as a bare KeyError."""
+        node_game.enter_node("lab_gate")
+        node_game.dungeon["nodes"]["lab_gate"]["actions"][0]["gate"]["skill"] = "Religion"
+        hero = node_game.party.characters[0]
+        with pytest.raises(NodeActionError, match="Religion"):
+            node_game.node_actions.examine("examine_symbol", hero)
+
+
+class TestNpcViewUnification:
+    def test_enter_node_npcs_carry_disposition(self, node_game):
+        """enter_node and interactions() must present the same NPC shape."""
+        context = node_game.enter_node("lab_tavern")
+        by_id = {npc["id"]: npc for npc in context["npcs"]}
+        assert by_id["friendly"]["disposition"] == "friendly"
+        assert by_id["grump"]["disposition"] == "hostile"
+
+
+class TestAuthoredQuestHints:
+    def test_gather_rumors_prefers_authored_npc_hint(self, tavern_game):
+        from dnd_engine.core.quest import QuestManager
+
+        tavern_game.dungeon["nodes"]["lab_tavern"]["actions"].append("gather_rumors")
+        quest_manager = QuestManager()
+        quest_manager.load_quests_from_dict(
+            {
+                "quests": [
+                    {
+                        "id": "investigate_crypt",
+                        "name": "The Crypt Problem",
+                        "description": "Strange lights at the crypt.",
+                        "unlocked_by_default": True,
+                        "npc_hints": {
+                            "available": {"friendly": "Psst - lights up at the crypt, love."}
+                        },
+                    }
+                ]
+            }
+        )
+        tavern_game.quest_manager = quest_manager
+
+        result = tavern_game.node_actions.gather_rumors()
+
+        friendly_texts = [r["text"] for r in result["rumors"] if r["npc_id"] == "friendly"]
+        assert "Psst - lights up at the crypt, love." in friendly_texts
+        assert "Strange lights at the crypt." not in friendly_texts

--- a/dnd-engine/tests/test_node_schema.py
+++ b/dnd-engine/tests/test_node_schema.py
@@ -381,3 +381,22 @@ class TestRoomRegistryValidation:
         data = registry.load_dungeon("good_settlement")
         assert data is not None
         assert data["surface"] == "node"
+
+
+class TestVocabularyActionsCannotBeGated:
+    """Only examine_* and transitions are skill-gated in v1; a gate on a
+    vocabulary action would be silently ignored at dispatch, so it fails
+    at load instead."""
+
+    def test_gated_vocabulary_action_rejected(self):
+        data = _minimal_settlement()
+        data["nodes"]["square"]["actions"] = [
+            {
+                "id": "shop",
+                "gate": {"skill": "persuasion", "dc": 15},
+                "on_success": "x",
+                "on_failure": "y",
+            }
+        ]
+        with pytest.raises(NodeSchemaError, match="gate"):
+            validate_node_location(data)

--- a/dnd-engine/tests/test_node_surface_state.py
+++ b/dnd-engine/tests/test_node_surface_state.py
@@ -111,11 +111,16 @@ class TestNodeNavigation:
         assert events[0].data["room_name"] == "The Old Gate"
 
     def test_enter_node_includes_npcs_present(self, node_game):
+        from dnd_engine.core.npc import NPCDisposition
+
         class StubNPC:
             def __init__(self):
                 self.id = "stub_npc"
                 self.name = "Stubby"
                 self.display_name = "Stubby the Stub"
+
+            def get_disposition(self):
+                return NPCDisposition.NEUTRAL
 
         class StubNPCManager:
             def get_npcs_in_room(self, room_guid):
@@ -125,7 +130,12 @@ class TestNodeNavigation:
 
         context = node_game.enter_node("lab_tavern")
         assert context["npcs"] == [
-            {"id": "stub_npc", "name": "Stubby", "display_name": "Stubby the Stub"}
+            {
+                "id": "stub_npc",
+                "name": "Stubby",
+                "display_name": "Stubby the Stub",
+                "disposition": "neutral",
+            }
         ]
 
     def test_node_api_raises_on_grid_surface(self, grid_game):


### PR DESCRIPTION
## Summary

Slice 3 of 8 for #684 (`plans/684-node-surface-slices.md`): the fixed node-action vocabulary now dispatches through existing engine systems via a new `NodeSurfaceActions` collaborator (`core/node_surface.py` — the extraction the slice-2 architecture review anticipated), exposed as `game_state.node_actions`.

- `talk`/`shop` route into NPC dialogue/shop/reputation data — disposition is always a word, never a number; hostile shopkeepers refuse service; friendly disposition discounts prices
- `rest` → `party_rest`; `gather_rumors` draws general knowledge + local lore from NPCs present (hostile NPCs refuse; `extra_hints` dispositions add available-quest hooks voiced with authored `npc_hints` wording via new `Quest.hint_for`, shared with the LLM chat path); `read_job_board` surfaces available quests
- `examine_*` resolves through `Character.make_skill_check` and returns authored success/failure prose — a failed roll is still a narrative beat
- Schema hardening from review: vocabulary actions can no longer carry gates (v1 dispatch only rolls gates on `examine_*`/transitions — an authored shop gate would have been silently ignored)

## Review

`/code-review` medium (3 finder angles): 6 confirmed findings fixed in the second commit (false examine error, KeyError contract leak, NPC-view drift, quest-hint divergence, deep-copy waste, unenforced vocabulary gates). Pre-existing engine-wide `load_skills()` caching gap filed as #688. Deferred with plan note: `unfriendly`/`allied` disposition_effects keys are unreachable in the 3-state disposition model (slice-6 authoring lint).

## Tests

- `tests/test_node_actions.py` — 29 tests; +1 schema test; +updated NPC-view test
- Full suites pristine: engine 3616 passed / 142 known skips, terminal 424 passed

Part of #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKLEzfGNCC17h7C2nkMx2c