### PR TITLE
[plan-684 s4] Transition seam — node ↔ grid, both directions

### DIFF
--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -1507,6 +1507,47 @@ class GameState:
         self.time_manager.advance_time(10, reason="surface_transition")
         return True
 
+    def _enter_dungeon_via_seam(self, dungeon_name: str, dungeon: dict[str, Any]) -> str:
+        """
+        Switch to a dungeon reached through a node's transition (forward seam).
+
+        Arrival follows the target's surface: a grid dungeon starts at its
+        start room with the usual arrival checks (passive perception, time,
+        enemies — this is the funnel where combat gets a grid); a node
+        target starts at its start node. Node bookkeeping resets on
+        crossing: the way back is authored as a grid exit naming a node id,
+        never remembered state.
+
+        Args:
+            dungeon_name: Target dungeon filename (without .json).
+            dungeon: The loaded (validated, registry-cached) dungeon data.
+
+        Returns:
+            The arrival location id (room or node).
+        """
+        logger.info(f"Transition seam: node {self.current_node_id} -> {dungeon_name}")
+        self.dungeon = dungeon
+        self.dungeon_name = dungeon_name
+        self.previous_node_id = None
+        self.previous_room_id = None
+        self.last_entry_direction = None
+
+        if dungeon.get("surface") == "node":
+            self.current_node_id = dungeon["start_node"]
+            self.current_room_id = None
+            node = dungeon["nodes"][self.current_node_id]
+            self._emit_room_enter(self.current_node_id, node["name"])
+            self.time_manager.advance_time(10, reason="surface_transition")
+            return self.current_node_id
+
+        self.current_node_id = None
+        self.current_room_id = dungeon["start_room"]
+        self._emit_room_enter(self.current_room_id, self.get_current_room()["name"])
+        self._check_passive_perception()
+        self.time_manager.advance_time(10, reason="surface_transition")
+        self._check_for_enemies()
+        return self.current_room_id
+
     def current_node(self) -> dict[str, Any]:
         """
         Get the current node's data (node surfaces only).

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -1466,6 +1466,47 @@ class GameState:
             )
         )
 
+    def _reenter_node_surface(self, node_id: str) -> bool:
+        """
+        Re-enter a settlement's node surface via a grid exit naming a node id.
+
+        The reverse direction of the transition seam: an authored grid exit
+        whose destination is a node id (e.g. the crypt stairs back up to town)
+        lands the party at that node. Grid-only arrival concerns (passive
+        perception, enemy checks) do not apply on a node surface.
+
+        Args:
+            node_id: The exit destination, tried as a node id.
+
+        Returns:
+            True if the destination resolved to a node and the surface
+            switched; False if no settlement authors that node.
+        """
+        node_dungeon_name = self.room_registry.get_dungeon_for_node(node_id)
+        if not node_dungeon_name:
+            return False
+        node_dungeon = self.room_registry.load_dungeon(node_dungeon_name)
+        if not node_dungeon or node_id not in node_dungeon.get("nodes", {}):
+            logger.warning(f"Node {node_id} not found in settlement {node_dungeon_name}")
+            return False
+
+        logger.info(
+            f"Transition seam: {self.current_room_id} -> node {node_id} "
+            f"(switched to {node_dungeon_name})"
+        )
+        self.dungeon = node_dungeon
+        self.dungeon_name = node_dungeon_name
+        self.current_room_id = None
+        self.previous_room_id = None
+        self.current_node_id = node_id
+        self.previous_node_id = None
+        # Flee direction has no meaning without walked geometry
+        self.last_entry_direction = None
+
+        self._emit_room_enter(node_id, node_dungeon["nodes"][node_id]["name"])
+        self.time_manager.advance_time(10, reason="surface_transition")
+        return True
+
     def current_node(self) -> dict[str, Any]:
         """
         Get the current node's data (node surfaces only).
@@ -2057,6 +2098,8 @@ class GameState:
                 else:
                     logger.warning(f"Room {new_room_id} not found in dungeon {new_dungeon_name}")
                     return False
+            elif self._reenter_node_surface(new_room_id):
+                return True
             else:
                 logger.warning(f"No dungeon found for room {new_room_id}")
                 return False

--- a/dnd-engine/dnd_engine/core/game_state.py
+++ b/dnd-engine/dnd_engine/core/game_state.py
@@ -1494,8 +1494,19 @@ class GameState:
             f"Transition seam: {self.current_room_id} -> node {node_id} "
             f"(switched to {node_dungeon_name})"
         )
-        self.dungeon = node_dungeon
-        self.dungeon_name = node_dungeon_name
+        self._arrive_at_node(node_dungeon_name, node_dungeon, node_id)
+        return True
+
+    def _arrive_at_node(self, dungeon_name: str, dungeon: dict[str, Any], node_id: str) -> None:
+        """
+        Point the game at a settlement node reached across the seam.
+
+        Shared arrival bookkeeping for both seam paths that land on a node
+        surface: the tile-room fields clear, and node history resets — the
+        way back to a grid is always authored, never remembered state.
+        """
+        self.dungeon = dungeon
+        self.dungeon_name = dungeon_name
         self.current_room_id = None
         self.previous_room_id = None
         self.current_node_id = node_id
@@ -1503,9 +1514,8 @@ class GameState:
         # Flee direction has no meaning without walked geometry
         self.last_entry_direction = None
 
-        self._emit_room_enter(node_id, node_dungeon["nodes"][node_id]["name"])
+        self._emit_room_enter(node_id, dungeon["nodes"][node_id]["name"])
         self.time_manager.advance_time(10, reason="surface_transition")
-        return True
 
     def _enter_dungeon_via_seam(self, dungeon_name: str, dungeon: dict[str, Any]) -> str:
         """
@@ -1526,27 +1536,26 @@ class GameState:
             The arrival location id (room or node).
         """
         logger.info(f"Transition seam: node {self.current_node_id} -> {dungeon_name}")
