### PR TITLE
[plan-684 s5] Terminal three-zone node rendering + hybrid input

### DIFF
--- a/client-terminal/pyproject.toml
+++ b/client-terminal/pyproject.toml
@@ -98,3 +98,8 @@ exclude_lines = [
     "if __name__ == .__main__.:",
     "if TYPE_CHECKING:",
 ]
+
+[dependency-groups]
+dev = [
+    "pexpect>=4.9",
+]

--- a/client-terminal/terminal_client/nlp/cli_context_adapter.py
+++ b/client-terminal/terminal_client/nlp/cli_context_adapter.py
@@ -47,12 +47,13 @@ class CLIContextAdapter(GameContextProvider):
         """Return list of item names available (room + inventory)."""
         items = []
 
-        # Get items from current room
-        room_items = self.game_state.get_room_items()
-        for item in room_items:
-            if item.get("type") not in ("gold", "currency"):
-                item_name = item.get("name", item.get("id", "unknown"))
-                items.append(item_name)
+        # Get items from current room (node surfaces have no room items)
+        if not self.game_state.is_node_surface():
+            room_items = self.game_state.get_available_items_in_room()
+            for item in room_items:
+                if item.get("type") not in ("gold", "currency"):
+                    item_name = item.get("name", item.get("id", "unknown"))
+                    items.append(item_name)
 
         # Get items from party inventories
         for char in self.game_state.party.characters:
@@ -67,13 +68,13 @@ class CLIContextAdapter(GameContextProvider):
                     if item_name not in items:
                         items.append(item_name)
 
-                # Get equipment
-                for slot in char.inventory.equipment.values():
-                    if slot:
+                # Get equipment (equipped maps slot -> item id)
+                for equipped_id in char.inventory.equipped.values():
+                    if equipped_id:
                         item_data = self.game_state.data_loader.load_items(
                             self.game_state.campaign_id
-                        ).get(slot.item_id, {})
-                        item_name = item_data.get("name", slot.item_id)
+                        ).get(equipped_id, {})
+                        item_name = item_data.get("name", equipped_id)
                         if item_name not in items:
                             items.append(item_name)
 
@@ -100,9 +101,9 @@ class CLIContextAdapter(GameContextProvider):
 
         # Get cantrips (always available)
         for spell_id in char.spells.cantrips:
-            spell_data = self.game_state.data_loader.load_spells(
-                self.game_state.campaign_id
-            ).get(spell_id, {})
+            spell_data = self.game_state.data_loader.load_spells(self.game_state.campaign_id).get(
+                spell_id, {}
+            )
             spell_name = spell_data.get("name", spell_id)
             spells.append(spell_name)
 
@@ -127,12 +128,14 @@ class CLIContextAdapter(GameContextProvider):
         return spells
 
     def get_available_npcs(self) -> list[str]:
-        """Return list of NPC names in the current room."""
+        """Return list of NPC names at the current location (room or node)."""
         npcs = []
         if self.game_state.npc_manager:
-            npc_list = self.game_state.npc_manager.get_npcs_in_room(
-                self.game_state.current_room_id
-            )
+            if self.game_state.is_node_surface():
+                location_id = self.game_state.current_node_id
+            else:
+                location_id = self.game_state.current_room_id
+            npc_list = self.game_state.npc_manager.get_npcs_in_room(location_id)
             for npc in npc_list:
                 npcs.append(npc.name)
         return npcs
@@ -144,3 +147,13 @@ class CLIContextAdapter(GameContextProvider):
     def is_in_combat(self) -> bool:
         """Return True if currently in combat."""
         return self.game_state.in_combat
+
+    def is_node_surface(self) -> bool:
+        """Return True when the current location is a settlement node surface."""
+        return self.game_state.is_node_surface()
+
+    def get_available_nodes(self) -> list[str]:
+        """Return display names of the settlement's nodes (node surfaces only)."""
+        if not self.game_state.is_node_surface():
+            return []
+        return [node["name"] for node in self.game_state.list_nodes()]

--- a/client-terminal/terminal_client/nlp/cli_context_adapter.py
+++ b/client-terminal/terminal_client/nlp/cli_context_adapter.py
@@ -55,15 +55,14 @@ class CLIContextAdapter(GameContextProvider):
                     item_name = item.get("name", item.get("id", "unknown"))
                     items.append(item_name)
 
-        # Get items from party inventories
+        # Get items from party inventories (one catalog load for all lookups)
+        items_db = self.game_state.data_loader.load_items(self.game_state.campaign_id)
         for char in self.game_state.party.characters:
             if char.is_alive:
                 # Get consumables
                 consumables = char.inventory.get_items_by_category("consumables")
                 for inv_item in consumables:
-                    item_data = self.game_state.data_loader.load_items(
-                        self.game_state.campaign_id
-                    ).get(inv_item.item_id, {})
+                    item_data = items_db.get(inv_item.item_id, {})
                     item_name = item_data.get("name", inv_item.item_id)
                     if item_name not in items:
                         items.append(item_name)
@@ -71,9 +70,7 @@ class CLIContextAdapter(GameContextProvider):
                 # Get equipment (equipped maps slot -> item id)
                 for equipped_id in char.inventory.equipped.values():
                     if equipped_id:
-                        item_data = self.game_state.data_loader.load_items(
-                            self.game_state.campaign_id
-                        ).get(equipped_id, {})
+                        item_data = items_db.get(equipped_id, {})
                         item_name = item_data.get("name", equipped_id)
                         if item_name not in items:
                             items.append(item_name)

--- a/client-terminal/terminal_client/nlp/command_parser.py
+++ b/client-terminal/terminal_client/nlp/command_parser.py
@@ -103,7 +103,14 @@ class CommandParser:
         "unlock": ["unlock", "open", "pick"],
         "enter_node": ["visit", "go to", "head to", "walk to", "travel to"],
         "gather_rumors": ["gather rumors", "rumors", "gossip", "ask around"],
-        "read_job_board": ["job board", "read board", "notice board", "read", "postings"],
+        "read_job_board": [
+            "job board",
+            "read board",
+            "notice board",
+            "read the job",
+            "read the board",
+            "postings",
+        ],
         "depart": ["depart", "leave", "set out"],
     }
 
@@ -212,7 +219,15 @@ class CommandParser:
         if action == "move" and self._on_node_surface():
             action = "enter_node"
         elif action in ("enter_node", "depart") and not self._on_node_surface():
