### PR TITLE
Convert Town of Arden to a node-surface settlement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ logs/
 # Generated dungeons (runtime artifacts, not source content)
 dnd-engine/dnd_engine/data/content/dungeons/generated_*.json
 saves/
+
+# Serena MCP tool cache
+.serena/

--- a/client-terminal/terminal_client/ui/main_menu_v2.py
+++ b/client-terminal/terminal_client/ui/main_menu_v2.py
@@ -70,6 +70,23 @@ class MainMenuV2:
 
         return choice_map.get(choice)
 
+    def _resolve_starting_dungeon(self, campaign_id: str, starting_room: str) -> str | None:
+        """Resolve the dungeon file that hosts a campaign's starting location.
+
+        The starting id may be a grid room (e.g. "crypt.entrance") or a
+        settlement node (e.g. "arden.town_square"). Node settlements have no
+        grid rooms, so fall back to node resolution when the room lookup
+        misses.
+        """
+        content_path = self.data_loader.data_path / "content"
+        room_registry = RoomRegistry(
+            campaign_id=campaign_id,
+            content_path=content_path,
+        )
+        return room_registry.get_dungeon_for_room(
+            starting_room
+        ) or room_registry.get_dungeon_for_node(starting_room)
+
     def _build_slot_choice_display(self, slot) -> str:
         """
         Build a display string for a save slot choice.
@@ -363,14 +380,11 @@ class MainMenuV2:
         party = Party(party_characters)
         campaign_progress = campaign_info.get("campaign_progress")
 
-        # Use room registry to find the dungeon containing the starting room
+        # Resolve the dungeon that hosts the campaign's starting location.
         starting_room = campaign_info["starting_room"]
-        content_path = self.data_loader.data_path / "content"
-        room_registry = RoomRegistry(
-            campaign_id=campaign_info["campaign_id"],
-            content_path=content_path,
+        starting_dungeon = self._resolve_starting_dungeon(
+            campaign_info["campaign_id"], starting_room
         )
-        starting_dungeon = room_registry.get_dungeon_for_room(starting_room)
 
         if not starting_dungeon:
             print_error(f"Could not find dungeon for room: {starting_room}")
@@ -385,8 +399,12 @@ class MainMenuV2:
                 campaign_progress=campaign_progress,
             )
 
-            # Override to start at the campaign's specific starting room
-            game_state.current_room_id = starting_room
+            # Grid dungeons need the campaign's specific starting room.
+            # Node settlements position themselves at their start_node
+            # during GameState init; overriding current_room_id would
+            # corrupt the node surface.
+            if not game_state.is_node_surface():
+                game_state.current_room_id = starting_room
 
             # Step 5: Save to slot with campaign progress and sync vault
             self.slot_manager.save_game(

--- a/client-terminal/tests/drivers/arden_settlement_driver.py
+++ b/client-terminal/tests/drivers/arden_settlement_driver.py
@@ -1,0 +1,35 @@
+# ABOUTME: E2E driver that boots the real CLI on the Town of Arden node surface (no LLM, no menus).
+# ABOUTME: Run under pexpect by test_arden_node_surface_e2e.py; only game setup is scripted.
+
+import sys
+from pathlib import Path
+
+from terminal_client.ui.cli import CLI
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from tests.support import make_arden_game_state  # noqa: E402
+
+
+class NoopCampaignManager:
+    """Save-less campaign manager so the e2e run never touches real save slots."""
+
+    def save_game(self, *args: object, **kwargs: object) -> None:
+        """Discard the save request."""
+        return None
+
+
+def main() -> None:
+    """Boot the CLI on the Town of Arden with a standard one-fighter party."""
+    game_state = make_arden_game_state()
+    cli = CLI(
+        game_state,
+        NoopCampaignManager(),
+        "the_unquiet_dead",
+        auto_save_enabled=False,
+        llm_enhancer=None,
+    )
+    cli.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/client-terminal/tests/support.py
+++ b/client-terminal/tests/support.py
@@ -37,3 +37,14 @@ def make_lab_game_state(dungeon_name: str = "lab_settlement") -> GameState:
         event_bus=EventBus(),
         data_loader=DataLoader(),
     )
+
+
+def make_arden_game_state() -> GameState:
+    """A GameState on the Town of Arden node surface (The Unquiet Dead)."""
+    return GameState(
+        party=make_test_party(),
+        dungeon_name="town_of_arden",
+        campaign_id="the_unquiet_dead",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+    )

--- a/client-terminal/tests/test_arden_node_surface_e2e.py
+++ b/client-terminal/tests/test_arden_node_surface_e2e.py
@@ -1,0 +1,66 @@
+# ABOUTME: True end-to-end test for the Town of Arden node surface in The Unquiet Dead.
+# ABOUTME: Drives the real CLI through a pty with pexpect — arrival, node nav, and the crypt seam.
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pexpect = pytest.importorskip("pexpect")
+
+DRIVER = Path(__file__).parent / "drivers" / "arden_settlement_driver.py"
+TIMEOUT = 25
+
+
+@pytest.fixture
+def game():
+    child = pexpect.spawn(
+        sys.executable,
+        [str(DRIVER)],
+        cwd=str(Path(__file__).parent.parent),
+        env={
+            "PATH": "/usr/bin:/bin",
+            "TERM": "dumb",
+            "NO_COLOR": "1",
+            "HOME": str(Path.home()),
+        },
+        encoding="utf-8",
+        timeout=TIMEOUT,
+    )
+    yield child
+    child.close(force=True)
+
+
+def _await_prompt(child):
+    """Wait for the node action menu to be on screen."""
+    child.expect("What do you do?")
+
+
+class TestArdenNodeSurfaceE2E:
+    # pexpect.spawn uses os.forkpty(), which CPython 3.13 deprecates in
+    # multi-threaded processes (pytest is one); harmless for a test child.
+    @pytest.mark.filterwarnings("ignore:This process.*forkpty:DeprecationWarning")
+    def test_arden_arrival_navigation_and_seam(self, game):
+        # Arrival on the settlement node surface — the path that previously
+        # crashed with "Could not find dungeon for room: arden.town_square".
+        game.expect("Town of Arden")
+        game.expect("Town Square")
+        _await_prompt(game)
+
+        # Prose navigation resolves to a named node with its authored NPC.
+        game.sendline("go to the tankard")
+        game.expect("The Crooked Tankard")
+        game.expect("Marta")
+        _await_prompt(game)
+
+        # Walk to the Town Gate; it exposes the seam into the crypt. The
+        # action prompt renders before its menu, so await it, then assert
+        # the seam option is offered.
+        game.sendline("go to the town gate")
+        game.expect("Town Gate")
+        _await_prompt(game)
+        game.expect("Depart for Crypt")
+
+        game.sendline("quit")
+        game.expect("Thanks for playing")
+        game.expect(pexpect.EOF)

--- a/client-terminal/tests/test_new_game_node_start.py
+++ b/client-terminal/tests/test_new_game_node_start.py
@@ -1,0 +1,92 @@
+# ABOUTME: Integration test for starting a campaign whose starting_room is a settlement node.
+# ABOUTME: Guards the Unquiet Dead new-game path where Arden is now a node surface, not a grid room.
+
+import json
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.core.room_registry import RoomRegistry
+from dnd_engine.rules.loader import DataLoader
+from terminal_client.ui.main_menu_v2 import MainMenuV2
+
+CAMPAIGN_ID = "the_unquiet_dead"
+STARTING_NODE = "arden.town_square"
+STARTING_DUNGEON = "town_of_arden"
+
+
+@pytest.fixture
+def party():
+    abilities = Abilities(
+        strength=12, dexterity=14, constitution=14, intelligence=10, wisdom=12, charisma=10
+    )
+    hero = Character(
+        name="Test Hero",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=abilities,
+        max_hp=12,
+        ac=16,
+    )
+    return Party([hero])
+
+
+@pytest.fixture
+def data_loader():
+    return DataLoader()
+
+
+@pytest.fixture
+def content_path(data_loader):
+    return data_loader.data_path / "content"
+
+
+@pytest.fixture
+def campaign_starting_room(content_path):
+    campaign_file = content_path / "campaigns" / CAMPAIGN_ID / "campaign.json"
+    return json.loads(campaign_file.read_text())["starting_room"]
+
+
+def test_campaign_starts_at_a_node(campaign_starting_room):
+    # The Unquiet Dead now opens on the Town of Arden node surface.
+    assert campaign_starting_room == STARTING_NODE
+
+
+def test_room_only_resolution_misses_the_node(content_path):
+    # The trap the fallback exists to cover: a node id has no grid-room
+    # prefix entry, so the room lookup alone returns None.
+    registry = RoomRegistry(campaign_id=CAMPAIGN_ID, content_path=content_path)
+    assert registry.get_dungeon_for_room(STARTING_NODE) is None
+    assert registry.get_dungeon_for_node(STARTING_NODE) == STARTING_DUNGEON
+
+
+def test_resolve_starting_dungeon_finds_the_node_settlement(campaign_starting_room):
+    menu = MainMenuV2()
+    resolved = menu._resolve_starting_dungeon(CAMPAIGN_ID, campaign_starting_room)
+    assert resolved == STARTING_DUNGEON
+
+
+def test_new_game_lands_on_arden_node_surface(campaign_starting_room, data_loader, party):
+    # Reproduces main_menu_v2._create_new_game's construction: resolve the
+    # dungeon, build the GameState, and never override current_room_id for a
+    # node surface. This is the path that raised
+    # "Could not find dungeon for room: arden.town_square".
+    menu = MainMenuV2()
+    starting_dungeon = menu._resolve_starting_dungeon(CAMPAIGN_ID, campaign_starting_room)
+    assert starting_dungeon is not None, "starting dungeon must resolve"
+
+    game_state = GameState(
+        party=party,
+        dungeon_name=starting_dungeon,
+        campaign_id=CAMPAIGN_ID,
+        data_loader=data_loader,
+    )
+    if not game_state.is_node_surface():
+        game_state.current_room_id = campaign_starting_room
+
+    assert game_state.is_node_surface()
+    assert game_state.current_node_id == STARTING_NODE
+    assert game_state.current_room_id is None

--- a/client-terminal/tests/test_quest_items.py
+++ b/client-terminal/tests/test_quest_items.py
@@ -159,7 +159,7 @@ class TestConditionalExits:
 
         game_state = GameState(
             party=test_party,
-            dungeon_name="town_of_arden",
+            dungeon_name="crypt",
             campaign_id="the_unquiet_dead",
             event_bus=event_bus,
             data_loader=data_loader,
@@ -196,7 +196,7 @@ class TestConditionalExits:
 
         game_state = GameState(
             party=test_party,
-            dungeon_name="town_of_arden",
+            dungeon_name="crypt",
             campaign_id="the_unquiet_dead",
             event_bus=event_bus,
             data_loader=data_loader,
@@ -238,15 +238,15 @@ class TestConditionalExits:
 
         game_state = GameState(
             party=test_party,
-            dungeon_name="town_of_arden",
+            dungeon_name="crypt",
             campaign_id="the_unquiet_dead",
             event_bus=event_bus,
             data_loader=data_loader,
         )
 
-        # Check a normal exit (town square has multiple exits without requirements)
-        game_state.current_room_id = "arden.town_square"
-        req_check = game_state.check_exit_requirements("north")
+        # Check a normal exit (the crypt entrance's interior exit has no requirements)
+        game_state.current_room_id = "crypt.graveyard_entrance"
+        req_check = game_state.check_exit_requirements("down")
         assert req_check["met"] is True
 
     def test_move_blocked_without_required_item(self, test_party):
@@ -256,7 +256,7 @@ class TestConditionalExits:
 
         game_state = GameState(
             party=test_party,
-            dungeon_name="town_of_arden",
+            dungeon_name="crypt",
             campaign_id="the_unquiet_dead",
             event_bus=event_bus,
             data_loader=data_loader,

--- a/dnd-engine/dnd_engine/data/content/campaigns/the_unquiet_dead/dungeons/town_of_arden.json
+++ b/dnd-engine/dnd_engine/data/content/campaigns/the_unquiet_dead/dungeons/town_of_arden.json
@@ -3,250 +3,98 @@
   "name": "Town of Arden",
   "campaign_id": "the_unquiet_dead",
   "description": "A small frontier town nestled at the edge of the wilderness. The townsfolk are hardworking and suspicious of strangers, though they've grown accustomed to adventurers passing through. Recent troubles at the old Davos family crypt have the locals on edge.",
-  "start_room": "arden.town_square",
+  "surface": "node",
+  "start_node": "arden.town_square",
   "level_range": "1-3",
   "estimated_playtime": "varies",
   "focus": "exploration, roleplay",
-  "notes": "Hub town for The Unquiet Dead campaign. Players start here and return between dungeons. Navigation uses compass directions. The Warrens will connect to the Cult Hideout via conditional exit (Issue #102).",
-  "rooms": {
+  "notes": "Hub settlement for The Unquiet Dead, presented as a node surface (issue #684). Players start here and return between dungeons via the Town Gate transition (to the crypt) and the reverse seam: the crypt and cult hideout exits name arden.town_road and arden.warrens_alley, so those node ids are preserved. The Warrens will connect to the Cult Hideout via a conditional transition (Issue #102).",
+  "nodes": {
     "arden.town_square": {
-      "id": "arden.town_square",
-      "location_type": "settlement",
-      "parent": "town_of_arden",
-      "safe_zone": true,
       "name": "Town Square",
-      "description": "You stand in the heart of Arden. Cobblestones worn smooth by generations of foot traffic spread beneath you. A weathered post displays a map of the town and a notice board covered in parchments - one catches your eye, something about trouble at the old Davos crypt. A stone fountain burbles at the square's center, its basin green with moss. To the north, the warm glow of the Crooked Tankard beckons weary travelers. The iron gates of Davos Manor stand to the west, while the spire of a chapel rises to the east. A sturdy timber building with a sign reading 'Gareth's Goods' stands to the northeast. Southward, the main road leads toward the town gate.",
-      "lighting": "bright",
-      "exits": {
-        "north": "arden.outside_inn",
-        "south": "arden.town_road",
-        "east": "arden.outside_chapel",
-        "west": "arden.outside_manor",
-        "northeast": "arden.outside_general_store"
-      },
-      "enemies": [],
-      "items": [],
-      "searched": false,
-      "searchable": false
+      "blurb": "The heart of Arden — a mossy fountain, a notice board, and roads running to every corner of town.",
+      "description": "You stand in the heart of Arden, cobblestones worn smooth by generations underfoot. A stone fountain burbles at the center, its basin green with moss, and a weathered post displays a town map beside a notice board thick with parchments — one scrap catches your eye, something about trouble at the old Davos crypt. The Crooked Tankard glows to the north, the iron gates of Davos Manor stand west, a chapel spire rises east, and Gareth's Goods sits to the northeast. Southward the main road runs down toward the town gate.",
+      "npcs": [],
+      "actions": ["gather_rumors", "read_job_board"]
     },
-    "arden.outside_inn": {
-      "id": "arden.outside_inn",
-      "location_type": "settlement",
-      "parent": "town_of_arden",
-      "safe_zone": true,
-      "name": "Outside the Crooked Tankard",
-      "description": "You stand before a two-story timber building that leans noticeably to one side, as if it had one too many drinks itself. A weathered sign depicting a tilted tankard creaks in the breeze above the door. Warm light spills from the windows, and the smell of roasting meat and fresh bread drifts out whenever the door swings open. A hitching post stands nearby, though no horses are tied there now. Laughter and the clink of mugs can be heard from within.",
-      "lighting": "bright",
-      "exits": {
-        "south": "arden.town_square",
-        "north": {
-          "destination": "arden.inn_common_room",
-          "label": "Enter the Inn"
-        }
-      },
-      "enemies": [],
-      "items": [],
-      "searched": false,
-      "searchable": false
+    "arden.crooked_tankard": {
+      "name": "The Crooked Tankard",
+      "blurb": "Arden's leaning inn — woodsmoke, spilled ale, and the town's best gossip.",
+      "description": "The Crooked Tankard earns its name from a foundation that settled a century ago, leaving the whole two-story building tilted as though it had one too many. Inside, a great stone fireplace throws dancing light across farmers, merchants, and the odd adventurer. Marta, the stout innkeeper, moves between the tables with surprising grace, and the smoky air is thick with rumor — strange lights near the graveyard, robed figures abroad at odd hours. A worn staircase climbs to rooms above.",
+      "npcs": [],
+      "actions": ["talk", "shop", "rest", "gather_rumors"]
     },
-    "arden.inn_common_room": {
-      "id": "arden.inn_common_room",
-      "location_type": "settlement",
-      "parent": "town_of_arden",
-      "safe_zone": true,
-      "name": "The Crooked Tankard - Common Room",
-      "description": "The smell of roasting meat and spilled ale washes over you. The Crooked Tankard earns its name from the building's distinct lean - the result of a foundation that settled unevenly a century ago. Despite this quirk, the inn has become the heart of Arden's social life. A massive stone fireplace dominates one wall, its flames casting dancing shadows across the faces of farmers, merchants, and the occasional adventurer. The innkeeper, a stout woman with arms like hams and a laugh like rolling thunder, moves between tables with surprising grace. A worn staircase leads to rooms above. The murmur of conversation fills the smoky air - rumors of strange lights near the old graveyard, whispers of figures in dark robes seen at odd hours.",
-      "lighting": "dim",
-      "exits": {
-        "south": {
-          "destination": "arden.outside_inn",
-          "label": "Exit to Street"
-        }
-      },
-      "enemies": [],
-      "items": [],
-      "searched": false,
-      "searchable": false
+    "arden.gareths_goods": {
+      "name": "Gareth's Goods",
+      "blurb": "The town outfitter — weapons, armor, and every adventuring sundry, if you can pay.",
+      "description": "A painted sign reads 'Gareth's Goods — Supplies for the Discerning Adventurer.' Within, the shop is a well-ordered maze of merchandise: blades and axes on the walls, leather and mail on the stands, shelves of potions, torches, and rope. A locked glass cabinet guards the finer wares. Behind a worn counter stands Gareth himself, sharp-eyed and ink-stained from his ledgers, ready to do business.",
+      "npcs": [],
+      "actions": ["talk", "shop"]
     },
-    "arden.outside_manor": {
-      "id": "arden.outside_manor",
-      "location_type": "settlement",
-      "parent": "town_of_arden",
-      "safe_zone": true,
-      "name": "Outside Davos Manor",
-      "description": "You stand before the iron gates of Davos Manor. The family crest - a radiant sun over crossed swords - is worked into the metalwork, though rust has claimed much of its former glory. Beyond the gates, manicured grounds have gone slightly wild from neglect. Overgrown hedges line a gravel path leading to the manor's front door. The manor itself is an imposing structure of grey stone, tall windows staring down like hollow eyes. Ivy creeps up the eastern wall unchecked. A servant in faded livery tends to the overgrown hedges, paying you little mind.",
-      "lighting": "bright",
-      "exits": {
-        "east": "arden.town_square",
-        "west": {
-          "destination": "arden.manor_interior",
-          "label": "Enter the Manor"
-        }
-      },
-      "enemies": [],
-      "items": [],
-      "searched": false,
-      "searchable": false
-    },
-    "arden.manor_interior": {
-      "id": "arden.manor_interior",
-      "location_type": "settlement",
-      "parent": "town_of_arden",
-      "safe_zone": true,
-      "name": "Davos Manor - Entry Hall",
-      "description": "The entry hall of Davos Manor speaks of wealth accumulated over generations, now fading into genteel decay. A grand staircase sweeps upward, its banister polished by countless hands over the centuries. Portraits of ancestors line the walls - stern men and women in the formal dress of ages past, and at the center, a larger painting of a man in clerical robes holding a sunburst holy symbol: Davos himself, the legendary cleric who defeated the devil Durgon. Dust motes drift in shafts of light from high windows. The current Lord Davos, old and frail, rarely leaves his study these days. Footsteps echo from somewhere above - servants going about their quiet duties in the old house.",
-      "lighting": "dim",
-      "exits": {
-        "east": {
-          "destination": "arden.outside_manor",
-          "label": "Exit to Grounds"
-        }
-      },
-      "enemies": [],
-      "items": [],
-      "searched": false,
-      "searchable": false
-    },
-    "arden.outside_chapel": {
-      "id": "arden.outside_chapel",
-      "location_type": "settlement",
-      "parent": "town_of_arden",
-      "safe_zone": true,
-      "name": "Outside the Chapel of the Light",
-      "description": "A modest stone chapel stands before you, its single spire topped with a sun-shaped symbol of burnished bronze that catches the light. The building is old - far older than most structures in Arden - its stones fitted together with a precision that modern masons envy. Local legend holds that Davos himself laid the cornerstone after returning victorious from his battle against the devil Durgon. A small graveyard wraps around the chapel's north side, its headstones leaning with age. The wooden doors are carved with scenes of light triumphing over shadow, worn smooth by the hands of generations of faithful.",
-      "lighting": "bright",
-      "exits": {
-        "west": "arden.town_square",
-        "east": {
-          "destination": "arden.chapel_interior",
-          "label": "Enter the Chapel"
-        }
-      },
-      "enemies": [],
-      "items": [],
-      "searched": false,
-      "searchable": false
-    },
-    "arden.chapel_interior": {
-      "id": "arden.chapel_interior",
-      "location_type": "settlement",
-      "parent": "town_of_arden",
-      "safe_zone": true,
-      "name": "Chapel of the Light - Sanctuary",
-      "description": "The interior of the chapel is cool and quiet, a sanctuary from the bustle of town life. Candles flicker in alcoves along the walls, their light playing across faded murals depicting scenes of divine warriors battling creatures of shadow - the victory of Davos over Durgon immortalized in paint and plaster. Wooden pews face a simple altar adorned with a golden sunburst. An elderly priest tends to his duties with slow, purposeful movements, occasionally pausing to offer comfort to those who come to pray. The air carries the faint scent of incense and old parchment. A collection box near the entrance suggests the church's coffers have seen better days, but the faithful still come - and lately, to ask for protection against whatever evil has awakened the dead.",
-      "lighting": "dim",
-      "exits": {
-        "west": {
-          "destination": "arden.outside_chapel",
-          "label": "Exit to Grounds"
-        }
-      },
-      "enemies": [],
-      "items": [],
-      "searched": false,
-      "searchable": false
-    },
-    "arden.town_road": {
-      "id": "arden.town_road",
-      "location_type": "settlement",
-      "parent": "town_of_arden",
-      "safe_zone": true,
-      "name": "Town Road",
-      "description": "The main road of Arden runs north to south, connecting the town square to the southern gate. Here the cobblestones are most worn, grooved by generations of cart wheels and foot traffic. The town gate stands open during daylight hours, watched over by a pair of bored-looking guards. Beyond the wooden palisade, a dirt road winds through farmland before disappearing into a copse of trees - that way lies the Davos family graveyard, and darker things besides. To the east, a narrow alley leads into the Warrens, the older and rougher part of town where the guard rarely ventures after dark.",
-      "lighting": "bright",
-      "exits": {
-        "north": "arden.town_square",
-        "south": {
-          "destination": "crypt.graveyard_entrance",
-          "label": "Road to Davos Family Graveyard"
-        },
-        "east": "arden.warrens_alley"
-      },
-      "enemies": [],
-      "items": [],
-      "searched": false,
-      "searchable": false
-    },
-    "arden.warrens_alley": {
-      "id": "arden.warrens_alley",
-      "location_type": "settlement",
-      "parent": "town_of_arden",
-      "safe_zone": true,
-      "name": "The Warrens - Alley Entrance",
-      "description": "The cobblestones give way to packed dirt as you enter the oldest part of Arden. Here the buildings lean together like drunken conspirators, their upper stories nearly touching across narrow lanes that twist without logic. This is the Warrens - home to those who cannot afford better and those who prefer not to be found. The town guard rarely patrols these streets after dark, and the locals eye strangers with a mixture of suspicion and calculation. Faded signs mark establishments of dubious reputation: a pawnbroker who asks no questions, a fortune teller whose predictions are said to be unsettlingly accurate, a nameless tavern where the ale is cheap and the clientele cheaper. Somewhere in this maze of alleys and abandoned warehouses, darker things stir - though whether the rumors of hooded figures and strange symbols are truth or tavern tales, none can say for certain.",
-      "lighting": "dim",
-      "examinable_objects": [
+    "arden.chapel_of_the_light": {
+      "name": "Chapel of the Light",
+      "blurb": "An ancient sun-spired chapel; the faithful now come asking protection from the restless dead.",
+      "description": "A modest stone chapel, older than most of Arden, its spire crowned with a burnished bronze sun. Legend holds Davos himself laid the cornerstone after defeating the devil Durgon, and faded murals inside show that victory of light over shadow. Candles flicker in wall alcoves; pews face a simple altar and its golden sunburst. Father Aldric tends his duties with slow, purposeful movements — and lately fields more and more pleas for protection against whatever has stirred the dead. A small graveyard wraps the chapel's north side.",
+      "npcs": [],
+      "actions": [
+        "talk",
+        "shop",
         {
-          "id": "basement_door",
-          "name": "weathered basement door",
-          "description": "A heavy wooden door set into the foundation of an abandoned warehouse. A strange symbol is carved deeply into the wood - a horned skull wreathed in flames. The door appears unlocked.",
-          "requires": {
-            "quest_item": "gorgus_journal"
-          },
-          "examine_checks": [
-            {
-              "skill": "religion",
-              "dc": 12,
-              "on_success": "You recognize the symbol as the mark of the Cult of Durgon - an ancient devil-worshipping sect thought to have been destroyed centuries ago. The crude map in the cultist's journal led you right to their door.",
-              "on_failure": "The symbol is unfamiliar to you, though its sinister appearance suggests nothing good lies beyond."
-            }
-          ]
+          "id": "examine_graveyard",
+          "gate": {"skill": "religion", "dc": 12},
+          "on_success": "Among the leaning headstones you find graves disturbed from below — soil pushed up, not dug down. Whatever walks the crypt has been practicing here.",
+          "on_failure": "The little churchyard is old and untended; the weathered stones give up nothing unusual."
         }
       ],
-      "exits": {
-        "west": "arden.town_road",
-        "down": {
-          "destination": "cult_hideout.entrance",
-          "label": "Basement Door",
-          "requires": {
-            "quest_item": "gorgus_journal"
-          },
-          "hidden_until_unlocked": true
-        }
-      },
-      "enemies": [],
-      "items": [],
-      "searched": false,
-      "searchable": false
+      "quest_hook": "investigate_crypt"
     },
-    "arden.outside_general_store": {
-      "id": "arden.outside_general_store",
-      "location_type": "settlement",
-      "parent": "town_of_arden",
-      "safe_zone": true,
-      "name": "Outside Gareth's Goods",
-      "description": "A sturdy two-story building of timber and stone stands before you, its construction more practical than decorative. A painted wooden sign above the door depicts a sword crossed with a potion bottle beneath the words 'Gareth's Goods - Supplies for the Discerning Adventurer'. Crates and barrels are stacked neatly against one wall, and a notice board beside the door advertises various wares and their prices. The door stands open during business hours, inviting customers within.",
-      "lighting": "bright",
-      "exits": {
-        "southwest": "arden.town_square",
-        "north": {
-          "destination": "arden.general_store",
-          "label": "Enter the Shop"
+    "arden.davos_manor": {
+      "name": "Davos Manor",
+      "blurb": "The fading seat of the Davos line, whose ancestor slew the devil Durgon.",
+      "description": "The iron gates bear the Davos crest — a radiant sun over crossed swords — rusted now, the grounds beyond gone half-wild. Within, the entry hall speaks of generations of wealth sliding into genteel decay: a grand staircase, ancestral portraits, and at their center a larger painting of a man in clerical robes holding a sunburst holy symbol — Davos, who bound the devil Durgon. Dust drifts in shafts of high window-light. The current Lord Davos, old and frail, rarely leaves his study, and the footsteps of quiet servants echo from above.",
+      "npcs": [],
+      "actions": [
+        "talk",
+        {
+          "id": "examine_portrait",
+          "gate": {"skill": "history", "dc": 12},
+          "on_success": "You recognize the sunburst Davos holds: the seal of the old ward that bound Durgon. In the painting it is whole — but the relic itself has been missing from the chapel for a generation.",
+          "on_failure": "A dignified portrait of a cleric in sunburst robes. Fine work, but it tells you little."
         }
-      },
-      "enemies": [],
-      "items": [],
-      "searched": false,
-      "searchable": false
+      ]
     },
-    "arden.general_store": {
-      "id": "arden.general_store",
-      "location_type": "settlement",
-      "parent": "town_of_arden",
-      "safe_zone": true,
-      "name": "Gareth's Goods - Interior",
-      "description": "The interior of the shop is a well-organized maze of merchandise. Weapons hang on the walls - swords, axes, and bows of various sizes. Armor stands display leather jerkins and mail shirts. Shelves hold potions, torches, rope, and countless other adventuring necessities. A glass-fronted cabinet near the counter contains more valuable items under lock and key. Behind a worn wooden counter stands Gareth himself, a middle-aged man with sharp eyes and ink-stained fingers from keeping his ledgers. He looks up as you enter, ready to do business.",
-      "lighting": "bright",
-      "exits": {
-        "south": {
-          "destination": "arden.outside_general_store",
-          "label": "Exit to Street"
+    "arden.warrens_alley": {
+      "name": "The Warrens",
+      "blurb": "Arden's oldest, roughest quarter, where the watch won't go after dark.",
+      "description": "The cobbles give way to packed dirt where Arden's oldest quarter leans together overhead, lanes twisting without logic. This is the Warrens — home to those who cannot afford better and those who would rather not be found. Faded signs mark a pawnbroker who asks no questions, a fortune teller of unsettling accuracy, and a nameless tavern with cheap ale and cheaper company. The watch rarely comes here after dark, and locals weigh strangers with equal parts suspicion and calculation. Somewhere in this maze, darker things are said to stir.",
+      "npcs": [],
+      "actions": [
+        "gather_rumors",
+        {
+          "id": "examine_cult_symbol",
+          "gate": {"skill": "investigation", "dc": 13},
+          "on_success": "Chalked beneath a broken sign is a sigil you have seen before — the mark of the Cult of Durgon, and fresh, drawn within the week. Someone here answers to it.",
+          "on_failure": "Grime and graffiti cover the alley walls; nothing in the scrawl resolves into meaning."
         }
-      },
-      "enemies": [],
-      "items": [],
-      "searched": false,
-      "searchable": false
+      ]
+    },
+    "arden.town_road": {
+      "name": "Town Gate",
+      "blurb": "The southern gate and the rutted road out — toward the farms, the Davos graveyard, and the crypt beyond.",
+      "description": "The main road runs down to Arden's southern gate, its cobbles grooved by generations of cart wheels. A pair of bored guards watch the gate, open through daylight hours. Beyond the wooden palisade a dirt road winds through farmland before vanishing into a copse of trees — that way lie the Davos family graveyard and darker things besides. A narrow alley off to the east leads into the Warrens.",
+      "npcs": [],
+      "actions": [],
+      "transition": {
+        "to": "crypt",
+        "on_success": "You pass through the town gate and follow the rutted road south, past the last farmstead, until the leaning stones of the Davos graveyard rise ahead under a bruised sky."
+      }
+    },
+    "arden.watch_house": {
+      "name": "The Watch House",
+      "blurb": "The town watch's cramped posting-house, its bounty board crowded since the dead began to walk.",
+      "description": "A squat, functional building of timber and stone hard by the town gate serves Arden's watch. A weapons rack lines one wall; a battered board by the door bristles with notices and bounties — more of them lately, and grimmer, since the trouble at the crypt began. Captain Roderick keeps order here, harried and short of hands, glad of anyone willing to take a posting.",
+      "npcs": [],
+      "actions": ["talk", "read_job_board"]
     }
   }
 }

--- a/dnd-engine/dnd_engine/data/content/campaigns/the_unquiet_dead/npcs.json
+++ b/dnd-engine/dnd_engine/data/content/campaigns/the_unquiet_dead/npcs.json
@@ -5,8 +5,8 @@
       "id": "marta_innkeeper",
       "name": "Marta",
       "display_name": "Marta, the Innkeeper",
-      "home_location": "arden.inn_common_room",
-      "current_location": "arden.inn_common_room",
+      "home_location": "arden.crooked_tankard",
+      "current_location": "arden.crooked_tankard",
       "can_move": false,
       "personality": {
         "traits": ["warm", "maternal", "practical", "gossip-loving"],
@@ -59,8 +59,8 @@
       "id": "father_aldric",
       "name": "Father Aldric",
       "display_name": "Father Aldric",
-      "home_location": "arden.chapel_interior",
-      "current_location": "arden.chapel_interior",
+      "home_location": "arden.chapel_of_the_light",
+      "current_location": "arden.chapel_of_the_light",
       "can_move": true,
       "personality": {
         "traits": ["devout", "worried", "scholarly", "gentle"],
@@ -101,10 +101,10 @@
       },
       "reputation_modifiers": null,
       "schedule": {
-        "morning": "arden.chapel_interior",
-        "afternoon": "arden.outside_chapel",
-        "evening": "arden.chapel_interior",
-        "night": "arden.chapel_interior"
+        "morning": "arden.chapel_of_the_light",
+        "afternoon": "arden.chapel_of_the_light",
+        "evening": "arden.chapel_of_the_light",
+        "night": "arden.chapel_of_the_light"
       },
       "services": {
         "healing": {"cost_per_hp": 1, "available": true},
@@ -115,8 +115,8 @@
       "id": "guard_captain_roderick",
       "name": "Captain Roderick",
       "display_name": "Captain Roderick of the Town Guard",
-      "home_location": "arden.town_gate",
-      "current_location": "arden.town_gate",
+      "home_location": "arden.watch_house",
+      "current_location": "arden.watch_house",
       "can_move": true,
       "personality": {
         "traits": ["gruff", "duty-bound", "protective", "suspicious"],
@@ -154,10 +154,10 @@
         "hostile_threshold": -10
       },
       "schedule": {
-        "morning": "arden.town_gate",
-        "afternoon": "arden.market_square",
-        "evening": "arden.town_gate",
-        "night": "arden.guard_barracks"
+        "morning": "arden.town_road",
+        "afternoon": "arden.town_square",
+        "evening": "arden.town_road",
+        "night": "arden.watch_house"
       },
       "services": null
     },
@@ -165,8 +165,8 @@
       "id": "lord_davos",
       "name": "Lord Davos",
       "display_name": "Lord Aldric Davos",
-      "home_location": "arden.manor_interior",
-      "current_location": "arden.manor_interior",
+      "home_location": "arden.davos_manor",
+      "current_location": "arden.davos_manor",
       "can_move": false,
       "personality": {
         "traits": ["elderly", "dignified", "melancholic", "grateful"],
@@ -217,8 +217,8 @@
       "id": "gareth_shopkeeper",
       "name": "Gareth",
       "display_name": "Gareth, the Shopkeeper",
-      "home_location": "arden.general_store",
-      "current_location": "arden.general_store",
+      "home_location": "arden.gareths_goods",
+      "current_location": "arden.gareths_goods",
       "can_move": false,
       "personality": {
         "traits": ["pragmatic", "shrewd", "fair", "talkative"],

--- a/dnd-engine/tests/test_arden_node_surface.py
+++ b/dnd-engine/tests/test_arden_node_surface.py
@@ -1,0 +1,157 @@
+# ABOUTME: Validates the Town of Arden as a node-surface settlement in The Unquiet Dead.
+# ABOUTME: Covers schema load, NPC placement onto nodes, the Town Gate transition, and both reverse seams.
+
+import pytest
+
+from dnd_engine.core.character import Character, CharacterClass
+from dnd_engine.core.creature import Abilities
+from dnd_engine.core.game_state import GameState
+from dnd_engine.core.party import Party
+from dnd_engine.rules.loader import DataLoader
+from dnd_engine.rules.node_schema import validate_location_surface
+from dnd_engine.utils.events import EventBus
+
+EXPECTED_NODES = {
+    "arden.town_square",
+    "arden.crooked_tankard",
+    "arden.gareths_goods",
+    "arden.chapel_of_the_light",
+    "arden.davos_manor",
+    "arden.warrens_alley",
+    "arden.town_road",
+    "arden.watch_house",
+}
+
+
+@pytest.fixture
+def party():
+    abilities = Abilities(
+        strength=12, dexterity=14, constitution=14, intelligence=10, wisdom=12, charisma=10
+    )
+    hero = Character(
+        name="Test Hero",
+        character_class=CharacterClass.FIGHTER,
+        level=1,
+        abilities=abilities,
+        max_hp=12,
+        ac=16,
+    )
+    return Party([hero])
+
+
+@pytest.fixture
+def arden():
+    return DataLoader().load_dungeon("town_of_arden", campaign_id="the_unquiet_dead")
+
+
+class TestArdenSchema:
+    def test_loads_as_node_surface(self, arden):
+        assert arden["surface"] == "node"
+        assert arden["start_node"] == "arden.town_square"
+
+    def test_passes_node_schema_validation(self, arden):
+        validate_location_surface(arden, source="town_of_arden")  # must not raise
+
+    def test_has_expected_nodes(self, arden):
+        assert set(arden["nodes"]) == EXPECTED_NODES
+
+    def test_no_grid_rooms_remain(self, arden):
+        assert "rooms" not in arden
+
+    def test_chapel_carries_the_crypt_quest_hook(self, arden):
+        # Father Aldric (chapel) is the giver of investigate_crypt.
+        assert arden["nodes"]["arden.chapel_of_the_light"]["quest_hook"] == "investigate_crypt"
+
+
+class TestArdenStartAndNpcPlacement:
+    def test_game_starts_on_node_surface(self, party):
+        gs = GameState(
+            party=party,
+            dungeon_name="town_of_arden",
+            campaign_id="the_unquiet_dead",
+            event_bus=EventBus(),
+            data_loader=DataLoader(),
+        )
+        assert gs.is_node_surface()
+        assert gs.current_node_id == "arden.town_square"
+
+    def test_static_npcs_placed_on_their_nodes(self, party):
+        gs = GameState(
+            party=party,
+            dungeon_name="town_of_arden",
+            campaign_id="the_unquiet_dead",
+            event_bus=EventBus(),
+            data_loader=DataLoader(),
+        )
+        nm = gs.npc_manager
+
+        def names_at(node_id):
+            return {n.name for n in nm.get_npcs_in_room(node_id)}
+
+        assert "Marta" in names_at("arden.crooked_tankard")
+        assert "Gareth" in names_at("arden.gareths_goods")
+        assert "Lord Davos" in names_at("arden.davos_manor")
+        assert "Father Aldric" in names_at("arden.chapel_of_the_light")
+
+    def test_roderick_has_a_home_on_a_real_node(self, party):
+        """Roderick was previously placed at a phantom room; he must now resolve to a real Arden node."""
+        gs = GameState(
+            party=party,
+            dungeon_name="town_of_arden",
+            campaign_id="the_unquiet_dead",
+            event_bus=EventBus(),
+            data_loader=DataLoader(),
+        )
+        nm = gs.npc_manager
+        located = {
+            node_id
+            for node_id in EXPECTED_NODES
+            if any(n.name == "Captain Roderick" for n in nm.get_npcs_in_room(node_id))
+        }
+        assert located, "Captain Roderick is not placed on any Arden node"
+        assert located <= EXPECTED_NODES
+
+
+class TestArdenSeams:
+    def _hero(self, party):
+        return party.get_living_members()[0]
+
+    def test_town_gate_transitions_to_crypt(self, party):
+        gs = GameState(
+            party=party,
+            dungeon_name="town_of_arden",
+            campaign_id="the_unquiet_dead",
+            event_bus=EventBus(),
+            data_loader=DataLoader(),
+        )
+        gs.enter_node("arden.town_road")
+        result = gs.node_actions.transition(self._hero(party))
+        assert result["success"] is True
+        assert gs.dungeon_name == "crypt"
+        assert gs.current_room_id == "crypt.graveyard_entrance"
+
+    def test_crypt_north_reenters_arden_node(self, party):
+        gs = GameState(
+            party=party,
+            dungeon_name="crypt",
+            campaign_id="the_unquiet_dead",
+            event_bus=EventBus(),
+            data_loader=DataLoader(),
+        )
+        assert gs.move("north", check_for_enemies=False) is True
+        assert gs.is_node_surface()
+        assert gs.current_node_id == "arden.town_road"
+        assert gs.dungeon_name == "town_of_arden"
+
+    def test_cult_hideout_up_reenters_arden_node(self, party):
+        gs = GameState(
+            party=party,
+            dungeon_name="cult_hideout",
+            campaign_id="the_unquiet_dead",
+            event_bus=EventBus(),
+            data_loader=DataLoader(),
+        )
+        assert gs.move("up", check_for_enemies=False) is True
+        assert gs.is_node_surface()
+        assert gs.current_node_id == "arden.warrens_alley"
+        assert gs.dungeon_name == "town_of_arden"

--- a/dnd-engine/tests/test_cross_dungeon_navigation.py
+++ b/dnd-engine/tests/test_cross_dungeon_navigation.py
@@ -1,5 +1,5 @@
-# ABOUTME: Integration tests for cross-dungeon navigation using room GUIDs.
-# ABOUTME: Tests moving between town and crypt dungeons via the room registry.
+# ABOUTME: Integration tests for the Arden(node) <-> crypt(grid) seam using real campaign content.
+# ABOUTME: Arden is a node surface; the Town Gate transitions into the crypt and the crypt exits back to the node.
 
 import pytest
 
@@ -28,172 +28,105 @@ def test_party():
     return Party([character])
 
 
+def _town(test_party):
+    return GameState(
+        party=test_party,
+        dungeon_name="town_of_arden",
+        campaign_id="the_unquiet_dead",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+    )
+
+
+def _crypt(test_party):
+    return GameState(
+        party=test_party,
+        dungeon_name="crypt",
+        campaign_id="the_unquiet_dead",
+        event_bus=EventBus(),
+        data_loader=DataLoader(),
+    )
+
+
 class TestCrossDungeonNavigation:
-    """Test navigation between different dungeons using room GUIDs."""
+    """Navigation across the Arden node surface <-> crypt grid seam."""
 
-    def test_start_in_town_navigate_to_crypt(self, test_party):
-        """Test starting in town and navigating to crypt."""
-        event_bus = EventBus()
-        data_loader = DataLoader()
+    def test_start_on_town_node_surface(self, test_party):
+        """Arden loads as a node surface; the party starts at the town square."""
+        game_state = _town(test_party)
 
-        # Start in town
-        game_state = GameState(
-            party=test_party,
-            dungeon_name="town_of_arden",
-            campaign_id="the_unquiet_dead",
-            event_bus=event_bus,
-            data_loader=data_loader,
-        )
-
-        # Should start in town square
-        assert game_state.current_room_id == "arden.town_square"
+        assert game_state.is_node_surface()
+        assert game_state.current_node_id == "arden.town_square"
+        assert game_state.current_room_id is None
         assert game_state.dungeon_name == "town_of_arden"
 
-        # Move south to town road
-        success = game_state.move("south", check_for_enemies=False)
-        assert success is True
-        assert game_state.current_room_id == "arden.town_road"
+    def test_town_gate_transition_enters_crypt(self, test_party):
+        """The Town Gate node transitions onto the crypt grid at its entrance (forward seam)."""
+        game_state = _town(test_party)
 
-        # Move south to crypt (cross-dungeon)
-        success = game_state.move("south", check_for_enemies=False)
-        assert success is True
-        assert game_state.current_room_id == "crypt.graveyard_entrance"
+        game_state.enter_node("arden.town_road")
+        result = game_state.node_actions.transition(game_state.party.get_living_members()[0])
+
+        assert result["success"] is True
         assert game_state.dungeon_name == "crypt"
-
-    def test_start_in_crypt_navigate_to_town(self, test_party):
-        """Test starting in crypt and navigating back to town."""
-        event_bus = EventBus()
-        data_loader = DataLoader()
-
-        # Start in crypt
-        game_state = GameState(
-            party=test_party,
-            dungeon_name="crypt",
-            campaign_id="the_unquiet_dead",
-            event_bus=event_bus,
-            data_loader=data_loader,
-        )
-
-        # Should start in graveyard entrance
         assert game_state.current_room_id == "crypt.graveyard_entrance"
-        assert game_state.dungeon_name == "crypt"
+        assert not game_state.is_node_surface()
 
-        # Move north to town (cross-dungeon)
+    def test_crypt_exit_reenters_town_node_surface(self, test_party):
+        """Moving north out of the crypt lands on the Arden node surface (reverse seam)."""
+        game_state = _crypt(test_party)
+        assert game_state.current_room_id == "crypt.graveyard_entrance"
+
         success = game_state.move("north", check_for_enemies=False)
+
         assert success is True
-        assert game_state.current_room_id == "arden.town_road"
+        assert game_state.is_node_surface()
+        assert game_state.current_node_id == "arden.town_road"
+        assert game_state.current_room_id is None
         assert game_state.dungeon_name == "town_of_arden"
 
-    def test_round_trip_navigation(self, test_party):
-        """Test navigating from town to crypt and back."""
-        event_bus = EventBus()
-        data_loader = DataLoader()
+    def test_round_trip_preserves_crypt_room_state(self, test_party):
+        """Crypt -> Arden node -> crypt, preserving crypt room state across the seam."""
+        game_state = _crypt(test_party)
 
-        # Start in town
-        game_state = GameState(
-            party=test_party,
-            dungeon_name="town_of_arden",
-            campaign_id="the_unquiet_dead",
-            event_bus=event_bus,
-            data_loader=data_loader,
-        )
+        # Mark the entrance searched before leaving.
+        game_state.get_current_room()["searched"] = True
 
-        # Go to crypt (south twice)
-        game_state.move("south", check_for_enemies=False)
-        game_state.move("south", check_for_enemies=False)
-        assert game_state.current_room_id == "crypt.graveyard_entrance"
-
-        # Go back to town (north)
+        # Up to the node surface via the reverse seam.
         game_state.move("north", check_for_enemies=False)
-        assert game_state.current_room_id == "arden.town_road"
-        assert game_state.dungeon_name == "town_of_arden"
+        assert game_state.current_node_id == "arden.town_road"
 
-        # Go back to crypt again (south)
-        game_state.move("south", check_for_enemies=False)
-        assert game_state.current_room_id == "crypt.graveyard_entrance"
+        # Back down through the Town Gate transition.
+        result = game_state.node_actions.transition(game_state.party.get_living_members()[0])
+        assert result["success"] is True
         assert game_state.dungeon_name == "crypt"
+        assert game_state.current_room_id == "crypt.graveyard_entrance"
 
-    def test_dungeon_state_preserved_across_transitions(self, test_party):
-        """Test that dungeon state is preserved when moving between dungeons."""
-        event_bus = EventBus()
-        data_loader = DataLoader()
-
-        # Start in crypt
-        game_state = GameState(
-            party=test_party,
-            dungeon_name="crypt",
-            campaign_id="the_unquiet_dead",
-            event_bus=event_bus,
-            data_loader=data_loader,
-        )
-
-        # Mark current room as searched
-        room = game_state.get_current_room()
-        room["searched"] = True
-
-        # Go to town (north)
-        game_state.move("north", check_for_enemies=False)
-        assert game_state.current_room_id == "arden.town_road"
-
-        # Go back to crypt (south)
-        game_state.move("south", check_for_enemies=False)
-
-        # The searched flag should still be set
-        room = game_state.get_current_room()
-        assert room["searched"] is True
+        # The searched flag survived the round trip.
+        assert game_state.get_current_room()["searched"] is True
 
     def test_room_info_after_cross_dungeon_move(self, test_party):
-        """Test that room info is correct after cross-dungeon moves."""
-        event_bus = EventBus()
-        data_loader = DataLoader()
+        """After entering the crypt from town, room info reflects the crypt entrance."""
+        game_state = _town(test_party)
 
-        # Start in town
-        game_state = GameState(
-            party=test_party,
-            dungeon_name="town_of_arden",
-            campaign_id="the_unquiet_dead",
-            event_bus=event_bus,
-            data_loader=data_loader,
-        )
+        game_state.enter_node("arden.town_road")
+        game_state.node_actions.transition(game_state.party.get_living_members()[0])
 
-        # Navigate to crypt (south twice)
-        game_state.move("south", check_for_enemies=False)
-        game_state.move("south", check_for_enemies=False)
-
-        # Check room info
         room = game_state.get_current_room()
         assert room["id"] == "crypt.graveyard_entrance"
         assert room["name"] == "Overgrown Graveyard"
         assert room["location_type"] == "dungeon"
         assert room["parent"] == "crypt"
 
-    def test_exits_available_after_cross_dungeon_move(self, test_party):
-        """Test that exits are correctly reported after cross-dungeon moves."""
-        event_bus = EventBus()
-        data_loader = DataLoader()
+    def test_crypt_exits_after_arrival(self, test_party):
+        """The crypt entrance exposes its interior exit and the road back to the Arden node."""
+        game_state = _crypt(test_party)
 
-        # Start in town
-        game_state = GameState(
-            party=test_party,
-            dungeon_name="town_of_arden",
-            campaign_id="the_unquiet_dead",
-            event_bus=event_bus,
-            data_loader=data_loader,
-        )
-
-        # Navigate to crypt (south twice)
-        game_state.move("south", check_for_enemies=False)
-        game_state.move("south", check_for_enemies=False)
-
-        # Check exits
         room = game_state.get_current_room()
         exits = room.get("exits", {})
 
-        # Should have exit down to hall_of_the_dead and north back to town
+        # Interior exit down, plus the north exit that names the Arden Town Gate node.
         assert "down" in exits
         assert "north" in exits
-
-        # Verify exit destinations
         assert exits["down"] == "crypt.hall_of_the_dead"
-        north_exit = exits["north"]
-        assert north_exit["destination"] == "arden.town_road"
+        assert exits["north"]["destination"] == "arden.town_road"

--- a/dnd-engine/tests/test_room_registry.py
+++ b/dnd-engine/tests/test_room_registry.py
@@ -227,7 +227,7 @@ class TestRoomRegistryWithRealData:
         assert registry.room_exists("crypt.family_shrine")
 
     def test_town_dungeon_registered(self):
-        """Test that the town of Arden is properly registered."""
+        """Arden is a node surface; its locations resolve through the node index."""
         from dnd_engine.rules.loader import DataLoader
 
         loader = DataLoader()
@@ -238,12 +238,12 @@ class TestRoomRegistryWithRealData:
             content_path=content_path,
         )
 
-        # Should find town rooms
-        assert registry.get_dungeon_for_room("arden.town_square") == "town_of_arden"
-        assert registry.room_exists("arden.town_road")
+        # Arden's nodes resolve to the settlement via the node index, not the room index.
+        assert registry.get_dungeon_for_node("arden.town_square") == "town_of_arden"
+        assert registry.get_dungeon_for_node("arden.town_road") == "town_of_arden"
 
     def test_cross_dungeon_exit_resolution(self):
-        """Test that exits between dungeons can be resolved."""
+        """The Town Gate node authors a transition into the crypt (replaces the old grid exit)."""
         from dnd_engine.rules.loader import DataLoader
 
         loader = DataLoader()
@@ -254,17 +254,12 @@ class TestRoomRegistryWithRealData:
             content_path=content_path,
         )
 
-        # Get the town road room (connects to crypt)
-        town_road = registry.get_room("arden.town_road")
-        assert town_road is not None
+        # The Town Gate node transitions to the crypt.
+        arden = registry.load_dungeon("town_of_arden")
+        town_gate = arden["nodes"]["arden.town_road"]
+        assert town_gate["transition"]["to"] == "crypt"
 
-        # Check the exit to crypt (south direction)
-        graveyard_exit = town_road["exits"].get("south")
-        assert graveyard_exit is not None
-        destination = graveyard_exit["destination"]
-
-        # Should be able to resolve the destination room
-        assert registry.room_exists(destination)
-        crypt_entrance = registry.get_room(destination)
-        assert crypt_entrance is not None
-        assert crypt_entrance["name"] == "Overgrown Graveyard"
+        # The transition target resolves to the crypt's start room.
+        crypt = registry.load_dungeon("crypt")
+        entrance = crypt["rooms"][crypt["start_room"]]
+        assert entrance["name"] == "Overgrown Graveyard"


### PR DESCRIPTION
## Summary
- Town of Arden becomes a **node surface** (8 nodes) in The Unquiet Dead, replacing its grid rooms.
- Static NPCs are migrated onto node ids; the campaign now opens directly on the Arden node surface.
- Fixes a new-game crash introduced by the conversion: `Could not find dungeon for room: arden.town_square`.

## Changes
- **town_of_arden.json**: grid rooms → 8 authored nodes with vocab actions, skill gates, and the Town Gate → crypt seam.
- **npcs.json**: relocate Marta, Gareth, Lord Davos, Father Aldric, and Captain Roderick onto real Arden nodes.
- **main_menu_v2.py**: resolve a node `starting_room` via `get_dungeon_for_node` (new `_resolve_starting_dungeon` helper) and skip the grid `current_room_id` override on node surfaces.
- **tests**: `test_arden_node_surface` (engine unit/integration), `test_new_game_node_start` (resolution regression guard), `test_arden_node_surface_e2e` + `arden_settlement_driver` (pexpect e2e), and refactors to `test_cross_dungeon_navigation` / `test_room_registry` / `test_quest_items`.
- **.gitignore**: ignore `.serena/` tool cache.

## Testing
- [x] Full suites green: engine **3655 passed**, client **506 passed**
- [x] New pexpect e2e drives the real CLI: arrival → prose nav to the Crooked Tankard (Marta present) → Town Gate seam → clean quit
- [x] `ruff check` + `ruff format --check` clean

## Notes
- Surfaced (and ticketed separately as #694) a pre-existing long-rest crash unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)