+        if dungeon.get("surface") == "node":
+            start_node = dungeon["start_node"]
+            self._arrive_at_node(dungeon_name, dungeon, start_node)
+            return start_node
+
+        # Resolve the arrival room before any state mutates so a malformed
+        # target (no start_room) fails with the game still on the node surface
+        start_room = dungeon["start_room"]
         self.dungeon = dungeon
         self.dungeon_name = dungeon_name
         self.previous_node_id = None
         self.previous_room_id = None
         self.last_entry_direction = None
-
-        if dungeon.get("surface") == "node":
-            self.current_node_id = dungeon["start_node"]
-            self.current_room_id = None
-            node = dungeon["nodes"][self.current_node_id]
-            self._emit_room_enter(self.current_node_id, node["name"])
-            self.time_manager.advance_time(10, reason="surface_transition")
-            return self.current_node_id
-
         self.current_node_id = None
-        self.current_room_id = dungeon["start_room"]
-        self._emit_room_enter(self.current_room_id, self.get_current_room()["name"])
+        self.current_room_id = start_room
+        self._emit_room_enter(start_room, self.get_current_room()["name"])
         self._check_passive_perception()
         self.time_manager.advance_time(10, reason="surface_transition")
         self._check_for_enemies()
-        return self.current_room_id
+        return start_room
 
     def current_node(self) -> dict[str, Any]:
         """
@@ -2106,9 +2115,6 @@ class GameState:
         if not req_check["met"]:
             return False  # Requirements not met
 
-        # Track direction for flee mechanic (before moving)
-        self.last_entry_direction = direction
-
         # Get destination (handle both string and dict formats)
         exit_info = exits[direction]
         if isinstance(exit_info, str):
@@ -2126,24 +2132,30 @@ class GameState:
                 return False
 
             new_dungeon_name = self.room_registry.get_dungeon_for_room(new_room_id)
+            resolved_as_room = False
             if new_dungeon_name:
                 new_dungeon = self.room_registry.load_dungeon(new_dungeon_name)
                 if new_dungeon and new_room_id in new_dungeon.get("rooms", {}):
                     # Switch to new dungeon
                     self.dungeon = new_dungeon
                     self.dungeon_name = new_dungeon_name
+                    resolved_as_room = True
                     logger.info(
                         f"Cross-dungeon move: {self.current_room_id} -> {new_room_id} "
                         f"(switched to {new_dungeon_name})"
                     )
-                else:
-                    logger.warning(f"Room {new_room_id} not found in dungeon {new_dungeon_name}")
-                    return False
-            elif self._reenter_node_surface(new_room_id):
-                return True
-            else:
-                logger.warning(f"No dungeon found for room {new_room_id}")
+            if not resolved_as_room:
+                # A dotted node id can share its prefix with a grid dungeon's
+                # rooms, so the node index is consulted whenever room
+                # resolution comes up empty — not only when the prefix misses.
+                if self._reenter_node_surface(new_room_id):
+                    return True
+                logger.warning(f"No dungeon authors {new_room_id!r} as a room or node")
                 return False
+
+        # Track direction for flee mechanic (before moving); only a resolved
+        # destination may set it, so failed moves never stale the flee path
+        self.last_entry_direction = direction
 
         # Track previous room for narrative transitions
         self.previous_room_id = self.current_room_id
@@ -6040,9 +6052,9 @@ class GameState:
                 "reason": f"Failed to retreat {retreat_direction} - exit may not exist",
             }
 
-        # Get new room info for return data
-        new_room = self.get_current_room()
-        retreat_room_name = new_room.get("name", "Unknown")
+        # Get new location info for return data; a retreat can cross the
+        # transition seam onto a settlement's node surface
+        _, retreat_room_name = self._current_location_identity()
 
         # Emit flee event
         self.event_bus.emit(

--- a/dnd-engine/dnd_engine/core/node_surface.py
+++ b/dnd-engine/dnd_engine/core/node_surface.py
@@ -216,6 +216,72 @@ class NodeSurfaceActions:
             "check": check,
         }
 
+    def transition(self, character: "Character") -> dict[str, Any]:
+        """
+        Depart the current node through its authored transition.
+
+        The forward direction of the transition seam: on success the target
+        dungeon loads at its start location and the node surface goes
+        dormant. A gated transition resolves through
+        Character.make_skill_check like examine; a failed roll is a
+        narrative beat that leaves the party where it stands.
+
+        Args:
+            character: The character attempting the transition (rolls the
+                gate when one is authored).
+
+        Returns:
+            On success: {"success": True, "prose", "check", "dungeon",
+            "location_id"} — check is None for ungated transitions.
+            On a failed gate: {"success": False, "prose", "check"}.
+
+        Raises:
+            RuntimeError: If the current location is not a node surface, or
+                if combat is in progress.
+            NodeActionError: If the node authors no transition, the gate
+                names an unknown skill, or the target dungeon cannot load.
+        """
+        node = self._live_node()
+        game = self.game_state
+        if game.in_combat:
+            raise RuntimeError("Cannot transition during combat")
+
+        spec = node.get("transition")
+        if spec is None:
+            raise NodeActionError(f"No transition authored at {game.current_node_id}")
+
+        check = None
+        gate = spec.get("gate")
+        if gate is not None:
+            skills_data = game.data_loader.load_skills()
+            try:
+                check = character.make_skill_check(gate["skill"], gate["dc"], skills_data)
+            except KeyError as exc:
+                raise NodeActionError(
+                    f"Unknown skill {gate['skill']!r} authored on the transition "
+                    f"at {game.current_node_id}"
+                ) from exc
+            if not check["success"]:
+                return {"success": False, "prose": spec["on_failure"], "check": check}
+
+        target_name = spec["to"]
+        registry = game.room_registry
+        target = registry.load_dungeon(target_name) if registry else None
+        if target is None:
+            raise NodeActionError(
+                f"Transition target {target_name!r} at {game.current_node_id} "
+                f"could not be loaded"
+            )
+
+        location_id = game._enter_dungeon_via_seam(target_name, target)
+        return {
+            "success": True,
+            "prose": spec.get("on_success"),
+            "check": check,
+            "dungeon": target_name,
+            "location_id": location_id,
+        }
+
     # ------------------------------------------------------------------
     # Internals
 

--- a/dnd-engine/dnd_engine/core/node_surface.py
+++ b/dnd-engine/dnd_engine/core/node_surface.py
@@ -202,13 +202,7 @@ class NodeSurfaceActions:
             raise NodeActionError(f"{action_id!r} is not an examinable action")
 
         gate = action["gate"]
-        skills_data = self.game_state.data_loader.load_skills()
-        try:
-            check = character.make_skill_check(gate["skill"], gate["dc"], skills_data)
-        except KeyError as exc:
-            raise NodeActionError(
-                f"Unknown skill {gate['skill']!r} authored on {action_id!r}"
-            ) from exc
+        check = self._resolve_gate(gate, character, f"{action_id!r}")
         success = check["success"]
         return {
             "success": success,
@@ -253,14 +247,7 @@ class NodeSurfaceActions:
         check = None
         gate = spec.get("gate")
         if gate is not None:
-            skills_data = game.data_loader.load_skills()
-            try:
-                check = character.make_skill_check(gate["skill"], gate["dc"], skills_data)
-            except KeyError as exc:
-                raise NodeActionError(
-                    f"Unknown skill {gate['skill']!r} authored on the transition "
-                    f"at {game.current_node_id}"
-                ) from exc
+            check = self._resolve_gate(gate, character, f"the transition at {game.current_node_id}")
             if not check["success"]:
                 return {"success": False, "prose": spec["on_failure"], "check": check}
 
@@ -272,6 +259,12 @@ class NodeSurfaceActions:
                 f"Transition target {target_name!r} at {game.current_node_id} "
                 f"could not be loaded"
             )
+        start_key = "start_node" if target.get("surface") == "node" else "start_room"
+        if start_key not in target:
+            raise NodeActionError(
+                f"Transition target {target_name!r} at {game.current_node_id} "
+                f"authors no {start_key}"
+            )
 
         location_id = game._enter_dungeon_via_seam(target_name, target)
         return {
@@ -281,6 +274,32 @@ class NodeSurfaceActions:
             "dungeon": target_name,
             "location_id": location_id,
         }
+
+    def _resolve_gate(
+        self, gate: dict[str, Any], character: "Character", context_label: str
+    ) -> dict[str, Any]:
+        """
+        Roll an authored skill gate through the d20-test primitive.
+
+        Shared by every gated node action so gate mechanics cannot drift
+        between them. An unknown authored skill fails inside the
+        NodeActionError contract, never as a bare KeyError.
+
+        Args:
+            gate: The authored gate ({"skill", "dc"}).
+            character: The character rolling the check.
+            context_label: Where the gate is authored, for the error message.
+
+        Returns:
+            The check dict from Character.make_skill_check.
+        """
+        skills_data = self.game_state.data_loader.load_skills()
+        try:
+            return character.make_skill_check(gate["skill"], gate["dc"], skills_data)
+        except KeyError as exc:
+            raise NodeActionError(
+                f"Unknown skill {gate['skill']!r} authored on {context_label}"
+            ) from exc
 
     # ------------------------------------------------------------------
     # Internals

--- a/dnd-engine/dnd_engine/core/room_registry.py
+++ b/dnd-engine/dnd_engine/core/room_registry.py
@@ -2,10 +2,13 @@
 # ABOUTME: Scans dungeon files on init and provides room lookup by GUID.
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
 from dnd_engine.rules.node_schema import validate_location_surface
+
+logger = logging.getLogger(__name__)
 
 
 class RoomRegistry:
@@ -47,6 +50,10 @@ class RoomRegistry:
 
         # Maps room GUID prefix to dungeon filename (without .json)
         self._prefix_to_dungeon: dict[str, str] = {}
+        # Maps full node id to the settlement that authors it. Nodes have no
+        # walked geometry, so the index is by full id, not prefix — a grid
+        # exit names a node id as its destination to cross the transition seam.
+        self._node_to_dungeon: dict[str, str] = {}
         # Maps dungeon filename to loaded dungeon data (lazy loaded)
         self._loaded_dungeons: dict[str, dict[str, Any]] = {}
 
@@ -72,6 +79,17 @@ class RoomRegistry:
                     prefix = self._get_prefix(room_id)
                     if prefix:
                         self._prefix_to_dungeon[prefix] = dungeon_file.stem
+
+                # Index node-surface settlements by full node id
+                for node_id in dungeon_data.get("nodes", {}).keys():
+                    existing = self._node_to_dungeon.get(node_id)
+                    if existing and existing != dungeon_file.stem:
+                        logger.warning(
+                            f"Node id {node_id!r} authored in both {existing} and "
+                            f"{dungeon_file.stem}; keeping {existing}"
+                        )
+                        continue
+                    self._node_to_dungeon[node_id] = dungeon_file.stem
 
             except (json.JSONDecodeError, OSError):
                 # Skip files that can't be parsed
@@ -105,6 +123,19 @@ class RoomRegistry:
         if prefix:
             return self._prefix_to_dungeon.get(prefix)
         return None
+
+    def get_dungeon_for_node(self, node_id: str) -> str | None:
+        """
+        Get the settlement filename that authors a node id.
+
+        Args:
+            node_id: Full node id (e.g., "lab_gate", "arden.warrens_alley")
+
+        Returns:
+            Settlement filename (without .json) or None if no settlement
+            authors this node
+        """
+        return self._node_to_dungeon.get(node_id)
 
     def load_dungeon(self, dungeon_name: str) -> dict[str, Any] | None:
         """