-            action = "move"
+            # "leave" during grid combat means fleeing, not walking a direction
+            if (
+                action == "depart"
+                and self.context_provider
+                and self.context_provider.is_in_combat()
+            ):
+                action = "flee"
+            else:
+                action = "move"
 
         # Extract parameters based on action type
         params, param_confidence, entity_suggestions = self._extract_params(
@@ -289,6 +304,14 @@ class CommandParser:
         elif action == "cast":
             return self._extract_spell_and_target(filtered)
         elif action in ("take", "use", "equip", "unequip", "look"):
+            # On a node surface, look/examine targets are authored node
+            # actions, not inventory items — pass the text through raw so
+            # inventory names can't hijack it.
+            if action == "look" and self._on_node_surface():
+                target = " ".join(t for t in filtered if t not in self.TARGET_INDICATORS)
+                if target:
+                    return {"item": target}, 0.7, {}
+                return {}, 0.5, {}
             return self._extract_item(filtered)
         elif action == "talk":
             return self._extract_npc(filtered)
@@ -527,7 +550,7 @@ class CommandParser:
     def _on_node_surface(self) -> bool:
         """True when the provider reports a node surface.
 
-        Providers predating the node protocol methods degrade to grid
+        Providers without the node protocol methods degrade to grid
         behavior rather than raising.
         """
         checker = getattr(self.context_provider, "is_node_surface", None)
@@ -572,12 +595,14 @@ class CommandParser:
 
         in_combat = self.context_provider.is_in_combat()
 
-        # Node-surface actions: exploration-only, and only in a settlement
+        # Node-surface actions: exploration-only, and only in a settlement.
+        # Messages use the spaced form of the action name, never internal ids.
         if action in self.NODE_ONLY_ACTIONS:
+            display_name = action.replace("_", " ")
             if in_combat:
-                return f"'{action}' is not available during combat"
+                return f"'{display_name}' is not available during combat"
             if not self._on_node_surface():
-                return f"'{action}' is only available in a settlement"
+                return f"'{display_name}' is only available in a settlement"
             return None
 
         if action in self.GRID_ONLY_ACTIONS and self._on_node_surface():

--- a/client-terminal/terminal_client/nlp/command_parser.py
+++ b/client-terminal/terminal_client/nlp/command_parser.py
@@ -58,6 +58,14 @@ class GameContextProvider(Protocol):
         """Return True if currently in combat."""
         ...
 
+    def is_node_surface(self) -> bool:
+        """Return True when the current location is a settlement node surface."""
+        ...
+
+    def get_available_nodes(self) -> list[str]:
+        """Return display names of the settlement's nodes (node surfaces only)."""
+        ...
+
 
 class CommandParser:
     """
@@ -93,7 +101,17 @@ class CommandParser:
         "effects": ["effects", "conditions", "buffs", "debuffs"],
         "time": ["time", "clock", "hour", "day"],
         "unlock": ["unlock", "open", "pick"],
+        "enter_node": ["visit", "go to", "head to", "walk to", "travel to"],
+        "gather_rumors": ["gather rumors", "rumors", "gossip", "ask around"],
+        "read_job_board": ["job board", "read board", "notice board", "read", "postings"],
+        "depart": ["depart", "leave", "set out"],
     }
+
+    # Actions that only exist on a settlement node surface
+    NODE_ONLY_ACTIONS = frozenset(["enter_node", "gather_rumors", "read_job_board", "depart"])
+
+    # Grid-only actions that have no meaning on a node surface
+    GRID_ONLY_ACTIONS = frozenset(["search", "take", "unlock"])
 
     # Direction aliases
     DIRECTION_ALIASES: dict[str, str] = {
@@ -188,6 +206,14 @@ class CommandParser:
                 suggestions=self._suggest_actions(tokens),
             )
 
+        # The same prose keywords resolve per surface: "go"/"head to" mean a
+        # direction on a grid but a destination node in a settlement, and
+        # "leave"/"depart" mean the settlement transition only on a node surface.
+        if action == "move" and self._on_node_surface():
+            action = "enter_node"
+        elif action in ("enter_node", "depart") and not self._on_node_surface():
+            action = "move"
+
         # Extract parameters based on action type
         params, param_confidence, entity_suggestions = self._extract_params(
             action, remaining_tokens
@@ -271,6 +297,8 @@ class CommandParser:
         elif action == "unlock":
             params, conf = self._extract_direction(filtered)
             return params, conf, {}
+        elif action == "enter_node":
+            return self._extract_node(filtered)
 
         # Actions with no params (inventory, status, help, etc.)
         return {}, 1.0, {}
@@ -305,9 +333,7 @@ class CommandParser:
                 break
 
         target_text = " ".join(tokens[target_start_idx:])
-        target_text = " ".join(
-            t for t in target_text.split() if t not in self.TARGET_INDICATORS
-        )
+        target_text = " ".join(t for t in target_text.split() if t not in self.TARGET_INDICATORS)
 
         if not target_text:
             return {}, 0.5, {}
@@ -414,9 +440,7 @@ class CommandParser:
 
         return params, confidence, entity_suggestions
 
-    def _extract_item(
-        self, tokens: list[str]
-    ) -> tuple[dict, float, dict[str, list[str]]]:
+    def _extract_item(self, tokens: list[str]) -> tuple[dict, float, dict[str, list[str]]]:
         """Extract item name from tokens."""
         if not tokens:
             return {}, 0.5, {}
@@ -445,9 +469,7 @@ class CommandParser:
 
         return {"item": item_text}, 0.7, {}
 
-    def _extract_npc(
-        self, tokens: list[str]
-    ) -> tuple[dict, float, dict[str, list[str]]]:
+    def _extract_npc(self, tokens: list[str]) -> tuple[dict, float, dict[str, list[str]]]:
         """Extract NPC name from tokens."""
         if not tokens:
             return {}, 0.5, {}
@@ -474,6 +496,47 @@ class CommandParser:
                     )
 
         return {"npc": npc_text}, 0.7, {}
+
+    def _extract_node(self, tokens: list[str]) -> tuple[dict, float, dict[str, list[str]]]:
+        """Extract a settlement node name from tokens."""
+        if not tokens:
+            return {}, 0.5, {}
+
+        node_text = " ".join(t for t in tokens if t not in self.TARGET_INDICATORS)
+
+        if not node_text:
+            return {}, 0.5, {}
+
+        candidates = self._available_nodes()
+        if candidates:
+            match = process.extractOne(node_text, candidates, scorer=fuzz.WRatio)
+            if match and match[1] >= self.FUZZY_THRESHOLD:
+                return {"node": match[0]}, match[1] / 100.0, {}
+
+            # Unlike free-text NPC names, an unknown node can never be acted
+            # on, so it is always flagged unmatched (suggestions may be empty).
+            suggestions = self._get_entity_suggestions(node_text, candidates)
+            return (
+                {"node": node_text, "node_unmatched": True},
+                0.3,
+                {"node": suggestions} if suggestions else {},
+            )
+
+        return {"node": node_text, "node_unmatched": True}, 0.3, {}
+
+    def _on_node_surface(self) -> bool:
+        """True when the provider reports a node surface.
+
+        Providers predating the node protocol methods degrade to grid
+        behavior rather than raising.
+        """
+        checker = getattr(self.context_provider, "is_node_surface", None)
+        return bool(checker()) if callable(checker) else False
+
+    def _available_nodes(self) -> list[str]:
+        """Node display names from the provider; [] when unsupported."""
+        getter = getattr(self.context_provider, "get_available_nodes", None)
+        return getter() if callable(getter) else []
 
     def _get_entity_suggestions(
         self, text: str, candidates: list[str], limit: int = 5
@@ -508,6 +571,17 @@ class CommandParser:
             return None
 
         in_combat = self.context_provider.is_in_combat()
+
+        # Node-surface actions: exploration-only, and only in a settlement
+        if action in self.NODE_ONLY_ACTIONS:
+            if in_combat:
+                return f"'{action}' is not available during combat"
+            if not self._on_node_surface():
+                return f"'{action}' is only available in a settlement"
+            return None
+
+        if action in self.GRID_ONLY_ACTIONS and self._on_node_surface():
+            return f"'{action}' is not available in a settlement"
 
         # Actions only valid in combat
         combat_only = {"attack", "flee", "stabilize", "end_turn"}

--- a/client-terminal/terminal_client/ui/cli.py
+++ b/client-terminal/terminal_client/ui/cli.py
@@ -120,6 +120,9 @@ class CLI:
         # Combat display management
         self.combat_status_shown = False
 
+        # Numbered action menu for the current settlement node
+        self._node_menu: list[dict] = []
+
         # Debug console for testing and development
         self.debug_console = DebugConsole(game_state, cli=self)
 
@@ -204,9 +207,16 @@ class CLI:
         else:
             self.display_room()
 
-    def display_node(self) -> None:
-        """Render the current node in three zones: status strip, prose, numbered actions."""
-        context = self.game_state.enter_node(self.game_state.current_node_id)
+    def display_node(self, context: dict | None = None) -> None:
+        """Render the current node in three zones: status strip, prose, numbered actions.
+
+        Args:
+            context: An enter_node display context to render; when None the
+                current node's context is fetched (same-node re-entry does
+                not re-fire arrival events).
+        """
+        if context is None:
+            context = self.game_state.enter_node(self.game_state.current_node_id)
 
         self._print_node_status_strip()
         print_room_description(context["name"], context["description"], [])
@@ -218,18 +228,46 @@ class CLI:
                 print_status_message(f"  • {npc['display_name']} ({npc['disposition']})", "info")
 
         self._node_menu = self._build_node_menu(context)
+        self._print_node_action_list()
+        print_status_message("(Pick a number, or say what you do.)", "info")
+
+    def _print_node_action_list(self) -> None:
+        """Zone 3: the numbered contextual action list for the current menu."""
         print_status_message("\nWhat do you do?", "info")
         for number, item in enumerate(self._node_menu, 1):
             print_message(f"  {number}. {item['label']}")
-        print_status_message("(Pick a number, or say what you do.)", "info")
+
+    def _refresh_node_menu(self) -> None:
+        """Rebuild the numbered menu after an action; reprint it when it changed.
+
+        Keeps the on-screen numbering honest when an action mutates node
+        state (NPC presence, authored actions) without a full re-render.
+        """
+        if not self.game_state.is_node_surface():
+            return
+        view = self.game_state.node_actions.interactions()
+        menu = self._build_node_menu(view)
+        changed = [item["label"] for item in menu] != [item["label"] for item in self._node_menu]
+        self._node_menu = menu
+        if changed:
+            self._print_node_action_list()
+
+    def _node_status_fields(self) -> tuple[str, str, str, int]:
+        """(settlement, node name, time, gold) for the strip and the toolbar.
+
+        Reads the raw authored dict — no deep copy; this runs on the
+        prompt-toolkit repaint path.
+        """
+        settlement = self.game_state.dungeon.get("name", self.game_state.dungeon_name)
+        node_name = self.game_state.dungeon["nodes"][self.game_state.current_node_id]["name"]
+        time_display = self.game_state.time_manager.get_elapsed_time_display()
+        return settlement, node_name, time_display, self._party_gold_display()
 
     def _print_node_status_strip(self) -> None:
         """Zone 1: one-line location · time · gold strip."""
-        node = self.game_state.current_node()
-        settlement = self.game_state.dungeon.get("name", self.game_state.dungeon_name)
-        time_display = self.game_state.time_manager.get_elapsed_time_display()
+        settlement, node_name, time_display, gold = self._node_status_fields()
         print_status_message(
-            f"{settlement} — {node['name']}  ·  {time_display}  ·  {self._party_gold_display()} gp",
+            f"{settlement} — {node_name}  ·  {time_display}  ·  {gold} gp",
             "info",
         )
 
@@ -370,10 +408,11 @@ class CLI:
             return
 
         if command.isdigit():
-            menu = getattr(self, "_node_menu", [])
+            menu = self._node_menu
             index = int(command)
             if menu and 1 <= index <= len(menu):
                 self._dispatch_node_menu_item(menu[index - 1])
+                self._refresh_node_menu()
             elif menu:
                 print_error(f"Pick a number between 1 and {len(menu)}.")
             else:
@@ -381,6 +420,7 @@ class CLI:
             return
 
         if self._try_fuzzy_parse(command):
+            self._refresh_node_menu()
             return
 
         print_status_message("Unknown command. Type 'help' for available commands.", "warning")
@@ -408,11 +448,11 @@ class CLI:
             return
 
         try:
-            self.game_state.enter_node(target_id)
+            context = self.game_state.enter_node(target_id)
         except RuntimeError as e:
             print_error(str(e))
             return
-        self.display_node()
+        self.display_node(context)
 
     def handle_go_elsewhere(self) -> None:
         """Show the settlement's node list and enter the chosen node."""
@@ -444,15 +484,21 @@ class CLI:
         if target is None:
             print_error(f"No place called '{choice}' here.")
             return
-        self.handle_enter_node(target["name"])
+        self.handle_enter_node(target["id"])
 
     def handle_node_rest(self) -> None:
         """Rest at the current node when the node authors a rest action."""
-        interactions = self.game_state.node_actions.interactions()
-        if not any(action["id"] == "rest" for action in interactions["actions"]):
+        node = self.game_state.dungeon["nodes"][self.game_state.current_node_id]
+        authored = any(
+            action == "rest" or (isinstance(action, dict) and action.get("id") == "rest")
+            for action in node.get("actions", [])
+        )
+        if not authored:
             print_status_message("There's nowhere to rest here.", "warning")
             return
-        self.handle_rest()
+        # Execution routes through the engine's node dispatch so the
+        # authored-action rule is enforced engine-side, not just here.
+        self.handle_rest(rest_executor=self.game_state.node_actions.rest)
 
     def handle_gather_rumors(self) -> None:
         """Collect and display rumors from NPCs at the current node."""
@@ -544,7 +590,7 @@ class CLI:
 
     def handle_node_depart(self) -> None:
         """Depart through the current node's authored transition."""
-        node = self.game_state.current_node()
+        node = self.game_state.dungeon["nodes"][self.game_state.current_node_id]
         spec = node.get("transition")
         if spec is None:
             print_status_message("There's no way onward from here — try 'go elsewhere'.", "warning")
@@ -855,17 +901,15 @@ class CLI:
         # Node surfaces have no room, lighting, or exits — show the
         # settlement strip instead (location · time · gold).
         if self.game_state.is_node_surface():
-            node = self.game_state.current_node()
-            settlement = self.game_state.dungeon.get("name", "Unknown")
-            time_display = self.game_state.time_manager.get_elapsed_time_display()
+            settlement, node_name, time_display, gold = self._node_status_fields()
             return HTML(
                 f'<style fg="cyan">{settlement}</style>'
                 f' <style fg="white">│</style> '
-                f'<style fg="white">{node["name"]}</style>'
+                f'<style fg="white">{node_name}</style>'
                 f' <style fg="white">│</style> '
                 f'<style fg="yellow">{time_display}</style>'
                 f' <style fg="white">│</style> '
-                f'<style fg="green">{self._party_gold_display()} gp</style>'
+                f'<style fg="green">{gold} gp</style>'
             )
 
         # Get current location
@@ -1240,6 +1284,8 @@ class CLI:
         if action == "help":
             if self.game_state.in_combat:
                 self.display_help_combat()
+            elif self.game_state.is_node_surface():
+                self.display_help_node()
             else:
                 self.display_help_exploration()
             return True
@@ -5275,12 +5321,18 @@ class CLI:
         except Exception as e:
             print_error(f"Failed to quick-save: {e}")
 
-    def handle_rest(self) -> None:
+    def handle_rest(self, rest_executor=None) -> None:
         """
         Handle rest command to allow party to rest and recover.
 
         Prompts player to choose between short rest or long rest.
         Game logic is handled by GameState.party_rest().
+
+        Args:
+            rest_executor: Callable taking a rest type ("short"/"long") and
+                returning a PartyRestResult; defaults to GameState.party_rest.
+                Node surfaces pass NodeSurfaceActions.rest so the engine
+                enforces the authored rest action.
         """
         from terminal_client.ui.rich_ui import print_message, print_section, print_status_message
 
@@ -5306,8 +5358,9 @@ class CLI:
         # Determine rest type
         rest_type = "short" if choice == "1" else "long"
 
-        # Delegate all game logic to GameState
-        result = self.game_state.party_rest(rest_type)
+        # Delegate all game logic to the engine
+        executor = rest_executor or self.game_state.party_rest
+        result = executor(rest_type)
 
         # Display rest results
         self._display_rest_results(result)

--- a/client-terminal/terminal_client/ui/cli.py
+++ b/client-terminal/terminal_client/ui/cli.py
@@ -16,6 +16,7 @@ from dnd_engine.core.game_state import (
     PartyRestResult,
     PlayerAttackResult,
 )
+from dnd_engine.core.node_surface import NodeActionError
 from dnd_engine.llm.npc_chat import NPCChatManager
 from dnd_engine.systems.action_economy import ActionType
 from dnd_engine.systems.ai import EnemyAI
@@ -195,6 +196,426 @@ class CLI:
 
         # Mark room as displayed so subsequent "look" commands show "already in room" narrative
         self.game_state.mark_room_displayed()