--- a/dnd-engine/dnd_engine/core/room_registry.py
+++ b/dnd-engine/dnd_engine/core/room_registry.py
@@ -64,7 +64,9 @@ class RoomRegistry:
         if not self.dungeons_path.exists():
             return
 
-        for dungeon_file in self.dungeons_path.glob("*.json"):
+        # Sorted so collision resolution ("first wins") is deterministic
+        # across filesystems, not directory-listing order
+        for dungeon_file in sorted(self.dungeons_path.glob("*.json")):
             # Skip generated dungeons
             if dungeon_file.stem.startswith("generated_"):
                 continue

--- a/dnd-engine/dnd_engine/data/content/dungeons/lab_dungeon.json
+++ b/dnd-engine/dnd_engine/data/content/dungeons/lab_dungeon.json
@@ -1,0 +1,17 @@
+{
+  "name": "Lab Dungeon",
+  "description": "The grid half of the lab settlement's transition seam. A tiny dungeon reached through the Old Gate; used by transition-seam tests and manual lab sessions.",
+  "start_room": "lab_entry",
+  "rooms": {
+    "lab_entry": {
+      "name": "Lab Dungeon Entry",
+      "description": "A cold stone chamber at the foot of the gate stairs. The way back up is behind you.",
+      "lighting": "bright",
+      "exits": {"up": "lab_gate"},
+      "enemies": [],
+      "items": [],
+      "searched": false,
+      "searchable": true
+    }
+  }
+}