+
+    def display_location(self) -> None:
+        """Render the current location for its surface (node or grid)."""
+        if self.game_state.is_node_surface():
+            self.display_node()
+        else:
+            self.display_room()
+
+    def display_node(self) -> None:
+        """Render the current node in three zones: status strip, prose, numbered actions."""
+        context = self.game_state.enter_node(self.game_state.current_node_id)
+
+        self._print_node_status_strip()
+        print_room_description(context["name"], context["description"], [])
+
+        npcs = context["npcs"]
+        if npcs:
+            print_status_message("\nPresent:", "info")
+            for npc in npcs:
+                print_status_message(f"  • {npc['display_name']} ({npc['disposition']})", "info")
+
+        self._node_menu = self._build_node_menu(context)
+        print_status_message("\nWhat do you do?", "info")
+        for number, item in enumerate(self._node_menu, 1):
+            print_message(f"  {number}. {item['label']}")
+        print_status_message("(Pick a number, or say what you do.)", "info")
+
+    def _print_node_status_strip(self) -> None:
+        """Zone 1: one-line location · time · gold strip."""
+        node = self.game_state.current_node()
+        settlement = self.game_state.dungeon.get("name", self.game_state.dungeon_name)
+        time_display = self.game_state.time_manager.get_elapsed_time_display()
+        print_status_message(
+            f"{settlement} — {node['name']}  ·  {time_display}  ·  {self._party_gold_display()} gp",
+            "info",
+        )
+
+    def _party_gold_display(self) -> int:
+        """Party's pooled coin expressed in whole gold pieces."""
+        total_copper = sum(
+            char.inventory.currency.to_copper()
+            for char in self.game_state.party.characters
+            if char.is_alive
+        )
+        return total_copper // 100
+
+    def _current_location_id(self) -> str:
+        """Location id NPC presence is keyed by (node id or room id)."""
+        if self.game_state.is_node_surface():
+            return self.game_state.current_node_id
+        return self.game_state.get_current_room().get("id", "")
+
+    @staticmethod
+    def _gate_suffix(gate: dict | None) -> str:
+        """Bracketed mechanics cue for a skill-gated action, e.g. ' [Religion DC 12]'."""
+        if not gate:
+            return ""
+        return f" [{gate['skill'].title()} DC {gate['dc']}]"
+
+    def _build_node_menu(self, context: dict) -> list[dict]:
+        """Build the numbered action list for a node's display context.
+
+        Items are dicts of {"label", "kind", "arg"}; kinds are dispatched by
+        _dispatch_node_menu_item. Talk expands to one item per present NPC;
+        the node list itself hides behind the trailing 'Go elsewhere' item.
+        """
+        menu: list[dict] = []
+        npcs = context["npcs"]
+
+        for action in context["actions"]:
+            entry = {"id": action} if isinstance(action, str) else action
+            action_id = entry["id"]
+            if action_id == "talk":
+                for npc in npcs:
+                    menu.append(
+                        {
+                            "label": f"Talk to {npc['display_name']}",
+                            "kind": "talk",
+                            "arg": npc["name"],
+                        }
+                    )
+            elif action_id == "shop":
+                if len(npcs) == 1:
+                    menu.append(
+                        {
+                            "label": f"Trade with {npcs[0]['display_name']}",
+                            "kind": "shop",
+                            "arg": npcs[0]["name"],
+                        }
+                    )
+                elif npcs:
+                    menu.append({"label": "Trade", "kind": "shop_menu", "arg": None})
+            elif action_id == "rest":
+                menu.append({"label": "Rest", "kind": "rest", "arg": None})
+            elif action_id == "gather_rumors":
+                menu.append({"label": "Gather rumors", "kind": "gather_rumors", "arg": None})
+            elif action_id == "read_job_board":
+                menu.append({"label": "Read the job board", "kind": "read_job_board", "arg": None})
+            elif action_id.startswith("examine_"):
+                target = action_id[len("examine_") :].replace("_", " ")
+                label = f"Examine the {target}{self._gate_suffix(entry.get('gate'))}"
+                menu.append({"label": label, "kind": "examine", "arg": entry})
+
+        transition = context.get("transition")
+        if transition:
+            destination = transition["to"].replace("_", " ").title()
+            label = f"Depart for {destination}{self._gate_suffix(transition.get('gate'))}"
+            menu.append({"label": label, "kind": "depart", "arg": None})
+
+        menu.append({"label": "Go elsewhere ▸", "kind": "go_elsewhere", "arg": None})
+        return menu
+
+    def _dispatch_node_menu_item(self, item: dict) -> None:
+        """Run one numbered menu item."""
+        kind = item["kind"]
+        try:
+            if kind == "talk":
+                self.handle_talk(item["arg"])
+            elif kind == "shop":
+                self.handle_shop(item["arg"])
+            elif kind == "shop_menu":
+                self.handle_shop_menu()
+            elif kind == "rest":
+                self.handle_node_rest()
+            elif kind == "gather_rumors":
+                self.handle_gather_rumors()
+            elif kind == "read_job_board":
+                self.handle_read_job_board()
+            elif kind == "examine":
+                self.handle_node_examine(item["arg"])
+            elif kind == "depart":
+                self.handle_node_depart()
+            elif kind == "go_elsewhere":
+                self.handle_go_elsewhere()
+        except NodeActionError as e:
+            print_error(str(e))
+
+    def process_node_command(self, command: str) -> None:
+        """
+        Process a command while on a settlement node surface.
+
+        Accepts a menu number or typed prose (hybrid input); prose routes
+        through the same fuzzy parser as exploration.
+        """
+        if self.debug_console.is_debug_command(command):
+            self.debug_console.execute(command)
+            return
+
+        if command in ["quit", "exit", "q"]:
+            self.running = False
+            print_status_message("Thanks for playing!", "success")
+            return
+
+        if command in ["help", "h", "?"]:
+            self.display_help_node()
+            return
+
+        if command in ["look", "l"]:
+            self.display_node()
+            return
+
+        if command in ["status", "stats"]:
+            self.display_player_status()
+            return
+
+        if command in ["qs", "quicksave"]:
+            self.handle_quick_save()
+            return
+
+        if command == "rest":
+            self.handle_node_rest()
+            return
+
+        if command.isdigit():
+            menu = getattr(self, "_node_menu", [])
+            index = int(command)
+            if menu and 1 <= index <= len(menu):
+                self._dispatch_node_menu_item(menu[index - 1])
+            elif menu:
+                print_error(f"Pick a number between 1 and {len(menu)}.")
+            else:
+                print_error("No actions to pick yet — try 'look'.")
+            return
+
+        if self._try_fuzzy_parse(command):
+            return
+
+        print_status_message("Unknown command. Type 'help' for available commands.", "warning")
+
+    def handle_enter_node(self, node_name: str) -> None:
+        """Enter a settlement node by display name (parser output) or id."""
+        lowered = node_name.lower()
+        target_id = None
+        for node in self.game_state.list_nodes():
+            if (
+                node["id"] == node_name
+                or node["name"].lower() == lowered
+                or lowered in node["name"].lower()
+            ):
+                target_id = node["id"]
+                break
+
+        if target_id is None:
+            names = ", ".join(n["name"] for n in self.game_state.list_nodes())
+            print_error(f"No place called '{node_name}' here. You know of: {names}")
+            return
+
+        if target_id == self.game_state.current_node_id:
+            print_status_message("You're already there.", "info")
+            return
+
+        try:
+            self.game_state.enter_node(target_id)
+        except RuntimeError as e:
+            print_error(str(e))
+            return
+        self.display_node()
+
+    def handle_go_elsewhere(self) -> None:
+        """Show the settlement's node list and enter the chosen node."""
+        nodes = self.game_state.list_nodes()
+        current_id = self.game_state.current_node_id
+
+        print_section("Go elsewhere")
+        for number, node in enumerate(nodes, 1):
+            marker = " (you are here)" if node["id"] == current_id else ""
+            print_message(f"  {number}. {node['name']}{marker} — {node['blurb']}")
+
+        choice = input("Where to? (number or name, blank to stay): ").strip()
+        if not choice:
+            print_status_message("You stay where you are.", "info")
+            return
+
+        target = None
+        if choice.isdigit():
+            index = int(choice)
+            if 1 <= index <= len(nodes):
+                target = nodes[index - 1]
+        else:
+            lowered = choice.lower()
+            for node in nodes:
+                if lowered in node["name"].lower():
+                    target = node
+                    break
+
+        if target is None:
+            print_error(f"No place called '{choice}' here.")
+            return
+        self.handle_enter_node(target["name"])
+
+    def handle_node_rest(self) -> None:
+        """Rest at the current node when the node authors a rest action."""
+        interactions = self.game_state.node_actions.interactions()
+        if not any(action["id"] == "rest" for action in interactions["actions"]):
+            print_status_message("There's nowhere to rest here.", "warning")
+            return
+        self.handle_rest()
+
+    def handle_gather_rumors(self) -> None:
+        """Collect and display rumors from NPCs at the current node."""
+        try:
+            result = self.game_state.node_actions.gather_rumors()
+        except NodeActionError as e:
+            print_error(str(e))
+            return
+
+        rumors = result["rumors"]
+        refusals = result["refusals"]
+        if not rumors and not refusals:
+            print_status_message("You find no one with news to share.", "info")
+            return
+
+        for rumor in rumors:
+            print_status_message(
+                f"{rumor['npc_name']} ({rumor['disposition']}): “{rumor['text']}”", "info"
+            )
+        for refusal in refusals:
+            print_status_message(
+                f"{refusal['npc_name']} waves you off: “{refusal['prose']}”", "warning"
+            )
+
+    def handle_read_job_board(self) -> None:
+        """Read the job board: hooks for currently available quests."""
+        try:
+            result = self.game_state.node_actions.read_job_board()
+        except NodeActionError as e:
+            print_error(str(e))
+            return
+
+        postings = result["postings"]
+        if not postings:
+            print_status_message("The job board is bare.", "info")
+            return
+
+        print_section("Job Board")
+        for posting in postings:
+            print_status_message(f"• {posting['name']}: {posting['description']}", "info")
+
+    def handle_node_examine(self, action: dict) -> None:
+        """Resolve a skill-gated examine action on the current node."""
+        gate = action["gate"]
+        target = action["id"][len("examine_") :].replace("_", " ")
+        character = self._prompt_character_for_skill_check(
+            f"examine the {target}", gate["skill"], gate["dc"]
+        )
+        if character is None:
+            return
+
+        try:
+            result = self.game_state.node_actions.examine(action["id"], character)
+        except NodeActionError as e:
+            print_error(str(e))
+            return
+
+        self._print_gate_check(character, result["check"])
+        print_status_message(result["prose"], "info")
+
+    def handle_node_examine_by_name(self, text: str) -> None:
+        """Route typed 'examine <thing>' to the node's authored examine actions."""
+        examine_actions = [
+            action
+            for action in self.game_state.node_actions.interactions()["actions"]
+            if action["id"].startswith("examine_")
+        ]
+        if not examine_actions:
+            print_status_message("There's nothing here to examine that way.", "info")
+            return
+
+        text_lower = (text or "").lower()
+        match = None
+        for action in examine_actions:
+            target = action["id"][len("examine_") :].replace("_", " ")
+            if not text_lower or text_lower in target or target in text_lower:
+                match = action
+                break
+        if match is None and len(examine_actions) == 1:
+            match = examine_actions[0]
+
+        if match is None:
+            targets = ", ".join(
+                action["id"][len("examine_") :].replace("_", " ") for action in examine_actions
+            )
+            print_status_message(f"You can examine: {targets}", "info")
+            return
+        self.handle_node_examine(match)
+
+    def handle_node_depart(self) -> None:
+        """Depart through the current node's authored transition."""
+        node = self.game_state.current_node()
+        spec = node.get("transition")
+        if spec is None:
+            print_status_message("There's no way onward from here — try 'go elsewhere'.", "warning")
+            return
+
+        gate = spec.get("gate")
+        if gate:
+            destination = spec["to"].replace("_", " ")
+            character = self._prompt_character_for_skill_check(
+                f"depart for the {destination}", gate["skill"], gate["dc"]
+            )
+            if character is None:
+                return
+        else:
+            character = next((c for c in self.game_state.party.characters if c.is_alive), None)
+            if character is None:
+                print_error("No one in the party can travel.")
+                return
+
+        try:
+            result = self.game_state.node_actions.transition(character)
+        except (NodeActionError, RuntimeError) as e:
+            print_error(str(e))
+            return
+
+        if result["check"]:
+            self._print_gate_check(character, result["check"])
+        if not result["success"]:
+            print_status_message(result["prose"], "warning")
+            return
+
+        if result.get("prose"):
+            print_status_message(result["prose"], "info")
+        self.display_location()
+
+    def _print_gate_check(self, character: Character, check: dict) -> None:
+        """Bracketed mechanics line for an authored skill gate."""
+        verdict = "success" if check["success"] else "failure"
+        print_status_message(
+            f"[{check['skill'].title()} DC {check['dc']}] {character.name} rolled "
+            f"{check['roll']} + {check['modifier']} = {check['total']} — {verdict}",
+            "success" if check["success"] else "warning",
+        )
+
+    def display_help_node(self) -> None:
+        """Display help for settlement (node surface) commands."""
+        print_help_section(
+            "Settlement Commands",
+            [
+                ("<number>", "Do one of the listed actions"),
+                ("go / visit <place>", "Go to another spot in the settlement"),
+                ("talk <name>", "Talk to someone present"),
+                ("shop", "Trade with someone present"),
+                ("gather rumors", "Ask around for news"),
+                ("read board", "Read the job board"),
+                ("examine <thing>", "Take a closer look"),
+                ("depart", "Leave through the marked way"),
+                ("look", "Show this place again"),
+                ("rest", "Rest, where the place allows it"),
+            ],
+        )
+        print_help_section(
+            "General Commands",
+            [
+                ("status", "Show party status"),
+                ("inventory (i)", "Manage inventory"),
+                ("save / qs", "Save the game"),
+                ("help (h, ?)", "Show this help"),
+                ("quit (q)", "Exit the game"),
+            ],
+        )
 
     def display_player_status(self) -> None:
         """Display status for all party members."""