--- a/dnd-engine/dnd_engine/data/content/dungeons/lab_settlement.json
+++ b/dnd-engine/dnd_engine/data/content/dungeons/lab_settlement.json
@@ -33,7 +33,7 @@
         }
       ],
       "transition": {
-        "to": "test_dungeon",
+        "to": "lab_dungeon",
         "gate": {"skill": "athletics", "dc": 10},
         "on_success": "The gate groans open, and stale air rolls up from the dark.",
         "on_failure": "You heave at the gate, but it will not budge."

--- a/dnd-engine/tests/test_node_actions.py
+++ b/dnd-engine/tests/test_node_actions.py
@@ -138,7 +138,7 @@ class TestInteractions:
     def test_transition_surfaces_in_view(self, node_game):
         node_game.enter_node("lab_gate")
         view = node_game.node_actions.interactions()
-        assert view["transition"]["to"] == "test_dungeon"
+        assert view["transition"]["to"] == "lab_dungeon"
 
 
 class TestTalk:

--- a/dnd-engine/tests/test_transition_seam.py
+++ b/dnd-engine/tests/test_transition_seam.py
@@ -7,8 +7,55 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
 from dnd_engine.core.room_registry import RoomRegistry
 from dnd_engine.rules.loader import DataLoader
+from dnd_engine.utils.events import EventBus, EventType
+
+
+@pytest.fixture
+def test_party():
+    abilities = Abilities(
+        strength=14,
+        dexterity=12,
+        constitution=13,
+        intelligence=10,
+        wisdom=11,
+        charisma=8,
+    )
+    character = Character(
+        name="Test Hero",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=abilities,
+        max_hp=12,
+        ac=16,
+    )
+    return Party([character])
+
+
+@pytest.fixture
+def grid_game(test_party):
+    """Start inside the lab dungeon, whose 'up' exit names the lab_gate node."""
+    return GameState(
+        party=test_party,
+        dungeon_name="lab_dungeon",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+    )
+
+
+@pytest.fixture
+def node_game(test_party):
+    return GameState(
+        party=test_party,
+        dungeon_name="lab_settlement",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+    )
 
 
 @pytest.fixture
@@ -83,3 +130,56 @@ class TestRegistryNodeIndex:
         registry = RoomRegistry(dungeons_path=dungeons_path)
         assert registry.get_dungeon_for_node("lab_gate") == "lab_settlement"
         assert registry.get_dungeon_for_node("lab_square") == "lab_settlement"
+
+
+class TestReverseSeam:
+    """A grid exit whose destination is a node id re-enters the settlement."""
+
+    def test_grid_exit_reenters_settlement_at_named_node(self, grid_game):
+        events = []
+        grid_game.event_bus.subscribe(EventType.ROOM_ENTER, events.append)
+
+        assert grid_game.move("up") is True
+
+        assert grid_game.is_node_surface()
+        assert grid_game.dungeon_name == "lab_settlement"
+        assert grid_game.current_node_id == "lab_gate"
+        assert grid_game.current_room_id is None
+        assert grid_game.previous_room_id is None
+        assert grid_game.previous_node_id is None
+        assert grid_game.last_entry_direction is None
+
+        assert len(events) == 1
+        assert events[0].data["room_id"] == "lab_gate"
+        assert events[0].data["room_name"] == "The Old Gate"
+        assert events[0].data["dungeon_id"] == "lab_settlement"
+
+    def test_reverse_seam_advances_time(self, grid_game):
+        before = grid_game.time_manager.elapsed_minutes
+        grid_game.move("up")
+        assert grid_game.time_manager.elapsed_minutes == before + 10
+
+    def test_dict_form_exit_destination(self, grid_game):
+        grid_game.dungeon["rooms"]["lab_entry"]["exits"]["door"] = {"destination": "lab_gate"}
+        assert grid_game.move("door") is True
+        assert grid_game.current_node_id == "lab_gate"
+
+    def test_locked_exit_still_blocks_before_resolution(self, grid_game):
+        grid_game.dungeon["rooms"]["lab_entry"]["exits"]["up"] = {
+            "destination": "lab_gate",
+            "locked": True,
+        }
+        assert grid_game.move("up") is False
+        assert not grid_game.is_node_surface()
+        assert grid_game.current_room_id == "lab_entry"
+
+    def test_move_to_node_without_registry_fails_gracefully(self, grid_game):
+        grid_game.room_registry = None
+        assert grid_game.move("up") is False
+        assert not grid_game.is_node_surface()
+        assert grid_game.current_room_id == "lab_entry"
+
+    def test_unknown_destination_still_fails(self, grid_game):
+        grid_game.dungeon["rooms"]["lab_entry"]["exits"]["down"] = "no_such_place"
+        assert grid_game.move("down") is False
+        assert grid_game.current_room_id == "lab_entry"

--- a/dnd-engine/tests/test_transition_seam.py
+++ b/dnd-engine/tests/test_transition_seam.py
@@ -10,6 +10,7 @@ import pytest
 from dnd_engine.core.character import Character, CharacterClass
 from dnd_engine.core.creature import Abilities
 from dnd_engine.core.game_state import GameState
+from dnd_engine.core.node_surface import NodeActionError
 from dnd_engine.core.party import Party
 from dnd_engine.core.room_registry import RoomRegistry
 from dnd_engine.rules.loader import DataLoader
@@ -183,3 +184,120 @@ class TestReverseSeam:
         grid_game.dungeon["rooms"]["lab_entry"]["exits"]["down"] = "no_such_place"
         assert grid_game.move("down") is False
         assert grid_game.current_room_id == "lab_entry"
+
+
+class TestForwardSeam:
+    """A node's authored transition loads the target grid dungeon at its start room."""
+
+    def _gate(self, game):
+        return game.dungeon["nodes"]["lab_gate"]["transition"]
+
+    def test_gated_success_enters_grid_at_start_room(self, node_game):
+        node_game.enter_node("lab_gate")
+        # DC 1 with a non-negative modifier cannot fail (d20 minimum is 1)
+        self._gate(node_game)["gate"]["dc"] = 1
+        hero = node_game.party.characters[0]
+        events = []
+        node_game.event_bus.subscribe(EventType.ROOM_ENTER, events.append)
+
+        result = node_game.node_actions.transition(hero)
+
+        assert result["success"] is True
+        assert result["prose"].startswith("The gate groans open")
+        assert result["check"]["skill"] == "athletics"
+        assert result["dungeon"] == "lab_dungeon"
+        assert result["location_id"] == "lab_entry"
+
+        assert not node_game.is_node_surface()
+        assert node_game.dungeon_name == "lab_dungeon"
+        assert node_game.current_room_id == "lab_entry"
+        assert node_game.current_node_id is None
+        assert node_game.previous_node_id is None
+
+        assert len(events) == 1
+        assert events[0].data["room_id"] == "lab_entry"
+        assert events[0].data["dungeon_id"] == "lab_dungeon"
+
+    def test_forward_seam_advances_time(self, node_game):
+        node_game.enter_node("lab_gate")
+        self._gate(node_game)["gate"]["dc"] = 1
+        before = node_game.time_manager.elapsed_minutes
+        node_game.node_actions.transition(node_game.party.characters[0])
+        assert node_game.time_manager.elapsed_minutes == before + 10
+
+    def test_gated_failure_is_a_narrative_beat_not_a_move(self, node_game):
+        node_game.enter_node("lab_gate")
+        # DC 40 cannot be reached by d20 + a level-1 modifier
+        self._gate(node_game)["gate"]["dc"] = 40
+        hero = node_game.party.characters[0]
+        events = []
+        node_game.event_bus.subscribe(EventType.ROOM_ENTER, events.append)
+        before = node_game.time_manager.elapsed_minutes
+
+        result = node_game.node_actions.transition(hero)
+
+        assert result["success"] is False
+        assert result["prose"].startswith("You heave at the gate")
+        assert result["check"]["dc"] == 40
+        assert node_game.is_node_surface()
+        assert node_game.current_node_id == "lab_gate"
+        assert events == []
+        assert node_game.time_manager.elapsed_minutes == before
+
+    def test_ungated_transition_needs_no_check(self, node_game):
+        node_game.enter_node("lab_gate")
+        del self._gate(node_game)["gate"]
+        result = node_game.node_actions.transition(node_game.party.characters[0])
+        assert result["success"] is True
+        assert result["check"] is None
+        assert node_game.current_room_id == "lab_entry"
+
+    def test_check_routes_through_make_skill_check(self, node_game):
+        """The gate must resolve via Character.make_skill_check (the d20-test
+        primitive), not a private dice path."""
+        node_game.enter_node("lab_gate")
+        hero = node_game.party.characters[0]
+        calls = {}
+        original = hero.make_skill_check
+
+        def spy(skill, dc, skills_data, **kwargs):
+            calls["skill"] = skill
+            calls["dc"] = dc
+            return original(skill, dc, skills_data, **kwargs)
+
+        hero.make_skill_check = spy
+
+        node_game.node_actions.transition(hero)
+
+        assert calls == {"skill": "athletics", "dc": 10}
+
+    def test_node_without_transition_raises(self, node_game):
+        hero = node_game.party.characters[0]
+        with pytest.raises(NodeActionError, match="lab_square"):
+            node_game.node_actions.transition(hero)
+
+    def test_unknown_gate_skill_raises_node_action_error(self, node_game):
+        node_game.enter_node("lab_gate")
+        self._gate(node_game)["gate"]["skill"] = "Athletics"
+        with pytest.raises(NodeActionError, match="Athletics"):
+            node_game.node_actions.transition(node_game.party.characters[0])
+
+    def test_unknown_target_raises_without_state_change(self, node_game):
+        node_game.enter_node("lab_gate")
+        self._gate(node_game)["gate"]["dc"] = 1
+        self._gate(node_game)["to"] = "no_such_dungeon"
+        with pytest.raises(NodeActionError, match="no_such_dungeon"):
+            node_game.node_actions.transition(node_game.party.characters[0])
+        assert node_game.is_node_surface()
+        assert node_game.current_node_id == "lab_gate"
+        assert node_game.dungeon_name == "lab_settlement"
+
+    def test_transition_off_surface_raises(self, grid_game):
+        with pytest.raises(RuntimeError, match="not a node surface"):
+            grid_game.node_actions.transition(grid_game.party.characters[0])
+
+    def test_transition_blocked_in_combat(self, node_game):
+        node_game.enter_node("lab_gate")
+        node_game.in_combat = True
+        with pytest.raises(RuntimeError, match="combat"):
+            node_game.node_actions.transition(node_game.party.characters[0])

--- a/dnd-engine/tests/test_transition_seam.py
+++ b/dnd-engine/tests/test_transition_seam.py
@@ -1,0 +1,85 @@
+# ABOUTME: Tests for the node<->grid transition seam (issue #684 slice 4).
+# ABOUTME: Covers registry node resolution, both seam directions, round trip, and save/load.
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from dnd_engine.core.room_registry import RoomRegistry
+from dnd_engine.rules.loader import DataLoader
+
+
+@pytest.fixture
+def temp_dungeons_dir():
+    """A dungeons dir holding one settlement (node surface) and one grid dungeon."""
+    with TemporaryDirectory() as tmpdir:
+        dungeons_path = Path(tmpdir)
+
+        settlement = {
+            "id": "test_settlement",
+            "surface": "node",
+            "start_node": "settle.square",
+            "nodes": {
+                "settle.square": {
+                    "name": "Settlement Square",
+                    "blurb": "The square.",
+                    "description": "A quiet square.",
+                },
+                "settle.gate": {
+                    "name": "Settlement Gate",
+                    "blurb": "The gate.",
+                    "description": "A rusted gate.",
+                    "transition": {"to": "test_crypt"},
+                },
+            },
+        }
+        with open(dungeons_path / "test_settlement.json", "w") as f:
+            json.dump(settlement, f)
+
+        crypt = {
+            "id": "test_crypt",
+            "name": "Test Crypt",
+            "start_room": "crypt.entrance",
+            "rooms": {
+                "crypt.entrance": {
+                    "name": "Crypt Entrance",
+                    "description": "A dark entrance",
+                    "exits": {"up": "settle.gate"},
+                },
+            },
+        }
+        with open(dungeons_path / "test_crypt.json", "w") as f:
+            json.dump(crypt, f)
+
+        yield dungeons_path
+
+
+class TestRegistryNodeIndex:
+    def test_node_resolves_to_its_settlement(self, temp_dungeons_dir):
+        registry = RoomRegistry(dungeons_path=temp_dungeons_dir)
+        assert registry.get_dungeon_for_node("settle.square") == "test_settlement"
+        assert registry.get_dungeon_for_node("settle.gate") == "test_settlement"
+
+    def test_unknown_node_resolves_to_none(self, temp_dungeons_dir):
+        registry = RoomRegistry(dungeons_path=temp_dungeons_dir)
+        assert registry.get_dungeon_for_node("settle.nowhere") is None
+
+    def test_room_ids_are_not_nodes(self, temp_dungeons_dir):
+        """Rooms and nodes stay separate concepts in the registry."""
+        registry = RoomRegistry(dungeons_path=temp_dungeons_dir)
+        assert registry.get_dungeon_for_node("crypt.entrance") is None
+
+    def test_room_lookups_unaffected(self, temp_dungeons_dir):
+        registry = RoomRegistry(dungeons_path=temp_dungeons_dir)
+        assert registry.get_dungeon_for_room("crypt.entrance") == "test_crypt"
+        assert registry.get_room("crypt.entrance")["name"] == "Crypt Entrance"
+
+    def test_unprefixed_node_ids_resolve(self):
+        """The lab fixture's node ids carry no dot prefix; the node index is
+        keyed by full id, so they resolve where the room prefix map cannot."""
+        dungeons_path = DataLoader().data_path / "content" / "dungeons"
+        registry = RoomRegistry(dungeons_path=dungeons_path)
+        assert registry.get_dungeon_for_node("lab_gate") == "lab_settlement"
+        assert registry.get_dungeon_for_node("lab_square") == "lab_settlement"

--- a/dnd-engine/tests/test_transition_seam.py
+++ b/dnd-engine/tests/test_transition_seam.py
@@ -301,3 +301,75 @@ class TestForwardSeam:
         node_game.in_combat = True
         with pytest.raises(RuntimeError, match="combat"):
             node_game.node_actions.transition(node_game.party.characters[0])
+
+
+class TestRoundTrip:
+    """The slice gate: settlement -> dungeon -> back to the originating node,
+    with state preserved on both sides of the seam."""
+
+    def test_round_trip_preserves_state_on_both_sides(self, node_game):
+        settlement = node_game.dungeon
+        hero = node_game.party.characters[0]
+        node_game.enter_node("lab_gate")
+        # DC 1 with a non-negative modifier cannot fail (d20 minimum is 1)
+        settlement["nodes"]["lab_gate"]["transition"]["gate"]["dc"] = 1
+
+        result = node_game.node_actions.transition(hero)
+        assert result["success"] is True
+
+        # Mutate dungeon-side state before returning
+        dungeon_side = node_game.dungeon
+        dungeon_side["rooms"]["lab_entry"]["searched"] = True
+
+        assert node_game.move("up") is True
+
+        # Back at the originating node, on the same settlement dict:
+        # session mutations (including the forced DC) survived the seam
+        assert node_game.dungeon is settlement
+        assert node_game.current_node_id == "lab_gate"
+        assert node_game.is_node_surface()
+
+        # Cross again: the dungeon side is the same dict too
+        result = node_game.node_actions.transition(hero)
+        assert result["success"] is True
+        assert node_game.dungeon is dungeon_side
+        assert node_game.dungeon["rooms"]["lab_entry"]["searched"] is True
+
+    def test_round_trip_keeps_party_and_clock(self, node_game):
+        hero = node_game.party.characters[0]
+        hero.current_hp = 5
+        node_game.enter_node("lab_gate")
+        node_game.dungeon["nodes"]["lab_gate"]["transition"]["gate"]["dc"] = 1
+
+        node_game.node_actions.transition(hero)
+        node_game.move("up")
+
+        assert node_game.party.characters[0] is hero
+        assert hero.current_hp == 5
+        # enter_node is free; each seam crossing costs 10 minutes
+        assert node_game.time_manager.elapsed_minutes == 20
+
+
+class TestSaveLoadAcrossSeam:
+    def test_save_in_dungeon_load_and_return_to_settlement(self, node_game, tmp_path):
+        from dnd_engine.core.save_slot_manager import SaveSlotManager
+
+        hero = node_game.party.characters[0]
+        node_game.enter_node("lab_gate")
+        node_game.dungeon["nodes"]["lab_gate"]["transition"]["gate"]["dc"] = 1
+        node_game.node_actions.transition(hero)
+        node_game.dungeon["rooms"]["lab_entry"]["searched"] = True
+
+        manager = SaveSlotManager(saves_dir=tmp_path)
+        manager.save_game(1, node_game)
+        loaded, _ = manager.load_game(1)
+
+        assert loaded.dungeon_name == "lab_dungeon"
+        assert loaded.current_room_id == "lab_entry"
+        assert loaded.current_node_id is None
+        assert loaded.dungeon["rooms"]["lab_entry"]["searched"] is True
+
+        assert loaded.move("up") is True
+        assert loaded.is_node_surface()
+        assert loaded.dungeon_name == "lab_settlement"
+        assert loaded.current_node_id == "lab_gate"

--- a/dnd-engine/tests/test_transition_seam_integration.py
+++ b/dnd-engine/tests/test_transition_seam_integration.py
@@ -303,6 +303,76 @@ class TestForwardSeam:
             node_game.node_actions.transition(node_game.party.characters[0])
 
 
+class TestSeamResolutionRobustness:
+    """Review findings: resolution and failure paths must degrade cleanly."""
+
+    def test_prefix_shadowed_node_id_still_resolves(self, grid_game, temp_dungeons_dir):
+        """A grid dungeon sharing the settlement's dotted prefix must not
+        shadow node destinations (the slice-6 arden.* hazard): when the
+        prefix-resolved dungeon lacks the room, resolution falls through to
+        the node index instead of failing."""
+        annex = {
+            "name": "Settle Annex",
+            "start_room": "settle.annex",
+            "rooms": {
+                "settle.annex": {
+                    "name": "Annex Hall",
+                    "description": "A hall sharing the settlement prefix",
+                    "exits": {},
+                },
+            },
+        }
+        with open(temp_dungeons_dir / "settle_annex.json", "w") as f:
+            json.dump(annex, f)
+
+        registry = RoomRegistry(dungeons_path=temp_dungeons_dir)
+        # The prefix map resolves "settle." ids to the annex grid dungeon
+        assert registry.get_dungeon_for_room("settle.gate") == "settle_annex"
+
+        grid_game.room_registry = registry
+        grid_game.dungeon["rooms"]["lab_entry"]["exits"]["down"] = "settle.gate"
+
+        assert grid_game.move("down") is True
+        assert grid_game.is_node_surface()
+        assert grid_game.dungeon_name == "test_settlement"
+        assert grid_game.current_node_id == "settle.gate"
+
+    def test_failed_move_does_not_stale_flee_direction(self, grid_game):
+        grid_game.dungeon["rooms"]["lab_entry"]["exits"]["down"] = "no_such_place"
+        assert grid_game.last_entry_direction is None
+        assert grid_game.move("down") is False
+        assert grid_game.last_entry_direction is None
+
+    def test_transition_target_missing_start_room_fails_without_state_change(self, node_game):
+        node_game.enter_node("lab_gate")
+        node_game.dungeon["nodes"]["lab_gate"]["transition"]["gate"]["dc"] = 1
+        node_game.dungeon["nodes"]["lab_gate"]["transition"]["to"] = "broken"
+        # Seed the registry cache with a dungeon that authors no start_room
+        node_game.room_registry._loaded_dungeons["broken"] = {
+            "name": "Broken",
+            "rooms": {"b1": {"name": "B1", "description": "x", "exits": {}}},
+        }
+        with pytest.raises(NodeActionError, match="broken"):
+            node_game.node_actions.transition(node_game.party.characters[0])
+        assert node_game.is_node_surface()
+        assert node_game.dungeon_name == "lab_settlement"
+        assert node_game.current_node_id == "lab_gate"
+
+    def test_flee_across_seam_lands_on_node_surface(self, grid_game):
+        """Fleeing combat through a node-bound exit crosses the seam instead
+        of crashing on the tile-room API."""
+        grid_game.last_entry_direction = "down"  # reverse is "up", the node exit
+        grid_game.in_combat = True
+        grid_game.active_enemies = []
+
+        result = grid_game.flee_combat()
+
+        assert result["success"] is True
+        assert result["retreat_room"] == "The Old Gate"
+        assert grid_game.is_node_surface()
+        assert grid_game.current_node_id == "lab_gate"
+
+
 class TestRoundTrip:
     """The slice gate: settlement -> dungeon -> back to the originating node,
     with state preserved on both sides of the seam."""

--- a/plans/684-node-surface-slices.md
+++ b/plans/684-node-surface-slices.md
@@ -8,7 +8,9 @@ check that runs without a human (pytest, pexpect, or headless MCP playtest), and
 each slice is one PR.
 
 Progress: slice 1 merged (PR #686), slice 2 merged (PR #687), slice 3 merged
-(PR #689). Next: slice 4 (transition seam). Standing review policy: deep
+(PR #689). Slice 4 implemented on `feature/684-s4-transition-seam`
+(architecture-guardian approved; /code-review high findings fixed in-branch);
+PR pending. Next after merge: slice 5 (terminal rendering). Standing review policy: deep
 multi-agent review offered to Joe only at slices 4 and 6; `/code-review` high on
 those two, medium elsewhere; architecture-guardian on 2/4/7. Merges are done by
 Joe (permission classifier blocks `gh pr merge`). Related: #688 tracks the
@@ -125,6 +127,16 @@ This is the crypt ↔ town seam.
 
 **Checkpoints:** architecture-guardian + deep adversarial panel.
 
+**Slice 4 outcome notes:** the seam's grid half is a dedicated
+`lab_dungeon.json` fixture (`test_dungeon.json` stays a pristine no-exit arena
+for ~35 unrelated test files; the settlement's `transition.to` was repointed).
+`previous_node_id` resets to None on every seam crossing — the way back is
+always authored (a grid exit naming a node id), never remembered state. Review
+fixes hardened resolution: node lookup runs whenever room resolution comes up
+empty (prefix-shadowing guard), `flee_combat` is surface-aware, failed moves
+can't stale `last_entry_direction`, malformed transition targets fail with
+zero state change, and registry scan order is sorted/deterministic.
+
 ### Slice 5 — Terminal three-zone rendering + hybrid input
 
 **Surface:** `client-terminal` — `ui/cli.py` node-surface branch in the run
@@ -150,6 +162,16 @@ resetting into a settlement; if an event consumer ever needs to distinguish
 surfaces, add a `surface` field to ROOM_ENTER data rather than a new event
 type.
 
+**Carried findings from slice 4 review:** the reverse seam makes the
+`display_room` crash concretely reachable — `cli.py` `handle_move` calls
+`display_room()` then `_check_for_enemies()` after any successful move, both
+of which raise on a node surface; the node render branch must gate on
+`is_node_surface()` right after `move()` returns. Also: `test_party` /
+`node_game` fixtures are now triplicated across the node test files
+(`test_node_surface_state.py`, `test_node_actions.py`,
+`test_transition_seam_integration.py`) — consolidate into `tests/conftest.py`
+during this slice's test work.
+
 ### Slice 6 — Arden cutover + full-beat e2e
 
 **Surface:** campaign data + save-load remap.
@@ -173,6 +195,14 @@ author them for Arden NPCs, or add an NPC-data lint; gate skills are not
 validated against skills.json at load (a typo fails at play time as
 NodeActionError) — lint authored gate skills when writing Arden content.
 
+**Carried design note from slice 4 review:** arrival logic now lives in three
+shapes (`move()`'s tail, `_arrive_at_node`, `_enter_dungeon_via_seam`'s grid
+branch). The slice-4 prefix-shadowing fallback de-fangs the acute `arden.*`
+hazard, but if cutover work touches arrival behavior (quest triggers on entry,
+NPC repositioning), consider consolidating into one
+resolve(id) → (dungeon, surface, location) + arrive() primitive rather than
+threading a fourth copy.
+
 **Checkpoint:** deep adversarial panel. Candidate for `/code-review ultra`
 (user-triggered).
 
@@ -186,6 +216,12 @@ terminal lacks.
 
 **Risk flag:** scope-check at slice start — current campaign/town support in
 client-2d is unverified; slice may shrink (MCP-only) or split.
+
+**Carried finding from slice 4 review:** `GameSession._transition_room`
+(`session.py:657`) calls `get_current_room()` with no surface guard after a
+successful `move()`; the reverse seam makes that a live crash for WASD and
+MCP-driven movement into a settlement — make it surface-aware alongside the
+adapter fix below.
 
 **Carried finding from slice 2 review:** `EngineAdapter.new_game` sets
 `_initialized = True` before calling `get_current_room()`, so a node-surface

--- a/plans/684-node-surface-slices.md
+++ b/plans/684-node-surface-slices.md
@@ -7,6 +7,13 @@ an ordered slice roster for **autonomous** implementation: every slice gates on 
 check that runs without a human (pytest, pexpect, or headless MCP playtest), and
 each slice is one PR.
 
+Progress: slice 1 merged (PR #686), slice 2 merged (PR #687), slice 3 merged
+(PR #689). Next: slice 4 (transition seam). Standing review policy: deep
+multi-agent review offered to Joe only at slices 4 and 6; `/code-review` high on
+those two, medium elsewhere; architecture-guardian on 2/4/7. Merges are done by
+Joe (permission classifier blocks `gh pr merge`). Related: #688 tracks the
+pre-existing `load_skills()` caching gap found in slice-3 review.
+
 Parent design: `docs/PARTIAL_TOTM_DESIGN.md` (town node surface).
 Related epics: plan-07 #536 (pillars — NOT built here), plan-10 #539 (engine owns
 rules, clients thin — governing constraint).
@@ -158,6 +165,13 @@ tile-room → node remap.
 **Gating tests:** data validation; save-migration unit tests; scripted pexpect
 run of the acceptance beat — quest hook, shop, rest, gather rumors, depart to
 crypt, return to town.
+
+**Carried findings from slice 3 review (authoring lints for this slice):**
+`disposition_effects` keys other than friendly/neutral/hostile are unreachable
+(the 3-state disposition model never yields "unfriendly"/"allied") — don't
+author them for Arden NPCs, or add an NPC-data lint; gate skills are not
+validated against skills.json at load (a typo fails at play time as
+NodeActionError) — lint authored gate skills when writing Arden content.
 
 **Checkpoint:** deep adversarial panel. Candidate for `/code-review ultra`
 (user-triggered).


### PR DESCRIPTION
## Summary
- Node `transition` action loads its target grid dungeon at the start room (`NodeSurfaceActions.transition` + `GameState._enter_dungeon_via_seam`); a failed skill gate is a narrative beat with zero state change; grid arrival runs the standard checks including enemies — this is the funnel where combat gets a grid.
- A grid exit whose destination is a node id re-enters the settlement at that node (`RoomRegistry` full-id node index + `GameState._reenter_node_surface` in `move()`'s cross-dungeon path).
- State preserved across the round trip via registry-cache dict identity; save/load across the seam rides the existing serializer.
- Review hardening: node resolution runs whenever room resolution comes up empty (kills the `arden.*` prefix-shadowing hazard ahead of slice 6), surface-aware `flee_combat`, no stale `last_entry_direction` on failed moves, malformed transition targets fail inside the `NodeActionError` contract, deterministic registry scan order, shared `_resolve_gate`/`_arrive_at_node` helpers.

## Changes
- **dnd_engine/core/room_registry.py**: full-id node index (`get_dungeon_for_node`), sorted deterministic scan.
- **dnd_engine/core/game_state.py**: reverse seam in `move()`, `_arrive_at_node`, `_enter_dungeon_via_seam`, surface-aware `flee_combat`.
- **dnd_engine/core/node_surface.py**: `transition(character)` mirroring `examine`'s gate contract; shared `_resolve_gate`.
- **data/content/dungeons/lab_dungeon.json** (new): the seam's grid half — `test_dungeon.json` stays a pristine no-exit arena for its ~35 unrelated consumers; `lab_settlement.json` `transition.to` repointed.
- **tests/test_transition_seam_integration.py** (new, 28 tests): registry resolution, both directions, gate branches, failure paths, round trip with dict-identity assertions, save/load across the seam, flee across the seam.

## Testing
- [x] Engine suite: 3644 passed, 142 skipped
- [x] Terminal suite: 424 passed
- [x] Checkpoints: architecture-guardian approved; /code-review high — 10 verified findings, 8 fixed here, 2 carried (terminal render guard → s5, GameSession surface guard → s7; recorded in plans/684-node-surface-slices.md)

## Related Issues
Part of #684 (slice 4 of plans/684-node-surface-slices.md — do not auto-close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKLEzfGNCC17h7C2nkMx2c