@@ -431,6 +852,22 @@ class CLI:
         """Build the status bar content for the bottom toolbar."""
         from prompt_toolkit.formatted_text import HTML
 
+        # Node surfaces have no room, lighting, or exits — show the
+        # settlement strip instead (location · time · gold).
+        if self.game_state.is_node_surface():
+            node = self.game_state.current_node()
+            settlement = self.game_state.dungeon.get("name", "Unknown")
+            time_display = self.game_state.time_manager.get_elapsed_time_display()
+            return HTML(
+                f'<style fg="cyan">{settlement}</style>'
+                f' <style fg="white">│</style> '
+                f'<style fg="white">{node["name"]}</style>'
+                f' <style fg="white">│</style> '
+                f'<style fg="yellow">{time_display}</style>'
+                f' <style fg="white">│</style> '
+                f'<style fg="green">{self._party_gold_display()} gp</style>'
+            )
+
         # Get current location
         room = self.game_state.get_current_room()
         room_name = room.get("name", "Unknown")
@@ -456,7 +893,14 @@ class CLI:
         icon, color, label = lighting_display.get(best_lighting, ("?", "white", "Unknown"))
 
         # Get available exits (compact format: N, S, E, W)
-        direction_abbrev = {"north": "N", "south": "S", "east": "E", "west": "W", "up": "U", "down": "D"}
+        direction_abbrev = {
+            "north": "N",
+            "south": "S",
+            "east": "E",
+            "west": "W",
+            "up": "U",
+            "down": "D",
+        }
         exits = self.game_state.get_available_exits()
         exit_dirs = [direction_abbrev.get(d, d.upper()[:1]) for d in exits.keys()]
         exits_str = ", ".join(exit_dirs) if exit_dirs else "None"
@@ -521,6 +965,12 @@ class CLI:
         result = self.command_parser.parse(command)
 
         if not result.success:
+            # A recognized action rejected by context validation (wrong
+            # surface, in/out of combat) gets its specific error, not
+            # "unknown command".
+            if result.action and result.error:
+                print_status_message(result.error, "warning")
+                return True
             # Show suggestions if available
             if result.suggestions:
                 suggestions_str = ", ".join(result.suggestions)
@@ -540,6 +990,36 @@ class CLI:
                 self.handle_move(direction)
             else:
                 print_error("Which direction? Try: north, south, east, west, up, down")
+            return True
+
+        if action == "enter_node":
+            node = params.get("node")
+            if params.get("node_unmatched"):
+                if "node" in result.entity_suggestions:
+                    selected = self._prompt_entity_suggestion(
+                        "place", result.entity_suggestions["node"], node
+                    )
+                    if selected:
+                        self.handle_enter_node(selected)
+                else:
+                    names = ", ".join(n["name"] for n in self.game_state.list_nodes())
+                    print_error(f"No place called '{node}' here. You know of: {names}")
+            elif node:
+                self.handle_enter_node(node)
+            else:
+                self.handle_go_elsewhere()
+            return True
+
+        if action == "gather_rumors":
+            self.handle_gather_rumors()
+            return True
+
+        if action == "read_job_board":
+            self.handle_read_job_board()
+            return True
+
+        if action == "depart":
+            self.handle_node_depart()
             return True
 
         if action == "attack":
@@ -676,6 +1156,14 @@ class CLI:
             return True
 
         if action == "look":
+            if self.game_state.is_node_surface():
+                # Node examine targets are authored actions, not room items
+                item = params.get("item")
+                if item:
+                    self.handle_node_examine_by_name(item)
+                else:
+                    self.display_node()
+                return True
             item = params.get("item")
             # Check if item didn't match and we have suggestions
             if params.get("item_unmatched") and "item" in result.entity_suggestions:
@@ -729,7 +1217,10 @@ class CLI:
             return True
 
         if action == "rest":
-            self.handle_rest()
+            if self.game_state.is_node_surface():
+                self.handle_node_rest()
+            else:
+                self.handle_rest()
             return True
 
         if action == "inventory":
@@ -1344,6 +1835,12 @@ class CLI:
         success = self.game_state.move(direction, check_for_enemies=False)
         if success:
             print_status_message(f"You move {direction}", "info")
+            # The reverse transition seam: a grid exit can land on a
+            # settlement's node surface, where room rendering and enemy
+            # checks don't apply.
+            if self.game_state.is_node_surface():
+                self.display_node()
+                return
             # Display room description FIRST
             self.display_room()
             # THEN check for enemies and potentially start combat
@@ -2329,10 +2826,8 @@ class CLI:
             print_error("No NPCs available in this campaign.")
             return
 
-        # Get NPCs in current room
-        current_room = self.game_state.get_current_room()
-        room_id = current_room.get("id", "")
-        npcs = self.game_state.npc_manager.get_npcs_in_room(room_id)
+        # Get NPCs at the current location (room or node)
+        npcs = self.game_state.npc_manager.get_npcs_in_room(self._current_location_id())
 
         if not npcs:
             print_status_message("There's no one here to talk to.", "info")
@@ -2369,10 +2864,8 @@ class CLI:
             print_error("No NPCs available in this campaign.")
             return
 
-        # Get NPCs in current room
-        current_room = self.game_state.get_current_room()
-        room_id = current_room.get("id", "")
-        npcs = self.game_state.npc_manager.get_npcs_in_room(room_id)
+        # Get NPCs at the current location (room or node)
+        npcs = self.game_state.npc_manager.get_npcs_in_room(self._current_location_id())
 
         if not npcs:
             print_status_message("There's no one here to talk to.", "info")
@@ -2530,10 +3023,8 @@ class CLI:
             print_error("No NPCs available in this campaign.")
             return
 
-        # Get NPCs in current room
-        current_room = self.game_state.get_current_room()
-        room_id = current_room.get("id", "")
-        npcs = self.game_state.npc_manager.get_npcs_in_room(room_id)
+        # Get NPCs at the current location (room or node)
+        npcs = self.game_state.npc_manager.get_npcs_in_room(self._current_location_id())
 
         # Filter to shopkeepers
         shopkeeper_npcs = []
@@ -2573,10 +3064,8 @@ class CLI:
             print_error("No NPCs available in this campaign.")
             return
 
-        # Get NPCs in current room
-        current_room = self.game_state.get_current_room()
-        room_id = current_room.get("id", "")
-        npcs = self.game_state.npc_manager.get_npcs_in_room(room_id)
+        # Get NPCs at the current location (room or node)
+        npcs = self.game_state.npc_manager.get_npcs_in_room(self._current_location_id())
 
         # Find NPC by name (case-insensitive partial match)
         target_npc = None
@@ -5441,8 +5930,8 @@ class CLI:
             print_status_message("Campaign reset successfully!", "success")
             print_message(f"Returned to dungeon entrance in {self.game_state.dungeon_name}")
 
-            # Display the new room
-            self.display_room()
+            # Display the new location (room or settlement node)
+            self.display_location()
 
         except Exception as e:
             print_error(f"Failed to reset campaign: {e}")
@@ -5547,7 +6036,7 @@ class CLI:
     def run(self) -> None:
         """Run the main game loop."""
         self.display_banner()
-        self.display_room()
+        self.display_location()
         self.display_player_status()
 
         # Start the game (GameState handles checking starting room for enemies)
@@ -5679,7 +6168,10 @@ class CLI:
                     self.process_enemy_turns()
             else:
                 command = self.get_player_command()
-                self.process_exploration_command(command)
+                if self.game_state.is_node_surface():
+                    self.process_node_command(command)
+                else:
+                    self.process_exploration_command(command)
 
         # Game over
         if self.game_state.is_game_over():

--- a/client-terminal/tests/drivers/lab_settlement_driver.py
+++ b/client-terminal/tests/drivers/lab_settlement_driver.py
@@ -1,0 +1,53 @@
+# ABOUTME: E2E driver that boots the real CLI on the lab settlement (no LLM, no menus).
+# ABOUTME: Run under pexpect by test_node_surface_e2e.py; only game setup is scripted.
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.utils.events import EventBus
+from terminal_client.ui.cli import CLI
+
+
+class NoopCampaignManager:
+    """Save-less campaign manager so the e2e run never touches real save slots."""
+
+    def save_game(self, *args, **kwargs):
+        return None
+
+
+def main() -> None:
+    character = Character(
+        name="Test Hero",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=Abilities(
+            strength=14,
+            dexterity=12,
+            constitution=13,
+            intelligence=10,
+            wisdom=11,
+            charisma=8,
+        ),
+        max_hp=12,
+        ac=16,
+    )
+    game_state = GameState(
+        party=Party([character]),
+        dungeon_name="lab_settlement",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+    )
+    cli = CLI(
+        game_state,
+        NoopCampaignManager(),
+        "lab",
+        auto_save_enabled=False,
+        llm_enhancer=None,
+    )
+    cli.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/client-terminal/tests/drivers/lab_settlement_driver.py
+++ b/client-terminal/tests/drivers/lab_settlement_driver.py
@@ -1,44 +1,26 @@
 # ABOUTME: E2E driver that boots the real CLI on the lab settlement (no LLM, no menus).
 # ABOUTME: Run under pexpect by test_node_surface_e2e.py; only game setup is scripted.
 
-from dnd_engine.core.character import Character, CharacterClass
-from dnd_engine.core.creature import Abilities
-from dnd_engine.core.game_state import GameState
-from dnd_engine.core.party import Party
-from dnd_engine.rules.loader import DataLoader
-from dnd_engine.utils.events import EventBus
+import sys
+from pathlib import Path
+
 from terminal_client.ui.cli import CLI
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from tests.support import make_lab_game_state  # noqa: E402
 
 
 class NoopCampaignManager:
     """Save-less campaign manager so the e2e run never touches real save slots."""
 
-    def save_game(self, *args, **kwargs):
+    def save_game(self, *args: object, **kwargs: object) -> None:
+        """Discard the save request."""
         return None
 
 
 def main() -> None:
-    character = Character(
-        name="Test Hero",
-        character_class=CharacterClass.FIGHTER,
-        level=1,
-        abilities=Abilities(
-            strength=14,
-            dexterity=12,
-            constitution=13,
-            intelligence=10,
-            wisdom=11,
-            charisma=8,
-        ),
-        max_hp=12,
-        ac=16,
-    )
-    game_state = GameState(
-        party=Party([character]),
-        dungeon_name="lab_settlement",
-        event_bus=EventBus(),
-        data_loader=DataLoader(),
-    )
+    """Boot the CLI on the lab settlement with a standard one-fighter party."""
+    game_state = make_lab_game_state()
     cli = CLI(
         game_state,
         NoopCampaignManager(),

--- a/client-terminal/tests/support.py
+++ b/client-terminal/tests/support.py
@@ -1,0 +1,39 @@
+# ABOUTME: Shared builders for node-surface tests and the pexpect e2e driver.
+# ABOUTME: One canonical test party and lab GameState used across suites.
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.utils.events import EventBus
+
+
+def make_test_party() -> Party:
+    """One level-1 fighter, the standard party for node-surface testing."""
+    character = Character(
+        name="Test Hero",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=Abilities(
+            strength=14,
+            dexterity=12,
+            constitution=13,
+            intelligence=10,
+            wisdom=11,
+            charisma=8,
+        ),
+        max_hp=12,
+        ac=16,
+    )
+    return Party([character])
+
+
+def make_lab_game_state(dungeon_name: str = "lab_settlement") -> GameState:
+    """A GameState on the given lab fixture with the standard test party."""
+    return GameState(
+        party=make_test_party(),
+        dungeon_name=dungeon_name,
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+    )

--- a/client-terminal/tests/test_cli_node_surface.py
+++ b/client-terminal/tests/test_cli_node_surface.py
@@ -1,0 +1,289 @@
+# ABOUTME: Integration tests for the CLI node-surface branch (issue #684 slice 5).
+# ABOUTME: Covers three-zone render, numbered/prose hybrid input, seam arrivals, and reset.
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.utils.events import EventBus
+from terminal_client.ui.cli import CLI
+from terminal_client.ui.rich_ui import console
+
+
+def _make_party() -> Party:
+    character = Character(
+        name="Test Hero",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=Abilities(
+            strength=14,
+            dexterity=12,
+            constitution=13,
+            intelligence=10,
+            wisdom=11,
+            charisma=8,
+        ),
+        max_hp=12,
+        ac=16,
+    )
+    return Party([character])
+
+
+def _make_cli(dungeon_name: str) -> CLI:
+    game_state = GameState(
+        party=_make_party(),
+        dungeon_name=dungeon_name,
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+    )
+    return CLI(game_state, Mock(), "lab", auto_save_enabled=False)
+
+
+@pytest.fixture
+def node_cli():
+    return _make_cli("lab_settlement")
+
+
+@pytest.fixture
+def grid_cli():
+    return _make_cli("lab_dungeon")
+
+
+def _capture(callable_, *args, **kwargs) -> str:
+    with console.capture() as cap:
+        callable_(*args, **kwargs)
+    return cap.get()
+
+
+class TestDisplayNode:
+    """Three zones: status strip, prose, numbered actions."""
+
+    def test_renders_node_name_and_description(self, node_cli):
+        output = _capture(node_cli.display_node)
+        assert "Lab Square" in output
+        assert "notice board" in output
+
+    def test_status_strip_has_settlement_time_and_gold(self, node_cli):
+        output = _capture(node_cli.display_node)
+        assert "Lab Settlement" in output
+        assert "gp" in output
+
+    def test_renders_numbered_actions_with_go_elsewhere(self, node_cli):
+        output = _capture(node_cli.display_node)
+        assert "1." in output
+        assert "Go elsewhere" in output
+
+    def test_display_location_dispatches_by_surface(self, node_cli, grid_cli):
+        node_output = _capture(node_cli.display_location)
+        assert "Lab Square" in node_output
+        grid_output = _capture(grid_cli.display_location)
+        assert "Lab Dungeon Entry" in grid_output
+
+
+class TestNodeMenu:
+    """Menu contents reflect the authored actions of the current node."""
+
+    def test_lab_square_menu(self, node_cli):
+        _capture(node_cli.display_node)
+        labels = [item["label"] for item in node_cli._node_menu]
+        assert any("rumors" in label.lower() for label in labels)
+        assert any("job board" in label.lower() for label in labels)
+        assert any("Go elsewhere" in label for label in labels)
+        assert not any("Talk" in label for label in labels)
+        assert not any("Rest" in label for label in labels)
+        assert not any("Depart" in label for label in labels)
+
+    def test_lab_gate_menu_brackets_mechanics(self, node_cli):
+        node_cli.game_state.enter_node("lab_gate")
+        _capture(node_cli.display_node)
+        labels = [item["label"] for item in node_cli._node_menu]
+        assert any("[Religion DC 12]" in label for label in labels)
+        assert any("Depart" in label and "[Athletics DC 10]" in label for label in labels)
+
+
+class TestNumberedDispatch:
+    """A typed number runs the corresponding menu item."""
+
+    def test_number_runs_menu_item(self, node_cli):
+        _capture(node_cli.display_node)
+        rumor_index = next(
+            i for i, item in enumerate(node_cli._node_menu, 1) if "rumors" in item["label"].lower()
+        )
+        output = _capture(node_cli.process_node_command, str(rumor_index))
+        assert "no one" in output.lower()
+
+    def test_out_of_range_number_reports_bounds(self, node_cli):
+        _capture(node_cli.display_node)
+        output = _capture(node_cli.process_node_command, "99")
+        assert "number" in output.lower()
+
+
+class TestProseInput:
+    """Typed prose routes through the parser to node intents."""
+
+    def test_go_to_node_by_prose(self, node_cli):
+        _capture(node_cli.display_node)
+        output = _capture(node_cli.process_node_command, "go to the tankard")
+        assert node_cli.game_state.current_node_id == "lab_tavern"
+        assert "Testing Tankard" in output
+
+    def test_typo_still_resolves_node(self, node_cli):
+        _capture(node_cli.display_node)
+        _capture(node_cli.process_node_command, "visit the tankerd")
+        assert node_cli.game_state.current_node_id == "lab_tavern"
+
+    def test_gather_rumors_by_prose(self, node_cli):
+        output = _capture(node_cli.process_node_command, "gather rumors")
+        assert "no one" in output.lower()
+
+    def test_read_job_board_by_prose(self, node_cli):
+        output = _capture(node_cli.process_node_command, "read the job board")
+        assert "board" in output.lower()
+
+    def test_grid_only_command_gets_friendly_error(self, node_cli):
+        output = _capture(node_cli.process_node_command, "search")
+        assert "settlement" in output.lower()
+        assert "unknown command" not in output.lower()
+
+    def test_look_rerenders_node(self, node_cli):
+        output = _capture(node_cli.process_node_command, "look")
+        assert "Lab Square" in output
+
+
+class TestGoElsewhere:
+    """The node list hides behind Go elsewhere."""
+
+    def test_go_elsewhere_lists_and_enters(self, node_cli):
+        _capture(node_cli.display_node)
+        with patch("builtins.input", return_value="2"):
+            output = _capture(node_cli.handle_go_elsewhere)
+        assert node_cli.game_state.current_node_id == "lab_tavern"
+        assert "Testing Tankard" in output
+
+    def test_go_elsewhere_accepts_name(self, node_cli):
+        with patch("builtins.input", return_value="old gate"):
+            _capture(node_cli.handle_go_elsewhere)
+        assert node_cli.game_state.current_node_id == "lab_gate"
+
+    def test_go_elsewhere_blank_cancels(self, node_cli):
+        with patch("builtins.input", return_value=""):
+            _capture(node_cli.handle_go_elsewhere)
+        assert node_cli.game_state.current_node_id == "lab_square"
+
+
+class TestSkillGatedActions:
+    """Examine and depart resolve authored gates; DC forced to pin outcomes."""
+
+    def _gate_node(self, cli):
+        cli.game_state.enter_node("lab_gate")
+        return cli.game_state.dungeon["nodes"]["lab_gate"]
+
+    def test_examine_success_prose(self, node_cli):
+        node = self._gate_node(node_cli)
+        node["actions"][0]["gate"]["dc"] = 0
+        character = node_cli.game_state.party.characters[0]
+        with patch.object(node_cli, "_prompt_character_for_skill_check", return_value=character):
+            _capture(node_cli.display_node)
+            output = _capture(
+                node_cli.process_node_command,
+                str(
+                    next(
+                        i
+                        for i, item in enumerate(node_cli._node_menu, 1)
+                        if "Examine" in item["label"]
+                    )
+                ),
+            )
+        assert "ward against the restless dead" in output
+
+    def test_examine_failure_prose(self, node_cli):
+        node = self._gate_node(node_cli)
+        node["actions"][0]["gate"]["dc"] = 40
+        character = node_cli.game_state.party.characters[0]
+        with patch.object(node_cli, "_prompt_character_for_skill_check", return_value=character):
+            _capture(node_cli.display_node)
+            output = _capture(
+                node_cli.process_node_command,
+                str(
+                    next(
+                        i
+                        for i, item in enumerate(node_cli._node_menu, 1)
+                        if "Examine" in item["label"]
+                    )
+                ),
+            )
+        assert "meaning escapes you" in output
+
+    def test_depart_success_crosses_seam(self, node_cli):
+        node = self._gate_node(node_cli)
+        node["transition"]["gate"]["dc"] = 0
+        character = node_cli.game_state.party.characters[0]
+        with patch.object(node_cli, "_prompt_character_for_skill_check", return_value=character):
+            output = _capture(node_cli.handle_node_depart)
+        assert not node_cli.game_state.is_node_surface()
+        assert node_cli.game_state.current_room_id == "lab_entry"
+        assert "stale air" in output
+
+    def test_depart_failure_stays_on_node(self, node_cli):
+        node = self._gate_node(node_cli)
+        node["transition"]["gate"]["dc"] = 40
+        character = node_cli.game_state.party.characters[0]
+        with patch.object(node_cli, "_prompt_character_for_skill_check", return_value=character):
+            output = _capture(node_cli.handle_node_depart)
+        assert node_cli.game_state.is_node_surface()
+        assert node_cli.game_state.current_node_id == "lab_gate"
+        assert "will not budge" in output
+
+
+class TestReverseSeamArrival:
+    """A grid exit into a settlement renders the node, not a crash."""
+
+    def test_move_into_settlement_renders_node(self, grid_cli):
+        output = _capture(grid_cli.handle_move, "up")
+        assert grid_cli.game_state.is_node_surface()
+        assert grid_cli.game_state.current_node_id == "lab_gate"
+        assert "Old Gate" in output
+
+
+class TestResetIntoSettlement:
+    """Reset lands on the settlement's start node without a false failure."""
+
+    def test_reset_renders_node(self, node_cli):
+        node_cli.game_state.enter_node("lab_gate")
+        with patch("builtins.input", return_value="y"):
+            output = _capture(node_cli.handle_reset, "reset")
+        assert "Failed to reset" not in output
+        assert "Lab Square" in output
+
+
+class TestStatusBarOnNodeSurface:
+    """The prompt-toolkit toolbar must not raise on a node surface."""
+
+    def test_status_bar_shows_node_identity(self, node_cli):
+        status = str(node_cli._get_status_bar())
+        assert "Lab Settlement" in status
+        assert "Lab Square" in status
+
+
+class TestTalkOnNodeSurface:
+    """Talk keys NPC lookup by node id and degrades kindly when empty."""
+
+    def test_talk_with_no_npcs(self, node_cli):
+        class EmptyNPCManager:
+            def __init__(self):
+                self.queried_with = None
+
+            def get_npcs_in_room(self, location_id):
+                self.queried_with = location_id
+                return []
+
+        manager = EmptyNPCManager()
+        node_cli.game_state.npc_manager = manager
+        output = _capture(node_cli.handle_talk, "marta")
+        assert "no one" in output.lower()
+        assert manager.queried_with == "lab_square"

--- a/client-terminal/tests/test_cli_node_surface.py
+++ b/client-terminal/tests/test_cli_node_surface.py
@@ -5,43 +5,13 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from dnd_engine.core.character import Character, CharacterClass
-from dnd_engine.core.creature import Abilities
-from dnd_engine.core.game_state import GameState
-from dnd_engine.core.party import Party
-from dnd_engine.rules.loader import DataLoader
-from dnd_engine.utils.events import EventBus
 from terminal_client.ui.cli import CLI
 from terminal_client.ui.rich_ui import console
-
-
-def _make_party() -> Party:
-    character = Character(
-        name="Test Hero",
-        character_class=CharacterClass.FIGHTER,
-        level=1,
-        abilities=Abilities(
-            strength=14,
-            dexterity=12,
-            constitution=13,
-            intelligence=10,
-            wisdom=11,
-            charisma=8,
-        ),
-        max_hp=12,
-        ac=16,
-    )
-    return Party([character])
+from tests.support import make_lab_game_state
 
 
 def _make_cli(dungeon_name: str) -> CLI:
-    game_state = GameState(
-        party=_make_party(),
-        dungeon_name=dungeon_name,
-        event_bus=EventBus(),
-        data_loader=DataLoader(),
-    )
-    return CLI(game_state, Mock(), "lab", auto_save_enabled=False)
+    return CLI(make_lab_game_state(dungeon_name), Mock(), "lab", auto_save_enabled=False)
 
 
 @pytest.fixture
@@ -153,6 +123,35 @@ class TestProseInput:
     def test_look_rerenders_node(self, node_cli):
         output = _capture(node_cli.process_node_command, "look")
         assert "Lab Square" in output
+
+    def test_fuzzy_help_shows_settlement_help(self, node_cli):
+        output = _capture(node_cli.process_node_command, "commands")
+        assert "Settlement Commands" in output
+
+    def test_menu_reprints_when_actions_change(self, node_cli):
+        _capture(node_cli.display_node)
+        assert any("job board" in item["label"].lower() for item in node_cli._node_menu)
+        # Simulate node state changing between render and dispatch
+        node_cli.game_state.dungeon["nodes"]["lab_square"]["actions"].remove("read_job_board")
+        output = _capture(node_cli.process_node_command, "1")
+        assert not any("job board" in item["label"].lower() for item in node_cli._node_menu)
+        assert "What do you do?" in output
+
+
+class TestNodeRest:
+    """Rest routes through the engine's node dispatch and respects authoring."""
+
+    def test_rest_unauthored_node_declines(self, node_cli):
+        output = _capture(node_cli.process_node_command, "rest")
+        assert "nowhere to rest" in output.lower()
+
+    def test_rest_authored_node_heals(self, node_cli):
+        node_cli.game_state.enter_node("lab_tavern")
+        hero = node_cli.game_state.party.characters[0]
+        hero.current_hp = 1
+        with patch("builtins.input", return_value="2"):
+            _capture(node_cli.process_node_command, "rest")
+        assert hero.current_hp == hero.max_hp
 
 
 class TestGoElsewhere:

--- a/client-terminal/tests/test_cli_status_bar.py
+++ b/client-terminal/tests/test_cli_status_bar.py
@@ -15,6 +15,7 @@ class TestStatusBar:
     def mock_game_state(self):
         """Create a mock game state for testing."""
         game_state = Mock()
+        game_state.is_node_surface.return_value = False
         game_state.dungeon = {"name": "The Crypt"}
         game_state.get_current_room.return_value = {"name": "Entrance Hall"}
         game_state.get_effective_lighting.return_value = "bright"

--- a/client-terminal/tests/test_command_parser_integration.py
+++ b/client-terminal/tests/test_command_parser_integration.py
@@ -20,7 +20,7 @@ def create_mock_game_state():
     char1.spells.prepared_spells = ["magic_missile", "shield"]
     char1.spells.known_spells = []
     char1.inventory.get_items_by_category.return_value = []
-    char1.inventory.equipment = {}
+    char1.inventory.equipped = {}
 
     char2 = MagicMock()
     char2.name = "Aragorn"
@@ -29,7 +29,7 @@ def create_mock_game_state():
     char2.spells.prepared_spells = []
     char2.spells.known_spells = []
     char2.inventory.get_items_by_category.return_value = []
-    char2.inventory.equipment = {}
+    char2.inventory.equipped = {}
 
     game_state.party.characters = [char1, char2]
 
@@ -38,8 +38,11 @@ def create_mock_game_state():
     game_state.initiative_tracker = None
     game_state.active_enemies = []
 
+    # Grid surface by default
+    game_state.is_node_surface.return_value = False
+
     # Mock room items
-    game_state.get_room_items.return_value = [
+    game_state.get_available_items_in_room.return_value = [
         {"id": "longsword", "name": "Longsword", "type": "weapon"},
         {"id": "healing_potion", "name": "Healing Potion", "type": "consumable"},
     ]
@@ -152,7 +155,7 @@ def create_combat_game_state():
     game_state.initiative_tracker.get_current_combatant.return_value = entry3
 
     # Mock other required attributes
-    game_state.get_room_items.return_value = []
+    game_state.get_available_items_in_room.return_value = []
     game_state.npc_manager = None
     game_state.data_loader.load_spells.return_value = {
         "fire_bolt": {"name": "Fire Bolt"},
@@ -216,7 +219,7 @@ def create_simple_combat_parser():
     game_state.initiative_tracker.get_combatant_display_name.return_value = "Goblin 1"
     game_state.initiative_tracker.get_current_combatant.return_value = entry2
 
-    game_state.get_room_items.return_value = []
+    game_state.get_available_items_in_room.return_value = []
     game_state.npc_manager = None
     game_state.data_loader.load_spells.return_value = {
         "magic_missile": {"name": "Magic Missile"},

--- a/client-terminal/tests/test_command_parser_integration.py
+++ b/client-terminal/tests/test_command_parser_integration.py
@@ -139,6 +139,7 @@ def create_combat_game_state():
 
     # Mock combat state
     game_state.in_combat = True
+    game_state.is_node_surface.return_value = False
 
     # Mock initiative tracker
     entry1 = MagicMock()
@@ -209,6 +210,7 @@ def create_simple_combat_parser():
     enemy1.current_hp = 5
 
     game_state.in_combat = True
+    game_state.is_node_surface.return_value = False
 
     entry1 = MagicMock()
     entry1.creature = enemy1

--- a/client-terminal/tests/test_command_parser_node.py
+++ b/client-terminal/tests/test_command_parser_node.py
@@ -1,0 +1,329 @@
+# ABOUTME: Unit tests for node-surface intents in the command parser (issue #684 slice 5).
+# ABOUTME: Covers enter_node routing, node social intents, surface remapping, and fuzzy node names.
+
+import pytest
+
+from terminal_client.nlp.command_parser import CommandParser
+
+LAB_NODES = ["Lab Square", "The Testing Tankard", "The Old Gate"]
+
+
+class NodeContextProvider:
+    """Context provider fake with node-surface awareness."""
+
+    def __init__(
+        self,
+        nodes: list[str] | None = None,
+        npcs: list[str] | None = None,
+        node_surface: bool = True,
+        in_combat: bool = False,
+    ):
+        self._nodes = nodes if nodes is not None else list(LAB_NODES)
+        self._npcs = npcs or []
+        self._node_surface = node_surface
+        self._in_combat = in_combat
+
+    def get_available_enemies(self) -> list[str]:
+        return []
+
+    def get_available_items(self) -> list[str]:
+        return []
+
+    def get_available_spells(self) -> list[str]:
+        return []
+
+    def get_available_npcs(self) -> list[str]:
+        return self._npcs
+
+    def get_party_member_names(self) -> list[str]:
+        return []
+
+    def is_in_combat(self) -> bool:
+        return self._in_combat
+
+    def is_node_surface(self) -> bool:
+        return self._node_surface
+
+    def get_available_nodes(self) -> list[str]:
+        return self._nodes
+
+
+class LegacyContextProvider:
+    """Pre-node provider shape: no node methods at all."""
+
+    def get_available_enemies(self) -> list[str]:
+        return []
+
+    def get_available_items(self) -> list[str]:
+        return []
+
+    def get_available_spells(self) -> list[str]:
+        return []
+
+    def get_available_npcs(self) -> list[str]:
+        return []
+
+    def get_party_member_names(self) -> list[str]:
+        return []
+
+    def is_in_combat(self) -> bool:
+        return False
+
+
+@pytest.fixture
+def node_parser():
+    return CommandParser(context_provider=NodeContextProvider())
+
+
+@pytest.fixture
+def grid_parser():
+    return CommandParser(context_provider=NodeContextProvider(node_surface=False))
+
+
+class TestEnterNodeIntent:
+    """Prose destination commands resolve to enter_node on a node surface."""
+
+    @pytest.mark.parametrize(
+        "text,expected_node",
+        [
+            ("go to the tankard", "The Testing Tankard"),
+            ("visit the old gate", "The Old Gate"),
+            ("head to lab square", "Lab Square"),
+            ("go tankard", "The Testing Tankard"),
+            ("walk to the testing tankard", "The Testing Tankard"),
+            ("enter the tankard", "The Testing Tankard"),
+        ],
+    )
+    def test_prose_routes_to_enter_node(self, node_parser, text, expected_node):
+        result = node_parser.parse(text)
+        assert result.success, result.error
+        assert result.action == "enter_node"
+        assert result.params["node"] == expected_node
+
+    def test_typo_in_node_name_fuzzy_matches(self, node_parser):
+        result = node_parser.parse("go to the tankerd")
+        assert result.success, result.error
+        assert result.action == "enter_node"
+        assert result.params["node"] == "The Testing Tankard"
+
+    def test_unknown_node_flags_unmatched(self, node_parser):
+        result = node_parser.parse("go to zzqxv")
+        assert result.action == "enter_node"
+        assert result.params.get("node_unmatched") is True
+
+    def test_bare_destination_keyword_prompts_for_node(self, node_parser):
+        result = node_parser.parse("go")
+        assert result.action == "enter_node"
+        assert "node" not in result.params
+
+
+class TestNodeSocialIntents:
+    """Node vocabulary actions parse from natural phrasings."""
+
+    @pytest.mark.parametrize(
+        "text",
+        ["gather rumors", "ask around", "rumors", "gossip"],
+    )
+    def test_gather_rumors(self, node_parser, text):
+        result = node_parser.parse(text)
+        assert result.success, result.error
+        assert result.action == "gather_rumors"
+
+    @pytest.mark.parametrize(
+        "text",
+        ["read the job board", "job board", "read board", "notice board", "read"],
+    )
+    def test_read_job_board(self, node_parser, text):
+        result = node_parser.parse(text)
+        assert result.success, result.error
+        assert result.action == "read_job_board"
+
+    @pytest.mark.parametrize("text", ["depart", "leave", "set out"])
+    def test_depart(self, node_parser, text):
+        result = node_parser.parse(text)
+        assert result.success, result.error
+        assert result.action == "depart"
+
+    def test_talk_still_matches_npcs_on_node_surface(self):
+        parser = CommandParser(context_provider=NodeContextProvider(npcs=["Marta"]))
+        result = parser.parse("talk to marta")
+        assert result.success, result.error
+        assert result.action == "talk"
+        assert result.params["npc"] == "Marta"
+
+
+class TestSurfaceRemap:
+    """The same keywords resolve per surface: directions on grid, nodes in settlements."""
+
+    def test_go_direction_still_moves_on_grid(self, grid_parser):
+        result = grid_parser.parse("go north")
+        assert result.success, result.error
+        assert result.action == "move"
+        assert result.params["direction"] == "north"
+
+    def test_visit_remaps_to_move_on_grid(self, grid_parser):
+        result = grid_parser.parse("visit the tavern")
+        assert result.action == "move"
+
+    def test_depart_remaps_to_move_on_grid(self, grid_parser):
+        result = grid_parser.parse("leave")
+        assert result.action == "move"
+
+    def test_gather_rumors_rejected_on_grid(self, grid_parser):
+        result = grid_parser.parse("gather rumors")
+        assert not result.success
+        assert "settlement" in result.error
+
+    def test_read_job_board_rejected_on_grid(self, grid_parser):
+        result = grid_parser.parse("job board")
+        assert not result.success
+        assert "settlement" in result.error
+
+    @pytest.mark.parametrize("text", ["search", "take the sword", "unlock north"])
+    def test_grid_only_actions_rejected_on_node_surface(self, node_parser, text):
+        result = node_parser.parse(text)
+        assert not result.success
+        assert "settlement" in result.error
+
+
+class TestNodeCombatValidation:
+    """Node actions are exploration-only."""
+
+    @pytest.mark.parametrize("text", ["gather rumors", "job board", "depart", "go to the tankard"])
+    def test_node_actions_rejected_in_combat(self, text):
+        parser = CommandParser(context_provider=NodeContextProvider(in_combat=True))
+        result = parser.parse(text)
+        assert not result.success
+        assert "combat" in result.error
+
+
+class TestAdapterNodeIntegration:
+    """CLIContextAdapter over a real GameState on the lab settlement."""
+
+    @pytest.fixture
+    def lab_adapter(self):
+        from dnd_engine.core.character import Character, CharacterClass
+        from dnd_engine.core.creature import Abilities
+        from dnd_engine.core.game_state import GameState
+        from dnd_engine.core.party import Party
+        from dnd_engine.rules.loader import DataLoader
+        from dnd_engine.utils.events import EventBus
+        from terminal_client.nlp.cli_context_adapter import CLIContextAdapter
+
+        character = Character(
+            name="Test Hero",
+            character_class=CharacterClass.FIGHTER,
+            level=1,
+            abilities=Abilities(
+                strength=14,
+                dexterity=12,
+                constitution=13,
+                intelligence=10,
+                wisdom=11,
+                charisma=8,
+            ),
+            max_hp=12,
+            ac=16,
+        )
+        game_state = GameState(
+            party=Party([character]),
+            dungeon_name="lab_settlement",
+            event_bus=EventBus(),
+            data_loader=DataLoader(),
+        )
+        return CLIContextAdapter(game_state)
+
+    def test_reports_node_surface(self, lab_adapter):
+        assert lab_adapter.is_node_surface() is True
+
+    def test_lists_node_names(self, lab_adapter):
+        assert lab_adapter.get_available_nodes() == [
+            "Lab Square",
+            "The Testing Tankard",
+            "The Old Gate",
+        ]
+
+    def test_npc_lookup_keys_by_node_id(self, lab_adapter):
+        class RecordingNPCManager:
+            def __init__(self):
+                self.queried_with = None
+
+            def get_npcs_in_room(self, location_id):
+                self.queried_with = location_id
+                return []
+
+        manager = RecordingNPCManager()
+        lab_adapter.game_state.npc_manager = manager
+        assert lab_adapter.get_available_npcs() == []
+        assert manager.queried_with == "lab_square"
+
+    def test_get_available_items_over_real_engine_on_node(self, lab_adapter):
+        # Regression for #691: adapter item lookup must survive real
+        # GameState/Inventory objects (no mocked attribute names).
+        assert isinstance(lab_adapter.get_available_items(), list)
+
+    def test_get_available_items_over_real_engine_on_grid(self):
+        from dnd_engine.core.game_state import GameState
+        from dnd_engine.rules.loader import DataLoader
+        from dnd_engine.utils.events import EventBus
+        from terminal_client.nlp.cli_context_adapter import CLIContextAdapter
+
+        lab_adapter_cls = CLIContextAdapter
+        node_adapter = lab_adapter_cls(
+            GameState(
+                party=self._party(),
+                dungeon_name="lab_dungeon",
+                event_bus=EventBus(),
+                data_loader=DataLoader(),
+            )
+        )
+        assert isinstance(node_adapter.get_available_items(), list)
+
+    @staticmethod
+    def _party():
+        from dnd_engine.core.character import Character, CharacterClass
+        from dnd_engine.core.creature import Abilities
+        from dnd_engine.core.party import Party
+
+        return Party(
+            [
+                Character(
+                    name="Test Hero",
+                    character_class=CharacterClass.FIGHTER,
+                    level=1,
+                    abilities=Abilities(
+                        strength=14,
+                        dexterity=12,
+                        constitution=13,
+                        intelligence=10,
+                        wisdom=11,
+                        charisma=8,
+                    ),
+                    max_hp=12,
+                    ac=16,
+                )
+            ]
+        )
+
+    def test_parser_end_to_end_over_real_adapter(self, lab_adapter):
+        parser = CommandParser(context_provider=lab_adapter)
+        result = parser.parse("head to the old gate")
+        assert result.success, result.error
+        assert result.action == "enter_node"
+        assert result.params["node"] == "The Old Gate"
+
+
+class TestLegacyProviderCompatibility:
+    """Providers without node methods degrade to grid behavior."""
+
+    def test_move_parses_with_legacy_provider(self):
+        parser = CommandParser(context_provider=LegacyContextProvider())
+        result = parser.parse("go north")
+        assert result.success, result.error
+        assert result.action == "move"
+
+    def test_node_actions_rejected_with_legacy_provider(self):
+        parser = CommandParser(context_provider=LegacyContextProvider())
+        result = parser.parse("gather rumors")
+        assert not result.success
+        assert "settlement" in result.error

--- a/client-terminal/tests/test_command_parser_node.py
+++ b/client-terminal/tests/test_command_parser_node.py
@@ -15,11 +15,13 @@ class NodeContextProvider:
         self,
         nodes: list[str] | None = None,
         npcs: list[str] | None = None,
+        items: list[str] | None = None,
         node_surface: bool = True,
         in_combat: bool = False,
     ):
         self._nodes = nodes if nodes is not None else list(LAB_NODES)
         self._npcs = npcs or []
+        self._items = items or []
         self._node_surface = node_surface
         self._in_combat = in_combat
 
@@ -27,7 +29,7 @@ class NodeContextProvider:
         return []
 
     def get_available_items(self) -> list[str]:
-        return []
+        return self._items
 
     def get_available_spells(self) -> list[str]:
         return []
@@ -131,12 +133,26 @@ class TestNodeSocialIntents:
 
     @pytest.mark.parametrize(
         "text",
-        ["read the job board", "job board", "read board", "notice board", "read"],
+        ["read the job board", "job board", "read board", "notice board", "read the board"],
     )
     def test_read_job_board(self, node_parser, text):
         result = node_parser.parse(text)
         assert result.success, result.error
         assert result.action == "read_job_board"
+
+    def test_read_of_other_things_is_not_job_board(self, node_parser):
+        # "read the plaque" must not open the job board
+        result = node_parser.parse("read the plaque")
+        assert result.action != "read_job_board"
+
+    def test_examine_target_not_hijacked_by_inventory(self):
+        # On a node, examine targets are authored actions; inventory names
+        # (Scimitar fuzzy-matches "altar") must not substitute the target.
+        parser = CommandParser(context_provider=NodeContextProvider(items=["Scimitar"]))
+        result = parser.parse("examine the altar")
+        assert result.success, result.error
+        assert result.action == "look"
+        assert result.params["item"] == "altar"
 
     @pytest.mark.parametrize("text", ["depart", "leave", "set out"])
     def test_depart(self, node_parser, text):
@@ -168,6 +184,23 @@ class TestSurfaceRemap:
     def test_depart_remaps_to_move_on_grid(self, grid_parser):
         result = grid_parser.parse("leave")
         assert result.action == "move"
+
+    def test_leave_during_grid_combat_means_flee(self):
+        parser = CommandParser(
+            context_provider=NodeContextProvider(node_surface=False, in_combat=True)
+        )
+        result = parser.parse("leave")
+        assert result.success, result.error
+        assert result.action == "flee"
+
+    def test_read_on_grid_is_not_a_settlement_error(self, grid_parser):
+        result = grid_parser.parse("read the inscription")
+        assert result.error is None or "settlement" not in result.error
+
+    def test_validation_errors_use_spaced_names(self, grid_parser):
+        result = grid_parser.parse("gather rumors")
+        assert "gather rumors" in result.error
+        assert "gather_rumors" not in result.error
 
     def test_gather_rumors_rejected_on_grid(self, grid_parser):
         result = grid_parser.parse("gather rumors")
@@ -202,36 +235,10 @@ class TestAdapterNodeIntegration:
 
     @pytest.fixture
     def lab_adapter(self):
-        from dnd_engine.core.character import Character, CharacterClass
-        from dnd_engine.core.creature import Abilities
-        from dnd_engine.core.game_state import GameState
-        from dnd_engine.core.party import Party
-        from dnd_engine.rules.loader import DataLoader
-        from dnd_engine.utils.events import EventBus
         from terminal_client.nlp.cli_context_adapter import CLIContextAdapter
+        from tests.support import make_lab_game_state
 
-        character = Character(
-            name="Test Hero",
-            character_class=CharacterClass.FIGHTER,
-            level=1,
-            abilities=Abilities(
-                strength=14,
-                dexterity=12,
-                constitution=13,
-                intelligence=10,
-                wisdom=11,
-                charisma=8,
-            ),
-            max_hp=12,
-            ac=16,
-        )
-        game_state = GameState(
-            party=Party([character]),
-            dungeon_name="lab_settlement",
-            event_bus=EventBus(),
-            data_loader=DataLoader(),
-        )
-        return CLIContextAdapter(game_state)
+        return CLIContextAdapter(make_lab_game_state())
 
     def test_reports_node_surface(self, lab_adapter):
         assert lab_adapter.is_node_surface() is True
@@ -263,47 +270,11 @@ class TestAdapterNodeIntegration:
         assert isinstance(lab_adapter.get_available_items(), list)
 
     def test_get_available_items_over_real_engine_on_grid(self):
-        from dnd_engine.core.game_state import GameState
-        from dnd_engine.rules.loader import DataLoader
-        from dnd_engine.utils.events import EventBus
         from terminal_client.nlp.cli_context_adapter import CLIContextAdapter
+        from tests.support import make_lab_game_state
 
-        lab_adapter_cls = CLIContextAdapter
-        node_adapter = lab_adapter_cls(
-            GameState(
-                party=self._party(),
-                dungeon_name="lab_dungeon",
-                event_bus=EventBus(),
-                data_loader=DataLoader(),
-            )
-        )
-        assert isinstance(node_adapter.get_available_items(), list)
-
-    @staticmethod
-    def _party():
-        from dnd_engine.core.character import Character, CharacterClass
-        from dnd_engine.core.creature import Abilities
-        from dnd_engine.core.party import Party
-
-        return Party(
-            [
-                Character(
-                    name="Test Hero",
-                    character_class=CharacterClass.FIGHTER,
-                    level=1,
-                    abilities=Abilities(
-                        strength=14,
-                        dexterity=12,
-                        constitution=13,
-                        intelligence=10,
-                        wisdom=11,
-                        charisma=8,
-                    ),
-                    max_hp=12,
-                    ac=16,
-                )
-            ]
-        )
+        grid_adapter = CLIContextAdapter(make_lab_game_state("lab_dungeon"))
+        assert isinstance(grid_adapter.get_available_items(), list)
 
     def test_parser_end_to_end_over_real_adapter(self, lab_adapter):
         parser = CommandParser(context_provider=lab_adapter)

--- a/client-terminal/tests/test_node_surface_e2e.py
+++ b/client-terminal/tests/test_node_surface_e2e.py
@@ -1,0 +1,99 @@
+# ABOUTME: True end-to-end tests for the settlement node surface (issue #684 slice 5).
+# ABOUTME: Drives the real CLI through a pty with pexpect — numbers AND typed prose.
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pexpect = pytest.importorskip("pexpect")
+
+DRIVER = Path(__file__).parent / "drivers" / "lab_settlement_driver.py"
+TIMEOUT = 20
+
+
+@pytest.fixture
+def game():
+    child = pexpect.spawn(
+        sys.executable,
+        [str(DRIVER)],
+        cwd=str(Path(__file__).parent.parent),
+        env={
+            "PATH": "/usr/bin:/bin",
+            "TERM": "dumb",
+            "NO_COLOR": "1",
+            "HOME": str(Path.home()),
+        },
+        encoding="utf-8",
+        timeout=TIMEOUT,
+    )
+    yield child
+    child.close(force=True)
+
+
+def _await_prompt(child):
+    """Wait for the node action menu to be on screen."""
+    child.expect("What do you do?")
+
+
+class TestLabSettlementE2E:
+    # pexpect.spawn uses os.forkpty(), which CPython 3.13 deprecates in
+    # multi-threaded processes (pytest is one); harmless for a test child.
+    @pytest.mark.filterwarnings(
+        "ignore:This process.*forkpty:DeprecationWarning"
+    )
+    def test_full_playthrough_numbers_and_prose(self, game):
+        # Arrival: start node renders with its three zones
+        game.expect("Lab Settlement")
+        game.expect("Lab Square")
+        _await_prompt(game)
+
+        # --- Numbered input: lab_square authors gather_rumors then read_job_board
+        game.sendline("2")
+        game.expect("The job board is bare")
+
+        game.sendline("1")
+        game.expect("no one with news")
+
+        # --- Prose input: destination by name
+        game.sendline("go to the tankard")
+        game.expect("The Testing Tankard")
+        _await_prompt(game)
+
+        # --- Prose with typo still resolves
+        game.sendline("visit the old gaet")
+        game.expect("The Old Gate")
+        _await_prompt(game)
+
+        # --- Examine through the authored skill gate (either branch is a beat)
+        game.sendline("examine the symbol")
+        game.expect("Choose a character")
+        game.sendline("")  # accept the top character
+        game.expect(["ward against the restless dead", "meaning escapes you"])
+
+        # --- Depart across the seam; retry the Athletics gate until it opens
+        for _ in range(12):
+            game.sendline("depart")
+            game.expect("Choose a character")
+            game.sendline("")
+            index = game.expect(["stale air", "will not budge"])
+            if index == 0:
+                break
+        else:
+            pytest.fail("Athletics DC 10 never succeeded in 12 attempts")
+
+        # Grid side of the seam
+        game.expect("Lab Dungeon Entry")
+
+        # --- Reverse seam: walk the grid exit back up into the settlement
+        game.sendline("go up")
+        game.expect("The Old Gate")
+        _await_prompt(game)
+
+        # --- Node help is the settlement help
+        game.sendline("help")
+        game.expect("Settlement Commands")
+
+        game.sendline("quit")
+        game.expect("Thanks for playing")
+        game.expect(pexpect.EOF)

--- a/dnd-engine/tests/conftest.py
+++ b/dnd-engine/tests/conftest.py
@@ -1,7 +1,11 @@
-# ABOUTME: Pytest plumbing for scenario-driven auto-play tests (issue #363).
-# ABOUTME: Exposes `scenario_session` + auto-discovers YAMLs under tests/scenarios/yaml/auto/.
+# ABOUTME: Pytest plumbing for scenario-driven auto-play tests (issue #363) and shared fixtures.
+# ABOUTME: Exposes `scenario_session` + auto-discovers YAMLs; shared node-surface fixtures (#684).
 
 """Auto-play harness conftest.
+
+Also home to fixtures shared across the node-surface test files
+(``test_party``, ``node_game``); files needing a specialized variant
+override the fixture locally, wrapping the shared one.
 
 Provides two pieces of pytest plumbing:
 
@@ -25,9 +29,47 @@ from pathlib import Path
 
 import pytest
 
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
 from dnd_engine.scenarios import LoadedScenario, ScenarioLoader
+from dnd_engine.utils.events import EventBus
 
 AUTO_SCENARIO_DIR = Path(__file__).parent / "scenarios" / "yaml" / "auto"
+
+
+@pytest.fixture
+def test_party() -> Party:
+    """One level-1 fighter, the standard party for node-surface tests."""
+    character = Character(
+        name="Test Hero",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=Abilities(
+            strength=14,
+            dexterity=12,
+            constitution=13,
+            intelligence=10,
+            wisdom=11,
+            charisma=8,
+        ),
+        max_hp=12,
+        ac=16,
+    )
+    return Party([character])
+
+
+@pytest.fixture
+def node_game(test_party: Party) -> GameState:
+    """A GameState started on the lab settlement's node surface."""
+    return GameState(
+        party=test_party,
+        dungeon_name="lab_settlement",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+    )
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/dnd-engine/tests/test_node_actions.py
+++ b/dnd-engine/tests/test_node_actions.py
@@ -3,15 +3,9 @@
 
 import pytest
 
-from dnd_engine.core.character import Character, CharacterClass
-from dnd_engine.core.creature import Abilities
-from dnd_engine.core.game_state import GameState
 from dnd_engine.core.node_surface import NodeActionError
 from dnd_engine.core.npc import NPC
-from dnd_engine.core.party import Party
 from dnd_engine.core.quest import QuestManager
-from dnd_engine.rules.loader import DataLoader
-from dnd_engine.utils.events import EventBus
 
 
 def _npc(npc_id: str, location: str, reputation: int = 0, **overrides) -> NPC:
@@ -68,42 +62,16 @@ class StubNPCManager:
 
 
 @pytest.fixture
-def test_party():
-    abilities = Abilities(
-        strength=14,
-        dexterity=12,
-        constitution=13,
-        intelligence=10,
-        wisdom=11,
-        charisma=8,
-    )
-    character = Character(
-        name="Test Hero",
-        character_class=CharacterClass.FIGHTER,
-        level=1,
-        abilities=abilities,
-        max_hp=12,
-        ac=16,
-    )
-    return Party([character])
-
-
-@pytest.fixture
-def node_game(test_party):
-    game = GameState(
-        party=test_party,
-        dungeon_name="lab_settlement",
-        event_bus=EventBus(),
-        data_loader=DataLoader(),
-    )
-    game.npc_manager = StubNPCManager(
+def node_game(node_game):
+    """The shared lab-settlement game, staffed with stub NPCs at the tavern."""
+    node_game.npc_manager = StubNPCManager(
         [
             _npc("tavernkeep", "lab_tavern", reputation=0),
             _npc("friendly", "lab_tavern", reputation=15),
             _npc("grump", "lab_tavern", reputation=-30),
         ]
     )
-    return game
+    return node_game
 
 
 @pytest.fixture

--- a/dnd-engine/tests/test_node_surface_state.py
+++ b/dnd-engine/tests/test_node_surface_state.py
@@ -3,43 +3,11 @@
 
 import pytest
 
-from dnd_engine.core.character import Character, CharacterClass
-from dnd_engine.core.creature import Abilities
 from dnd_engine.core.game_state import GameState
-from dnd_engine.core.party import Party
 from dnd_engine.rules.loader import DataLoader
 from dnd_engine.utils.events import EventBus, EventType
 
-
-@pytest.fixture
-def test_party():
-    abilities = Abilities(
-        strength=14,
-        dexterity=12,
-        constitution=13,
-        intelligence=10,
-        wisdom=11,
-        charisma=8,
-    )
-    character = Character(
-        name="Test Hero",
-        character_class=CharacterClass.FIGHTER,
-        level=1,
-        abilities=abilities,
-        max_hp=12,
-        ac=16,
-    )
-    return Party([character])
-
-
-@pytest.fixture
-def node_game(test_party):
-    return GameState(
-        party=test_party,
-        dungeon_name="lab_settlement",
-        event_bus=EventBus(),
-        data_loader=DataLoader(),
-    )
+# test_party and node_game come from tests/conftest.py
 
 
 @pytest.fixture

--- a/dnd-engine/tests/test_transition_seam_integration.py
+++ b/dnd-engine/tests/test_transition_seam_integration.py
@@ -7,35 +7,13 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-from dnd_engine.core.character import Character, CharacterClass
-from dnd_engine.core.creature import Abilities
 from dnd_engine.core.game_state import GameState
 from dnd_engine.core.node_surface import NodeActionError
-from dnd_engine.core.party import Party
 from dnd_engine.core.room_registry import RoomRegistry
 from dnd_engine.rules.loader import DataLoader
 from dnd_engine.utils.events import EventBus, EventType
 
-
-@pytest.fixture
-def test_party():
-    abilities = Abilities(
-        strength=14,
-        dexterity=12,
-        constitution=13,
-        intelligence=10,
-        wisdom=11,
-        charisma=8,
-    )
-    character = Character(
-        name="Test Hero",
-        character_class=CharacterClass.FIGHTER,
-        level=1,
-        abilities=abilities,
-        max_hp=12,
-        ac=16,
-    )
-    return Party([character])
+# test_party and node_game come from tests/conftest.py
 
 
 @pytest.fixture
@@ -44,16 +22,6 @@ def grid_game(test_party):
     return GameState(
         party=test_party,
         dungeon_name="lab_dungeon",
-        event_bus=EventBus(),
-        data_loader=DataLoader(),
-    )
-
-
-@pytest.fixture
-def node_game(test_party):
-    return GameState(
-        party=test_party,
-        dungeon_name="lab_settlement",
         event_bus=EventBus(),
         data_loader=DataLoader(),
     )

--- a/plans/684-node-surface-slices.md
+++ b/plans/684-node-surface-slices.md
@@ -8,13 +8,16 @@ check that runs without a human (pytest, pexpect, or headless MCP playtest), and
 each slice is one PR.
 
 Progress: slice 1 merged (PR #686), slice 2 merged (PR #687), slice 3 merged
-(PR #689). Slice 4 implemented on `feature/684-s4-transition-seam`
-(architecture-guardian approved; /code-review high findings fixed in-branch);
-PR pending. Next after merge: slice 5 (terminal rendering). Standing review policy: deep
-multi-agent review offered to Joe only at slices 4 and 6; `/code-review` high on
-those two, medium elsewhere; architecture-guardian on 2/4/7. Merges are done by
-Joe (permission classifier blocks `gh pr merge`). Related: #688 tracks the
-pre-existing `load_skills()` caching gap found in slice-3 review.
+(PR #689), slice 4 merged (PR #690). Slice 5 implemented on
+`feature/684-s5-terminal-node-ui` (/code-review medium: 8 verified findings,
+fixed in-branch); PR pending. Next after merge: slice 6 (Arden cutover).
+Standing review policy: deep multi-agent review offered to Joe only at slices
+4 and 6; `/code-review` high on those two, medium elsewhere;
+architecture-guardian on 2/4/7. Merges are done by Joe (permission classifier
+blocks `gh pr merge`). Related: #688 tracks the pre-existing `load_skills()`
+caching gap found in slice-3 review; #691 (adapter item-lookup dead
+references) was found and fixed during slice 5; #692 tracks debug-console
+node-awareness.
 
 Parent design: `docs/PARTIAL_TOTM_DESIGN.md` (town node surface).
 Related epics: plan-07 #536 (pillars — NOT built here), plan-10 #539 (engine owns
@@ -171,6 +174,31 @@ of which raise on a node surface; the node render branch must gate on
 (`test_node_surface_state.py`, `test_node_actions.py`,
 `test_transition_seam_integration.py`) — consolidate into `tests/conftest.py`
 during this slice's test work.
+
+**Slice 5 outcome notes:** hybrid input landed as designed (numbers + prose
+through the rule-based parser; per-surface keyword remapping, with "leave"
+resolving to flee during grid combat). Review fixes hardened the seam UX:
+the bare "read" alias was narrowed to board phrases, examine targets bypass
+inventory fuzzy-matching on nodes, validation errors use spaced action names,
+fuzzy help is surface-aware, the numbered menu rebuilds after every action
+(reprints when it changed), and node rest executes through
+`NodeSurfaceActions.rest` so authoring is enforced engine-side. The node
+status strip and prompt toolbar share one field helper reading raw authored
+dicts (no deepcopy on the repaint path). Client-terminal node tests and the
+pexpect driver share one party builder (`tests/support.py`).
+
+**Carried findings from slice 5 review (for slice 6):** departing a node into
+a grid whose start room has enemies prints combat start BEFORE the departure
+prose and room description — `_enter_dungeon_via_seam` runs
+`_check_for_enemies` inside `transition()`, inverting the room-first ordering
+`handle_move` preserves; if the Arden→crypt seam authors enemies at the
+arrival room, add an engine seam (e.g. `transition(check_for_enemies=False)`
++ client-triggered check) rather than reordering client-side. Also: the
+schema's fixed `NODE_ACTION_VOCABULARY` means any vocabulary addition must
+update `CLI._build_node_menu`'s label chain in the same change; menu
+staleness on NPC movement is now handled, but `update_npc_locations` still
+has no production caller — wiring it to time advance is where that refresh
+starts mattering.
 
 ### Slice 6 — Arden cutover + full-beat e2e
 

--- a/uv.lock
+++ b/uv.lock
@@ -598,6 +598,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pexpect" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "dnd-engine", editable = "dnd-engine" },
@@ -612,6 +617,9 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pexpect", specifier = ">=4.9" }]
 
 [[package]]
 name = "dnspython"
@@ -1363,6 +1371,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "11.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1483,6 +1503,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Settlement nodes render in three zones in the terminal client: status strip (settlement — node · time · gold), authored prose (DM voice), and a numbered contextual action list with `Go elsewhere ▸` hiding the node list. Gated actions carry bracketed mechanics cues (`[Religion DC 12]`), text-only.
- The prompt accepts **a number or prose**. `CommandParser` gains node intents (`enter_node`, `gather_rumors`, `read_job_board`, `depart`) with per-surface keyword resolution: "go north" moves on a grid, "go to the tankard" enters a node in a settlement, and "leave" during grid combat resolves to flee. `GameContextProvider` grows `is_node_surface`/`get_available_nodes` (older providers degrade to grid behavior).
- Carried findings from slices 2/4 fixed: `display_room`/`handle_move`/`_check_for_enemies` gate on `is_node_surface()` (reverse seam renders the node instead of crashing), `reset` into a settlement renders the node, the prompt-toolkit status bar has a node branch, `handle_talk`/`handle_shop`/menus key NPC lookup by node id, and the triplicated engine-test fixtures moved to `dnd-engine/tests/conftest.py`.
- Fixes #691 (adapter called nonexistent `get_room_items()` and `inventory.equipment`; caught live by the new e2e) — item lookup now uses `get_available_items_in_room()`/`inventory.equipped`, with real-engine regression tests.

## Review (per protocol: /code-review medium)
8 verified findings (4 agent-verified, 4 confirmed direct), all fixed in-branch: bare `read` alias hijacking "read X" everywhere; examine targets corrupted by inventory fuzzy-matching on nodes; `leave` mid-combat printing a direction prompt; fuzzy `help` showing grid help in settlements; internal snake_case ids leaking into errors; combat parser mocks silently running node-surface; stale numbered menu (now rebuilt after every action, reprinted when changed); per-keystroke node deepcopy in the toolbar. One finding carried to slice 6 (depart-into-enemies print ordering — engine seam ordering; recorded in the plan doc). #692 filed for debug-console node-awareness.

## Testing
- [x] Parser unit suite: node intents, surface remapping, combat/surface validation, fuzzy node names (`tests/test_command_parser_node.py`)
- [x] CLI integration suite over real GameState + lab settlement (`tests/test_cli_node_surface.py`)
- [x] True e2e: pexpect drives the real CLI through a pty — numbered AND prose playthrough, examine/depart gates, both seam directions (`tests/test_node_surface_e2e.py` + driver)
- [x] Terminal suite: 501 passed (pristine, no warnings). Engine suite: 3644 passed, 88% coverage.

## Related Issues
Part of #684 (slice 5 of plans/684-node-surface-slices.md — do not auto-close). Fixes #691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKLEzfGNCC17h7C2nkMx2c